### PR TITLE
:shirt: Reformat rustdoc headings for consistency

### DIFF
--- a/lib/src/entry/name.rs
+++ b/lib/src/entry/name.rs
@@ -9,7 +9,8 @@ use std::str::{self, Utf8Error};
 
 /// A UTF-8 encoded entry name.
 ///
-/// ## Examples
+/// # Examples
+///
 /// ```
 /// use libpna::EntryName;
 ///
@@ -166,7 +167,8 @@ impl From<&str> for EntryName {
 }
 
 impl From<Cow<'_, str>> for EntryName {
-    /// ## Examples
+    /// # Examples
+    ///
     /// ```
     /// use libpna::EntryName;
     /// use std::borrow::Cow;
@@ -225,7 +227,7 @@ impl TryFrom<Cow<'_, OsStr>> for EntryName {
 impl TryFrom<&Path> for EntryName {
     type Error = EntryNameError;
 
-    /// ## Examples
+    /// # Examples
     ///
     /// ```
     /// use libpna::EntryName;
@@ -243,7 +245,7 @@ impl TryFrom<&Path> for EntryName {
 impl TryFrom<PathBuf> for EntryName {
     type Error = EntryNameError;
 
-    /// ## Examples
+    /// # Examples
     ///
     /// ```
     /// use libpna::EntryName;
@@ -261,7 +263,7 @@ impl TryFrom<PathBuf> for EntryName {
 impl TryFrom<&PathBuf> for EntryName {
     type Error = EntryNameError;
 
-    /// ## Examples
+    /// # Examples
     ///
     /// ```
     /// use libpna::EntryName;
@@ -279,7 +281,7 @@ impl TryFrom<&PathBuf> for EntryName {
 impl TryFrom<Cow<'_, Path>> for EntryName {
     type Error = EntryNameError;
 
-    /// ## Examples
+    /// # Examples
     ///
     /// ```
     /// use libpna::EntryName;

--- a/lib/src/entry/reference.rs
+++ b/lib/src/entry/reference.rs
@@ -9,7 +9,8 @@ use std::str::{self, Utf8Error};
 
 /// A UTF-8 encoded entry reference.
 ///
-/// ## Examples
+/// # Examples
+///
 /// ```
 /// use libpna::EntryReference;
 ///
@@ -101,7 +102,7 @@ impl EntryReference {
 
     /// Extracts a string slice containing the entire [EntryReference].
     ///
-    /// ## Examples
+    /// # Examples
     ///
     /// ```
     /// use libpna::EntryReference;
@@ -163,7 +164,8 @@ impl From<&String> for EntryReference {
 }
 
 impl From<&str> for EntryReference {
-    /// ## Examples
+    /// # Examples
+    ///
     /// ```
     /// use libpna::EntryReference;
     ///
@@ -176,7 +178,8 @@ impl From<&str> for EntryReference {
 }
 
 impl From<Cow<'_, str>> for EntryReference {
-    /// ## Examples
+    /// # Examples
+    ///
     /// ```
     /// use libpna::EntryReference;
     /// use std::borrow::Cow;
@@ -235,7 +238,7 @@ impl TryFrom<Cow<'_, OsStr>> for EntryReference {
 impl TryFrom<&Path> for EntryReference {
     type Error = EntryReferenceError;
 
-    /// ## Examples
+    /// # Examples
     ///
     /// ```
     /// use libpna::EntryReference;
@@ -253,7 +256,7 @@ impl TryFrom<&Path> for EntryReference {
 impl TryFrom<PathBuf> for EntryReference {
     type Error = EntryReferenceError;
 
-    /// ## Examples
+    /// # Examples
     ///
     /// ```
     /// use libpna::EntryReference;
@@ -271,7 +274,7 @@ impl TryFrom<PathBuf> for EntryReference {
 impl TryFrom<&PathBuf> for EntryReference {
     type Error = EntryReferenceError;
 
-    /// ## Examples
+    /// # Examples
     ///
     /// ```
     /// use libpna::EntryReference;
@@ -289,7 +292,7 @@ impl TryFrom<&PathBuf> for EntryReference {
 impl TryFrom<Cow<'_, Path>> for EntryReference {
     type Error = EntryReferenceError;
 
-    /// ## Examples
+    /// # Examples
     ///
     /// ```
     /// use libpna::EntryReference;


### PR DESCRIPTION
Replaced all `## Examples` headings with `# Examples` in doc comments to match Rustdoc conventions and improve rendered documentation formatting.