### PR TITLE
:boom: Change in default behavior for archiving directories

### DIFF
--- a/cli/benches/create.rs
+++ b/cli/benches/create.rs
@@ -15,7 +15,6 @@ fn store(b: &mut Bencher) {
             &format!("{}/bench/store.pna", env!("CARGO_TARGET_TMPDIR")),
             "--store",
             "--overwrite",
-            "-r",
             "../resources/test/raw/",
         ]))
         .unwrap()
@@ -32,7 +31,6 @@ fn zstd(b: &mut Bencher) {
             &format!("{}/bench/zstd.pna", env!("CARGO_TARGET_TMPDIR")),
             "--zstd",
             "--overwrite",
-            "-r",
             "../resources/test/raw/",
         ]))
         .unwrap()
@@ -49,7 +47,6 @@ fn deflate(b: &mut Bencher) {
             &format!("{}/bench/deflate.pna", env!("CARGO_TARGET_TMPDIR")),
             "--deflate",
             "--overwrite",
-            "-r",
             "../resources/test/raw/",
         ]))
         .unwrap()
@@ -66,7 +63,6 @@ fn xz(b: &mut Bencher) {
             &format!("{}/bench/xz.pna", env!("CARGO_TARGET_TMPDIR")),
             "--xz",
             "--overwrite",
-            "-r",
             "../resources/test/raw/",
         ]))
         .unwrap()
@@ -87,7 +83,6 @@ fn zstd_keep_timestamp(b: &mut Bencher) {
             "--zstd",
             "--keep-timestamp",
             "--overwrite",
-            "-r",
             "../resources/test/raw/",
         ]))
         .unwrap()
@@ -108,7 +103,6 @@ fn zstd_keep_permission(b: &mut Bencher) {
             "--zstd",
             "--keep-permission",
             "--overwrite",
-            "-r",
             "../resources/test/raw/",
         ]))
         .unwrap()

--- a/cli/benches/split.rs
+++ b/cli/benches/split.rs
@@ -20,7 +20,6 @@ fn create_with_split(b: &mut Bencher) {
             "--split",
             "3MB",
             "--overwrite",
-            "-r",
             "../resources/test/raw/",
         ]))
         .unwrap()

--- a/cli/src/command/append.rs
+++ b/cli/src/command/append.rs
@@ -42,8 +42,13 @@ use std::{fs::File, io, path::PathBuf};
     group(ArgGroup::new("windows-unstable-keep-permission").args(["keep_permission"]).requires("unstable")),
 ))]
 pub(crate) struct AppendCommand {
-    #[arg(short, long, help = "Add the directory to the archive recursively")]
-    pub(crate) recursive: bool,
+    #[arg(
+        short,
+        long,
+        help = "Add the directory to the archive recursively",
+        default_value_t = true
+    )]
+    recursive: bool,
     #[arg(long, help = "Archiving the directories")]
     pub(crate) keep_dir: bool,
     #[arg(

--- a/cli/src/command/create.rs
+++ b/cli/src/command/create.rs
@@ -48,8 +48,13 @@ use std::{
     group(ArgGroup::new("windows-unstable-keep-permission").args(["keep_permission"]).requires("unstable")),
 ))]
 pub(crate) struct CreateCommand {
-    #[arg(short, long, help = "Add the directory to the archive recursively")]
-    pub(crate) recursive: bool,
+    #[arg(
+        short,
+        long,
+        help = "Add the directory to the archive recursively",
+        default_value_t = true
+    )]
+    recursive: bool,
     #[arg(long, help = "Overwrite file")]
     pub(crate) overwrite: bool,
     #[arg(long, help = "Archiving the directories")]

--- a/cli/src/command/stdio.rs
+++ b/cli/src/command/stdio.rs
@@ -48,7 +48,12 @@ pub(crate) struct StdioCommand {
     extract: bool,
     #[arg(short = 't', long, help = "List files in archive")]
     list: bool,
-    #[arg(short, long, help = "Add the directory to the archive recursively")]
+    #[arg(
+        short,
+        long,
+        help = "Add the directory to the archive recursively",
+        default_value_t = true
+    )]
     recursive: bool,
     #[arg(long, help = "Overwrite file")]
     overwrite: bool,

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -54,8 +54,13 @@ use std::{
     group(ArgGroup::new("windows-unstable-keep-permission").args(["keep_permission"]).requires("unstable")),
 ))]
 pub(crate) struct UpdateCommand {
-    #[arg(short, long, help = "Add the directory to the archive recursively")]
-    pub(crate) recursive: bool,
+    #[arg(
+        short,
+        long,
+        help = "Add the directory to the archive recursively",
+        default_value_t = true
+    )]
+    recursive: bool,
     #[arg(long, help = "Archiving the directories")]
     pub(crate) keep_dir: bool,
     #[arg(

--- a/cli/tests/cli/acl.rs
+++ b/cli/tests/cli/acl.rs
@@ -16,7 +16,6 @@ fn archive_acl_get_set() {
         "c",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/acl_get_set/acl_get_set.pna"),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/acl_get_set/in/"),
     ]))
     .unwrap();

--- a/cli/tests/cli/append.rs
+++ b/cli/tests/cli/append.rs
@@ -16,7 +16,6 @@ fn archive_append() {
         "c",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_append/append.pna"),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_append/in/"),
     ]))
     .unwrap();
@@ -79,7 +78,6 @@ fn archive_append_split() {
             "/archive_append_split/append_split.pna"
         ),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_append_split/in/"),
         "--split",
         "100kib",

--- a/cli/tests/cli/chmod.rs
+++ b/cli/tests/cli/chmod.rs
@@ -12,7 +12,6 @@ fn archive_chmod() {
         "c",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/chmod/chmod.pna"),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/chmod/in/"),
         "--keep-permission",
         #[cfg(windows)]

--- a/cli/tests/cli/chown.rs
+++ b/cli/tests/cli/chown.rs
@@ -12,7 +12,6 @@ fn archive_chown() {
         "c",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/chown/chown.pna"),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/chown/in/"),
         "--keep-permission",
         #[cfg(windows)]

--- a/cli/tests/cli/combination.rs
+++ b/cli/tests/cli/combination.rs
@@ -49,7 +49,6 @@ fn combination_fs() {
                     joined_options
                 ),
                 "--overwrite",
-                "-r",
                 concat!(env!("CARGO_TARGET_TMPDIR"), "/combination_fs/in/"),
                 #[cfg(windows)]
                 "--unstable",
@@ -136,7 +135,6 @@ fn combination_stdio() {
                 "experimental",
                 "stdio",
                 "-c",
-                "-r",
                 concat!(env!("CARGO_TARGET_TMPDIR"), "/combination_stdio/in/"),
                 #[cfg(windows)]
                 "--unstable",

--- a/cli/tests/cli/concat.rs
+++ b/cli/tests/cli/concat.rs
@@ -16,7 +16,6 @@ fn concat_archive() {
         "create",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/concat_archive/concat.pna"),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/concat_archive/in"),
     ]))
     .unwrap();

--- a/cli/tests/cli/create/exclude.rs
+++ b/cli/tests/cli/create/exclude.rs
@@ -13,7 +13,6 @@ fn create_with_exclude() {
         "c",
         "create_with_exclude/create_with_exclude.pna",
         "--overwrite",
-        "-r",
         "create_with_exclude/in/",
         "--exclude",
         "**.txt",

--- a/cli/tests/cli/create/password_from_file.rs
+++ b/cli/tests/cli/create/password_from_file.rs
@@ -16,7 +16,6 @@ fn create_with_password_file() {
         "c",
         "create_with_password_file/password_from_file.pna",
         "--overwrite",
-        "-r",
         "create_with_password_file/in/",
         "--password-file",
         password_file_path,

--- a/cli/tests/cli/create/password_hash.rs
+++ b/cli/tests/cli/create/password_hash.rs
@@ -19,7 +19,6 @@ fn aes_ctr_argon2_archive() {
             "/aes_argon2_ctr/zstd_aes_argon2_ctr.pna"
         ),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/aes_argon2_ctr/in/"),
         "--password",
         "password",
@@ -75,7 +74,6 @@ fn aes_ctr_argon2_with_params_archive() {
             "/aes_argon2_with_params_ctr/zstd_aes_argon2_with_params_ctr.pna"
         ),
         "--overwrite",
-        "-r",
         concat!(
             env!("CARGO_TARGET_TMPDIR"),
             "/aes_argon2_with_params_ctr/in/"
@@ -143,7 +141,6 @@ fn aes_ctr_pbkdf2_archive() {
             "/aes_pbkdf2_ctr/zstd_aes_pbkdf2_ctr.pna"
         ),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/aes_pbkdf2_ctr/in/"),
         "--password",
         "password",
@@ -197,7 +194,6 @@ fn aes_ctr_pbkdf2_with_params_archive() {
             "/aes_pbkdf2_with_params_ctr/zstd_aes_pbkdf2_with_params_ctr.pna"
         ),
         "--overwrite",
-        "-r",
         concat!(
             env!("CARGO_TARGET_TMPDIR"),
             "/aes_pbkdf2_with_params_ctr/in/"

--- a/cli/tests/cli/create/substitution.rs
+++ b/cli/tests/cli/create/substitution.rs
@@ -13,7 +13,6 @@ fn create_with_substitution() {
         "c",
         "create_with_substitution/create_with_substitution.pna",
         "--overwrite",
-        "-r",
         "create_with_substitution/in/",
         "-s",
         "#create_with_substitution/in/##",

--- a/cli/tests/cli/create/transform.rs
+++ b/cli/tests/cli/create/transform.rs
@@ -13,7 +13,6 @@ fn create_with_transform() {
         "c",
         "create_with_transform/create_with_transform.pna",
         "--overwrite",
-        "-r",
         "create_with_transform/in/",
         "--transform",
         "s,create_with_transform/in/,,",

--- a/cli/tests/cli/delete.rs
+++ b/cli/tests/cli/delete.rs
@@ -20,7 +20,6 @@ fn delete_overwrite() {
             "/delete_overwrite/delete_overwrite.pna"
         ),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_overwrite/in/"),
     ]))
     .unwrap();
@@ -85,7 +84,6 @@ fn delete_output() {
             "/delete_output/delete_output.pna"
         ),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_output/in/"),
     ]))
     .unwrap();
@@ -145,7 +143,6 @@ fn delete_output_exclude() {
             "/delete_output_exclude/delete_output_exclude.pna"
         ),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_output_exclude/in/"),
     ]))
     .unwrap();
@@ -215,7 +212,6 @@ fn delete_solid() {
         ),
         "--overwrite",
         "--solid",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_solid/in/"),
     ]))
     .unwrap();
@@ -276,7 +272,6 @@ fn delete_unsolid() {
         ),
         "--overwrite",
         "--solid",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_unsolid/in/"),
     ]))
     .unwrap();

--- a/cli/tests/cli/encrypt.rs
+++ b/cli/tests/cli/encrypt.rs
@@ -19,7 +19,6 @@ fn aes_ctr_archive() {
             "/zstd_aes_ctr/zstd_aes_ctr.pna"
         ),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/zstd_aes_ctr/in/"),
         "--password",
         "password",
@@ -69,7 +68,6 @@ fn aes_cbc_archive() {
             "/zstd_aes_cbc/zstd_aes_cbc.pna"
         ),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/zstd_aes_cbc/in/"),
         "--password",
         "password",
@@ -119,7 +117,6 @@ fn camellia_ctr_archive() {
             "/zstd_camellia_ctr/zstd_camellia_ctr.pna"
         ),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/zstd_camellia_ctr/in/"),
         "--password",
         "password",
@@ -173,7 +170,6 @@ fn camellia_cbc_archive() {
             "/zstd_camellia_cbc/zstd_camellia_cbc.pna"
         ),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/zstd_camellia_cbc/in/"),
         "--password",
         "password",

--- a/cli/tests/cli/extract/exclude.rs
+++ b/cli/tests/cli/extract/exclude.rs
@@ -13,7 +13,6 @@ fn extract_with_exclude() {
         "c",
         "extract_with_exclude/extract_with_exclude.pna",
         "--overwrite",
-        "-r",
         "extract_with_exclude/in/",
     ]))
     .unwrap();

--- a/cli/tests/cli/extract/password_from_file.rs
+++ b/cli/tests/cli/extract/password_from_file.rs
@@ -16,7 +16,6 @@ fn extract_with_password_file() {
         "c",
         "extract_with_password_file/password_from_file.pna",
         "--overwrite",
-        "-r",
         "extract_with_password_file/in/",
         "--password",
         password,

--- a/cli/tests/cli/extract/substitution.rs
+++ b/cli/tests/cli/extract/substitution.rs
@@ -13,7 +13,6 @@ fn extract_with_substitution() {
         "c",
         "extract_with_substitution/extract_with_substitution.pna",
         "--overwrite",
-        "-r",
         "extract_with_substitution/in/",
     ]))
     .unwrap();

--- a/cli/tests/cli/extract/transform.rs
+++ b/cli/tests/cli/extract/transform.rs
@@ -13,7 +13,6 @@ fn extract_with_transform() {
         "c",
         "extract_with_transform/extract_with_transform.pna",
         "--overwrite",
-        "-r",
         "extract_with_transform/in/",
     ]))
     .unwrap();

--- a/cli/tests/cli/keep_acl.rs
+++ b/cli/tests/cli/keep_acl.rs
@@ -17,7 +17,6 @@ fn archive_keep_acl() {
         "c",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/keep_acl/keep_acl.pna"),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/keep_acl/in/"),
         "--keep-acl",
         "--unstable",

--- a/cli/tests/cli/keep_all.rs
+++ b/cli/tests/cli/keep_all.rs
@@ -20,7 +20,6 @@ fn archive_keep_all() {
             "/archive_keep_all/keep_all.pna"
         ),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_keep_all/in/"),
         #[cfg(not(target_os = "netbsd"))]
         "--keep-xattr",

--- a/cli/tests/cli/list.rs
+++ b/cli/tests/cli/list.rs
@@ -12,7 +12,6 @@ fn archive_list() {
         "c",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/list/list.pna"),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/list/in/"),
     ]))
     .unwrap();
@@ -38,7 +37,6 @@ fn archive_list_solid() {
         "c",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/list_solid/list_solid.pna"),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/list_solid/in/"),
         "--solid",
     ]))
@@ -66,7 +64,6 @@ fn archive_list_detail() {
         "c",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/list_detail/list_detail.pna"),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/list_detail/in/"),
         #[cfg(not(target_os = "netbsd"))]
         "--keep-xattr",
@@ -110,7 +107,6 @@ fn archive_list_solid_detail() {
             "/list_solid_detail/list_solid_detail.pna"
         ),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/list_solid_detail/in/"),
         "--solid",
         #[cfg(not(target_os = "netbsd"))]
@@ -155,7 +151,6 @@ fn archive_list_jsonl() {
         "c",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/list_jsonl/list_jsonl.pna"),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/list_jsonl/in/"),
         #[cfg(not(target_os = "netbsd"))]
         "--keep-xattr",
@@ -203,7 +198,6 @@ fn archive_list_solid_jsonl() {
             "/list_solid_jsonl/list_solid_jsonl.pna"
         ),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/list_solid_jsonl/in/"),
         "--solid",
         #[cfg(not(target_os = "netbsd"))]
@@ -253,7 +247,6 @@ fn archive_list_tree() {
         "c",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/list_tree/list_tree.pna"),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/list_tree/in/"),
         #[cfg(not(target_os = "netbsd"))]
         "--keep-xattr",
@@ -301,7 +294,6 @@ fn archive_list_solid_tree() {
             "/list_solid_tree/list_solid_tree.pna"
         ),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/list_solid_tree/in/"),
         "--solid",
         #[cfg(not(target_os = "netbsd"))]

--- a/cli/tests/cli/solid_mode.rs
+++ b/cli/tests/cli/solid_mode.rs
@@ -17,7 +17,6 @@ fn solid_store_archive() {
         concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_store/solid_store.pna"),
         "--store",
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_store/in/"),
         "--solid",
     ]))
@@ -56,7 +55,6 @@ fn solid_zstd_archive() {
         concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_zstd/solid_zstd.pna"),
         "--zstd",
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_zstd/in/"),
         "--solid",
     ]))
@@ -96,7 +94,6 @@ fn solid_xz_archive() {
         concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_xz/solid_xz.pna"),
         "--xz",
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_xz/in/"),
         "--solid",
     ]))
@@ -139,7 +136,6 @@ fn solid_deflate_archive() {
         ),
         "--deflate",
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_deflate/in/"),
         "--solid",
     ]))

--- a/cli/tests/cli/split.rs
+++ b/cli/tests/cli/split.rs
@@ -17,7 +17,6 @@ fn split_archive() {
         "create",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/split_archive/split.pna"),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/split_archive/in/"),
     ]))
     .unwrap();

--- a/cli/tests/cli/strip.rs
+++ b/cli/tests/cli/strip.rs
@@ -19,7 +19,6 @@ fn archive_strip_metadata() {
             "/archive_strip_metadata/strip_metadata.pna"
         ),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_strip_metadata/in/"),
         #[cfg(not(target_os = "netbsd"))]
         "--keep-xattr",

--- a/cli/tests/cli/symlink.rs
+++ b/cli/tests/cli/symlink.rs
@@ -31,7 +31,6 @@ fn symlink() {
         "c",
         &format!("{}/symlink.pna", env!("CARGO_TARGET_TMPDIR")),
         "--overwrite",
-        "-r",
         &format!("{}/symlink/source", env!("CARGO_TARGET_TMPDIR")),
     ]))
     .unwrap();

--- a/cli/tests/cli/update.rs
+++ b/cli/tests/cli/update.rs
@@ -27,7 +27,6 @@ fn archive_update_newer_mtime() {
             "/archive_update_newer_mtime/update_newer_mtime.pna"
         ),
         "--overwrite",
-        "-r",
         concat!(
             env!("CARGO_TARGET_TMPDIR"),
             "/archive_update_newer_mtime/in/"
@@ -71,7 +70,6 @@ fn archive_update_newer_mtime() {
             env!("CARGO_TARGET_TMPDIR"),
             "/archive_update_newer_mtime/update_newer_mtime.pna"
         ),
-        "-r",
         concat!(
             env!("CARGO_TARGET_TMPDIR"),
             "/archive_update_newer_mtime/in/"
@@ -155,7 +153,6 @@ fn archive_update_older_mtime() {
             "/archive_update_older_mtime/update_older_mtime.pna"
         ),
         "--overwrite",
-        "-r",
         concat!(
             env!("CARGO_TARGET_TMPDIR"),
             "/archive_update_older_mtime/in/"
@@ -199,7 +196,6 @@ fn archive_update_older_mtime() {
             env!("CARGO_TARGET_TMPDIR"),
             "/archive_update_older_mtime/update_older_mtime.pna"
         ),
-        "-r",
         concat!(
             env!("CARGO_TARGET_TMPDIR"),
             "/archive_update_older_mtime/in/"
@@ -272,7 +268,6 @@ fn archive_update_deletion() {
             "/archive_update_deletion/update_deletion.pna"
         ),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_update_deletion/in/"),
         "--keep-timestamp",
     ]))
@@ -294,7 +289,6 @@ fn archive_update_deletion() {
             env!("CARGO_TARGET_TMPDIR"),
             "/archive_update_deletion/update_deletion.pna"
         ),
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_update_deletion/in/"),
         "--keep-timestamp",
     ]))

--- a/cli/tests/cli/update/exclude.rs
+++ b/cli/tests/cli/update/exclude.rs
@@ -24,7 +24,6 @@ fn archive_update_newer_mtime_with_exclude() {
             "/archive_update_newer_mtime_with_exclude/update_newer_mtime.pna"
         ),
         "--overwrite",
-        "-r",
         concat!(
             env!("CARGO_TARGET_TMPDIR"),
             "/archive_update_newer_mtime_with_exclude/in/"
@@ -68,7 +67,6 @@ fn archive_update_newer_mtime_with_exclude() {
             env!("CARGO_TARGET_TMPDIR"),
             "/archive_update_newer_mtime_with_exclude/update_newer_mtime.pna"
         ),
-        "-r",
         concat!(
             env!("CARGO_TARGET_TMPDIR"),
             "/archive_update_newer_mtime_with_exclude/in/"

--- a/cli/tests/cli/user_group.rs
+++ b/cli/tests/cli/user_group.rs
@@ -23,7 +23,6 @@ fn archive_create_uname_gname() {
             "/archive_create_uname_gname/create_uname_gname.pna"
         ),
         "--overwrite",
-        "-r",
         concat!(
             env!("CARGO_TARGET_TMPDIR"),
             "/archive_create_uname_gname/in/"
@@ -99,7 +98,6 @@ fn archive_create_uid_gid() {
             "/archive_create_uid_gid/create_uid_gid.pna"
         ),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_create_uid_gid/in/"),
         "--keep-permission",
         "--uid",

--- a/cli/tests/cli/xattr.rs
+++ b/cli/tests/cli/xattr.rs
@@ -16,7 +16,6 @@ fn archive_xattr_set() {
         "c",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/xattr_set/xattr_set.pna"),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/xattr_set/in/"),
         #[cfg(not(target_os = "netbsd"))]
         "--keep-xattr",
@@ -87,7 +86,6 @@ fn archive_xattr_remove() {
             "/xattr_remove/xattr_remove.pna"
         ),
         "--overwrite",
-        "-r",
         concat!(env!("CARGO_TARGET_TMPDIR"), "/xattr_remove/in/"),
         #[cfg(not(target_os = "netbsd"))]
         "--keep-xattr",


### PR DESCRIPTION
In version 0.22.0, the `--recursive (-r)` option was required to include directories recursively when archiving. However, starting from version 0.23.0, if a directory is included in the target, its contents will be recursively archived even without specifying the `--recursive (-r)` option.

In other words, from version 0.23.0 onward, the following two commands will behave the same way:

```
pna create archive.pna -r target_dir
pna create archive.pna target_dir
```

#1531