### PR TITLE
:bug: Fixed `EntryPart::split` could be returning empty `EntryPart`

### DIFF
--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -1124,7 +1124,7 @@ impl<'a> EntryPart<&'a [u8]> {
                     first.push(x);
                     remaining.push_front(y);
                 } else {
-                    remaining.push_front(chunk);
+                    first.push(chunk);
                 }
                 break;
             }
@@ -1155,7 +1155,7 @@ impl EntryPart {
                     first.push(x.into());
                     remaining.push_front(y.into());
                 } else {
-                    remaining.push_front(chunk);
+                    first.push(chunk);
                 }
                 break;
             }


### PR DESCRIPTION
There was an issue where requesting a split on an indivisible chunk would always return an empty `EntryPart`. Additionally, this issue could potentially cause an infinite loop.