### PR TITLE
✨ Add SolidArchive for easily writing solid mode archive

### DIFF
--- a/lib/src/archive/entry.rs
+++ b/lib/src/archive/entry.rs
@@ -9,7 +9,7 @@ mod reference;
 mod write;
 
 pub use self::{attr::*, builder::*, header::*, meta::*, name::*, options::*, reference::*};
-use self::{private::*, read::*, write::*};
+pub(crate) use self::{private::*, read::*, write::*};
 use crate::{
     chunk::{chunk_data_split, ChunkExt, ChunkReader, ChunkType, RawChunk, MIN_CHUNK_BYTES_SIZE},
     util::slice::skip_while,

--- a/lib/src/chunk.rs
+++ b/lib/src/chunk.rs
@@ -5,7 +5,10 @@ mod types;
 mod write;
 
 use self::crc::Crc32;
-pub(crate) use self::{read::ChunkReader, write::ChunkWriter};
+pub(crate) use self::{
+    read::ChunkReader,
+    write::{ChunkStreamWriter, ChunkWriter},
+};
 pub use self::{traits::*, types::*};
 use std::{
     io::{self, Write},

--- a/lib/src/chunk/write.rs
+++ b/lib/src/chunk/write.rs
@@ -55,6 +55,11 @@ impl<W> ChunkStreamWriter<W> {
             w: ChunkWriter::from(inner),
         }
     }
+
+    #[inline]
+    pub(crate) fn into_inner(self) -> W {
+        self.w.w
+    }
 }
 
 impl<W: Write> Write for ChunkStreamWriter<W> {


### PR DESCRIPTION
```rust
use libpna::{Archive, EntryBuilder, WriteOption};
use std::fs::File;
use std::io;

fn main() -> io::Result<()> {
    let option = WriteOption::builder().build();
    let file = File::create("example.pna")?;
    let mut archive = Archive::write_solid_header(file, option)?;
    archive.add_entry(
        EntryBuilder::new_file("example.txt".try_into().unwrap(), WriteOption::store())?.build()?,
    )?;
    archive.finalize()?;
    Ok(())
}
```