### PR TITLE
:truck: Reorder EntryName::from_path_lossy for logical grouping

### DIFF
--- a/lib/src/entry/name.rs
+++ b/lib/src/entry/name.rs
@@ -46,18 +46,6 @@ impl EntryName {
         Ok(Self::new_from_utf8path(Utf8Path::new(name)))
     }
 
-    fn from_path_lossy(p: &Path) -> Self {
-        let p = normalize_path(p);
-        let iter = p.components().filter_map(|c| match c {
-            Component::Prefix(_)
-            | Component::RootDir
-            | Component::CurDir
-            | Component::ParentDir => None,
-            Component::Normal(p) => Some(p.to_string_lossy()),
-        });
-        Self(join_with_capacity(iter, "/", p.as_os_str().len()))
-    }
-
     /// Create an [`EntryName`] from a struct impl <code>[Into]<[PathBuf]></code>.
     ///
     /// Any non-Unicode sequences are replaced with
@@ -78,6 +66,18 @@ impl EntryName {
     #[inline]
     pub fn from_lossy<T: Into<PathBuf>>(p: T) -> Self {
         Self::from_path_lossy(&p.into())
+    }
+
+    fn from_path_lossy(p: &Path) -> Self {
+        let p = normalize_path(p);
+        let iter = p.components().filter_map(|c| match c {
+            Component::Prefix(_)
+            | Component::RootDir
+            | Component::CurDir
+            | Component::ParentDir => None,
+            Component::Normal(p) => Some(p.to_string_lossy()),
+        });
+        Self(join_with_capacity(iter, "/", p.as_os_str().len()))
     }
 
     #[inline]


### PR DESCRIPTION
Moved the private `from_path_lossy` method below the public `from_lossy` constructor to group related methods together and improve code readability.