### PR TITLE
Revert ":construction_worker: Pin rust nightly channel for CI fuzzing to avoid ICE"

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -33,7 +33,7 @@ jobs:
       - id: install_rust
         uses: ./.github/actions/setup-rust
         with:
-          channel: nightly-2025-01-13
+          channel: nightly
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
       - name: Run fuzzing


### PR DESCRIPTION
Reverts ChanTsune/Portable-Network-Archive#1429

fixed #1430 