### PR TITLE
:zap: `SolidEntryBuilder::build` return type `io::Result<impl Entry>` to `io::Result<SolidEntry>`

### DIFF
--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -694,7 +694,7 @@ impl SolidEntryBuilder {
     /// ```
     #[inline]
     #[must_use = "building an entry without using it is wasteful"]
-    pub fn build(self) -> io::Result<impl Entry + Sized> {
+    pub fn build(self) -> io::Result<SolidEntry> {
         self.build_as_entry()
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Refined return type specification in the public interface for improved clarity and specificity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChanTsune/Portable-Network-Archive/pull/1513)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->