### PR TITLE
929 ansi term unmaintained

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,15 +62,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "ansitok"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,6 +1302,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5438dd2b2ff4c6df6e1ce22d825ed2fa93ee2922235cc45186991717f0a892d"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1cb62d7a07189335d41d8196638aa01bc1000a31889ba7a249d2bac25d9e48"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1466,7 +1466,6 @@ checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 name = "portable-network-archive"
 version = "0.15.0"
 dependencies = [
- "ansi_term",
  "base64",
  "bitflags 2.6.0",
  "bytesize",
@@ -1482,6 +1481,7 @@ dependencies = [
  "libc",
  "nix",
  "normalize-path",
+ "nu-ansi-term",
  "pna",
  "rand",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,11 +1303,11 @@ checksum = "f5438dd2b2ff4c6df6e1ce22d825ed2fa93ee2922235cc45186991717f0a892d"
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.28.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1cb62d7a07189335d41d8196638aa01bc1000a31889ba7a249d2bac25d9e48"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,7 +10,6 @@ keywords = ["pna", "archive", "cli", "crypto", "data"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ansi_term = "0.12.1"
 base64 = "0.22.1"
 bitflags = "2.6.0"
 bytesize = "1.3.0"
@@ -21,6 +20,7 @@ glob = "0.3.1"
 indicatif = { version = "0.17.8", features = ["improved_unicode"] }
 itertools = "0.13.0"
 normalize-path = "0.2.1"
+nu-ansi-term = "0.28.0"
 pna = { version = "0.15.0", path = "../pna" }
 rayon = "1.10.0"
 rpassword = "7.3.1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -20,7 +20,7 @@ glob = "0.3.1"
 indicatif = { version = "0.17.8", features = ["improved_unicode"] }
 itertools = "0.13.0"
 normalize-path = "0.2.1"
-nu-ansi-term = "0.28.0"
+nu-ansi-term = "0.50.1"
 pna = { version = "0.15.0", path = "../pna" }
 rayon = "1.10.0"
 rpassword = "7.3.1"

--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -8,9 +8,9 @@ use crate::{
     },
     utils::GlobPatterns,
 };
-use ansi_term::{ANSIString, Colour, Style};
 use chrono::{DateTime, Local};
 use clap::{ArgGroup, Parser};
+use nu_ansi_term::{ANSIString, Color as Colour, Style};
 use pna::{
     Chunk, Compression, DataKind, Encryption, ExtendedAttribute, ReadEntry, ReadOptions,
     RegularEntry, SolidHeader,

--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use chrono::{DateTime, Local};
 use clap::{ArgGroup, Parser};
-use nu_ansi_term::{ANSIString, Color as Colour, Style};
+use nu_ansi_term::{AnsiString as ANSIString, Color as Colour, Style};
 use pna::{
     Chunk, Compression, DataKind, Encryption, ExtendedAttribute, ReadEntry, ReadOptions,
     RegularEntry, SolidHeader,


### PR DESCRIPTION
`ansi_term` is Unmaintained, so remove dependency from `portable-network-archive`.

`nu-ansi-term` is forked from `ansi_term`