### PR TITLE
Rename option structs

### DIFF
--- a/cli/src/command/commons.rs
+++ b/cli/src/command/commons.rs
@@ -6,7 +6,7 @@ use crate::{
 use nix::unistd::{Group, User};
 use normalize_path::*;
 use pna::{
-    Archive, Entry, EntryBuilder, EntryName, EntryPart, EntryReference, RegularEntry, WriteOption,
+    Archive, Entry, EntryBuilder, EntryName, EntryPart, EntryReference, RegularEntry, WriteOptions,
     MIN_CHUNK_BYTES_SIZE, PNA_HEADER,
 };
 #[cfg(unix)]
@@ -36,7 +36,7 @@ pub(crate) struct OwnerOptions {
 
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub(crate) struct CreateOptions {
-    pub(crate) option: WriteOption,
+    pub(crate) option: WriteOptions,
     pub(crate) keep_options: KeepOptions,
     pub(crate) owner_options: OwnerOptions,
 }
@@ -123,9 +123,9 @@ pub(crate) fn entry_option(
     compression: CompressionAlgorithmArgs,
     cipher: CipherAlgorithmArgs,
     password: Option<String>,
-) -> WriteOption {
+) -> WriteOptions {
     let (algorithm, level) = compression.algorithm();
-    let mut option_builder = WriteOption::builder();
+    let mut option_builder = WriteOptions::builder();
     option_builder
         .compression(algorithm)
         .compression_level(level.unwrap_or_default())

--- a/cli/src/command/create.rs
+++ b/cli/src/command/create.rs
@@ -13,7 +13,7 @@ use crate::{
 use bytesize::ByteSize;
 use clap::{ArgGroup, Parser, ValueHint};
 use indicatif::HumanDuration;
-use pna::{Archive, SolidEntryBuilder, WriteOption};
+use pna::{Archive, SolidEntryBuilder, WriteOptions};
 use rayon::ThreadPoolBuilder;
 use std::{
     fs::{self, File},
@@ -193,7 +193,7 @@ fn create_archive(args: CreateCommand, verbosity: Verbosity) -> io::Result<()> {
 
 pub(crate) fn create_archive_file<W, F>(
     mut get_writer: F,
-    write_option: WriteOption,
+    write_option: WriteOptions,
     keep_options: KeepOptions,
     owner_options: OwnerOptions,
     solid: bool,
@@ -210,7 +210,7 @@ where
 
     let (tx, rx) = std::sync::mpsc::channel();
     let option = if solid {
-        WriteOption::store()
+        WriteOptions::store()
     } else {
         write_option.clone()
     };
@@ -252,7 +252,7 @@ where
 
 fn create_archive_with_split(
     archive: &Path,
-    write_option: WriteOption,
+    write_option: WriteOptions,
     keep_options: KeepOptions,
     owner_options: OwnerOptions,
     solid: bool,
@@ -266,7 +266,7 @@ fn create_archive_with_split(
 
     let (tx, rx) = std::sync::mpsc::channel();
     let option = if solid {
-        WriteOption::store()
+        WriteOptions::store()
     } else {
         write_option.clone()
     };

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -13,7 +13,7 @@ use clap::{ArgGroup, Parser, ValueHint};
 use indicatif::HumanDuration;
 #[cfg(unix)]
 use nix::unistd::{Group, User};
-use pna::{DataKind, EntryReference, Permission, ReadOption, RegularEntry};
+use pna::{DataKind, EntryReference, Permission, ReadOptions, RegularEntry};
 use rayon::ThreadPoolBuilder;
 use std::ops::Add;
 #[cfg(target_os = "macos")]
@@ -257,14 +257,14 @@ pub(crate) fn extract_entry(
                 }
                 file.set_times(times)?;
             }
-            let mut reader = item.reader(ReadOption::with_password(password))?;
+            let mut reader = item.reader(ReadOptions::with_password(password))?;
             io::copy(&mut reader, &mut file)?;
         }
         DataKind::Directory => {
             fs::create_dir_all(&path)?;
         }
         DataKind::SymbolicLink => {
-            let reader = item.reader(ReadOption::with_password(password))?;
+            let reader = item.reader(ReadOptions::with_password(password))?;
             let original = EntryReference::from_lossy(io::read_to_string(reader)?);
             if overwrite && path.exists() {
                 utils::fs::remove(&path)?;
@@ -272,7 +272,7 @@ pub(crate) fn extract_entry(
             utils::fs::symlink(original.as_str(), &path)?;
         }
         DataKind::HardLink => {
-            let reader = item.reader(ReadOption::with_password(password))?;
+            let reader = item.reader(ReadOptions::with_password(password))?;
             let original = EntryReference::from_lossy(io::read_to_string(reader)?);
             let mut original = PathBuf::from(original.as_str());
             if let Some(parent) = path.parent() {

--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -12,7 +12,7 @@ use ansi_term::{ANSIString, Colour, Style};
 use chrono::{DateTime, Local};
 use clap::{ArgGroup, Parser};
 use pna::{
-    Chunk, Compression, DataKind, Encryption, ExtendedAttribute, ReadEntry, ReadOption,
+    Chunk, Compression, DataKind, Encryption, ExtendedAttribute, ReadEntry, ReadOptions,
     RegularEntry, SolidHeader,
 };
 use rayon::prelude::*;
@@ -186,7 +186,7 @@ impl
             ) {
                 let path = header.path().to_string();
                 let original = entry
-                    .reader(ReadOption::with_password(password))
+                    .reader(ReadOptions::with_password(password))
                     .map(|r| io::read_to_string(r).unwrap_or_else(|_| "-".to_string()))
                     .unwrap_or_default();
                 format!("{} -> {}", path, original)

--- a/cli/tests/hardlink.rs
+++ b/cli/tests/hardlink.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use pna::{Archive, EntryBuilder, WriteOption};
+use pna::{Archive, EntryBuilder, WriteOptions};
 use portable_network_archive::{cli, command};
 use std::{fs, io::Write, path::Path};
 
@@ -14,7 +14,7 @@ fn init_resource<P: AsRef<Path>>(path: P) {
     writer
         .add_entry({
             let mut builder =
-                EntryBuilder::new_file("origin1.txt".into(), WriteOption::builder().build())
+                EntryBuilder::new_file("origin1.txt".into(), WriteOptions::builder().build())
                     .unwrap();
             builder.write_all(b"original text\n").unwrap();
             builder.build().unwrap()
@@ -39,7 +39,7 @@ fn init_resource<P: AsRef<Path>>(path: P) {
     writer
         .add_entry({
             let mut builder =
-                EntryBuilder::new_file("dir/origin2.txt".into(), WriteOption::builder().build())
+                EntryBuilder::new_file("dir/origin2.txt".into(), WriteOptions::builder().build())
                     .unwrap();
             builder.write_all(b"original text text\n").unwrap();
             builder.build().unwrap()

--- a/lib/README.md
+++ b/lib/README.md
@@ -16,7 +16,7 @@ libpna = "0.12"
 ## Reading an archive
 
 ```rust
-use libpna::{Archive, ReadOption};
+use libpna::{Archive, ReadOptions};
 use std::fs::File;
 use std::io::{self, copy, prelude::*};
 
@@ -26,7 +26,7 @@ fn main() -> io::Result<()> {
     for entry in archive.entries_skip_solid() {
         let entry = entry?;
         let mut file = File::create(entry.header().path().as_path())?;
-        let mut reader = entry.reader(ReadOption::builder().build())?;
+        let mut reader = entry.reader(ReadOptions::builder().build())?;
         copy(&mut reader, &mut file)?;
     }
     Ok(())

--- a/lib/README.md
+++ b/lib/README.md
@@ -36,7 +36,7 @@ fn main() -> io::Result<()> {
 ## Writing an archive
 
 ```rust
-use libpna::{Archive, EntryBuilder, WriteOption};
+use libpna::{Archive, EntryBuilder, WriteOptions};
 use std::fs::File;
 use std::io::{self, prelude::*};
 
@@ -45,7 +45,7 @@ fn main() -> io::Result<()> {
     let mut archive = Archive::write_header(file)?;
     let mut entry_builder = EntryBuilder::new_file(
         "bar.txt".into(),
-        WriteOption::builder().build(),
+        WriteOptions::builder().build(),
     )?;
     entry_builder.write(b"content")?;
     let entry = entry_builder.build()?;

--- a/lib/benches/create_extract/archive.rs
+++ b/lib/benches/create_extract/archive.rs
@@ -1,23 +1,23 @@
 extern crate test;
 
 use crate::{bench_read_archive, bench_write_archive};
-use libpna::{CipherMode, Compression, Encryption, WriteOption};
+use libpna::{CipherMode, Compression, Encryption, WriteOptions};
 use test::Bencher;
 
 #[bench]
 fn write_store_archive(b: &mut Bencher) {
-    bench_write_archive(b, WriteOption::builder());
+    bench_write_archive(b, WriteOptions::builder());
 }
 
 #[bench]
 fn read_store_archive(b: &mut Bencher) {
-    bench_read_archive(b, WriteOption::builder());
+    bench_read_archive(b, WriteOptions::builder());
 }
 
 #[bench]
 fn write_zstd_archive(b: &mut Bencher) {
     bench_write_archive(b, {
-        let mut builder = WriteOption::builder();
+        let mut builder = WriteOptions::builder();
         builder.compression(Compression::ZStandard);
         builder
     });
@@ -26,7 +26,7 @@ fn write_zstd_archive(b: &mut Bencher) {
 #[bench]
 fn read_zstd_archive(b: &mut Bencher) {
     bench_read_archive(b, {
-        let mut builder = WriteOption::builder();
+        let mut builder = WriteOptions::builder();
         builder.compression(Compression::ZStandard);
         builder
     });
@@ -35,7 +35,7 @@ fn read_zstd_archive(b: &mut Bencher) {
 #[bench]
 fn write_deflate_archive(b: &mut Bencher) {
     bench_write_archive(b, {
-        let mut builder = WriteOption::builder();
+        let mut builder = WriteOptions::builder();
         builder.compression(Compression::Deflate);
         builder
     });
@@ -44,7 +44,7 @@ fn write_deflate_archive(b: &mut Bencher) {
 #[bench]
 fn read_deflate_archive(b: &mut Bencher) {
     bench_read_archive(b, {
-        let mut builder = WriteOption::builder();
+        let mut builder = WriteOptions::builder();
         builder.compression(Compression::Deflate);
         builder
     });
@@ -53,7 +53,7 @@ fn read_deflate_archive(b: &mut Bencher) {
 #[bench]
 fn write_lzma_archive(b: &mut Bencher) {
     bench_write_archive(b, {
-        let mut builder = WriteOption::builder();
+        let mut builder = WriteOptions::builder();
         builder.compression(Compression::XZ);
         builder
     });
@@ -62,7 +62,7 @@ fn write_lzma_archive(b: &mut Bencher) {
 #[bench]
 fn read_lzma_archive(b: &mut Bencher) {
     bench_read_archive(b, {
-        let mut builder = WriteOption::builder();
+        let mut builder = WriteOptions::builder();
         builder.compression(Compression::XZ);
         builder
     });
@@ -71,7 +71,7 @@ fn read_lzma_archive(b: &mut Bencher) {
 #[bench]
 fn write_aes_ctr_archive(b: &mut Bencher) {
     bench_write_archive(b, {
-        let mut builder = WriteOption::builder();
+        let mut builder = WriteOptions::builder();
         builder
             .encryption(Encryption::Aes)
             .cipher_mode(CipherMode::CTR);
@@ -82,7 +82,7 @@ fn write_aes_ctr_archive(b: &mut Bencher) {
 #[bench]
 fn read_aes_ctr_archive(b: &mut Bencher) {
     bench_read_archive(b, {
-        let mut builder = WriteOption::builder();
+        let mut builder = WriteOptions::builder();
         builder
             .encryption(Encryption::Aes)
             .cipher_mode(CipherMode::CTR);
@@ -93,7 +93,7 @@ fn read_aes_ctr_archive(b: &mut Bencher) {
 #[bench]
 fn write_aes_cbc_archive(b: &mut Bencher) {
     bench_write_archive(b, {
-        let mut builder = WriteOption::builder();
+        let mut builder = WriteOptions::builder();
         builder
             .encryption(Encryption::Aes)
             .cipher_mode(CipherMode::CBC);
@@ -104,7 +104,7 @@ fn write_aes_cbc_archive(b: &mut Bencher) {
 #[bench]
 fn read_aes_cbc_archive(b: &mut Bencher) {
     bench_read_archive(b, {
-        let mut builder = WriteOption::builder();
+        let mut builder = WriteOptions::builder();
         builder
             .encryption(Encryption::Aes)
             .cipher_mode(CipherMode::CBC);
@@ -115,7 +115,7 @@ fn read_aes_cbc_archive(b: &mut Bencher) {
 #[bench]
 fn write_camellia_ctr_archive(b: &mut Bencher) {
     bench_write_archive(b, {
-        let mut builder = WriteOption::builder();
+        let mut builder = WriteOptions::builder();
         builder
             .encryption(Encryption::Camellia)
             .cipher_mode(CipherMode::CTR);
@@ -126,7 +126,7 @@ fn write_camellia_ctr_archive(b: &mut Bencher) {
 #[bench]
 fn read_camellia_ctr_archive(b: &mut Bencher) {
     bench_read_archive(b, {
-        let mut builder = WriteOption::builder();
+        let mut builder = WriteOptions::builder();
         builder
             .encryption(Encryption::Camellia)
             .cipher_mode(CipherMode::CTR);
@@ -137,7 +137,7 @@ fn read_camellia_ctr_archive(b: &mut Bencher) {
 #[bench]
 fn write_camellia_cbc_archive(b: &mut Bencher) {
     bench_write_archive(b, {
-        let mut builder = WriteOption::builder();
+        let mut builder = WriteOptions::builder();
         builder
             .encryption(Encryption::Camellia)
             .cipher_mode(CipherMode::CBC);
@@ -148,7 +148,7 @@ fn write_camellia_cbc_archive(b: &mut Bencher) {
 #[bench]
 fn read_camellia_cbc_archive(b: &mut Bencher) {
     bench_read_archive(b, {
-        let mut builder = WriteOption::builder();
+        let mut builder = WriteOptions::builder();
         builder
             .encryption(Encryption::Camellia)
             .cipher_mode(CipherMode::CBC);

--- a/lib/benches/create_extract/empty.rs
+++ b/lib/benches/create_extract/empty.rs
@@ -1,6 +1,6 @@
 extern crate test;
 
-use libpna::{Archive, ReadOption};
+use libpna::{Archive, ReadOptions};
 use std::io;
 use test::Bencher;
 
@@ -23,7 +23,7 @@ fn read_empty_archive(b: &mut Bencher) {
         for entry in reader.entries_skip_solid() {
             let item = entry.expect("failed to read entry");
             io::read_to_string(
-                item.reader(ReadOption::builder().build())
+                item.reader(ReadOptions::builder().build())
                     .expect("failed to read entry"),
             )
             .expect("failed to make string");

--- a/lib/benches/create_extract/main.rs
+++ b/lib/benches/create_extract/main.rs
@@ -1,14 +1,14 @@
 #![feature(test)]
 extern crate test;
 
-use libpna::{Archive, EntryBuilder, ReadOption, WriteOptionBuilder};
+use libpna::{Archive, EntryBuilder, ReadOption, WriteOptionsBuilder};
 use std::io::{Read, Write};
 use test::Bencher;
 
 mod archive;
 mod empty;
 
-fn bench_write_archive(b: &mut Bencher, mut options: WriteOptionBuilder) {
+fn bench_write_archive(b: &mut Bencher, mut options: WriteOptionsBuilder) {
     let buf = [24; 1111];
     b.iter(|| {
         let mut vec = Vec::with_capacity(10000);
@@ -28,7 +28,7 @@ fn bench_write_archive(b: &mut Bencher, mut options: WriteOptionBuilder) {
     })
 }
 
-fn bench_read_archive(b: &mut Bencher, mut options: WriteOptionBuilder) {
+fn bench_read_archive(b: &mut Bencher, mut options: WriteOptionsBuilder) {
     let buf = [24; 1111];
     let mut writer = Archive::write_header(Vec::with_capacity(10000)).unwrap();
     writer

--- a/lib/benches/create_extract/main.rs
+++ b/lib/benches/create_extract/main.rs
@@ -1,7 +1,7 @@
 #![feature(test)]
 extern crate test;
 
-use libpna::{Archive, EntryBuilder, ReadOption, WriteOptionsBuilder};
+use libpna::{Archive, EntryBuilder, ReadOptions, WriteOptionsBuilder};
 use std::io::{Read, Write};
 use test::Bencher;
 
@@ -47,7 +47,7 @@ fn bench_read_archive(b: &mut Bencher, mut options: WriteOptionsBuilder) {
         for item in reader.entries_skip_solid() {
             let mut buf = Vec::with_capacity(1000);
             item.unwrap()
-                .reader(ReadOption::with_password(Some("password")))
+                .reader(ReadOptions::with_password(Some("password")))
                 .unwrap()
                 .read_to_end(&mut buf)
                 .unwrap();

--- a/lib/examples/async_io.rs
+++ b/lib/examples/async_io.rs
@@ -1,4 +1,4 @@
-use libpna::{Archive, EntryBuilder, ReadOption, WriteOptions};
+use libpna::{Archive, EntryBuilder, ReadOptions, WriteOptions};
 use std::io;
 
 #[tokio::main]
@@ -32,7 +32,7 @@ async fn extract(path: String) -> io::Result<()> {
     let mut archive = Archive::read_header_async(file).await?;
     while let Some(entry) = archive.read_entry_async().await? {
         let mut file = async_std::fs::File::create(entry.header().path().as_path()).await?;
-        let mut reader = entry.reader(ReadOption::builder().build())?;
+        let mut reader = entry.reader(ReadOptions::builder().build())?;
         async_std::io::copy(&mut reader, &mut file).await?;
     }
     Ok(())

--- a/lib/examples/async_io.rs
+++ b/lib/examples/async_io.rs
@@ -1,4 +1,4 @@
-use libpna::{Archive, EntryBuilder, ReadOption, WriteOption};
+use libpna::{Archive, EntryBuilder, ReadOption, WriteOptions};
 use std::io;
 
 #[tokio::main]
@@ -18,7 +18,7 @@ async fn create(path: String, file_names: &[String]) -> io::Result<()> {
     for file_name in file_names {
         let mut file = async_std::fs::File::open(file_name).await?;
         let mut entry_builder =
-            EntryBuilder::new_file(file_name.as_str().into(), WriteOption::builder().build())?;
+            EntryBuilder::new_file(file_name.as_str().into(), WriteOptions::builder().build())?;
         async_std::io::copy(&mut file, &mut entry_builder).await?;
         let entry = entry_builder.build()?;
         archive.add_entry_async(entry).await?;

--- a/lib/examples/change_compression_method.rs
+++ b/lib/examples/change_compression_method.rs
@@ -1,4 +1,4 @@
-use libpna::{Archive, Compression, EntryBuilder, ReadOption, WriteOption};
+use libpna::{Archive, Compression, EntryBuilder, ReadOption, WriteOptions};
 use std::io::{self, Read, Write};
 
 /// Change the entries compression method
@@ -14,7 +14,7 @@ fn change_compression_method<R: Read, W: Write>(
         let header = entry.header();
         let mut builder = EntryBuilder::new_file(
             header.path().clone(),
-            WriteOption::builder().compression(compression).build(),
+            WriteOptions::builder().compression(compression).build(),
         )?;
         let mut reader = entry.reader(ReadOption::builder().build())?;
         io::copy(&mut reader, &mut builder)?;

--- a/lib/examples/change_compression_method.rs
+++ b/lib/examples/change_compression_method.rs
@@ -1,4 +1,4 @@
-use libpna::{Archive, Compression, EntryBuilder, ReadOption, WriteOptions};
+use libpna::{Archive, Compression, EntryBuilder, ReadOptions, WriteOptions};
 use std::io::{self, Read, Write};
 
 /// Change the entries compression method
@@ -16,7 +16,7 @@ fn change_compression_method<R: Read, W: Write>(
             header.path().clone(),
             WriteOptions::builder().compression(compression).build(),
         )?;
-        let mut reader = entry.reader(ReadOption::builder().build())?;
+        let mut reader = entry.reader(ReadOptions::builder().build())?;
         io::copy(&mut reader, &mut builder)?;
         writer.add_entry(builder.build()?)?;
     }

--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -16,7 +16,7 @@ use std::io::prelude::*;
 /// # Examples
 /// Creates a new PNA file and adds entry to it.
 /// ```no_run
-/// # use libpna::{Archive, EntryBuilder, WriteOption};
+/// # use libpna::{Archive, EntryBuilder, WriteOptions};
 /// # use std::fs::File;
 /// # use std::io::{self, prelude::*};
 ///
@@ -24,7 +24,7 @@ use std::io::prelude::*;
 /// let file = File::create("foo.pna")?;
 /// let mut archive = Archive::write_header(file)?;
 /// let mut entry_builder =
-///     EntryBuilder::new_file("bar.txt".into(), WriteOption::builder().build())?;
+///     EntryBuilder::new_file("bar.txt".into(), WriteOptions::builder().build())?;
 /// entry_builder.write_all(b"content")?;
 /// let entry = entry_builder.build()?;
 /// archive.add_entry(entry)?;
@@ -80,15 +80,15 @@ impl<T> Archive<T> {
 /// # Examples
 /// Creates a new solid mode PNA file and adds entry to it.
 /// ```no_run
-/// use libpna::{Archive, EntryBuilder, WriteOption};
+/// use libpna::{Archive, EntryBuilder, WriteOptions};
 /// use std::fs::File;
 /// # use std::io::{self, prelude::*};
 ///
 /// # fn main() -> io::Result<()> {
-/// let option = WriteOption::builder().build();
+/// let option = WriteOptions::builder().build();
 /// let file = File::create("foo.pna")?;
 /// let mut archive = Archive::write_solid_header(file, option)?;
-/// let mut entry_builder = EntryBuilder::new_file("bar.txt".into(), WriteOption::store())?;
+/// let mut entry_builder = EntryBuilder::new_file("bar.txt".into(), WriteOptions::store())?;
 /// entry_builder.write_all(b"content")?;
 /// let entry = entry_builder.build()?;
 /// archive.add_entry(entry)?;
@@ -111,7 +111,7 @@ mod tests {
     fn store_archive() {
         archive(
             b"src data bytes",
-            WriteOption::builder().compression(Compression::No).build(),
+            WriteOptions::builder().compression(Compression::No).build(),
         )
         .unwrap()
     }
@@ -120,7 +120,7 @@ mod tests {
     fn deflate_archive() {
         archive(
             b"src data bytes",
-            WriteOption::builder()
+            WriteOptions::builder()
                 .compression(Compression::Deflate)
                 .build(),
         )
@@ -131,7 +131,7 @@ mod tests {
     fn zstd_archive() {
         archive(
             b"src data bytes",
-            WriteOption::builder()
+            WriteOptions::builder()
                 .compression(Compression::ZStandard)
                 .build(),
         )
@@ -142,7 +142,7 @@ mod tests {
     fn xz_archive() {
         archive(
             b"src data bytes",
-            WriteOption::builder().compression(Compression::XZ).build(),
+            WriteOptions::builder().compression(Compression::XZ).build(),
         )
         .unwrap();
     }
@@ -151,7 +151,7 @@ mod tests {
     fn store_with_aes_cbc_archive() {
         archive(
             b"plain text",
-            WriteOption::builder()
+            WriteOptions::builder()
                 .compression(Compression::No)
                 .encryption(Encryption::Aes)
                 .cipher_mode(CipherMode::CBC)
@@ -165,7 +165,7 @@ mod tests {
     fn zstd_with_aes_ctr_archive() {
         archive(
             b"plain text",
-            WriteOption::builder()
+            WriteOptions::builder()
                 .compression(Compression::ZStandard)
                 .encryption(Encryption::Aes)
                 .cipher_mode(CipherMode::CTR)
@@ -179,7 +179,7 @@ mod tests {
     fn zstd_with_aes_cbc_archive() {
         archive(
             b"plain text",
-            WriteOption::builder()
+            WriteOptions::builder()
                 .compression(Compression::ZStandard)
                 .encryption(Encryption::Aes)
                 .cipher_mode(CipherMode::CBC)
@@ -193,7 +193,7 @@ mod tests {
     fn zstd_with_camellia_ctr_archive() {
         archive(
             b"plain text",
-            WriteOption::builder()
+            WriteOptions::builder()
                 .compression(Compression::ZStandard)
                 .encryption(Encryption::Camellia)
                 .cipher_mode(CipherMode::CTR)
@@ -207,7 +207,7 @@ mod tests {
     fn zstd_with_camellia_cbc_archive() {
         archive(
             b"plain text",
-            WriteOption::builder()
+            WriteOptions::builder()
                 .compression(Compression::ZStandard)
                 .encryption(Encryption::Camellia)
                 .cipher_mode(CipherMode::CBC)
@@ -221,7 +221,7 @@ mod tests {
     fn xz_with_aes_cbc_archive() {
         archive(
             b"plain text",
-            WriteOption::builder()
+            WriteOptions::builder()
                 .compression(Compression::XZ)
                 .encryption(Encryption::Aes)
                 .cipher_mode(CipherMode::CBC)
@@ -236,7 +236,7 @@ mod tests {
     fn xz_with_camellia_cbc_archive() {
         archive(
             b"plain text",
-            WriteOption::builder()
+            WriteOptions::builder()
                 .compression(Compression::XZ)
                 .encryption(Encryption::Camellia)
                 .cipher_mode(CipherMode::CBC)
@@ -247,7 +247,7 @@ mod tests {
         .unwrap()
     }
 
-    fn create_archive(src: &[u8], options: WriteOption) -> io::Result<Vec<u8>> {
+    fn create_archive(src: &[u8], options: WriteOptions) -> io::Result<Vec<u8>> {
         let mut writer = Archive::write_header(Vec::with_capacity(src.len()))?;
         writer.add_entry({
             let mut builder = EntryBuilder::new_file("test/text".into(), options)?;
@@ -257,7 +257,7 @@ mod tests {
         writer.finalize()
     }
 
-    fn archive(src: &[u8], options: WriteOption) -> io::Result<()> {
+    fn archive(src: &[u8], options: WriteOptions) -> io::Result<()> {
         let archive = create_archive(src, options.clone())?;
         let mut archive_reader = Archive::read_header(archive.as_slice())?;
         let item = archive_reader.entries_skip_solid().next().unwrap().unwrap();
@@ -272,12 +272,12 @@ mod tests {
 
     #[test]
     fn solid_archive() {
-        let write_option = WriteOption::builder().password(Some("PASSWORD")).build();
+        let write_option = WriteOptions::builder().password(Some("PASSWORD")).build();
         let mut archive = Archive::write_solid_header(Vec::new(), write_option).unwrap();
         archive
             .add_entry({
                 let mut builder =
-                    EntryBuilder::new_file("test/text".into(), WriteOption::store()).unwrap();
+                    EntryBuilder::new_file("test/text".into(), WriteOptions::store()).unwrap();
                 builder.write_all(b"text").unwrap();
                 builder.build().unwrap()
             })
@@ -301,13 +301,13 @@ mod tests {
                 builder.build().unwrap()
             };
             let file_entry = {
-                let options = WriteOption::builder().build();
+                let options = WriteOptions::builder().build();
                 let mut builder = EntryBuilder::new_file("test/text".into(), options)?;
                 builder.write_all("text".as_bytes())?;
                 builder.build()?
             };
             writer.add_entry({
-                let mut builder = SolidEntryBuilder::new(WriteOption::builder().build()).unwrap();
+                let mut builder = SolidEntryBuilder::new(WriteOptions::builder().build()).unwrap();
                 builder.add_entry(dir_entry).unwrap();
                 builder.add_entry(file_entry).unwrap();
                 builder.build().unwrap()
@@ -325,7 +325,7 @@ mod tests {
 
     #[test]
     fn copy_entry() {
-        let archive = create_archive(b"archive text", WriteOption::builder().build())
+        let archive = create_archive(b"archive text", WriteOptions::builder().build())
             .expect("failed to create archive");
         let mut reader =
             Archive::read_header(archive.as_slice()).expect("failed to read archive header");
@@ -349,7 +349,7 @@ mod tests {
         writer
             .add_entry({
                 let builder =
-                    EntryBuilder::new_file("text1.txt".into(), WriteOption::builder().build())
+                    EntryBuilder::new_file("text1.txt".into(), WriteOptions::builder().build())
                         .unwrap();
                 builder.build().unwrap()
             })
@@ -361,7 +361,7 @@ mod tests {
         appender
             .add_entry({
                 let builder =
-                    EntryBuilder::new_file("text2.txt".into(), WriteOption::builder().build())
+                    EntryBuilder::new_file("text2.txt".into(), WriteOptions::builder().build())
                         .unwrap();
                 builder.build().unwrap()
             })
@@ -380,7 +380,7 @@ mod tests {
     fn metadata() {
         let original_entry = {
             let mut builder =
-                EntryBuilder::new_file("name".into(), WriteOption::builder().build()).unwrap();
+                EntryBuilder::new_file("name".into(), WriteOptions::builder().build()).unwrap();
             builder.created(Duration::from_secs(31));
             builder.modified(Duration::from_secs(32));
             builder.accessed(Duration::from_secs(33));

--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -35,7 +35,7 @@ use std::io::prelude::*;
 ///
 /// Read the entries of a pna file.
 /// ```no_run
-/// # use libpna::{Archive, ReadOption};
+/// # use libpna::{Archive, ReadOptions};
 /// # use std::fs::File;
 /// # use std::io::{self, copy, prelude::*};
 ///
@@ -45,7 +45,7 @@ use std::io::prelude::*;
 /// for entry in archive.entries_skip_solid() {
 ///     let entry = entry?;
 ///     let mut file = File::create(entry.header().path().as_path())?;
-///     let mut reader = entry.reader(ReadOption::builder().build())?;
+///     let mut reader = entry.reader(ReadOptions::builder().build())?;
 ///     copy(&mut reader, &mut file)?;
 /// }
 /// #     Ok(())
@@ -262,7 +262,7 @@ mod tests {
         let mut archive_reader = Archive::read_header(archive.as_slice())?;
         let item = archive_reader.entries_skip_solid().next().unwrap().unwrap();
         let mut reader = item
-            .reader(ReadOption::with_password(options.password))
+            .reader(ReadOptions::with_password(options.password))
             .unwrap();
         let mut dist = Vec::new();
         io::copy(&mut reader, &mut dist)?;
@@ -286,7 +286,7 @@ mod tests {
         let mut archive = Archive::read_header(&buf[..]).unwrap();
         let mut entries = archive.entries_with_password(Some("PASSWORD"));
         let entry = entries.next().unwrap().unwrap();
-        let mut reader = entry.reader(ReadOption::builder().build()).unwrap();
+        let mut reader = entry.reader(ReadOptions::builder().build()).unwrap();
         let mut body = Vec::new();
         reader.read_to_end(&mut body).unwrap();
         assert_eq!(b"text", &body[..]);

--- a/lib/src/archive/read.rs
+++ b/lib/src/archive/read.rs
@@ -333,7 +333,7 @@ impl<'r, R: Read> Entries<'r, R> {
     ///
     /// # Example
     /// ```no_run
-    /// use libpna::{Archive, ReadEntry, ReadOption};
+    /// use libpna::{Archive, ReadEntry, ReadOptions};
     /// use std::fs;
     /// # use std::io;
     ///
@@ -341,7 +341,7 @@ impl<'r, R: Read> Entries<'r, R> {
     /// let file = fs::File::open("foo.pna")?;
     /// let mut archive = Archive::read_header(file)?;
     /// for entry in archive.entries().extract_solid_entries(Some("password")) {
-    ///     let mut reader = entry?.reader(ReadOption::builder().build());
+    ///     let mut reader = entry?.reader(ReadOptions::builder().build());
     ///     // fill your code
     /// }
     /// #    Ok(())
@@ -472,7 +472,7 @@ mod tests {
     #[cfg(feature = "unstable-async")]
     #[tokio::test]
     async fn extract_async() -> io::Result<()> {
-        use crate::ReadOption;
+        use crate::ReadOptions;
         let file = async_std::fs::File::open("../resources/test/zstd.pna").await?;
         let mut archive = Archive::read_header_async(file).await?;
         let dist_dir = std::path::PathBuf::from("../target/tmp/");
@@ -482,7 +482,7 @@ mod tests {
                 async_std::fs::create_dir_all(parents).await?;
             }
             let mut file = async_std::fs::File::create(path).await?;
-            let mut reader = entry.reader(ReadOption::builder().build())?;
+            let mut reader = entry.reader(ReadOptions::builder().build())?;
             async_std::io::copy(&mut reader, &mut file).await?;
         }
         Ok(())

--- a/lib/src/archive/write.rs
+++ b/lib/src/archive/write.rs
@@ -5,7 +5,7 @@ use crate::{
     compress::CompressionWriter,
     entry::{
         get_writer, get_writer_context, Cipher, Entry, EntryHeader, EntryName, EntryPart, Metadata,
-        RegularEntry, SealedEntryExt, SolidHeader, WriteOption,
+        RegularEntry, SealedEntryExt, SolidHeader, WriteOptions,
     },
     io::TryIntoInner,
 };
@@ -91,7 +91,7 @@ impl<W: Write> Archive<W> {
     ///
     /// # Example
     /// ```no_run
-    /// use libpna::{Archive, Metadata, WriteOption};
+    /// use libpna::{Archive, Metadata, WriteOptions};
     /// # use std::error::Error;
     /// use std::fs;
     /// use std::io::{self, prelude::*};
@@ -102,7 +102,7 @@ impl<W: Write> Archive<W> {
     /// archive.write_file(
     ///     "bar.txt".into(),
     ///     Metadata::new(),
-    ///     WriteOption::builder().build(),
+    ///     WriteOptions::builder().build(),
     ///     |writer| writer.write_all(b"text"),
     /// )?;
     /// archive.finalize()?;
@@ -113,7 +113,7 @@ impl<W: Write> Archive<W> {
         &mut self,
         name: EntryName,
         metadata: Metadata,
-        option: WriteOption,
+        option: WriteOptions,
         mut f: F,
     ) -> io::Result<()>
     where
@@ -165,7 +165,7 @@ impl<W: Write> Archive<W> {
     /// # Examples
     ///
     /// ```no_run
-    /// use libpna::{Archive, EntryBuilder, WriteOption};
+    /// use libpna::{Archive, EntryBuilder, WriteOptions};
     /// use std::fs;
     /// # use std::io;
     ///
@@ -173,7 +173,7 @@ impl<W: Write> Archive<W> {
     /// let file = fs::File::create("example.pna")?;
     /// let mut archive = Archive::write_header(file)?;
     /// archive.add_entry(
-    ///     EntryBuilder::new_file("example.txt".into(), WriteOption::builder().build())?.build()?,
+    ///     EntryBuilder::new_file("example.txt".into(), WriteOptions::builder().build())?.build()?,
     /// )?;
     /// archive.finalize()?;
     /// #     Ok(())
@@ -192,7 +192,7 @@ impl<W: Write> Archive<W> {
     /// # Examples
     ///
     /// ```no_run
-    /// # use libpna::{Archive, EntryBuilder, EntryPart, WriteOption};
+    /// # use libpna::{Archive, EntryBuilder, EntryPart, WriteOptions};
     /// # use std::fs::File;
     /// # use std::io;
     ///
@@ -200,7 +200,7 @@ impl<W: Write> Archive<W> {
     /// let part1_file = File::create("example.part1.pna")?;
     /// let mut archive_part1 = Archive::write_header(part1_file)?;
     /// let entry =
-    ///     EntryBuilder::new_file("example.txt".into(), WriteOption::builder().build())?.build()?;
+    ///     EntryBuilder::new_file("example.txt".into(), WriteOptions::builder().build())?.build()?;
     /// archive_part1.add_entry_part(EntryPart::from(entry))?;
     ///
     /// let part2_file = File::create("example.part2.pna")?;
@@ -227,7 +227,7 @@ impl<W: Write> Archive<W> {
     ///
     /// # Examples
     /// ```no_run
-    /// # use libpna::{Archive, EntryBuilder, EntryPart, WriteOption};
+    /// # use libpna::{Archive, EntryBuilder, EntryPart, WriteOptions};
     /// # use std::fs::File;
     /// # use std::io;
     ///
@@ -235,7 +235,7 @@ impl<W: Write> Archive<W> {
     /// let part1_file = File::create("example.part1.pna")?;
     /// let mut archive_part1 = Archive::write_header(part1_file)?;
     /// let entry =
-    ///     EntryBuilder::new_file("example.txt".into(), WriteOption::builder().build())?.build()?;
+    ///     EntryBuilder::new_file("example.txt".into(), WriteOptions::builder().build())?.build()?;
     /// archive_part1.add_entry_part(EntryPart::from(entry))?;
     ///
     /// let part2_file = File::create("example.part2.pna")?;
@@ -323,7 +323,7 @@ impl<W: Write> Archive<W> {
     /// # Arguments
     ///
     /// * `write` - The [Write] object to write the header to.
-    /// * `option` - The [WriteOption] object of a solid mode option.
+    /// * `option` - The [WriteOptions] object of a solid mode option.
     ///
     /// # Returns
     ///
@@ -336,19 +336,19 @@ impl<W: Write> Archive<W> {
     /// # Examples
     ///
     /// ```no_run
-    /// use libpna::{Archive, WriteOption};
+    /// use libpna::{Archive, WriteOptions};
     /// use std::fs::File;
     /// # use std::io;
     ///
     /// # fn main() -> io::Result<()> {
-    /// let option = WriteOption::builder().build();
+    /// let option = WriteOptions::builder().build();
     /// let file = File::create("example.pna")?;
     /// let mut archive = Archive::write_solid_header(file, option)?;
     /// archive.finalize()?;
     /// #    Ok(())
     /// # }
     /// ```
-    pub fn write_solid_header(write: W, option: WriteOption) -> io::Result<SolidArchive<W>> {
+    pub fn write_solid_header(write: W, option: WriteOptions) -> io::Result<SolidArchive<W>> {
         let header = SolidHeader::new(option.compression, option.encryption, option.cipher_mode);
         let context = get_writer_context(option)?;
 
@@ -380,16 +380,16 @@ impl<W: Write> SolidArchive<W> {
     /// # Examples
     ///
     /// ```no_run
-    /// use libpna::{Archive, EntryBuilder, WriteOption};
+    /// use libpna::{Archive, EntryBuilder, WriteOptions};
     /// use std::fs::File;
     /// # use std::io;
     ///
     /// # fn main() -> io::Result<()> {
-    /// let option = WriteOption::builder().build();
+    /// let option = WriteOptions::builder().build();
     /// let file = File::create("example.pna")?;
     /// let mut archive = Archive::write_solid_header(file, option)?;
     /// archive
-    ///     .add_entry(EntryBuilder::new_file("example.txt".into(), WriteOption::store())?.build()?)?;
+    ///     .add_entry(EntryBuilder::new_file("example.txt".into(), WriteOptions::store())?.build()?)?;
     /// archive.finalize()?;
     /// #     Ok(())
     /// # }
@@ -402,14 +402,14 @@ impl<W: Write> SolidArchive<W> {
     ///
     /// # Example
     /// ```no_run
-    /// use libpna::{Archive, Metadata, WriteOption};
+    /// use libpna::{Archive, Metadata, WriteOptions};
     /// # use std::error::Error;
     /// use std::fs;
     /// use std::io::{self, prelude::*};
     ///
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let file = fs::File::create("foo.pna")?;
-    /// let option = WriteOption::builder().build();
+    /// let option = WriteOptions::builder().build();
     /// let mut archive = Archive::write_solid_header(file, option)?;
     /// archive.write_file("bar.txt".into(), Metadata::new(), |writer| {
     ///     writer.write_all(b"text")
@@ -422,7 +422,7 @@ impl<W: Write> SolidArchive<W> {
     where
         F: FnMut(&mut SolidArchiveEntryDataWriter<W>) -> io::Result<()>,
     {
-        let option = WriteOption::store();
+        let option = WriteOptions::store();
         let header = EntryHeader::for_file(
             option.compression,
             option.encryption,
@@ -469,12 +469,12 @@ impl<W: Write> SolidArchive<W> {
     /// # Examples
     /// Create an empty archive.
     /// ```no_run
-    /// use libpna::{Archive, WriteOption};
+    /// use libpna::{Archive, WriteOptions};
     /// use std::fs::File;
     /// # use std::io;
     ///
     /// # fn main() -> io::Result<()> {
-    /// let option = WriteOption::builder().build();
+    /// let option = WriteOptions::builder().build();
     /// let file = File::create("example.pna")?;
     /// let mut archive = Archive::write_solid_header(file, option)?;
     /// archive.finalize()?;
@@ -506,7 +506,7 @@ mod tests {
 
     #[test]
     fn archive_write_file_entry() {
-        let option = WriteOption::builder().build();
+        let option = WriteOptions::builder().build();
         let mut writer = Archive::write_header(Vec::new()).expect("failed to write header");
         writer
             .write_file(
@@ -535,7 +535,7 @@ mod tests {
 
     #[test]
     fn solid_write_file_entry() {
-        let option = WriteOption::builder().build();
+        let option = WriteOptions::builder().build();
         let mut writer =
             Archive::write_solid_header(Vec::new(), option).expect("failed to write header");
         writer

--- a/lib/src/archive/write.rs
+++ b/lib/src/archive/write.rs
@@ -493,7 +493,7 @@ impl<W: Write> SolidArchive<W> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ReadOption;
+    use crate::ReadOptions;
     use std::io::Read;
 
     #[test]
@@ -524,7 +524,7 @@ mod tests {
             .expect("failed to get entry")
             .expect("failed to read entry");
         let mut data_reader = entry
-            .reader(ReadOption::builder().build())
+            .reader(ReadOptions::builder().build())
             .expect("failed to read entry data");
         let mut data = Vec::new();
         data_reader
@@ -553,7 +553,7 @@ mod tests {
             .expect("failed to get entry")
             .expect("failed to read entry");
         let mut data_reader = entry
-            .reader(ReadOption::builder().build())
+            .reader(ReadOptions::builder().build())
             .expect("failed to read entry data");
         let mut data = Vec::new();
         data_reader

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -204,7 +204,7 @@ impl SolidEntry {
     ///
     /// # Example
     /// ```no_run
-    /// use libpna::{Archive, ReadEntry, ReadOption};
+    /// use libpna::{Archive, ReadEntry, ReadOptions};
     /// use std::fs;
     /// # use std::io;
     ///
@@ -216,7 +216,7 @@ impl SolidEntry {
     ///         ReadEntry::Solid(solid_entry) => {
     ///             for entry in solid_entry.entries(Some("password"))? {
     ///                 let entry = entry?;
-    ///                 let mut reader = entry.reader(ReadOption::builder().build());
+    ///                 let mut reader = entry.reader(ReadOptions::builder().build());
     ///                 // fill your code
     ///             }
     ///         }
@@ -540,7 +540,7 @@ impl RegularEntry {
     ///
     /// # Examples
     /// ```no_run
-    /// use libpna::{Archive, ReadOption};
+    /// use libpna::{Archive, ReadOptions};
     /// use std::{fs, io};
     ///
     /// # fn main() -> io::Result<()> {
@@ -548,7 +548,7 @@ impl RegularEntry {
     /// let mut archive = Archive::read_header(file)?;
     /// for entry in archive.entries_skip_solid() {
     ///     let entry = entry?;
-    ///     let mut reader = entry.reader(ReadOption::builder().build())?;
+    ///     let mut reader = entry.reader(ReadOptions::builder().build())?;
     ///     let name = entry.header().path();
     ///     let mut dist_file = fs::File::create(name)?;
     ///     io::copy(&mut reader, &mut dist_file)?;
@@ -557,7 +557,7 @@ impl RegularEntry {
     /// # }
     /// ```
     #[inline]
-    pub fn reader(&self, option: ReadOption) -> io::Result<EntryDataReader> {
+    pub fn reader(&self, option: ReadOptions) -> io::Result<EntryDataReader> {
         let raw_data_reader =
             crate::io::FlattenReader::new(self.data.iter().map(|it| it.as_slice()).collect());
         let decrypt_reader = decrypt_reader(

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -5,7 +5,7 @@ use crate::{
     entry::{
         get_writer, get_writer_context, private::SealedEntryExt, Cipher, DataKind, Entry,
         EntryHeader, EntryName, EntryReference, ExtendedAttribute, Metadata, Permission,
-        RegularEntry, SolidEntry, SolidHeader, WriteOption,
+        RegularEntry, SolidEntry, SolidHeader, WriteOptions,
     },
     io::TryIntoInner,
 };
@@ -81,7 +81,7 @@ impl EntryBuilder {
     /// # Returns
     ///
     /// A Result containing the new [EntryBuilder], or an I/O error if creation fails.
-    pub fn new_file(name: EntryName, option: WriteOption) -> io::Result<Self> {
+    pub fn new_file(name: EntryName, option: WriteOptions) -> io::Result<Self> {
         let header = EntryHeader::for_file(
             option.compression,
             option.encryption,
@@ -124,7 +124,7 @@ impl EntryBuilder {
     /// let entry = builder.build().unwrap();
     /// ```
     pub fn new_symbolic_link(name: EntryName, source: EntryReference) -> io::Result<Self> {
-        let option = WriteOption::store();
+        let option = WriteOptions::store();
         let context = get_writer_context(option)?;
         let mut writer = get_writer(crate::io::FlattenWriter::new(), &context)?;
         writer.write_all(source.as_bytes())?;
@@ -162,7 +162,7 @@ impl EntryBuilder {
     /// let entry = builder.build().unwrap();
     /// ```
     pub fn new_hard_link(name: EntryName, source: EntryReference) -> io::Result<Self> {
-        let option = WriteOption::store();
+        let option = WriteOptions::store();
         let context = get_writer_context(option)?;
         let mut writer = get_writer(crate::io::FlattenWriter::new(), &context)?;
         writer.write_all(source.as_bytes())?;
@@ -375,7 +375,7 @@ impl SolidEntryBuilder {
     /// # Returns
     ///
     /// A new [SolidEntryBuilder].
-    pub fn new(option: WriteOption) -> io::Result<Self> {
+    pub fn new(option: WriteOptions) -> io::Result<Self> {
         let header = SolidHeader::new(option.compression, option.encryption, option.cipher_mode);
         let context = get_writer_context(option)?;
         let writer = get_writer(crate::io::FlattenWriter::new(), &context)?;
@@ -400,16 +400,16 @@ impl SolidEntryBuilder {
     /// # Examples
     ///
     /// ```no_run
-    /// use libpna::{EntryBuilder, SolidEntryBuilder, WriteOption};
+    /// use libpna::{EntryBuilder, SolidEntryBuilder, WriteOptions};
     /// use std::io;
     /// use std::io::Write;
     ///
     /// # fn main() -> io::Result<()> {
-    /// let mut builder = SolidEntryBuilder::new(WriteOption::builder().build())?;
+    /// let mut builder = SolidEntryBuilder::new(WriteOptions::builder().build())?;
     /// let dir_entry = EntryBuilder::new_dir("example".into()).build()?;
     /// builder.add_entry(dir_entry)?;
     /// let mut entry_builder =
-    ///     EntryBuilder::new_file("example/text.txt".into(), WriteOption::store())?;
+    ///     EntryBuilder::new_file("example/text.txt".into(), WriteOptions::store())?;
     /// entry_builder.write_all(b"content")?;
     /// let file_entry = entry_builder.build()?;
     /// builder.add_entry(file_entry)?;
@@ -447,11 +447,11 @@ impl SolidEntryBuilder {
     /// # Examples
     ///
     /// ```no_run
-    /// use libpna::{SolidEntryBuilder, WriteOption};
+    /// use libpna::{SolidEntryBuilder, WriteOptions};
     /// use std::io;
     ///
     /// # fn main() -> io::Result<()> {
-    /// let builder = SolidEntryBuilder::new(WriteOption::builder().build())?;
+    /// let builder = SolidEntryBuilder::new(WriteOptions::builder().build())?;
     /// let entries = builder.build()?;
     /// #     Ok(())
     /// # }
@@ -484,7 +484,7 @@ mod tests {
 
     #[test]
     fn solid_entry_extra_chunk() {
-        let mut builder = SolidEntryBuilder::new(WriteOption::store()).unwrap();
+        let mut builder = SolidEntryBuilder::new(WriteOptions::store()).unwrap();
         builder.add_extra_chunk(RawChunk::from_data(
             unsafe { ChunkType::from_unchecked(*b"abCd") },
             [],

--- a/lib/src/entry/options.rs
+++ b/lib/src/entry/options.rs
@@ -450,7 +450,7 @@ impl ReadOptions {
     ///
     /// # Returns
     ///
-    /// [ReadOptionBuilder]: Builder object for [ReadOptions].
+    /// [ReadOptionsBuilder]: Builder object for [ReadOptions].
     ///
     /// # Examples
     /// ```
@@ -459,15 +459,15 @@ impl ReadOptions {
     /// let builder = ReadOptions::builder();
     /// ```
     #[inline]
-    pub const fn builder() -> ReadOptionBuilder {
-        ReadOptionBuilder::new()
+    pub const fn builder() -> ReadOptionsBuilder {
+        ReadOptionsBuilder::new()
     }
 
-    /// Converts [ReadOptions] into a [ReadOptionBuilder].
+    /// Converts [ReadOptions] into a [ReadOptionsBuilder].
     ///
     /// # Returns
     ///
-    /// [ReadOptionBuilder]: Builder object for [ReadOptions].
+    /// [ReadOptionsBuilder]: Builder object for [ReadOptions].
     ///
     /// # Examples
     /// ```
@@ -477,18 +477,28 @@ impl ReadOptions {
     /// let builder = read_option.into_builder();
     /// ```
     #[inline]
-    pub fn into_builder(self) -> ReadOptionBuilder {
+    pub fn into_builder(self) -> ReadOptionsBuilder {
         self.into()
     }
 }
 
+/// Type alias of [`ReadOptionsBuilder`].
+///
+/// This type alias will be removed in the future version.
+/// Use [`ReadOptionsBuilder`] instead.
+#[deprecated(
+    note = "`ReadOptionBuilder` was renamed to `ReadOptionsBuilder`. This type alias will be removed in the future version.",
+    since = "0.12.1"
+)]
+pub type ReadOptionBuilder = ReadOptionsBuilder;
+
 /// Builder for [`ReadOptions`].
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
-pub struct ReadOptionBuilder {
+pub struct ReadOptionsBuilder {
     password: Option<String>,
 }
 
-impl From<ReadOptions> for ReadOptionBuilder {
+impl From<ReadOptions> for ReadOptionsBuilder {
     #[inline]
     fn from(value: ReadOptions) -> Self {
         Self {
@@ -497,7 +507,7 @@ impl From<ReadOptions> for ReadOptionBuilder {
     }
 }
 
-impl ReadOptionBuilder {
+impl ReadOptionsBuilder {
     const fn new() -> Self {
         Self { password: None }
     }

--- a/lib/src/entry/options.rs
+++ b/lib/src/entry/options.rs
@@ -223,9 +223,19 @@ impl TryFrom<u8> for DataKind {
     }
 }
 
+/// Type alias of [`WriteOptions`].
+///
+/// This type alias will be removed in the future version.
+/// Use [`WriteOptions`] instead.
+#[deprecated(
+    note = "`WriteOption` was renamed to `WriteOptions`. This type alias will be removed in the future version.",
+    since = "0.12.1"
+)]
+pub type WriteOption = WriteOptions;
+
 /// Options for writing an entry.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub struct WriteOption {
+pub struct WriteOptions {
     pub(crate) compression: Compression,
     pub(crate) compression_level: CompressionLevel,
     pub(crate) encryption: Encryption,
@@ -234,15 +244,15 @@ pub struct WriteOption {
     pub(crate) password: Option<String>,
 }
 
-impl WriteOption {
-    /// A new [WriteOption] to simply store.
+impl WriteOptions {
+    /// A new [WriteOptions] to simply store.
     ///
     /// # Examples
     ///
     /// ```
-    /// use libpna::{EntryBuilder, WriteOption};
+    /// use libpna::{EntryBuilder, WriteOptions};
     ///
-    /// EntryBuilder::new_file("example.txt".into(), WriteOption::store()).unwrap();
+    /// EntryBuilder::new_file("example.txt".into(), WriteOptions::store()).unwrap();
     /// ```
     ///
     /// [Entry]: crate::Entry
@@ -258,35 +268,35 @@ impl WriteOption {
         }
     }
 
-    /// Returns a builder for [WriteOption].
+    /// Returns a builder for [WriteOptions].
     ///
     /// # Returns
     ///
-    /// [WriteOptionBuilder] Builder object for [WriteOption].
+    /// [WriteOptionBuilder] Builder object for [WriteOptions].
     ///
     /// # Examples
     ///
     /// ```
-    /// use libpna::WriteOption;
+    /// use libpna::WriteOptions;
     ///
-    /// let builder = WriteOption::builder();
+    /// let builder = WriteOptions::builder();
     /// ```
     #[inline]
     pub const fn builder() -> WriteOptionBuilder {
         WriteOptionBuilder::new()
     }
 
-    /// Converts [WriteOption] into a [WriteOptionBuilder].
+    /// Converts [WriteOptions] into a [WriteOptionBuilder].
     ///
     /// # Returns
     ///
-    /// [WriteOptionBuilder]: Builder object for [WriteOption].
+    /// [WriteOptionBuilder]: Builder object for [WriteOptions].
     ///
     /// # Examples
     /// ```
-    /// use libpna::WriteOption;
+    /// use libpna::WriteOptions;
     ///
-    /// let write_option = WriteOption::builder().build();
+    /// let write_option = WriteOptions::builder().build();
     /// let builder = write_option.into_builder();
     /// ```
     #[inline]
@@ -295,7 +305,7 @@ impl WriteOption {
     }
 }
 
-/// Builder for [`WriteOption`].
+/// Builder for [`WriteOptions`].
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct WriteOptionBuilder {
     compression: Compression,
@@ -312,9 +322,9 @@ impl Default for WriteOptionBuilder {
     }
 }
 
-impl From<WriteOption> for WriteOptionBuilder {
+impl From<WriteOptions> for WriteOptionBuilder {
     #[inline]
-    fn from(value: WriteOption) -> Self {
+    fn from(value: WriteOptions) -> Self {
         Self {
             compression: value.compression,
             compression_level: value.compression_level,
@@ -380,10 +390,10 @@ impl WriteOptionBuilder {
         self
     }
 
-    /// Create new [WriteOption] parameters set from this builder.
+    /// Create new [WriteOptions] parameters set from this builder.
     #[inline]
-    pub fn build(&self) -> WriteOption {
-        WriteOption {
+    pub fn build(&self) -> WriteOptions {
+        WriteOptions {
             compression: self.compression,
             compression_level: self.compression_level,
             encryption: self.encryption,

--- a/lib/src/entry/options.rs
+++ b/lib/src/entry/options.rs
@@ -272,7 +272,7 @@ impl WriteOptions {
     ///
     /// # Returns
     ///
-    /// [WriteOptionBuilder] Builder object for [WriteOptions].
+    /// [WriteOptionsBuilder] Builder object for [WriteOptions].
     ///
     /// # Examples
     ///
@@ -282,15 +282,15 @@ impl WriteOptions {
     /// let builder = WriteOptions::builder();
     /// ```
     #[inline]
-    pub const fn builder() -> WriteOptionBuilder {
-        WriteOptionBuilder::new()
+    pub const fn builder() -> WriteOptionsBuilder {
+        WriteOptionsBuilder::new()
     }
 
-    /// Converts [WriteOptions] into a [WriteOptionBuilder].
+    /// Converts [WriteOptions] into a [WriteOptionsBuilder].
     ///
     /// # Returns
     ///
-    /// [WriteOptionBuilder]: Builder object for [WriteOptions].
+    /// [WriteOptionsBuilder]: Builder object for [WriteOptions].
     ///
     /// # Examples
     /// ```
@@ -300,14 +300,24 @@ impl WriteOptions {
     /// let builder = write_option.into_builder();
     /// ```
     #[inline]
-    pub fn into_builder(self) -> WriteOptionBuilder {
+    pub fn into_builder(self) -> WriteOptionsBuilder {
         self.into()
     }
 }
 
+/// Type alias of [`WriteOptionsBuilder`].
+///
+/// This type alias will be removed in the future version.
+/// Use [`WriteOptionsBuilder`] instead.
+#[deprecated(
+    note = "`WriteOptionBuilder` was renamed to `WriteOptionsBuilder`. This type alias will be removed in the future version.",
+    since = "0.12.1"
+)]
+pub type WriteOptionBuilder = WriteOptionsBuilder;
+
 /// Builder for [`WriteOptions`].
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub struct WriteOptionBuilder {
+pub struct WriteOptionsBuilder {
     compression: Compression,
     compression_level: CompressionLevel,
     encryption: Encryption,
@@ -316,13 +326,13 @@ pub struct WriteOptionBuilder {
     password: Option<String>,
 }
 
-impl Default for WriteOptionBuilder {
+impl Default for WriteOptionsBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl From<WriteOptions> for WriteOptionBuilder {
+impl From<WriteOptions> for WriteOptionsBuilder {
     #[inline]
     fn from(value: WriteOptions) -> Self {
         Self {
@@ -336,7 +346,7 @@ impl From<WriteOptions> for WriteOptionBuilder {
     }
 }
 
-impl WriteOptionBuilder {
+impl WriteOptionsBuilder {
     const fn new() -> Self {
         Self {
             compression: Compression::No,

--- a/lib/src/entry/options.rs
+++ b/lib/src/entry/options.rs
@@ -414,20 +414,30 @@ impl WriteOptionsBuilder {
     }
 }
 
+/// Type alias of [`ReadOptions`].
+///
+/// This type alias will be removed in the future version.
+/// Use [`ReadOptions`] instead.
+#[deprecated(
+    note = "`ReadOption` was renamed to `ReadOptions`. This type alias will be removed in the future version.",
+    since = "0.12.1"
+)]
+pub type ReadOption = ReadOptions;
+
 /// Options for reading an entry.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub struct ReadOption {
+pub struct ReadOptions {
     pub(crate) password: Option<String>,
 }
 
-impl ReadOption {
-    /// Create a new [`ReadOption`] with optional password.
+impl ReadOptions {
+    /// Create a new [`ReadOptions`] with optional password.
     ///
     /// # Examples
     /// ```
-    /// use libpna::ReadOption;
+    /// use libpna::ReadOptions;
     ///
-    /// let read_option = ReadOption::with_password(Some("password"));
+    /// let read_option = ReadOptions::with_password(Some("password"));
     /// ```
     #[inline]
     pub fn with_password<T: Into<String>>(password: Option<T>) -> Self {
@@ -436,34 +446,34 @@ impl ReadOption {
         }
     }
 
-    /// Returns a builder for [ReadOption].
+    /// Returns a builder for [ReadOptions].
     ///
     /// # Returns
     ///
-    /// [ReadOptionBuilder]: Builder object for [ReadOption].
+    /// [ReadOptionBuilder]: Builder object for [ReadOptions].
     ///
     /// # Examples
     /// ```
-    /// use libpna::ReadOption;
+    /// use libpna::ReadOptions;
     ///
-    /// let builder = ReadOption::builder();
+    /// let builder = ReadOptions::builder();
     /// ```
     #[inline]
     pub const fn builder() -> ReadOptionBuilder {
         ReadOptionBuilder::new()
     }
 
-    /// Converts [ReadOption] into a [ReadOptionBuilder].
+    /// Converts [ReadOptions] into a [ReadOptionBuilder].
     ///
     /// # Returns
     ///
-    /// [ReadOptionBuilder]: Builder object for [ReadOption].
+    /// [ReadOptionBuilder]: Builder object for [ReadOptions].
     ///
     /// # Examples
     /// ```
-    /// use libpna::ReadOption;
+    /// use libpna::ReadOptions;
     ///
-    /// let read_option = ReadOption::builder().build();
+    /// let read_option = ReadOptions::builder().build();
     /// let builder = read_option.into_builder();
     /// ```
     #[inline]
@@ -472,15 +482,15 @@ impl ReadOption {
     }
 }
 
-/// Builder for [`ReadOption`].
+/// Builder for [`ReadOptions`].
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct ReadOptionBuilder {
     password: Option<String>,
 }
 
-impl From<ReadOption> for ReadOptionBuilder {
+impl From<ReadOptions> for ReadOptionBuilder {
     #[inline]
-    fn from(value: ReadOption) -> Self {
+    fn from(value: ReadOptions) -> Self {
         Self {
             password: value.password,
         }
@@ -492,10 +502,10 @@ impl ReadOptionBuilder {
         Self { password: None }
     }
 
-    /// Create a new [`ReadOption`]
+    /// Create a new [`ReadOptions`]
     #[inline]
-    pub fn build(&self) -> ReadOption {
-        ReadOption {
+    pub fn build(&self) -> ReadOptions {
+        ReadOptions {
             password: self.password.clone(),
         }
     }

--- a/lib/src/entry/write.rs
+++ b/lib/src/entry/write.rs
@@ -1,7 +1,7 @@
 use crate::{
     cipher::{CipherWriter, Ctr128BEWriter, EncryptCbcAes256Writer, EncryptCbcCamellia256Writer},
     compress::CompressionWriter,
-    entry::{CipherMode, Compression, CompressionLevel, Encryption, HashAlgorithm, WriteOption},
+    entry::{CipherMode, Compression, CompressionLevel, Encryption, HashAlgorithm, WriteOptions},
     hash, random,
 };
 use aes::Aes256;
@@ -71,7 +71,7 @@ fn get_cipher(
 }
 
 #[inline]
-pub(crate) fn get_writer_context(option: WriteOption) -> io::Result<EntryWriterContext> {
+pub(crate) fn get_writer_context(option: WriteOptions) -> io::Result<EntryWriterContext> {
     let (cipher, phsf) = get_cipher(
         option.password.as_deref(),
         option.hash_algorithm,

--- a/lib/tests/extract_compatibility.rs
+++ b/lib/tests/extract_compatibility.rs
@@ -1,4 +1,4 @@
-use libpna::{Archive, DataKind, ReadOption};
+use libpna::{Archive, DataKind, ReadOptions};
 use std::io;
 
 fn extract_all(bytes: &[u8], password: Option<&str>) {
@@ -10,7 +10,7 @@ fn extract_all(bytes: &[u8], password: Option<&str>) {
         }
         let path = item.header().path().to_string();
         let mut dist = Vec::new();
-        let mut reader = item.reader(ReadOption::with_password(password)).unwrap();
+        let mut reader = item.reader(ReadOptions::with_password(password)).unwrap();
         io::copy(&mut reader, &mut dist).unwrap();
         match &*path {
             "raw/first/second/third/pna.txt" => {

--- a/lib/tests/extract_multipart_compatibility.rs
+++ b/lib/tests/extract_multipart_compatibility.rs
@@ -1,4 +1,4 @@
-use libpna::{Archive, DataKind, ReadOption};
+use libpna::{Archive, DataKind, ReadOptions};
 use std::io;
 
 fn extract_all(follows: &[&[u8]], password: Option<&str>) {
@@ -13,7 +13,7 @@ fn extract_all(follows: &[&[u8]], password: Option<&str>) {
             }
             let path = item.header().path().to_string();
             let mut dist = Vec::new();
-            let mut reader = item.reader(ReadOption::with_password(password)).unwrap();
+            let mut reader = item.reader(ReadOptions::with_password(password)).unwrap();
             io::copy(&mut reader, &mut dist).unwrap();
             match &*path {
                 "multipart_test.txt" => assert_eq!(

--- a/lib/tests/extract_solid_compatibility.rs
+++ b/lib/tests/extract_solid_compatibility.rs
@@ -1,4 +1,4 @@
-use libpna::{Archive, DataKind, ReadOption};
+use libpna::{Archive, DataKind, ReadOptions};
 use std::io;
 
 fn extract_all(bytes: &[u8], password: Option<&str>) {
@@ -10,7 +10,7 @@ fn extract_all(bytes: &[u8], password: Option<&str>) {
         }
         let path = item.header().path().to_string();
         let mut dist = Vec::new();
-        let mut reader = item.reader(ReadOption::with_password(password)).unwrap();
+        let mut reader = item.reader(ReadOptions::with_password(password)).unwrap();
         io::copy(&mut reader, &mut dist).unwrap();
         match &*path {
             "raw/first/second/third/pna.txt" => assert_eq!(

--- a/pna/README.md
+++ b/pna/README.md
@@ -36,7 +36,7 @@ fn main() -> io::Result<()> {
 ## Writing an archive
 
 ```rust
-use pna::{Archive, EntryBuilder, WriteOption};
+use pna::{Archive, EntryBuilder, WriteOptions};
 use std::fs::File;
 use std::io::{self, prelude::*};
 
@@ -45,7 +45,7 @@ fn main() -> io::Result<()> {
     let mut archive = Archive::write_header(file)?;
     let mut entry_builder = EntryBuilder::new_file(
         "bar.txt".into(),
-        WriteOption::builder().build(),
+        WriteOptions::builder().build(),
     )?;
     entry_builder.write(b"content")?;
     let entry = entry_builder.build()?;

--- a/pna/README.md
+++ b/pna/README.md
@@ -16,7 +16,7 @@ pna = "0.12"
 ## Reading an archive
 
 ```rust
-use pna::{Archive, ReadOption};
+use pna::{Archive, ReadOptions};
 use std::fs::File;
 use std::io::{self, copy, prelude::*};
 
@@ -26,7 +26,7 @@ fn main() -> io::Result<()> {
     for entry in archive.entries_skip_solid() {
         let entry = entry?;
         let mut file = File::create(entry.header().path().as_path())?;
-        let mut reader = entry.reader(ReadOption::builder().build())?;
+        let mut reader = entry.reader(ReadOptions::builder().build())?;
         copy(&mut reader, &mut file)?;
     }
     Ok(())


### PR DESCRIPTION
Rename the structure that handles options following the naming convention of the standard library.

- Rename `WriteOption` to `WriteOptions`
- Rename `WriteOptionBuilder` to `WriteOptionsBuilder`
- Rename `ReadOption` to `ReadOptions`
- Rename `ReadOptionBuilder` to `ReadOptionsBuilder`
