### PR TITLE
:construction_worker: Set `timeout-minutes` for vm using CI test

### DIFF
--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   solaris-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 100
     name: Test on Solaris
     steps:
       - uses: actions/checkout@v4
@@ -37,6 +38,7 @@ jobs:
 
   NetBSD-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 100
     name: Test on NetBSD
     steps:
       - uses: actions/checkout@v4.1.6
@@ -62,6 +64,7 @@ jobs:
 
   FreeBSD-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 100
     name: Test on FreeBSD
     steps:
       - uses: actions/checkout@v4
@@ -86,6 +89,7 @@ jobs:
 
   OpenBSD-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 100
     name: Test on OpenBSD
     steps:
       - uses: actions/checkout@v4.1.6
@@ -109,6 +113,7 @@ jobs:
 
 #  DragonflyBSD-test:
 #    runs-on: ubuntu-latest
+#    timeout-minutes: 100
 #    name: Test on DragonflyBSD
 #    steps:
 #      - uses: actions/checkout@v4
@@ -132,6 +137,7 @@ jobs:
 
   OmniOS-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 100
     name: Test on OmniOS
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The default timeout for GitHub Actions is too long, so set the timeout to 100 minutes.