### PR TITLE
:recycle: use `&[T]::split_at_checked`

### DIFF
--- a/lib/src/archive/read/slice.rs
+++ b/lib/src/archive/read/slice.rs
@@ -6,8 +6,9 @@ use std::borrow::Cow;
 use std::io;
 
 pub(crate) fn read_header_from_slice(bytes: &[u8]) -> io::Result<&[u8]> {
-    // TODO: use split_at_checked instead
-    let (header, body) = bytes.split_at(PNA_HEADER.len());
+    let (header, body) = bytes
+        .split_at_checked(PNA_HEADER.len())
+        .ok_or(io::ErrorKind::UnexpectedEof)?;
     if header != PNA_HEADER {
         return Err(io::Error::new(io::ErrorKind::InvalidData, "It's not PNA"));
     }

--- a/lib/src/chunk.rs
+++ b/lib/src/chunk.rs
@@ -256,15 +256,17 @@ pub(crate) fn chunk_data_split(
     data: &[u8],
     mid: usize,
 ) -> (RawChunk<&[u8]>, Option<RawChunk<&[u8]>>) {
-    // TODO: use split_at_checked
-    if data.len() <= mid {
-        (RawChunk::from_slice(ty, data), None)
+    if let Some((first, last)) = data.split_at_checked(mid) {
+        if last.is_empty() {
+            (RawChunk::from_slice(ty, first), None)
+        } else {
+            (
+                RawChunk::from_slice(ty, first),
+                Some(RawChunk::from_slice(ty, last)),
+            )
+        }
     } else {
-        let (first, last) = data.split_at(mid);
-        (
-            RawChunk::from_slice(ty, first),
-            Some(RawChunk::from_slice(ty, last)),
-        )
+        (RawChunk::from_slice(ty, data), None)
     }
 }
 

--- a/lib/src/chunk/read.rs
+++ b/lib/src/chunk/read.rs
@@ -134,8 +134,9 @@ pub(crate) fn read_chunk_from_slice(bytes: &[u8]) -> io::Result<(RawChunk<&[u8]>
     crc_hasher.update(&ty[..]);
 
     // read chunk data
-    // TODO: use split_at_checked instead
-    let (data, r) = r.split_at(length as usize);
+    let (data, r) = r
+        .split_at_checked(length as usize)
+        .ok_or(io::ErrorKind::UnexpectedEof)?;
     crc_hasher.update(data);
 
     // read crc sum

--- a/lib/src/entry/attr.rs
+++ b/lib/src/entry/attr.rs
@@ -54,8 +54,9 @@ impl ExtendedAttribute {
             .split_first_chunk::<{ mem::size_of::<u32>() }>()
             .ok_or(io::ErrorKind::UnexpectedEof)?;
         let len = u32::from_be_bytes(*len) as usize;
-        // TODO: use split_at_checked instead
-        let (name, value) = value.split_at(len);
+        let (name, value) = value
+            .split_at_checked(len)
+            .ok_or(io::ErrorKind::UnexpectedEof)?;
         let name = String::from_utf8(name.to_vec()).map_err(|_| io::ErrorKind::InvalidData)?;
 
         let (len, value) = value


### PR DESCRIPTION
`&[T]::split_at_checked` was stabilized on rust 1.80