### PR TITLE
:boom: Change return type of`SolidEntryBuilder::add_entry`

### DIFF
--- a/lib/src/archive/entry/builder.rs
+++ b/lib/src/archive/entry/builder.rs
@@ -366,9 +366,8 @@ impl SolidEntryBuilder {
     /// #     Ok(())
     /// # }
     /// ```
-    pub fn add_entry(&mut self, entry: RegularEntry) -> io::Result<()> {
-        entry.write_in(&mut self.data)?;
-        Ok(())
+    pub fn add_entry(&mut self, entry: RegularEntry) -> io::Result<usize> {
+        entry.write_in(&mut self.data)
     }
 
     fn build_as_entry(self) -> io::Result<SolidEntry> {


### PR DESCRIPTION
`SolidEntryBuilder::add_entry` now return written bytes length in `usize`