### PR TITLE
:construction: Add `--keep-acl` option as unstable to each subcommands

### DIFF
--- a/cli/src/command/append.rs
+++ b/cli/src/command/append.rs
@@ -16,6 +16,7 @@ use std::{fs::File, io, path::PathBuf};
 
 #[derive(Parser, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[command(
+    group(ArgGroup::new("unstable-acl").args(["keep_acl"]).requires("unstable")),
     group(ArgGroup::new("unstable-append-exclude").args(["exclude"]).requires("unstable")),
     group(ArgGroup::new("unstable-files-from").args(["files_from"]).requires("unstable")),
     group(ArgGroup::new("unstable-files-from-stdin").args(["files_from_stdin"]).requires("unstable")),
@@ -38,6 +39,8 @@ pub(crate) struct AppendCommand {
     pub(crate) keep_permission: bool,
     #[arg(long, help = "Archiving the extended attributes of the files")]
     pub(crate) keep_xattr: bool,
+    #[arg(long, help = "Archiving the acl of the files")]
+    pub(crate) keep_acl: bool,
     #[arg(long, help = "Archiving user to the entries from given name")]
     pub(crate) uname: Option<String>,
     #[arg(long, help = "Archiving group to the entries from given name")]
@@ -136,6 +139,7 @@ fn append_to_archive(args: AppendCommand, verbosity: Verbosity) -> io::Result<()
         keep_timestamp: args.keep_timestamp,
         keep_permission: args.keep_permission,
         keep_xattr: args.keep_xattr,
+        keep_acl: args.keep_acl,
     };
     let owner_options = OwnerOptions {
         uname: if args.numeric_owner {

--- a/cli/src/command/commons.rs
+++ b/cli/src/command/commons.rs
@@ -23,6 +23,7 @@ pub(crate) struct KeepOptions {
     pub(crate) keep_timestamp: bool,
     pub(crate) keep_permission: bool,
     pub(crate) keep_xattr: bool,
+    pub(crate) keep_acl: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/cli/src/command/create.rs
+++ b/cli/src/command/create.rs
@@ -24,6 +24,7 @@ use std::{
 
 #[derive(Parser, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[command(
+    group(ArgGroup::new("unstable-acl").args(["keep_acl"]).requires("unstable")),
     group(ArgGroup::new("unstable-create-exclude").args(["exclude"]).requires("unstable")),
     group(ArgGroup::new("unstable-files-from").args(["files_from"]).requires("unstable")),
     group(ArgGroup::new("unstable-files-from-stdin").args(["files_from_stdin"]).requires("unstable")),
@@ -48,6 +49,8 @@ pub(crate) struct CreateCommand {
     pub(crate) keep_permission: bool,
     #[arg(long, help = "Archiving the extended attributes of the files")]
     pub(crate) keep_xattr: bool,
+    #[arg(long, help = "Archiving the acl of the files")]
+    pub(crate) keep_acl: bool,
     #[arg(long, help = "Split archive by total entry size")]
     pub(crate) split: Option<Option<ByteSize>>,
     #[arg(long, help = "Solid mode archive")]
@@ -140,6 +143,7 @@ fn create_archive(args: CreateCommand, verbosity: Verbosity) -> io::Result<()> {
         keep_timestamp: args.keep_timestamp,
         keep_permission: args.keep_permission,
         keep_xattr: args.keep_xattr,
+        keep_acl: args.keep_acl,
     };
     let owner_options = OwnerOptions {
         uname: if args.numeric_owner {

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -31,6 +31,7 @@ use std::{
 
 #[derive(Parser, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[command(
+    group(ArgGroup::new("unstable-acl").args(["keep_acl"]).requires("unstable")),
     group(ArgGroup::new("user-flag").args(["numeric_owner", "uname"])),
     group(ArgGroup::new("group-flag").args(["numeric_owner", "gname"])),
 )]
@@ -47,6 +48,8 @@ pub(crate) struct ExtractCommand {
     pub(crate) keep_permission: bool,
     #[arg(long, help = "Restore the extended attributes of the files")]
     pub(crate) keep_xattr: bool,
+    #[arg(long, help = "Restore the acl of the files")]
+    pub(crate) keep_acl: bool,
     #[arg(long, help = "Restore user from given name")]
     pub(crate) uname: Option<String>,
     #[arg(long, help = "Restore group from given name")]
@@ -85,6 +88,7 @@ fn extract_archive(args: ExtractCommand, verbosity: Verbosity) -> io::Result<()>
         keep_timestamp: args.keep_timestamp,
         keep_permission: args.keep_permission,
         keep_xattr: args.keep_xattr,
+        keep_acl: args.keep_acl,
     };
     let owner_options = OwnerOptions {
         uname: if args.numeric_owner {

--- a/cli/src/command/stdio.rs
+++ b/cli/src/command/stdio.rs
@@ -21,6 +21,7 @@ use std::{
 
 #[derive(Args, Clone, Eq, PartialEq, Hash, Debug)]
 #[command(
+    group(ArgGroup::new("unstable-acl").args(["keep_acl"]).requires("unstable")),
     group(ArgGroup::new("bundled-flags").args(["create", "extract"]).required(true)),
     group(ArgGroup::new("unstable-exclude-from").args(["files_from"]).requires("unstable")),
     group(ArgGroup::new("unstable-files-from").args(["files_from"]).requires("unstable")),
@@ -44,6 +45,8 @@ pub(crate) struct StdioCommand {
     keep_permission: bool,
     #[arg(long, help = "Archiving the extended attributes of the files")]
     keep_xattr: bool,
+    #[arg(long, help = "Archiving the acl of the files")]
+    pub(crate) keep_acl: bool,
     #[arg(long, help = "Solid mode archive")]
     pub(crate) solid: bool,
     #[command(flatten)]
@@ -147,6 +150,7 @@ fn run_create_archive(args: StdioCommand, verbosity: Verbosity) -> io::Result<()
         keep_timestamp: args.keep_timestamp,
         keep_permission: args.keep_permission,
         keep_xattr: args.keep_xattr,
+        keep_acl: args.keep_acl,
     };
     let owner_options = OwnerOptions {
         uname: if args.numeric_owner {
@@ -194,6 +198,7 @@ fn run_extract_archive(args: StdioCommand, verbosity: Verbosity) -> io::Result<(
             keep_timestamp: args.keep_timestamp,
             keep_permission: args.keep_permission,
             keep_xattr: args.keep_xattr,
+            keep_acl: args.keep_acl,
         },
         owner_options: OwnerOptions {
             uname: if args.numeric_owner {

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -23,6 +23,7 @@ use std::{
 
 #[derive(Parser, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[command(
+    group(ArgGroup::new("unstable-acl").args(["keep_acl"]).requires("unstable")),
     group(ArgGroup::new("unstable-update-exclude").args(["exclude"]).requires("unstable")),
     group(ArgGroup::new("unstable-files-from").args(["files_from"]).requires("unstable")),
     group(ArgGroup::new("unstable-files-from-stdin").args(["files_from_stdin"]).requires("unstable")),
@@ -45,6 +46,8 @@ pub(crate) struct UpdateCommand {
     pub(crate) keep_permission: bool,
     #[arg(long, help = "Archiving the extended attributes of the files")]
     pub(crate) keep_xattr: bool,
+    #[arg(long, help = "Archiving the acl of the files")]
+    pub(crate) keep_acl: bool,
     #[arg(long, help = "Archiving user to the entries from given name")]
     pub(crate) uname: Option<String>,
     #[arg(long, help = "Archiving group to the entries from given name")]
@@ -123,6 +126,7 @@ fn update_archive(args: UpdateCommand, verbosity: Verbosity) -> io::Result<()> {
         keep_timestamp: args.keep_timestamp,
         keep_permission: args.keep_permission,
         keep_xattr: args.keep_xattr,
+        keep_acl: args.keep_acl,
     };
     let owner_options = OwnerOptions {
         uname: if args.numeric_owner {


### PR DESCRIPTION
however, currently that's noeffect