### PR TITLE
:racehorse: use `EntryPart<&[u8]>::split` to avoid copy for performance  improvement

### DIFF
--- a/cli/src/command/commons.rs
+++ b/cli/src/command/commons.rs
@@ -271,10 +271,10 @@ pub(crate) fn apply_metadata(
 }
 
 pub(crate) fn split_to_parts(
-    mut entry_part: EntryPart,
+    mut entry_part: EntryPart<&[u8]>,
     first: usize,
     max: usize,
-) -> Vec<EntryPart> {
+) -> Vec<EntryPart<&[u8]>> {
     let mut parts = vec![];
     let mut split_size = first;
     loop {
@@ -513,8 +513,9 @@ where
     let max_file_size = max_file_size - (PNA_HEADER.len() + MIN_CHUNK_BYTES_SIZE * 3 + 8);
     let mut written_entry_size = 0;
     for entry in entries {
+        let p = EntryPart::from(entry?);
         let parts = split_to_parts(
-            EntryPart::from(entry?),
+            p.as_ref(),
             max_file_size - written_entry_size,
             max_file_size,
         );


### PR DESCRIPTION
Before
```
$ cargo +nightly bench split
    Finished `bench` profile [optimized] target(s) in 0.64s
     Running unittests src/lib.rs (target/release/deps/libpna-7c13e9ba111e4488)
...
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s

     Running benches/split.rs (target/release/deps/split-5b7839c129085926)

running 2 tests
test create_with_split ... bench:  16,709,934.20 ns/iter (+/- 11,876,727.33)
test split             ... bench:  10,346,815.10 ns/iter (+/- 10,597,196.51)

test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured; 1 filtered out; finished in 8.38s
```

After
```
$ cargo +nightly bench split
    Finished `bench` profile [optimized] target(s) in 0.31s
     Running unittests src/lib.rs (target/release/deps/libpna-7c13e9ba111e4488)
...
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s

     Running benches/split.rs (target/release/deps/split-5b7839c129085926)

running 2 tests
test create_with_split ... bench:  10,380,744.30 ns/iter (+/- 3,855,647.82)
test split             ... bench:  11,052,741.70 ns/iter (+/- 7,957,370.03)
```