### PR TITLE
:sparkles: Add `-q` option to list subcommand

### DIFF
--- a/cli/src/command/stdio.rs
+++ b/cli/src/command/stdio.rs
@@ -251,6 +251,7 @@ fn run_list_archive(args: StdioCommand) -> io::Result<()> {
         show_private: false,
         time_format: TimeFormat::Auto(SystemTime::now()),
         numeric_owner: args.numeric_owner,
+        hide_control_chars: false,
         format: None,
     };
     if let Some(path) = args.file {


### PR DESCRIPTION
force printing of non-graphic characters in file names as the character '?', this is same as ls -q