### PR TITLE
:boom: Changed argument type of `NormalEntry::with_xattr`

### DIFF
--- a/cli/src/command/xattr.rs
+++ b/cli/src/command/xattr.rs
@@ -311,7 +311,7 @@ impl SetAttrStrategy {
                         .into_iter()
                         .map(|(key, value)| pna::ExtendedAttribute::new(key.into(), value.into()))
                         .collect::<Vec<_>>();
-                    entry.with_xattrs(&xattrs)
+                    entry.with_xattrs(xattrs)
                 } else {
                     entry
                 }
@@ -365,7 +365,7 @@ fn transform_entry<T>(
     remove: Option<&str>,
 ) -> NormalEntry<T> {
     let xattrs = transform_xattr(entry.xattrs(), name, value, remove);
-    entry.with_xattrs(&xattrs)
+    entry.with_xattrs(xattrs)
 }
 
 #[inline]

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -784,7 +784,7 @@ impl<T> NormalEntry<T> {
     /// # }
     /// ```
     #[inline]
-    pub fn with_xattrs(mut self, xattrs: &[ExtendedAttribute]) -> Self {
+    pub fn with_xattrs(mut self, xattrs: impl Into<Vec<ExtendedAttribute>>) -> Self {
         self.xattrs = xattrs.into();
         self
     }


### PR DESCRIPTION
Argument type changed `&[ExtendedAttribute]` to `impl Into<Vec<ExtendedAttribute>>`