### PR TITLE
Refactor: Use utils::setup in CLI tests for temp dirs

### DIFF
--- a/cli/tests/cli/acl.rs
+++ b/cli/tests/cli/acl.rs
@@ -10,18 +10,14 @@ use portable_network_archive::{cli, command};
 #[test]
 fn archive_acl_get_set() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/acl_get_set/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "acl_get_set/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/acl_get_set/acl_get_set.pna"),
+        "acl_get_set/acl_get_set.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/acl_get_set/in/"),
+        "acl_get_set/in/",
     ]))
     .unwrap();
     command::entry(cli::Cli::parse_from([
@@ -30,8 +26,8 @@ fn archive_acl_get_set() {
         "experimental",
         "acl",
         "set",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/acl_get_set/acl_get_set.pna"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/acl_get_set/in/raw/text.txt"),
+        "acl_get_set/acl_get_set.pna",
+        "acl_get_set/in/raw/text.txt",
         "-m",
         "u:test:r,w,x",
     ]))
@@ -42,8 +38,8 @@ fn archive_acl_get_set() {
         "experimental",
         "acl",
         "set",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/acl_get_set/acl_get_set.pna"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/acl_get_set/in/raw/text.txt"),
+        "acl_get_set/acl_get_set.pna",
+        "acl_get_set/in/raw/text.txt",
         "-m",
         "g:test_group:r,w,x",
     ]))
@@ -54,8 +50,8 @@ fn archive_acl_get_set() {
         "experimental",
         "acl",
         "set",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/acl_get_set/acl_get_set.pna"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/acl_get_set/in/raw/text.txt"),
+        "acl_get_set/acl_get_set.pna",
+        "acl_get_set/in/raw/text.txt",
         "-x",
         "g:test_group",
     ]))
@@ -66,26 +62,22 @@ fn archive_acl_get_set() {
         "experimental",
         "acl",
         "get",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/acl_get_set/acl_get_set.pna"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/acl_get_set/in/raw/text.txt"),
+        "acl_get_set/acl_get_set.pna",
+        "acl_get_set/in/raw/text.txt",
     ]))
     .unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "x",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/acl_get_set/acl_get_set.pna"),
+        "acl_get_set/acl_get_set.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/acl_get_set/out/"),
+        "acl_get_set/out/",
         "--strip-components",
-        &components_count(concat!(env!("CARGO_TARGET_TMPDIR"), "/acl_get_set/in/")).to_string(),
+        &components_count("acl_get_set/in/").to_string(),
     ]))
     .unwrap();
 
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/acl_get_set/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/acl_get_set/out/"),
-    )
-    .unwrap();
+    diff("acl_get_set/in/", "acl_get_set/out/").unwrap();
 }

--- a/cli/tests/cli/append.rs
+++ b/cli/tests/cli/append.rs
@@ -7,138 +7,87 @@ use portable_network_archive::{cli, command};
 #[test]
 fn archive_append() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_append/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "archive_append/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_append/append.pna"),
+        "archive_append/append.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_append/in/"),
+        "archive_append/in/",
     ]))
     .unwrap();
 
     // Copy extra input
-    TestResources::extract_in(
-        "store.pna",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_append/in/"),
-    )
-    .unwrap();
-    TestResources::extract_in(
-        "zstd.pna",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_append/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("store.pna", "archive_append/in/").unwrap();
+    TestResources::extract_in("zstd.pna", "archive_append/in/").unwrap();
 
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "append",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_append/append.pna"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_append/in/store.pna"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_append/in/zstd.pna"),
+        "archive_append/append.pna",
+        "archive_append/in/store.pna",
+        "archive_append/in/zstd.pna",
     ]))
     .unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "x",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_append/append.pna"),
+        "archive_append/append.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_append/out/"),
+        "archive_append/out/",
         "--strip-components",
-        &components_count(concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_append/in/")).to_string(),
+        &components_count("archive_append/in/").to_string(),
     ]))
     .unwrap();
     // check completely extracted
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_append/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_append/out/"),
-    )
-    .unwrap();
+    diff("archive_append/in/", "archive_append/out/").unwrap();
 }
 
 #[test]
 fn archive_append_split() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_append_split/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "archive_append_split/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_append_split/append_split.pna"
-        ),
+        "archive_append_split/append_split.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_append_split/in/"),
+        "archive_append_split/in/",
         "--split",
         "100kib",
     ]))
     .unwrap();
 
     // Copy extra input
-    TestResources::extract_in(
-        "store.pna",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_append_split/in/"),
-    )
-    .unwrap();
-    TestResources::extract_in(
-        "zstd.pna",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_append_split/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("store.pna", "archive_append_split/in/").unwrap();
+    TestResources::extract_in("zstd.pna", "archive_append_split/in/").unwrap();
 
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "append",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_append_split/append_split.part1.pna"
-        ),
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_append_split/in/store.pna"
-        ),
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_append_split/in/zstd.pna"
-        ),
+        "archive_append_split/append_split.part1.pna",
+        "archive_append_split/in/store.pna",
+        "archive_append_split/in/zstd.pna",
     ]))
     .unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_append_split/append_split.part1.pna"
-        ),
+        "archive_append_split/append_split.part1.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_append_split/out/"),
+        "archive_append_split/out/",
         "--strip-components",
-        &components_count(concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_append_split/out/"
-        ))
-        .to_string(),
+        &components_count("archive_append_split/out/").to_string(),
     ]))
     .unwrap();
     // check completely extracted
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_append_split/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_append_split/out/"),
-    )
-    .unwrap();
+    diff("archive_append_split/in/", "archive_append_split/out/").unwrap();
 }

--- a/cli/tests/cli/cd_option.rs
+++ b/cli/tests/cli/cd_option.rs
@@ -4,109 +4,69 @@ use std::fs;
 #[test]
 fn create_extract_with_cd() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/create_extract_with_cd/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "create_extract_with_cd/in/").unwrap();
 
     let mut cmd = assert_cmd::Command::cargo_bin("pna").unwrap();
     cmd.args([
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/create_extract_with_cd/create_extract_with_cd.pna"
-        ),
+        "create_extract_with_cd/create_extract_with_cd.pna",
         "--overwrite",
         "-C",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/create_extract_with_cd/in/"),
+        "create_extract_with_cd/in/",
         ".",
     ]);
     cmd.assert().success();
 
-    assert!(fs::exists(concat!(
-        env!("CARGO_TARGET_TMPDIR"),
-        "/create_extract_with_cd/create_extract_with_cd.pna"
-    ))
-    .unwrap());
+    assert!(fs::exists("create_extract_with_cd/create_extract_with_cd.pna").unwrap());
 
     let mut cmd = assert_cmd::Command::cargo_bin("pna").unwrap();
     cmd.args([
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/create_extract_with_cd/create_extract_with_cd.pna"
-        ),
+        "create_extract_with_cd/create_extract_with_cd.pna",
         "--overwrite",
         "-C",
-        env!("CARGO_TARGET_TMPDIR"),
+        ".",
         "--out-dir",
-        "./create_extract_with_cd/out/",
+        "create_extract_with_cd/out/",
     ]);
     cmd.assert().success();
 
     // check completely extracted
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/create_extract_with_cd/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/create_extract_with_cd/out/"),
-    )
-    .unwrap();
+    diff("create_extract_with_cd/in/", "create_extract_with_cd/out/").unwrap();
 }
 
 #[test]
 fn append_with_cd() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/append_with_cd/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "append_with_cd/in/").unwrap();
 
     let mut cmd = assert_cmd::Command::cargo_bin("pna").unwrap();
     cmd.args([
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/append_with_cd/append_with_cd.pna"
-        ),
+        "append_with_cd/append_with_cd.pna",
         "--overwrite",
         "-C",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/append_with_cd/in/"),
+        "append_with_cd/in/",
         ".",
     ]);
     cmd.assert().success();
 
-    assert!(fs::exists(concat!(
-        env!("CARGO_TARGET_TMPDIR"),
-        "/append_with_cd/append_with_cd.pna"
-    ))
-    .unwrap());
+    assert!(fs::exists("append_with_cd/append_with_cd.pna").unwrap());
 
     // Copy extra input
-    TestResources::extract_in(
-        "store.pna",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/append_with_cd/in/"),
-    )
-    .unwrap();
-    TestResources::extract_in(
-        "zstd.pna",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/append_with_cd/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("store.pna", "append_with_cd/in/").unwrap();
+    TestResources::extract_in("zstd.pna", "append_with_cd/in/").unwrap();
 
     let mut cmd = assert_cmd::Command::cargo_bin("pna").unwrap();
     cmd.args([
         "--quiet",
         "append",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/append_with_cd/append_with_cd.pna"
-        ),
+        "append_with_cd/append_with_cd.pna",
         "-C",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/append_with_cd/in/"),
+        "append_with_cd/in/",
         "store.pna",
         "zstd.pna",
     ]);
@@ -116,79 +76,50 @@ fn append_with_cd() {
     cmd.args([
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/append_with_cd/append_with_cd.pna"
-        ),
+        "append_with_cd/append_with_cd.pna",
         "--overwrite",
         "-C",
-        env!("CARGO_TARGET_TMPDIR"),
+        ".",
         "--out-dir",
-        "./append_with_cd/out/",
+        "append_with_cd/out/",
     ]);
     cmd.assert().success();
 
     // check completely extracted
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/append_with_cd/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/append_with_cd/out/"),
-    )
-    .unwrap();
+    diff("append_with_cd/in/", "append_with_cd/out/").unwrap();
 }
 
 #[test]
 fn update_with_cd() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/update_with_cd/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "update_with_cd/in/").unwrap();
 
     let mut cmd = assert_cmd::Command::cargo_bin("pna").unwrap();
     cmd.args([
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/update_with_cd/update_with_cd.pna"
-        ),
+        "update_with_cd/update_with_cd.pna",
         "--overwrite",
         "-C",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/update_with_cd/in/"),
+        "update_with_cd/in/",
         ".",
     ]);
     cmd.assert().success();
 
-    assert!(fs::exists(concat!(
-        env!("CARGO_TARGET_TMPDIR"),
-        "/update_with_cd/update_with_cd.pna"
-    ))
-    .unwrap());
+    assert!(fs::exists("update_with_cd/update_with_cd.pna").unwrap());
 
     // Copy extra input
-    TestResources::extract_in(
-        "store.pna",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/update_with_cd/in/"),
-    )
-    .unwrap();
-    TestResources::extract_in(
-        "zstd.pna",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/update_with_cd/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("store.pna", "update_with_cd/in/").unwrap();
+    TestResources::extract_in("zstd.pna", "update_with_cd/in/").unwrap();
 
     let mut cmd = assert_cmd::Command::cargo_bin("pna").unwrap();
     cmd.args([
         "--quiet",
         "experimental",
         "update",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/update_with_cd/update_with_cd.pna"
-        ),
+        "update_with_cd/update_with_cd.pna",
         "-C",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/update_with_cd/in/"),
+        "update_with_cd/in/",
         ".",
     ]);
     cmd.assert().success();
@@ -197,22 +128,15 @@ fn update_with_cd() {
     cmd.args([
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/update_with_cd/update_with_cd.pna"
-        ),
+        "update_with_cd/update_with_cd.pna",
         "--overwrite",
         "-C",
-        env!("CARGO_TARGET_TMPDIR"),
+        ".",
         "--out-dir",
-        "./update_with_cd/out/",
+        "update_with_cd/out/",
     ]);
     cmd.assert().success();
 
     // check completely extracted
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/update_with_cd/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/update_with_cd/out/"),
-    )
-    .unwrap();
+    diff("update_with_cd/in/", "update_with_cd/out/").unwrap();
 }

--- a/cli/tests/cli/chown.rs
+++ b/cli/tests/cli/chown.rs
@@ -5,14 +5,14 @@ use portable_network_archive::{cli, command};
 #[test]
 fn archive_chown() {
     setup();
-    TestResources::extract_in("raw/", concat!(env!("CARGO_TARGET_TMPDIR"), "/chown/in/")).unwrap();
+    TestResources::extract_in("raw/", "chown/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/chown/chown.pna"),
+        "chown/chown.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/chown/in/"),
+        "chown/in/",
         "--keep-permission",
         #[cfg(windows)]
         "--unstable",
@@ -23,9 +23,9 @@ fn archive_chown() {
         "--quiet",
         "experimental",
         "chown",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/chown/chown.pna"),
+        "chown/chown.pna",
         "user:group",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/chown/in/raw/text.txt"),
+        "chown/in/raw/text.txt",
     ]))
     .unwrap();
 }

--- a/cli/tests/cli/combination.rs
+++ b/cli/tests/cli/combination.rs
@@ -33,8 +33,7 @@ const SOLID_OPTIONS: &[Option<&str>] = &[None, Some("--solid")];
 #[test]
 fn combination_fs() {
     setup();
-    LibSourceCode::extract_all(concat!(env!("CARGO_TARGET_TMPDIR"), "/combination_fs/in/"))
-        .unwrap();
+    LibSourceCode::extract_all("combination_fs/in/").unwrap();
     fn inner(options: Vec<&str>) {
         let joined_options = options.iter().join("");
 
@@ -43,13 +42,9 @@ fn combination_fs() {
             [
                 "--quiet",
                 "c",
-                &format!(
-                    "{}/combination_fs/{}.pna",
-                    env!("CARGO_TARGET_TMPDIR"),
-                    joined_options
-                ),
+                &format!("combination_fs/{}.pna", joined_options),
                 "--overwrite",
-                concat!(env!("CARGO_TARGET_TMPDIR"), "/combination_fs/in/"),
+                "combination_fs/in/",
                 #[cfg(windows)]
                 "--unstable",
             ]
@@ -61,21 +56,12 @@ fn combination_fs() {
         cmd.args([
             "--quiet",
             "x",
-            &format!(
-                "{}/combination_fs/{}.pna",
-                env!("CARGO_TARGET_TMPDIR"),
-                joined_options
-            ),
+            &format!("combination_fs/{}.pna", joined_options),
             "--overwrite",
             "--out-dir",
-            &format!(
-                "{}/combination_fs/out/{}/",
-                env!("CARGO_TARGET_TMPDIR"),
-                joined_options
-            ),
+            &format!("combination_fs/out/{}/", joined_options),
             "--strip-components",
-            &components_count(concat!(env!("CARGO_TARGET_TMPDIR"), "/combination_fs/in/"))
-                .to_string(),
+            &components_count("combination_fs/in/").to_string(),
             "--password",
             "password",
             #[cfg(windows)]
@@ -83,12 +69,8 @@ fn combination_fs() {
         ]);
         cmd.assert().success();
         diff(
-            concat!(env!("CARGO_TARGET_TMPDIR"), "/combination_fs/in/"),
-            format!(
-                "{}/combination_fs/out/{}",
-                env!("CARGO_TARGET_TMPDIR"),
-                joined_options,
-            ),
+            "combination_fs/in/",
+            format!("combination_fs/out/{}", joined_options),
         )
         .unwrap();
     }
@@ -121,11 +103,7 @@ fn combination_fs() {
 #[test]
 fn combination_stdio() {
     setup();
-    LibSourceCode::extract_all(concat!(
-        env!("CARGO_TARGET_TMPDIR"),
-        "/combination_stdio/in/"
-    ))
-    .unwrap();
+    LibSourceCode::extract_all("combination_stdio/in/").unwrap();
     fn inner(options: Vec<&str>) {
         let joined_options = options.iter().join("");
 
@@ -136,7 +114,7 @@ fn combination_stdio() {
                 "experimental",
                 "stdio",
                 "-c",
-                concat!(env!("CARGO_TARGET_TMPDIR"), "/combination_stdio/in/"),
+                "combination_stdio/in/",
                 #[cfg(windows)]
                 "--unstable",
             ]
@@ -154,17 +132,9 @@ fn combination_stdio() {
             "-x",
             "--overwrite",
             "--out-dir",
-            &format!(
-                "{}/combination_stdio/out/{}/",
-                env!("CARGO_TARGET_TMPDIR"),
-                joined_options
-            ),
+            &format!("combination_stdio/out/{}/", joined_options),
             "--strip-components",
-            &components_count(concat!(
-                env!("CARGO_TARGET_TMPDIR"),
-                "/combination_stdio/in/"
-            ))
-            .to_string(),
+            &components_count("combination_stdio/in/").to_string(),
             "--password",
             "password",
             #[cfg(windows)]
@@ -172,12 +142,8 @@ fn combination_stdio() {
         ]);
         cmd.assert().success();
         diff(
-            concat!(env!("CARGO_TARGET_TMPDIR"), "/combination_stdio/in/"),
-            format!(
-                "{}/combination_stdio/out/{}",
-                env!("CARGO_TARGET_TMPDIR"),
-                joined_options,
-            ),
+            "combination_stdio/in/",
+            format!("combination_stdio/out/{}", joined_options),
         )
         .unwrap();
     }

--- a/cli/tests/cli/concat.rs
+++ b/cli/tests/cli/concat.rs
@@ -5,25 +5,21 @@ use portable_network_archive::{cli, command};
 #[test]
 fn concat_archive() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/concat_archive/in"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "concat_archive/in").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "create",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/concat_archive/concat.pna"),
+        "concat_archive/concat.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/concat_archive/in"),
+        "concat_archive/in",
     ]))
     .unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "split",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/concat_archive/concat.pna"),
+        "concat_archive/concat.pna",
         "--overwrite",
         "--max-size",
         "100kb",
@@ -33,14 +29,8 @@ fn concat_archive() {
         "pna",
         "--quiet",
         "concat",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/concat_archive/concatenated.pna"
-        ),
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/concat_archive/concat.part1.pna"
-        ),
+        "concat_archive/concatenated.pna",
+        "concat_archive/concat.part1.pna",
         "--overwrite",
     ]))
     .unwrap();
@@ -48,20 +38,13 @@ fn concat_archive() {
         "pna",
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/concat_archive/concatenated.pna"
-        ),
+        "concat_archive/concatenated.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/concat_archive/out"),
+        "concat_archive/out",
         "--strip-components",
-        &components_count(concat!(env!("CARGO_TARGET_TMPDIR"), "/concat_archive/in")).to_string(),
+        &components_count("concat_archive/in").to_string(),
     ]))
     .unwrap();
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/concat_archive/in"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/concat_archive/out"),
-    )
-    .unwrap();
+    diff("concat_archive/in", "concat_archive/out").unwrap();
 }

--- a/cli/tests/cli/create/password_hash.rs
+++ b/cli/tests/cli/create/password_hash.rs
@@ -5,21 +5,14 @@ use portable_network_archive::{cli, command};
 #[test]
 fn aes_ctr_argon2_archive() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/aes_argon2_ctr/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "aes_argon2_ctr/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/aes_argon2_ctr/zstd_aes_argon2_ctr.pna"
-        ),
+        "aes_argon2_ctr/zstd_aes_argon2_ctr.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/aes_argon2_ctr/in/"),
+        "aes_argon2_ctr/in/",
         "--password",
         "password",
         "--aes",
@@ -31,53 +24,33 @@ fn aes_ctr_argon2_archive() {
         "pna",
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/aes_argon2_ctr/zstd_aes_argon2_ctr.pna"
-        ),
+        "aes_argon2_ctr/zstd_aes_argon2_ctr.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/aes_argon2_ctr/out/"),
+        "aes_argon2_ctr/out/",
         "--password",
         "password",
         "--strip-components",
-        &components_count(concat!(env!("CARGO_TARGET_TMPDIR"), "/aes_argon2_ctr/in/")).to_string(),
+        &components_count("aes_argon2_ctr/in/").to_string(),
     ]))
     .unwrap();
 
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/aes_argon2_ctr/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/aes_argon2_ctr/out/"),
-    )
-    .unwrap();
+    diff("aes_argon2_ctr/in/", "aes_argon2_ctr/out/").unwrap();
 }
 
 #[test]
 fn aes_ctr_argon2_with_params_archive() {
     setup();
 
-    TestResources::extract_in(
-        "raw/",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/aes_argon2_with_params_ctr/in/"
-        ),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "aes_argon2_with_params_ctr/in/").unwrap();
 
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/aes_argon2_with_params_ctr/zstd_aes_argon2_with_params_ctr.pna"
-        ),
+        "aes_argon2_with_params_ctr/zstd_aes_argon2_with_params_ctr.pna",
         "--overwrite",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/aes_argon2_with_params_ctr/in/"
-        ),
+        "aes_argon2_with_params_ctr/in/",
         "--password",
         "password",
         "--aes",
@@ -90,36 +63,20 @@ fn aes_ctr_argon2_with_params_archive() {
         "pna",
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/aes_argon2_with_params_ctr/zstd_aes_argon2_with_params_ctr.pna"
-        ),
+        "aes_argon2_with_params_ctr/zstd_aes_argon2_with_params_ctr.pna",
         "--overwrite",
         "--out-dir",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/aes_argon2_with_params_ctr/out/"
-        ),
+        "aes_argon2_with_params_ctr/out/",
         "--password",
         "password",
         "--strip-components",
-        &components_count(concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/aes_argon2_with_params_ctr/in/"
-        ))
-        .to_string(),
+        &components_count("aes_argon2_with_params_ctr/in/").to_string(),
     ]))
     .unwrap();
 
     diff(
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/aes_argon2_with_params_ctr/in/"
-        ),
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/aes_argon2_with_params_ctr/out/"
-        ),
+        "aes_argon2_with_params_ctr/in/",
+        "aes_argon2_with_params_ctr/out/",
     )
     .unwrap();
 }
@@ -127,21 +84,14 @@ fn aes_ctr_argon2_with_params_archive() {
 #[test]
 fn aes_ctr_pbkdf2_archive() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/aes_pbkdf2_ctr/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "aes_pbkdf2_ctr/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/aes_pbkdf2_ctr/zstd_aes_pbkdf2_ctr.pna"
-        ),
+        "aes_pbkdf2_ctr/zstd_aes_pbkdf2_ctr.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/aes_pbkdf2_ctr/in/"),
+        "aes_pbkdf2_ctr/in/",
         "--password",
         "password",
         "--aes",
@@ -153,51 +103,31 @@ fn aes_ctr_pbkdf2_archive() {
         "pna",
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/aes_pbkdf2_ctr/zstd_aes_pbkdf2_ctr.pna"
-        ),
+        "aes_pbkdf2_ctr/zstd_aes_pbkdf2_ctr.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/aes_pbkdf2_ctr/out/"),
+        "aes_pbkdf2_ctr/out/",
         "--password",
         "password",
         "--strip-components",
-        &components_count(concat!(env!("CARGO_TARGET_TMPDIR"), "/aes_pbkdf2_ctr/in/")).to_string(),
+        &components_count("aes_pbkdf2_ctr/in/").to_string(),
     ]))
     .unwrap();
 
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/aes_pbkdf2_ctr/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/aes_pbkdf2_ctr/out/"),
-    )
-    .unwrap();
+    diff("aes_pbkdf2_ctr/in/", "aes_pbkdf2_ctr/out/").unwrap();
 }
 
 #[test]
 fn aes_ctr_pbkdf2_with_params_archive() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/aes_pbkdf2_with_params_ctr/in/"
-        ),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "aes_pbkdf2_with_params_ctr/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/aes_pbkdf2_with_params_ctr/zstd_aes_pbkdf2_with_params_ctr.pna"
-        ),
+        "aes_pbkdf2_with_params_ctr/zstd_aes_pbkdf2_with_params_ctr.pna",
         "--overwrite",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/aes_pbkdf2_with_params_ctr/in/"
-        ),
+        "aes_pbkdf2_with_params_ctr/in/",
         "--password",
         "password",
         "--aes",
@@ -210,36 +140,20 @@ fn aes_ctr_pbkdf2_with_params_archive() {
         "pna",
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/aes_pbkdf2_with_params_ctr/zstd_aes_pbkdf2_with_params_ctr.pna"
-        ),
+        "aes_pbkdf2_with_params_ctr/zstd_aes_pbkdf2_with_params_ctr.pna",
         "--overwrite",
         "--out-dir",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/aes_pbkdf2_with_params_ctr/out/"
-        ),
+        "aes_pbkdf2_with_params_ctr/out/",
         "--password",
         "password",
         "--strip-components",
-        &components_count(concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/aes_pbkdf2_with_params_ctr/in/"
-        ))
-        .to_string(),
+        &components_count("aes_pbkdf2_with_params_ctr/in/").to_string(),
     ]))
     .unwrap();
 
     diff(
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/aes_pbkdf2_with_params_ctr/in/"
-        ),
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/aes_pbkdf2_with_params_ctr/out/"
-        ),
+        "aes_pbkdf2_with_params_ctr/in/",
+        "aes_pbkdf2_with_params_ctr/out/",
     )
     .unwrap();
 }

--- a/cli/tests/cli/delete.rs
+++ b/cli/tests/cli/delete.rs
@@ -8,21 +8,14 @@ use std::fs;
 #[test]
 fn delete_overwrite() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_overwrite/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "delete_overwrite/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/delete_overwrite/delete_overwrite.pna"
-        ),
+        "delete_overwrite/delete_overwrite.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_overwrite/in/"),
+        "delete_overwrite/in/",
     ]))
     .unwrap();
     command::entry(cli::Cli::parse_from([
@@ -30,63 +23,38 @@ fn delete_overwrite() {
         "--quiet",
         "experimental",
         "delete",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/delete_overwrite/delete_overwrite.pna"
-        ),
+        "delete_overwrite/delete_overwrite.pna",
         "**/raw/empty.txt",
     ]))
     .unwrap();
-    fs::remove_file(concat!(
-        env!("CARGO_TARGET_TMPDIR"),
-        "/delete_overwrite/in/raw/empty.txt"
-    ))
-    .unwrap();
+    fs::remove_file("delete_overwrite/in/raw/empty.txt").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/delete_overwrite/delete_overwrite.pna"
-        ),
+        "delete_overwrite/delete_overwrite.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_overwrite/out/"),
+        "delete_overwrite/out/",
         "--strip-components",
-        &components_count(concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/delete_overwrite/in/"
-        ))
-        .to_string(),
+        &components_count("delete_overwrite/in/").to_string(),
     ]))
     .unwrap();
 
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_overwrite/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_overwrite/out/"),
-    )
-    .unwrap();
+    diff("delete_overwrite/in/", "delete_overwrite/out/").unwrap();
 }
 
 #[test]
 fn delete_output() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_output/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "delete_output/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/delete_output/delete_output.pna"
-        ),
+        "delete_output/delete_output.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_output/in/"),
+        "delete_output/in/",
     ]))
     .unwrap();
     command::entry(cli::Cli::parse_from([
@@ -94,59 +62,41 @@ fn delete_output() {
         "--quiet",
         "experimental",
         "delete",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/delete_output/delete_output.pna"
-        ),
+        "delete_output/delete_output.pna",
         "**/raw/text.txt",
         "--output",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_output/deleted.pna"),
+        "delete_output/deleted.pna",
     ]))
     .unwrap();
-    fs::remove_file(concat!(
-        env!("CARGO_TARGET_TMPDIR"),
-        "/delete_output/in/raw/text.txt"
-    ))
-    .unwrap();
+    fs::remove_file("delete_output/in/raw/text.txt").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "x",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_output/deleted.pna"),
+        "delete_output/deleted.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_output/out/"),
+        "delete_output/out/",
         "--strip-components",
-        &components_count(concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_output/in/")).to_string(),
+        &components_count("delete_output/in/").to_string(),
     ]))
     .unwrap();
 
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_output/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_output/out/"),
-    )
-    .unwrap();
+    diff("delete_output/in/", "delete_output/out/").unwrap();
 }
 
 #[test]
 fn delete_solid() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_solid/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "delete_solid/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/delete_solid/delete_solid.pna"
-        ),
+        "delete_solid/delete_solid.pna",
         "--overwrite",
         "--solid",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_solid/in/"),
+        "delete_solid/in/",
     ]))
     .unwrap();
     command::entry(cli::Cli::parse_from([
@@ -154,59 +104,38 @@ fn delete_solid() {
         "--quiet",
         "experimental",
         "delete",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/delete_solid/delete_solid.pna"
-        ),
+        "delete_solid/delete_solid.pna",
         "**/raw/text.txt",
     ]))
     .unwrap();
-    fs::remove_file(concat!(
-        env!("CARGO_TARGET_TMPDIR"),
-        "/delete_solid/in/raw/text.txt"
-    ))
-    .unwrap();
+    fs::remove_file("delete_solid/in/raw/text.txt").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/delete_solid/delete_solid.pna"
-        ),
+        "delete_solid/delete_solid.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_solid/out/"),
+        "delete_solid/out/",
         "--strip-components",
-        &components_count(concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_solid/in/")).to_string(),
+        &components_count("delete_solid/in/").to_string(),
     ]))
     .unwrap();
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_solid/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_solid/out/"),
-    )
-    .unwrap();
+    diff("delete_solid/in/", "delete_solid/out/").unwrap();
 }
 
 #[test]
 fn delete_unsolid() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_unsolid/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "delete_unsolid/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/delete_unsolid/delete_unsolid.pna"
-        ),
+        "delete_unsolid/delete_unsolid.pna",
         "--overwrite",
         "--solid",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_unsolid/in/"),
+        "delete_unsolid/in/",
     ]))
     .unwrap();
     command::entry(cli::Cli::parse_from([
@@ -215,37 +144,23 @@ fn delete_unsolid() {
         "experimental",
         "delete",
         "--unsolid",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/delete_unsolid/delete_unsolid.pna"
-        ),
+        "delete_unsolid/delete_unsolid.pna",
         "**/raw/text.txt",
     ]))
     .unwrap();
-    fs::remove_file(concat!(
-        env!("CARGO_TARGET_TMPDIR"),
-        "/delete_unsolid/in/raw/text.txt"
-    ))
-    .unwrap();
+    fs::remove_file("delete_unsolid/in/raw/text.txt").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/delete_unsolid/delete_unsolid.pna"
-        ),
+        "delete_unsolid/delete_unsolid.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_unsolid/out/"),
+        "delete_unsolid/out/",
         "--strip-components",
-        &components_count(concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_unsolid/in/")).to_string(),
+        &components_count("delete_unsolid/in/").to_string(),
     ]))
     .unwrap();
 
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_unsolid/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/delete_unsolid/out/"),
-    )
-    .unwrap();
+    diff("delete_unsolid/in/", "delete_unsolid/out/").unwrap();
 }

--- a/cli/tests/cli/encrypt.rs
+++ b/cli/tests/cli/encrypt.rs
@@ -5,21 +5,14 @@ use portable_network_archive::{cli, command};
 #[test]
 fn aes_ctr_archive() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/zstd_aes_ctr/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "zstd_aes_ctr/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/zstd_aes_ctr/zstd_aes_ctr.pna"
-        ),
+        "zstd_aes_ctr/zstd_aes_ctr.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/zstd_aes_ctr/in/"),
+        "zstd_aes_ctr/in/",
         "--password",
         "password",
         "--aes",
@@ -30,45 +23,31 @@ fn aes_ctr_archive() {
         "pna",
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/zstd_aes_ctr/zstd_aes_ctr.pna"
-        ),
+        "zstd_aes_ctr/zstd_aes_ctr.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/zstd_aes_ctr/out/"),
+        "zstd_aes_ctr/out/",
         "--password",
         "password",
         "--strip-components",
-        &components_count(concat!(env!("CARGO_TARGET_TMPDIR"), "/zstd_aes_ctr/in/")).to_string(),
+        &components_count("zstd_aes_ctr/in/").to_string(),
     ]))
     .unwrap();
 
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/zstd_aes_ctr/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/zstd_aes_ctr/out/"),
-    )
-    .unwrap();
+    diff("zstd_aes_ctr/in/", "zstd_aes_ctr/out/").unwrap();
 }
 
 #[test]
 fn aes_cbc_archive() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/zstd_aes_cbc/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "zstd_aes_cbc/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/zstd_aes_cbc/zstd_aes_cbc.pna"
-        ),
+        "zstd_aes_cbc/zstd_aes_cbc.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/zstd_aes_cbc/in/"),
+        "zstd_aes_cbc/in/",
         "--password",
         "password",
         "--aes",
@@ -79,45 +58,31 @@ fn aes_cbc_archive() {
         "pna",
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/zstd_aes_cbc/zstd_aes_cbc.pna"
-        ),
+        "zstd_aes_cbc/zstd_aes_cbc.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/zstd_aes_cbc/out/"),
+        "zstd_aes_cbc/out/",
         "--password",
         "password",
         "--strip-components",
-        &components_count(concat!(env!("CARGO_TARGET_TMPDIR"), "/zstd_aes_cbc/in/")).to_string(),
+        &components_count("zstd_aes_cbc/in/").to_string(),
     ]))
     .unwrap();
 
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/zstd_aes_cbc/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/zstd_aes_cbc/out/"),
-    )
-    .unwrap();
+    diff("zstd_aes_cbc/in/", "zstd_aes_cbc/out/").unwrap();
 }
 
 #[test]
 fn camellia_ctr_archive() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/zstd_camellia_ctr/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "zstd_camellia_ctr/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/zstd_camellia_ctr/zstd_camellia_ctr.pna"
-        ),
+        "zstd_camellia_ctr/zstd_camellia_ctr.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/zstd_camellia_ctr/in/"),
+        "zstd_camellia_ctr/in/",
         "--password",
         "password",
         "--camellia",
@@ -128,49 +93,31 @@ fn camellia_ctr_archive() {
         "pna",
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/zstd_camellia_ctr/zstd_camellia_ctr.pna"
-        ),
+        "zstd_camellia_ctr/zstd_camellia_ctr.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/zstd_camellia_ctr/out/"),
+        "zstd_camellia_ctr/out/",
         "--password",
         "password",
         "--strip-components",
-        &components_count(concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/zstd_camellia_ctr/in/"
-        ))
-        .to_string(),
+        &components_count("zstd_camellia_ctr/in/").to_string(),
     ]))
     .unwrap();
 
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/zstd_camellia_ctr/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/zstd_camellia_ctr/out/"),
-    )
-    .unwrap();
+    diff("zstd_camellia_ctr/in/", "zstd_camellia_ctr/out/").unwrap();
 }
 
 #[test]
 fn camellia_cbc_archive() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/zstd_camellia_cbc/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "zstd_camellia_cbc/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/zstd_camellia_cbc/zstd_camellia_cbc.pna"
-        ),
+        "zstd_camellia_cbc/zstd_camellia_cbc.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/zstd_camellia_cbc/in/"),
+        "zstd_camellia_cbc/in/",
         "--password",
         "password",
         "--aes",
@@ -181,27 +128,16 @@ fn camellia_cbc_archive() {
         "pna",
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/zstd_camellia_cbc/zstd_camellia_cbc.pna"
-        ),
+        "zstd_camellia_cbc/zstd_camellia_cbc.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/zstd_camellia_cbc/out/"),
+        "zstd_camellia_cbc/out/",
         "--password",
         "password",
         "--strip-components",
-        &components_count(concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/zstd_camellia_cbc/in/"
-        ))
-        .to_string(),
+        &components_count("zstd_camellia_cbc/in/").to_string(),
     ]))
     .unwrap();
 
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/zstd_camellia_cbc/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/zstd_camellia_cbc/out/"),
-    )
-    .unwrap();
+    diff("zstd_camellia_cbc/in/", "zstd_camellia_cbc/out/").unwrap();
 }

--- a/cli/tests/cli/extract/chroot.rs
+++ b/cli/tests/cli/extract/chroot.rs
@@ -9,44 +9,30 @@ fn archive_extract_chroot() {
         return;
     }
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/extract_chroot/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "extract_chroot/in/").unwrap();
 
     let mut cmd = assert_cmd::Command::cargo_bin("pna").unwrap();
     cmd.args([
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/extract_chroot/extract_chroot.pna"
-        ),
+        "extract_chroot/extract_chroot.pna",
         "--overwrite",
         "-C",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/extract_chroot/in/"),
+        "extract_chroot/in/",
         ".",
     ]);
     cmd.assert().success();
 
-    assert!(fs::exists(concat!(
-        env!("CARGO_TARGET_TMPDIR"),
-        "/extract_chroot/extract_chroot.pna"
-    ))
-    .unwrap());
+    assert!(fs::exists("extract_chroot/extract_chroot.pna").unwrap());
 
     let mut cmd = assert_cmd::Command::cargo_bin("pna").unwrap();
     cmd.args([
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/extract_chroot/extract_chroot.pna"
-        ),
+        "extract_chroot/extract_chroot.pna",
         "--overwrite",
         "-C",
-        env!("CARGO_TARGET_TMPDIR"),
+        ".",
         "--chroot",
         "--out-dir",
         "/extract_chroot/out/",
@@ -54,9 +40,5 @@ fn archive_extract_chroot() {
     cmd.assert().success();
 
     // check completely extracted
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/extract_chroot/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/extract_chroot/out/"),
-    )
-    .unwrap();
+    diff("extract_chroot/in/", "extract_chroot/out/").unwrap();
 }

--- a/cli/tests/cli/keep_acl.rs
+++ b/cli/tests/cli/keep_acl.rs
@@ -6,18 +6,14 @@ use portable_network_archive::{cli, command};
 #[test]
 fn archive_keep_acl() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/keep_acl/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "keep_acl/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/keep_acl/keep_acl.pna"),
+        "keep_acl/keep_acl.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/keep_acl/in/"),
+        "keep_acl/in/",
         "--keep-acl",
         "--unstable",
     ]))
@@ -26,20 +22,16 @@ fn archive_keep_acl() {
         "pna",
         "--quiet",
         "x",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/keep_acl/keep_acl.pna"),
+        "keep_acl/keep_acl.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/keep_acl/out/"),
+        "keep_acl/out/",
         "--keep-acl",
         "--unstable",
         "--strip-components",
-        &components_count(concat!(env!("CARGO_TARGET_TMPDIR"), "/keep_acl/in/")).to_string(),
+        &components_count("keep_acl/in/").to_string(),
     ]))
     .unwrap();
 
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/keep_acl/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/keep_acl/out/"),
-    )
-    .unwrap();
+    diff("keep_acl/in/", "keep_acl/out/").unwrap();
 }

--- a/cli/tests/cli/keep_all.rs
+++ b/cli/tests/cli/keep_all.rs
@@ -6,21 +6,14 @@ use std::fs;
 #[test]
 fn archive_keep_all() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_keep_all/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "archive_keep_all/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_keep_all/keep_all.pna"
-        ),
+        "archive_keep_all/keep_all.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_keep_all/in/"),
+        "archive_keep_all/in/",
         #[cfg(not(target_os = "netbsd"))]
         "--keep-xattr",
         "--keep-timestamp",
@@ -29,40 +22,25 @@ fn archive_keep_all() {
         "--unstable",
     ]))
     .unwrap();
-    assert!(fs::exists(concat!(
-        env!("CARGO_TARGET_TMPDIR"),
-        "/archive_keep_all/keep_all.pna"
-    ))
-    .unwrap());
+    assert!(fs::exists("archive_keep_all/keep_all.pna").unwrap());
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_keep_all/keep_all.pna"
-        ),
+        "archive_keep_all/keep_all.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_keep_all/out/"),
+        "archive_keep_all/out/",
         #[cfg(not(target_os = "netbsd"))]
         "--keep-xattr",
         "--keep-timestamp",
         "--keep-permission",
         "--strip-components",
-        &components_count(concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_keep_all/in/"
-        ))
-        .to_string(),
+        &components_count("archive_keep_all/in/").to_string(),
         #[cfg(windows)]
         "--unstable",
     ]))
     .unwrap();
 
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_keep_all/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_keep_all/out/"),
-    )
-    .unwrap();
+    diff("archive_keep_all/in/", "archive_keep_all/out/").unwrap();
 }

--- a/cli/tests/cli/list.rs
+++ b/cli/tests/cli/list.rs
@@ -5,46 +5,37 @@ use portable_network_archive::{cli, command};
 #[test]
 fn archive_list() {
     setup();
-    TestResources::extract_in("raw/", concat!(env!("CARGO_TARGET_TMPDIR"), "/list/in/")).unwrap();
+    TestResources::extract_in("raw/", "list/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/list/list.pna"),
+        "list/list.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/list/in/"),
+        "list/in/",
     ]))
     .unwrap();
-    command::entry(cli::Cli::parse_from([
-        "pna",
-        "list",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/list/list.pna"),
-    ]))
-    .unwrap();
+    command::entry(cli::Cli::parse_from(["pna", "list", "list/list.pna"])).unwrap();
 }
 
 #[test]
 fn archive_list_solid() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/list_solid/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "list_solid/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/list_solid/list_solid.pna"),
+        "list_solid/list_solid.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/list_solid/in/"),
+        "list_solid/in/",
         "--solid",
     ]))
     .unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "list",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/list_solid/list_solid.pna"),
+        "list_solid/list_solid.pna",
         "--solid",
     ]))
     .unwrap();
@@ -53,18 +44,14 @@ fn archive_list_solid() {
 #[test]
 fn archive_list_detail() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/list_detail/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "list_detail/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/list_detail/list_detail.pna"),
+        "list_detail/list_detail.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/list_detail/in/"),
+        "list_detail/in/",
         #[cfg(not(target_os = "netbsd"))]
         "--keep-xattr",
         "--keep-timestamp",
@@ -83,7 +70,7 @@ fn archive_list_detail() {
         "pna",
         "list",
         "-l",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/list_detail/list_detail.pna"),
+        "list_detail/list_detail.pna",
         "--password",
         "password",
     ]))
@@ -93,21 +80,14 @@ fn archive_list_detail() {
 #[test]
 fn archive_list_solid_detail() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/list_solid_detail/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "list_solid_detail/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/list_solid_detail/list_solid_detail.pna"
-        ),
+        "list_solid_detail/list_solid_detail.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/list_solid_detail/in/"),
+        "list_solid_detail/in/",
         "--solid",
         #[cfg(not(target_os = "netbsd"))]
         "--keep-xattr",
@@ -126,10 +106,7 @@ fn archive_list_solid_detail() {
         "pna",
         "list",
         "-l",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/list_solid_detail/list_solid_detail.pna"
-        ),
+        "list_solid_detail/list_solid_detail.pna",
         "--solid",
         "--password",
         "password",
@@ -140,18 +117,14 @@ fn archive_list_solid_detail() {
 #[test]
 fn archive_list_jsonl() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/list_jsonl/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "list_jsonl/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/list_jsonl/list_jsonl.pna"),
+        "list_jsonl/list_jsonl.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/list_jsonl/in/"),
+        "list_jsonl/in/",
         #[cfg(not(target_os = "netbsd"))]
         "--keep-xattr",
         "--keep-timestamp",
@@ -173,7 +146,7 @@ fn archive_list_jsonl() {
         "-l",
         "--format",
         "jsonl",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/list_jsonl/list_jsonl.pna"),
+        "list_jsonl/list_jsonl.pna",
         "--password",
         "password",
         "--unstable",
@@ -184,21 +157,14 @@ fn archive_list_jsonl() {
 #[test]
 fn archive_list_solid_jsonl() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/list_solid_jsonl/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "list_solid_jsonl/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/list_solid_jsonl/list_solid_jsonl.pna"
-        ),
+        "list_solid_jsonl/list_solid_jsonl.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/list_solid_jsonl/in/"),
+        "list_solid_jsonl/in/",
         "--solid",
         #[cfg(not(target_os = "netbsd"))]
         "--keep-xattr",
@@ -221,10 +187,7 @@ fn archive_list_solid_jsonl() {
         "-l",
         "--format",
         "jsonl",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/list_solid_jsonl/list_solid_jsonl.pna"
-        ),
+        "list_solid_jsonl/list_solid_jsonl.pna",
         "--solid",
         "--password",
         "password",
@@ -236,18 +199,14 @@ fn archive_list_solid_jsonl() {
 #[test]
 fn archive_list_tree() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/list_tree/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "list_tree/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/list_tree/list_tree.pna"),
+        "list_tree/list_tree.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/list_tree/in/"),
+        "list_tree/in/",
         #[cfg(not(target_os = "netbsd"))]
         "--keep-xattr",
         "--keep-timestamp",
@@ -269,7 +228,7 @@ fn archive_list_tree() {
         "-l",
         "--format",
         "tree",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/list_tree/list_tree.pna"),
+        "list_tree/list_tree.pna",
         "--password",
         "password",
         "--unstable",
@@ -280,21 +239,14 @@ fn archive_list_tree() {
 #[test]
 fn archive_list_solid_tree() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/list_solid_tree/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "list_solid_tree/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/list_solid_tree/list_solid_tree.pna"
-        ),
+        "list_solid_tree/list_solid_tree.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/list_solid_tree/in/"),
+        "list_solid_tree/in/",
         "--solid",
         #[cfg(not(target_os = "netbsd"))]
         "--keep-xattr",
@@ -317,10 +269,7 @@ fn archive_list_solid_tree() {
         "-l",
         "--format",
         "tree",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/list_solid_tree/list_solid_tree.pna"
-        ),
+        "list_solid_tree/list_solid_tree.pna",
         "--solid",
         "--password",
         "password",

--- a/cli/tests/cli/restore_acl_0_19_1.rs
+++ b/cli/tests/cli/restore_acl_0_19_1.rs
@@ -7,15 +7,15 @@ use portable_network_archive::{cli, command};
 #[test]
 fn extract_windows_acl() {
     setup();
-    TestResources::extract_in("0.19.1/windows_acl.pna", env!("CARGO_TARGET_TMPDIR")).unwrap();
+    TestResources::extract_in("0.19.1/windows_acl.pna", ".").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "x",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/0.19.1/windows_acl.pna"),
+        "0.19.1/windows_acl.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/0.19.1/windows_acl/out/"),
+        "0.19.1/windows_acl/out/",
         "--keep-acl",
         "--unstable",
     ]))
@@ -25,15 +25,15 @@ fn extract_windows_acl() {
 #[test]
 fn extract_linux_acl() {
     setup();
-    TestResources::extract_in("0.19.1/linux_acl.pna", env!("CARGO_TARGET_TMPDIR")).unwrap();
+    TestResources::extract_in("0.19.1/linux_acl.pna", ".").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "x",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/0.19.1/linux_acl.pna"),
+        "0.19.1/linux_acl.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/0.19.1/linux_acl/out/"),
+        "0.19.1/linux_acl/out/",
         "--keep-acl",
         "--unstable",
     ]))
@@ -43,15 +43,15 @@ fn extract_linux_acl() {
 #[test]
 fn extract_macos_acl() {
     setup();
-    TestResources::extract_in("0.19.1/macos_acl.pna", env!("CARGO_TARGET_TMPDIR")).unwrap();
+    TestResources::extract_in("0.19.1/macos_acl.pna", ".").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "x",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/0.19.1/macos_acl.pna"),
+        "0.19.1/macos_acl.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/0.19.1/macos_acl/out/"),
+        "0.19.1/macos_acl/out/",
         "--keep-acl",
         "--unstable",
     ]))
@@ -61,15 +61,15 @@ fn extract_macos_acl() {
 #[test]
 fn extract_freebsd_acl() {
     setup();
-    TestResources::extract_in("0.19.1/freebsd_acl.pna", env!("CARGO_TARGET_TMPDIR")).unwrap();
+    TestResources::extract_in("0.19.1/freebsd_acl.pna", ".").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "x",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/0.19.1/freebsd_acl.pna"),
+        "0.19.1/freebsd_acl.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/0.19.1/freebsd_acl/out/"),
+        "0.19.1/freebsd_acl/out/",
         "--keep-acl",
         "--unstable",
     ]))

--- a/cli/tests/cli/solid_mode.rs
+++ b/cli/tests/cli/solid_mode.rs
@@ -5,19 +5,15 @@ use portable_network_archive::{cli, command};
 #[test]
 fn solid_store_archive() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_store/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "solid_store/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_store/solid_store.pna"),
+        "solid_store/solid_store.pna",
         "--store",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_store/in/"),
+        "solid_store/in/",
         "--solid",
     ]))
     .unwrap();
@@ -25,37 +21,29 @@ fn solid_store_archive() {
         "pna",
         "--quiet",
         "x",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_store/solid_store.pna"),
+        "solid_store/solid_store.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_store/out/"),
+        "solid_store/out/",
         "--strip-components",
-        &components_count(concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_store/out/")).to_string(),
+        &components_count("solid_store/out/").to_string(),
     ]))
     .unwrap();
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_store/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_store/out/"),
-    )
-    .unwrap();
+    diff("solid_store/in/", "solid_store/out/").unwrap();
 }
 
 #[test]
 fn solid_zstd_archive() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_zstd/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "solid_zstd/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_zstd/solid_zstd.pna"),
+        "solid_zstd/solid_zstd.pna",
         "--zstd",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_zstd/in/"),
+        "solid_zstd/in/",
         "--solid",
     ]))
     .unwrap();
@@ -63,38 +51,30 @@ fn solid_zstd_archive() {
         "pna",
         "--quiet",
         "x",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_zstd/solid_zstd.pna"),
+        "solid_zstd/solid_zstd.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_zstd/out/"),
+        "solid_zstd/out/",
         "--strip-components",
-        &components_count(concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_zstd/in/")).to_string(),
+        &components_count("solid_zstd/in/").to_string(),
     ]))
     .unwrap();
 
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_zstd/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_zstd/out/"),
-    )
-    .unwrap();
+    diff("solid_zstd/in/", "solid_zstd/out/").unwrap();
 }
 
 #[test]
 fn solid_xz_archive() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_xz/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "solid_xz/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_xz/solid_xz.pna"),
+        "solid_xz/solid_xz.pna",
         "--xz",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_xz/in/"),
+        "solid_xz/in/",
         "--solid",
     ]))
     .unwrap();
@@ -102,41 +82,30 @@ fn solid_xz_archive() {
         "pna",
         "--quiet",
         "x",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_xz/solid_xz.pna"),
+        "solid_xz/solid_xz.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_xz/out/"),
+        "solid_xz/out/",
         "--strip-components",
-        &components_count(concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_xz/in/")).to_string(),
+        &components_count("solid_xz/in/").to_string(),
     ]))
     .unwrap();
 
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_xz/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_xz/out/"),
-    )
-    .unwrap();
+    diff("solid_xz/in/", "solid_xz/out/").unwrap();
 }
 
 #[test]
 fn solid_deflate_archive() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_deflate/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "solid_deflate/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/solid_deflate/solid_deflate.pna"
-        ),
+        "solid_deflate/solid_deflate.pna",
         "--deflate",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_deflate/in/"),
+        "solid_deflate/in/",
         "--solid",
     ]))
     .unwrap();
@@ -144,20 +113,13 @@ fn solid_deflate_archive() {
         "pna",
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/solid_deflate/solid_deflate.pna"
-        ),
+        "solid_deflate/solid_deflate.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_deflate/out/"),
+        "solid_deflate/out/",
         "--strip-components",
-        &components_count(concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_deflate/in/")).to_string(),
+        &components_count("solid_deflate/in/").to_string(),
     ]))
     .unwrap();
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_deflate/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/solid_deflate/out/"),
-    )
-    .unwrap();
+    diff("solid_deflate/in/", "solid_deflate/out/").unwrap();
 }

--- a/cli/tests/cli/split.rs
+++ b/cli/tests/cli/split.rs
@@ -6,40 +6,31 @@ use std::fs;
 #[test]
 fn split_archive() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/split_archive/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "split_archive/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "create",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/split_archive/split.pna"),
+        "split_archive/split.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/split_archive/in/"),
+        "split_archive/in/",
     ]))
     .unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "split",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/split_archive/split.pna"),
+        "split_archive/split.pna",
         "--overwrite",
         "--max-size",
         "100kb",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/split_archive/split/"),
+        "split_archive/split/",
     ]))
     .unwrap();
 
     // check split file size
-    for entry in fs::read_dir(concat!(
-        env!("CARGO_TARGET_TMPDIR"),
-        "/split_archive/split/"
-    ))
-    .unwrap()
-    {
+    for entry in fs::read_dir("split_archive/split/").unwrap() {
         assert!(fs::metadata(entry.unwrap().path()).unwrap().len() <= 100 * 1000);
     }
 
@@ -47,22 +38,15 @@ fn split_archive() {
         "pna",
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/split_archive/split/split.part1.pna"
-        ),
+        "split_archive/split/split.part1.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/split_archive/out/"),
+        "split_archive/out/",
         "--strip-components",
-        &components_count(concat!(env!("CARGO_TARGET_TMPDIR"), "/split_archive/in/")).to_string(),
+        &components_count("split_archive/in/").to_string(),
     ]))
     .unwrap();
 
     // check completely extracted
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/split_archive/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/split_archive/out/"),
-    )
-    .unwrap();
+    diff("split_archive/in/", "split_archive/out/").unwrap();
 }

--- a/cli/tests/cli/strip.rs
+++ b/cli/tests/cli/strip.rs
@@ -5,21 +5,14 @@ use portable_network_archive::{cli, command};
 #[test]
 fn archive_strip_metadata() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_strip_metadata/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "archive_strip_metadata/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_strip_metadata/strip_metadata.pna"
-        ),
+        "archive_strip_metadata/strip_metadata.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_strip_metadata/in/"),
+        "archive_strip_metadata/in/",
         #[cfg(not(target_os = "netbsd"))]
         "--keep-xattr",
         "--keep-timestamp",
@@ -32,10 +25,7 @@ fn archive_strip_metadata() {
         "pna",
         "--quiet",
         "strip",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_strip_metadata/strip_metadata.pna"
-        ),
+        "archive_strip_metadata/strip_metadata.pna",
         "--keep-xattr",
         "--keep-timestamp",
         "--keep-permission",
@@ -47,31 +37,20 @@ fn archive_strip_metadata() {
         "pna",
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_strip_metadata/strip_metadata.pna"
-        ),
+        "archive_strip_metadata/strip_metadata.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_strip_metadata/out/"),
+        "archive_strip_metadata/out/",
         #[cfg(not(target_os = "netbsd"))]
         "--keep-xattr",
         "--keep-timestamp",
         "--keep-permission",
         "--strip-components",
-        &components_count(concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_strip_metadata/in/"
-        ))
-        .to_string(),
+        &components_count("archive_strip_metadata/in/").to_string(),
         #[cfg(windows)]
         "--unstable",
     ]))
     .unwrap();
 
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_strip_metadata/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_strip_metadata/out/"),
-    )
-    .unwrap();
+    diff("archive_strip_metadata/in/", "archive_strip_metadata/out/").unwrap();
 }

--- a/cli/tests/cli/update.rs
+++ b/cli/tests/cli/update.rs
@@ -10,27 +10,14 @@ const DURATION_24_HOURS: time::Duration = time::Duration::from_secs(24 * 60 * 60
 #[test]
 fn archive_update_newer_mtime() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime/in/"
-        ),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "archive_update_newer_mtime/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime/update_newer_mtime.pna"
-        ),
+        "archive_update_newer_mtime/update_newer_mtime.pna",
         "--overwrite",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime/in/"
-        ),
+        "archive_update_newer_mtime/in/",
         "--keep-timestamp",
     ]))
     .unwrap();
@@ -38,10 +25,7 @@ fn archive_update_newer_mtime() {
     let mut file = fs::File::options()
         .write(true)
         .truncate(true)
-        .open(concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime/in/raw/empty.txt"
-        ))
+        .open("archive_update_newer_mtime/in/raw/empty.txt")
         .unwrap();
     file.write_all(b"this is updated, but mtime older than now, so this should empty")
         .unwrap();
@@ -51,10 +35,7 @@ fn archive_update_newer_mtime() {
     let mut file = fs::File::options()
         .write(true)
         .truncate(true)
-        .open(concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime/in/raw/text.txt"
-        ))
+        .open("archive_update_newer_mtime/in/raw/text.txt")
         .unwrap();
     file.write_all(b"updated!").unwrap();
     file.set_modified(time::SystemTime::now() + DURATION_24_HOURS)
@@ -66,61 +47,32 @@ fn archive_update_newer_mtime() {
         "experimental",
         "update",
         "--newer-mtime",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime/update_newer_mtime.pna"
-        ),
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime/in/"
-        ),
+        "archive_update_newer_mtime/update_newer_mtime.pna",
+        "archive_update_newer_mtime/in/",
         "--keep-timestamp",
     ]))
     .unwrap();
 
     // restore original empty.txt
-    TestResources::extract_in(
-        "raw/empty.txt",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime/in/"
-        ),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/empty.txt", "archive_update_newer_mtime/in/").unwrap();
 
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime/update_newer_mtime.pna"
-        ),
+        "archive_update_newer_mtime/update_newer_mtime.pna",
         "--overwrite",
         "--out-dir",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime/out/"
-        ),
+        "archive_update_newer_mtime/out/",
         "--keep-timestamp",
         "--strip-components",
-        &components_count(concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime/in/"
-        ))
-        .to_string(),
+        &components_count("archive_update_newer_mtime/in/").to_string(),
     ]))
     .unwrap();
 
     diff(
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime/in/"
-        ),
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime/out/"
-        ),
+        "archive_update_newer_mtime/in/",
+        "archive_update_newer_mtime/out/",
     )
     .unwrap();
 }
@@ -128,35 +80,15 @@ fn archive_update_newer_mtime() {
 #[test]
 fn archive_update_older_mtime() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_older_mtime/in/"
-        ),
-    )
-    .unwrap();
-    TestResources::extract_in(
-        "raw/",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_older_mtime/in/"
-        ),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "archive_update_older_mtime/in/").unwrap();
+    TestResources::extract_in("raw/", "archive_update_older_mtime/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_older_mtime/update_older_mtime.pna"
-        ),
+        "archive_update_older_mtime/update_older_mtime.pna",
         "--overwrite",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_older_mtime/in/"
-        ),
+        "archive_update_older_mtime/in/",
         "--keep-timestamp",
     ]))
     .unwrap();
@@ -164,10 +96,7 @@ fn archive_update_older_mtime() {
     let mut file = fs::File::options()
         .write(true)
         .truncate(true)
-        .open(concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_older_mtime/in/raw/empty.txt"
-        ))
+        .open("archive_update_older_mtime/in/raw/empty.txt")
         .unwrap();
     file.write_all(b"this is updated, but mtime newer than now, so this should empty")
         .unwrap();
@@ -177,10 +106,7 @@ fn archive_update_older_mtime() {
     let mut file = fs::File::options()
         .write(true)
         .truncate(true)
-        .open(concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_older_mtime/in/raw/text.txt"
-        ))
+        .open("archive_update_older_mtime/in/raw/text.txt")
         .unwrap();
     file.write_all(b"updated!").unwrap();
     file.set_modified(time::SystemTime::now() - DURATION_24_HOURS)
@@ -192,61 +118,32 @@ fn archive_update_older_mtime() {
         "experimental",
         "update",
         "--older-mtime",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_older_mtime/update_older_mtime.pna"
-        ),
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_older_mtime/in/"
-        ),
+        "archive_update_older_mtime/update_older_mtime.pna",
+        "archive_update_older_mtime/in/",
         "--keep-timestamp",
     ]))
     .unwrap();
 
     // restore original empty.txt
-    TestResources::extract_in(
-        "raw/empty.txt",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_older_mtime/in/"
-        ),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/empty.txt", "archive_update_older_mtime/in/").unwrap();
 
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_older_mtime/update_older_mtime.pna"
-        ),
+        "archive_update_older_mtime/update_older_mtime.pna",
         "--overwrite",
         "--out-dir",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_older_mtime/out/"
-        ),
+        "archive_update_older_mtime/out/",
         "--keep-timestamp",
         "--strip-components",
-        &components_count(concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_older_mtime/in/"
-        ))
-        .to_string(),
+        &components_count("archive_update_older_mtime/in/").to_string(),
     ]))
     .unwrap();
 
     diff(
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_older_mtime/in/"
-        ),
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_older_mtime/out/"
-        ),
+        "archive_update_older_mtime/in/",
+        "archive_update_older_mtime/out/",
     )
     .unwrap();
 }
@@ -254,30 +151,19 @@ fn archive_update_older_mtime() {
 #[test]
 fn archive_update_deletion() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_update_deletion/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "archive_update_deletion/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_deletion/update_deletion.pna"
-        ),
+        "archive_update_deletion/update_deletion.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_update_deletion/in/"),
+        "archive_update_deletion/in/",
         "--keep-timestamp",
     ]))
     .unwrap();
 
-    fs::remove_file(concat!(
-        env!("CARGO_TARGET_TMPDIR"),
-        "/archive_update_deletion/in/raw/empty.txt"
-    ))
-    .unwrap();
+    fs::remove_file("archive_update_deletion/in/raw/empty.txt").unwrap();
 
     command::entry(cli::Cli::parse_from([
         "pna",
@@ -285,11 +171,8 @@ fn archive_update_deletion() {
         "experimental",
         "update",
         "--newer-mtime",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_deletion/update_deletion.pna"
-        ),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_update_deletion/in/"),
+        "archive_update_deletion/update_deletion.pna",
+        "archive_update_deletion/in/",
         "--keep-timestamp",
     ]))
     .unwrap();
@@ -298,33 +181,22 @@ fn archive_update_deletion() {
         "pna",
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_deletion/update_deletion.pna"
-        ),
+        "archive_update_deletion/update_deletion.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_update_deletion/out/"),
+        "archive_update_deletion/out/",
         "--keep-timestamp",
         "--strip-components",
-        &components_count(concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_deletion/in/"
-        ))
-        .to_string(),
+        &components_count("archive_update_deletion/in/").to_string(),
     ]))
     .unwrap();
 
     // restore original empty.txt
-    TestResources::extract_in(
-        "raw/empty.txt",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_update_deletion/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/empty.txt", "archive_update_deletion/in/").unwrap();
 
     diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_update_deletion/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_update_deletion/out/"),
+        "archive_update_deletion/in/",
+        "archive_update_deletion/out/",
     )
     .unwrap();
 }

--- a/cli/tests/cli/update/exclude.rs
+++ b/cli/tests/cli/update/exclude.rs
@@ -7,27 +7,14 @@ use std::{fs, io::prelude::*, time};
 #[test]
 fn archive_update_newer_mtime_with_exclude() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime_with_exclude/in/"
-        ),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "archive_update_newer_mtime_with_exclude/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime_with_exclude/update_newer_mtime.pna"
-        ),
+        "archive_update_newer_mtime_with_exclude/update_newer_mtime.pna",
         "--overwrite",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime_with_exclude/in/"
-        ),
+        "archive_update_newer_mtime_with_exclude/in/",
         "--keep-timestamp",
     ]))
     .unwrap();
@@ -35,10 +22,7 @@ fn archive_update_newer_mtime_with_exclude() {
     let mut file = fs::File::options()
         .write(true)
         .truncate(true)
-        .open(concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime_with_exclude/in/raw/empty.txt"
-        ))
+        .open("archive_update_newer_mtime_with_exclude/in/raw/empty.txt")
         .unwrap();
     file.write_all(b"this is updated, but this is excluded, so this should empty")
         .unwrap();
@@ -48,10 +32,7 @@ fn archive_update_newer_mtime_with_exclude() {
     let mut file = fs::File::options()
         .write(true)
         .truncate(true)
-        .open(concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime_with_exclude/in/raw/text.txt"
-        ))
+        .open("archive_update_newer_mtime_with_exclude/in/raw/text.txt")
         .unwrap();
     file.write_all(b"updated!").unwrap();
     file.set_modified(time::SystemTime::now() + DURATION_24_HOURS)
@@ -63,20 +44,11 @@ fn archive_update_newer_mtime_with_exclude() {
         "experimental",
         "update",
         "--newer-mtime",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime_with_exclude/update_newer_mtime.pna"
-        ),
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime_with_exclude/in/"
-        ),
+        "archive_update_newer_mtime_with_exclude/update_newer_mtime.pna",
+        "archive_update_newer_mtime_with_exclude/in/",
         "--keep-timestamp",
         "--exclude",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime_with_exclude/in/raw/empty.txt"
-        ),
+        "archive_update_newer_mtime_with_exclude/in/raw/empty.txt",
         "--unstable",
     ]))
     .unwrap();
@@ -84,10 +56,7 @@ fn archive_update_newer_mtime_with_exclude() {
     // restore original empty.txt
     TestResources::extract_in(
         "raw/empty.txt",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime_with_exclude/in/"
-        ),
+        "archive_update_newer_mtime_with_exclude/in/",
     )
     .unwrap();
 
@@ -95,35 +64,19 @@ fn archive_update_newer_mtime_with_exclude() {
         "pna",
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime_with_exclude/update_newer_mtime.pna"
-        ),
+        "archive_update_newer_mtime_with_exclude/update_newer_mtime.pna",
         "--overwrite",
         "--out-dir",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime_with_exclude/out/"
-        ),
+        "archive_update_newer_mtime_with_exclude/out/",
         "--keep-timestamp",
         "--strip-components",
-        &components_count(concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime_with_exclude/in/"
-        ))
-        .to_string(),
+        &components_count("archive_update_newer_mtime_with_exclude/in/").to_string(),
     ]))
     .unwrap();
 
     diff(
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime_with_exclude/in/"
-        ),
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_update_newer_mtime_with_exclude/out/"
-        ),
+        "archive_update_newer_mtime_with_exclude/in/",
+        "archive_update_newer_mtime_with_exclude/out/",
     )
     .unwrap();
 }

--- a/cli/tests/cli/user_group.rs
+++ b/cli/tests/cli/user_group.rs
@@ -6,27 +6,14 @@ use portable_network_archive::{cli, command};
 #[test]
 fn archive_create_uname_gname() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_create_uname_gname/in/"
-        ),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "archive_create_uname_gname/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_create_uname_gname/create_uname_gname.pna"
-        ),
+        "archive_create_uname_gname/create_uname_gname.pna",
         "--overwrite",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_create_uname_gname/in/"
-        ),
+        "archive_create_uname_gname/in/",
         "--keep-permission",
         "--uname",
         "test_user",
@@ -38,45 +25,26 @@ fn archive_create_uname_gname() {
         "pna",
         "ls",
         "-lh",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_create_uname_gname/create_uname_gname.pna"
-        ),
+        "archive_create_uname_gname/create_uname_gname.pna",
     ]))
     .unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_create_uname_gname/create_uname_gname.pna"
-        ),
+        "archive_create_uname_gname/create_uname_gname.pna",
         "--overwrite",
         "--out-dir",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_create_uname_gname/out/"
-        ),
+        "archive_create_uname_gname/out/",
         "--keep-permission",
         "--strip-components",
-        &components_count(concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_create_uname_gname/in/"
-        ))
-        .to_string(),
+        &components_count("archive_create_uname_gname/in/").to_string(),
     ]))
     .unwrap();
 
     diff(
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_create_uname_gname/in/"
-        ),
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_create_uname_gname/out/"
-        ),
+        "archive_create_uname_gname/in/",
+        "archive_create_uname_gname/out/",
     )
     .unwrap();
 }
@@ -84,21 +52,14 @@ fn archive_create_uname_gname() {
 #[test]
 fn archive_create_uid_gid() {
     setup();
-    TestResources::extract_in(
-        "raw/",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_create_uid_gid/in/"),
-    )
-    .unwrap();
+    TestResources::extract_in("raw/", "archive_create_uid_gid/in/").unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "c",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_create_uid_gid/create_uid_gid.pna"
-        ),
+        "archive_create_uid_gid/create_uid_gid.pna",
         "--overwrite",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_create_uid_gid/in/"),
+        "archive_create_uid_gid/in/",
         "--keep-permission",
         "--uid",
         "0",
@@ -111,36 +72,22 @@ fn archive_create_uid_gid() {
         "ls",
         "-lh",
         "--numeric-owner",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_create_uid_gid/create_uid_gid.pna"
-        ),
+        "archive_create_uid_gid/create_uid_gid.pna",
     ]))
     .unwrap();
     command::entry(cli::Cli::parse_from([
         "pna",
         "--quiet",
         "x",
-        concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_create_uid_gid/create_uid_gid.pna"
-        ),
+        "archive_create_uid_gid/create_uid_gid.pna",
         "--overwrite",
         "--out-dir",
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_create_uid_gid/out/"),
+        "archive_create_uid_gid/out/",
         "--keep-permission",
         "--strip-components",
-        &components_count(concat!(
-            env!("CARGO_TARGET_TMPDIR"),
-            "/archive_create_uid_gid/in/"
-        ))
-        .to_string(),
+        &components_count("archive_create_uid_gid/in/").to_string(),
     ]))
     .unwrap();
 
-    diff(
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_create_uid_gid/in/"),
-        concat!(env!("CARGO_TARGET_TMPDIR"), "/archive_create_uid_gid/out/"),
-    )
-    .unwrap();
+    diff("archive_create_uid_gid/in/", "archive_create_uid_gid/out/").unwrap();
 }


### PR DESCRIPTION
Unifies the coding style of test cases under cli/tests/cli/ by removing direct usage of env!("CARGO_TARGET_TMPDIR").

Affected test files now consistently use the utils::setup() function to establish a temporary working directory and utilize relative paths for test assets. This change makes the test setup more uniform and relies on the centralized setup logic in utils::setup().

No changes were made to utils::setup() itself. The refactoring was applied to 20 test files that previously had direct invocations of env!("CARGO_TARGET_TMPDIR").

All tests pass after this refactoring.