### PR TITLE
:wrench: Added metadata section for cargo-release to Cargo.toml

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -66,3 +66,9 @@ name = "change_compression_method"
 [[bench]]
 name = "create_extract"
 harness = false
+
+[package.metadata.release]
+pre-release-replacements = [
+    { file = "README.md", search = "libpna = \"[0-9]+\\.[0-9]+\"", replace = "libpna = \"{{version}}\"" },
+    { file = "src/lib.rs", search = "https://docs.rs/libpna/[0-9]+\\.[0-9]+\\.[0-9]+", replace = "https://docs.rs/libpna/{{version}}" },
+]

--- a/pna/Cargo.toml
+++ b/pna/Cargo.toml
@@ -22,3 +22,9 @@ zlib-ng = ["libpna/zlib-ng"]
 
 [lib]
 name = "pna"
+
+[package.metadata.release]
+pre-release-replacements = [
+    { file = "README.md", search = "pna = \"[0-9]+\\.[0-9]+\"", replace = "pna = \"{{version}}\"" },
+    { file = "src/lib.rs", search = "https://docs.rs/pna/[0-9]+\\.[0-9]+\\.[0-9]+", replace = "https://docs.rs/pna/{{version}}" },
+]


### PR DESCRIPTION
Wait until partial application is possible for only the major version and minor version parts as follows:
```
{{version.major}}.{{version.minor}}
```
or
```
{{major_version}}.{{minor_version}}
```

https://github.com/crate-ci/cargo-release/issues/116
