### PR TITLE
Optimize imports in CLI test files

### DIFF
--- a/cli/tests/cli/acl.rs
+++ b/cli/tests/cli/acl.rs
@@ -5,22 +5,24 @@ mod restore;
 
 use crate::utils::{components_count, diff::diff, setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 
 #[test]
 fn archive_acl_get_set() {
     setup();
     TestResources::extract_in("raw/", "acl_get_set/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
         "acl_get_set/acl_get_set.pna",
         "--overwrite",
         "acl_get_set/in/",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "experimental",
@@ -30,9 +32,11 @@ fn archive_acl_get_set() {
         "acl_get_set/in/raw/text.txt",
         "-m",
         "u:test:r,w,x",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "experimental",
@@ -42,9 +46,11 @@ fn archive_acl_get_set() {
         "acl_get_set/in/raw/text.txt",
         "-m",
         "g:test_group:r,w,x",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "experimental",
@@ -54,9 +60,11 @@ fn archive_acl_get_set() {
         "acl_get_set/in/raw/text.txt",
         "-x",
         "g:test_group",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "experimental",
@@ -64,9 +72,11 @@ fn archive_acl_get_set() {
         "get",
         "acl_get_set/acl_get_set.pna",
         "acl_get_set/in/raw/text.txt",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -76,7 +86,9 @@ fn archive_acl_get_set() {
         "acl_get_set/out/",
         "--strip-components",
         &components_count("acl_get_set/in/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff("acl_get_set/in/", "acl_get_set/out/").unwrap();

--- a/cli/tests/cli/append.rs
+++ b/cli/tests/cli/append.rs
@@ -2,36 +2,40 @@ mod exclude;
 
 use crate::utils::{components_count, diff::diff, setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 
 #[test]
 fn archive_append() {
     setup();
     TestResources::extract_in("raw/", "archive_append/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
         "archive_append/append.pna",
         "--overwrite",
         "archive_append/in/",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     // Copy extra input
     TestResources::extract_in("store.pna", "archive_append/in/").unwrap();
     TestResources::extract_in("zstd.pna", "archive_append/in/").unwrap();
 
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "append",
         "archive_append/append.pna",
         "archive_append/in/store.pna",
         "archive_append/in/zstd.pna",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -41,7 +45,9 @@ fn archive_append() {
         "archive_append/out/",
         "--strip-components",
         &components_count("archive_append/in/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
     // check completely extracted
     diff("archive_append/in/", "archive_append/out/").unwrap();
@@ -51,7 +57,7 @@ fn archive_append() {
 fn archive_append_split() {
     setup();
     TestResources::extract_in("raw/", "archive_append_split/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -60,23 +66,27 @@ fn archive_append_split() {
         "archive_append_split/in/",
         "--split",
         "100kib",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     // Copy extra input
     TestResources::extract_in("store.pna", "archive_append_split/in/").unwrap();
     TestResources::extract_in("zstd.pna", "archive_append_split/in/").unwrap();
 
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "append",
         "archive_append_split/append_split.part1.pna",
         "archive_append_split/in/store.pna",
         "archive_append_split/in/zstd.pna",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -86,7 +96,9 @@ fn archive_append_split() {
         "archive_append_split/out/",
         "--strip-components",
         &components_count("archive_append_split/out/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
     // check completely extracted
     diff("archive_append_split/in/", "archive_append_split/out/").unwrap();

--- a/cli/tests/cli/append/exclude.rs
+++ b/cli/tests/cli/append/exclude.rs
@@ -3,13 +3,13 @@ use crate::utils::{
     setup, TestResources,
 };
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 
 #[test]
 fn append_exclude() {
     setup();
     TestResources::extract_in("raw/", "append_exclude/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -19,14 +19,16 @@ fn append_exclude() {
         "--exclude",
         "*/extra/*",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     // Copy extra input
     TestResources::extract_in("store.pna", "append_exclude/in/extra/").unwrap();
     TestResources::extract_in("zstd.pna", "append_exclude/in/extra/").unwrap();
 
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "append",
@@ -35,9 +37,11 @@ fn append_exclude() {
         "--exclude",
         "*/z*.pna",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -47,7 +51,9 @@ fn append_exclude() {
         "append_exclude/out/",
         "--strip-components",
         "2",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
     // check completely extracted
     let result = diff("append_exclude/in/", "append_exclude/out/").unwrap();

--- a/cli/tests/cli/chmod.rs
+++ b/cli/tests/cli/chmod.rs
@@ -1,6 +1,6 @@
 use crate::utils::{diff::diff, setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 #[cfg(unix)]
 use std::fs;
 #[cfg(unix)]
@@ -14,7 +14,7 @@ fn archive_chmod() {
     #[cfg(unix)]
     fs::set_permissions("chmod/in/raw/text.txt", fs::Permissions::from_mode(0o777)).unwrap();
 
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -24,9 +24,11 @@ fn archive_chmod() {
         "--keep-permission",
         #[cfg(windows)]
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "experimental",
@@ -35,9 +37,11 @@ fn archive_chmod() {
         "--",
         "-x",
         "chmod/in/raw/text.txt",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -50,7 +54,9 @@ fn archive_chmod() {
         "--unstable",
         "--strip-components",
         "2",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
     #[cfg(unix)]
     {

--- a/cli/tests/cli/chown.rs
+++ b/cli/tests/cli/chown.rs
@@ -1,12 +1,12 @@
 use crate::utils::{setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 
 #[test]
 fn archive_chown() {
     setup();
     TestResources::extract_in("raw/", "chown/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -16,9 +16,11 @@ fn archive_chown() {
         "--keep-permission",
         #[cfg(windows)]
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "experimental",
@@ -26,6 +28,8 @@ fn archive_chown() {
         "chown/chown.pna",
         "user:group",
         "chown/in/raw/text.txt",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 }

--- a/cli/tests/cli/concat.rs
+++ b/cli/tests/cli/concat.rs
@@ -1,21 +1,23 @@
 use crate::utils::{components_count, diff::diff, setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 
 #[test]
 fn concat_archive() {
     setup();
     TestResources::extract_in("raw/", "concat_archive/in").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "create",
         "concat_archive/concat.pna",
         "--overwrite",
         "concat_archive/in",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "split",
@@ -23,18 +25,22 @@ fn concat_archive() {
         "--overwrite",
         "--max-size",
         "100kb",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "concat",
         "concat_archive/concatenated.pna",
         "concat_archive/concat.part1.pna",
         "--overwrite",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -44,7 +50,9 @@ fn concat_archive() {
         "concat_archive/out",
         "--strip-components",
         &components_count("concat_archive/in").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
     diff("concat_archive/in", "concat_archive/out").unwrap();
 }

--- a/cli/tests/cli/create/exclude.rs
+++ b/cli/tests/cli/create/exclude.rs
@@ -1,13 +1,13 @@
 use crate::utils::{self, diff::diff, setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 use std::fs;
 
 #[test]
 fn create_with_exclude() {
     setup();
     TestResources::extract_in("raw/", "create_with_exclude/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -17,11 +17,13 @@ fn create_with_exclude() {
         "--exclude",
         "**.txt",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
     assert!(fs::exists("create_with_exclude/create_with_exclude.pna").unwrap());
 
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -31,7 +33,9 @@ fn create_with_exclude() {
         "create_with_exclude/out/",
         "--strip-components",
         "2",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     // Remove files that are expected to be excluded from input for comparison

--- a/cli/tests/cli/create/no_recursive.rs
+++ b/cli/tests/cli/create/no_recursive.rs
@@ -1,13 +1,13 @@
 use crate::utils::{setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 use std::fs;
 
 #[test]
 fn no_recursive() {
     setup();
     TestResources::extract_in("raw/", "no_recursive/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -15,11 +15,13 @@ fn no_recursive() {
         "--overwrite",
         "--no-recursive",
         "no_recursive/in/",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
     assert!(fs::exists("no_recursive/no_recursive.pna").unwrap());
 
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -29,7 +31,9 @@ fn no_recursive() {
         "no_recursive/out/",
         "--strip-components",
         "2",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
     fs::create_dir_all("no_recursive/out/").unwrap();
     assert_eq!(fs::read_dir("no_recursive/out/").unwrap().count(), 0);

--- a/cli/tests/cli/create/password_from_file.rs
+++ b/cli/tests/cli/create/password_from_file.rs
@@ -1,6 +1,6 @@
 use crate::utils::{diff::diff, setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 use std::fs;
 
 #[test]
@@ -10,7 +10,7 @@ fn create_with_password_file() {
     let password_file_path = "create_with_password_file/password_file";
     let password = "create_with_password_file";
     fs::write(password_file_path, password).unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -23,9 +23,11 @@ fn create_with_password_file() {
         "ctr",
         "--argon2",
         "t=1,m=50",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -37,7 +39,9 @@ fn create_with_password_file() {
         password,
         "--strip-components",
         "2",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff(

--- a/cli/tests/cli/create/password_hash.rs
+++ b/cli/tests/cli/create/password_hash.rs
@@ -1,12 +1,12 @@
 use crate::utils::{components_count, diff::diff, setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 
 #[test]
 fn aes_ctr_argon2_archive() {
     setup();
     TestResources::extract_in("raw/", "aes_argon2_ctr/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -18,9 +18,11 @@ fn aes_ctr_argon2_archive() {
         "--aes",
         "ctr",
         "--argon2",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -32,7 +34,9 @@ fn aes_ctr_argon2_archive() {
         "password",
         "--strip-components",
         &components_count("aes_argon2_ctr/in/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff("aes_argon2_ctr/in/", "aes_argon2_ctr/out/").unwrap();
@@ -44,7 +48,7 @@ fn aes_ctr_argon2_with_params_archive() {
 
     TestResources::extract_in("raw/", "aes_argon2_with_params_ctr/in/").unwrap();
 
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -57,9 +61,11 @@ fn aes_ctr_argon2_with_params_archive() {
         "ctr",
         "--argon2",
         "t=100,m=250,p=2",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -71,7 +77,9 @@ fn aes_ctr_argon2_with_params_archive() {
         "password",
         "--strip-components",
         &components_count("aes_argon2_with_params_ctr/in/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff(
@@ -85,7 +93,7 @@ fn aes_ctr_argon2_with_params_archive() {
 fn aes_ctr_pbkdf2_archive() {
     setup();
     TestResources::extract_in("raw/", "aes_pbkdf2_ctr/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -97,9 +105,11 @@ fn aes_ctr_pbkdf2_archive() {
         "--aes",
         "ctr",
         "--pbkdf2",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -111,7 +121,9 @@ fn aes_ctr_pbkdf2_archive() {
         "password",
         "--strip-components",
         &components_count("aes_pbkdf2_ctr/in/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff("aes_pbkdf2_ctr/in/", "aes_pbkdf2_ctr/out/").unwrap();
@@ -121,7 +133,7 @@ fn aes_ctr_pbkdf2_archive() {
 fn aes_ctr_pbkdf2_with_params_archive() {
     setup();
     TestResources::extract_in("raw/", "aes_pbkdf2_with_params_ctr/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -134,9 +146,11 @@ fn aes_ctr_pbkdf2_with_params_archive() {
         "ctr",
         "--pbkdf2",
         "r=1",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -148,7 +162,9 @@ fn aes_ctr_pbkdf2_with_params_archive() {
         "password",
         "--strip-components",
         &components_count("aes_pbkdf2_with_params_ctr/in/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff(

--- a/cli/tests/cli/create/substitution.rs
+++ b/cli/tests/cli/create/substitution.rs
@@ -1,13 +1,13 @@
 use crate::utils::{diff::diff, setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 use std::fs;
 
 #[test]
 fn create_with_substitution() {
     setup();
     TestResources::extract_in("raw/", "create_with_substitution/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -17,11 +17,13 @@ fn create_with_substitution() {
         "-s",
         "#create_with_substitution/in/##",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
     assert!(fs::exists("create_with_substitution/create_with_substitution.pna").unwrap());
 
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -29,7 +31,9 @@ fn create_with_substitution() {
         "--overwrite",
         "--out-dir",
         "create_with_substitution/out/",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff(

--- a/cli/tests/cli/create/symlink.rs
+++ b/cli/tests/cli/create/symlink.rs
@@ -1,6 +1,6 @@
 use crate::utils::setup;
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -25,7 +25,7 @@ fn init_resource<P: AsRef<Path>>(dir: P) {
 fn symlink_no_follow() {
     setup();
     init_resource("symlink_no_follow/source");
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -33,9 +33,11 @@ fn symlink_no_follow() {
         "--overwrite",
         "--keep-dir",
         "symlink_no_follow/source",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -45,7 +47,9 @@ fn symlink_no_follow() {
         "symlink_no_follow/dist",
         "--strip-components",
         "2",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     assert!(PathBuf::from("symlink_no_follow/dist/link.txt").is_symlink());
@@ -62,7 +66,7 @@ fn symlink_no_follow() {
 fn symlink_follow() {
     setup();
     init_resource("symlink_follow/source");
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -71,9 +75,11 @@ fn symlink_follow() {
         "--keep-dir",
         "--follow-links",
         "symlink_follow/source",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -83,7 +89,9 @@ fn symlink_follow() {
         "symlink_follow/dist",
         "--strip-components",
         "2",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     assert!(!PathBuf::from("symlink_follow/dist/link.txt").is_symlink());

--- a/cli/tests/cli/create/transform.rs
+++ b/cli/tests/cli/create/transform.rs
@@ -1,13 +1,13 @@
 use crate::utils::{diff::diff, setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 use std::fs;
 
 #[test]
 fn create_with_transform() {
     setup();
     TestResources::extract_in("raw/", "create_with_transform/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -17,11 +17,13 @@ fn create_with_transform() {
         "--transform",
         "s,create_with_transform/in/,,",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
     assert!(fs::exists("create_with_transform/create_with_transform.pna").unwrap());
 
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -29,7 +31,9 @@ fn create_with_transform() {
         "--overwrite",
         "--out-dir",
         "create_with_transform/out/",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff("create_with_transform/in/", "create_with_transform/out/").unwrap();

--- a/cli/tests/cli/delete.rs
+++ b/cli/tests/cli/delete.rs
@@ -2,33 +2,37 @@ mod exclude;
 
 use crate::utils::{components_count, diff::diff, setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 use std::fs;
 
 #[test]
 fn delete_overwrite() {
     setup();
     TestResources::extract_in("raw/", "delete_overwrite/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
         "delete_overwrite/delete_overwrite.pna",
         "--overwrite",
         "delete_overwrite/in/",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "experimental",
         "delete",
         "delete_overwrite/delete_overwrite.pna",
         "**/raw/empty.txt",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
     fs::remove_file("delete_overwrite/in/raw/empty.txt").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -38,7 +42,9 @@ fn delete_overwrite() {
         "delete_overwrite/out/",
         "--strip-components",
         &components_count("delete_overwrite/in/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff("delete_overwrite/in/", "delete_overwrite/out/").unwrap();
@@ -48,16 +54,18 @@ fn delete_overwrite() {
 fn delete_output() {
     setup();
     TestResources::extract_in("raw/", "delete_output/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
         "delete_output/delete_output.pna",
         "--overwrite",
         "delete_output/in/",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "experimental",
@@ -66,10 +74,12 @@ fn delete_output() {
         "**/raw/text.txt",
         "--output",
         "delete_output/deleted.pna",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
     fs::remove_file("delete_output/in/raw/text.txt").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -79,7 +89,9 @@ fn delete_output() {
         "delete_output/out/",
         "--strip-components",
         &components_count("delete_output/in/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff("delete_output/in/", "delete_output/out/").unwrap();
@@ -89,7 +101,7 @@ fn delete_output() {
 fn delete_solid() {
     setup();
     TestResources::extract_in("raw/", "delete_solid/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -97,19 +109,23 @@ fn delete_solid() {
         "--overwrite",
         "--solid",
         "delete_solid/in/",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "experimental",
         "delete",
         "delete_solid/delete_solid.pna",
         "**/raw/text.txt",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
     fs::remove_file("delete_solid/in/raw/text.txt").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -119,7 +135,9 @@ fn delete_solid() {
         "delete_solid/out/",
         "--strip-components",
         &components_count("delete_solid/in/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
     diff("delete_solid/in/", "delete_solid/out/").unwrap();
 }
@@ -128,7 +146,7 @@ fn delete_solid() {
 fn delete_unsolid() {
     setup();
     TestResources::extract_in("raw/", "delete_unsolid/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -136,9 +154,11 @@ fn delete_unsolid() {
         "--overwrite",
         "--solid",
         "delete_unsolid/in/",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "experimental",
@@ -146,10 +166,12 @@ fn delete_unsolid() {
         "--unsolid",
         "delete_unsolid/delete_unsolid.pna",
         "**/raw/text.txt",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
     fs::remove_file("delete_unsolid/in/raw/text.txt").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -159,7 +181,9 @@ fn delete_unsolid() {
         "delete_unsolid/out/",
         "--strip-components",
         &components_count("delete_unsolid/in/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff("delete_unsolid/in/", "delete_unsolid/out/").unwrap();

--- a/cli/tests/cli/delete/exclude.rs
+++ b/cli/tests/cli/delete/exclude.rs
@@ -1,22 +1,24 @@
 use crate::utils::{diff::diff, setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 use std::fs;
 
 #[test]
 fn delete_output_exclude() {
     setup();
     TestResources::extract_in("raw/", "delete_output_exclude/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
         "delete_output_exclude/delete_output_exclude.pna",
         "--overwrite",
         "delete_output_exclude/in/",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "experimental",
@@ -28,10 +30,12 @@ fn delete_output_exclude() {
         "--unstable",
         "--output",
         "delete_output_exclude/delete_excluded.pna",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -41,7 +45,9 @@ fn delete_output_exclude() {
         "delete_output_exclude/out/",
         "--strip-components",
         "2",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     fs::remove_file("delete_output_exclude/in/raw/pna/nest.pna").unwrap();

--- a/cli/tests/cli/encrypt.rs
+++ b/cli/tests/cli/encrypt.rs
@@ -1,12 +1,12 @@
 use crate::utils::{components_count, diff::diff, setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 
 #[test]
 fn aes_ctr_archive() {
     setup();
     TestResources::extract_in("raw/", "zstd_aes_ctr/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -17,9 +17,11 @@ fn aes_ctr_archive() {
         "password",
         "--aes",
         "ctr",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -31,7 +33,9 @@ fn aes_ctr_archive() {
         "password",
         "--strip-components",
         &components_count("zstd_aes_ctr/in/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff("zstd_aes_ctr/in/", "zstd_aes_ctr/out/").unwrap();
@@ -41,7 +45,7 @@ fn aes_ctr_archive() {
 fn aes_cbc_archive() {
     setup();
     TestResources::extract_in("raw/", "zstd_aes_cbc/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -52,9 +56,11 @@ fn aes_cbc_archive() {
         "password",
         "--aes",
         "cbc",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -66,7 +72,9 @@ fn aes_cbc_archive() {
         "password",
         "--strip-components",
         &components_count("zstd_aes_cbc/in/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff("zstd_aes_cbc/in/", "zstd_aes_cbc/out/").unwrap();
@@ -76,7 +84,7 @@ fn aes_cbc_archive() {
 fn camellia_ctr_archive() {
     setup();
     TestResources::extract_in("raw/", "zstd_camellia_ctr/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -87,9 +95,11 @@ fn camellia_ctr_archive() {
         "password",
         "--camellia",
         "ctr",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -101,7 +111,9 @@ fn camellia_ctr_archive() {
         "password",
         "--strip-components",
         &components_count("zstd_camellia_ctr/in/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff("zstd_camellia_ctr/in/", "zstd_camellia_ctr/out/").unwrap();
@@ -111,7 +123,7 @@ fn camellia_ctr_archive() {
 fn camellia_cbc_archive() {
     setup();
     TestResources::extract_in("raw/", "zstd_camellia_cbc/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -122,9 +134,11 @@ fn camellia_cbc_archive() {
         "password",
         "--aes",
         "cbc",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -136,7 +150,9 @@ fn camellia_cbc_archive() {
         "password",
         "--strip-components",
         &components_count("zstd_camellia_cbc/in/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff("zstd_camellia_cbc/in/", "zstd_camellia_cbc/out/").unwrap();

--- a/cli/tests/cli/extract/exclude.rs
+++ b/cli/tests/cli/extract/exclude.rs
@@ -1,24 +1,27 @@
 use crate::utils::{self, diff::diff, setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::cli;
+use portable_network_archive::command::Command;
 use std::fs;
 
 #[test]
 fn extract_with_exclude() {
     setup();
     TestResources::extract_in("raw/", "extract_with_exclude/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
         "extract_with_exclude/extract_with_exclude.pna",
         "--overwrite",
         "extract_with_exclude/in/",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
     assert!(fs::exists("extract_with_exclude/extract_with_exclude.pna").unwrap());
 
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -31,7 +34,9 @@ fn extract_with_exclude() {
         "--exclude",
         "**.txt",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     // Remove files that are expected to be excluded from input for comparison

--- a/cli/tests/cli/extract/password_from_file.rs
+++ b/cli/tests/cli/extract/password_from_file.rs
@@ -1,6 +1,6 @@
 use crate::utils::{diff::diff, setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 use std::fs;
 
 #[test]
@@ -10,7 +10,7 @@ fn extract_with_password_file() {
     let password_file_path = "extract_with_password_file/password_file";
     let password = "extract_with_password_file";
     fs::write(password_file_path, password).unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -23,9 +23,11 @@ fn extract_with_password_file() {
         "ctr",
         "--argon2",
         "t=1,m=50",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -37,7 +39,9 @@ fn extract_with_password_file() {
         password_file_path,
         "--strip-components",
         "2",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff(

--- a/cli/tests/cli/extract/substitution.rs
+++ b/cli/tests/cli/extract/substitution.rs
@@ -1,24 +1,26 @@
 use crate::utils::{diff::diff, setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 use std::fs;
 
 #[test]
 fn extract_with_substitution() {
     setup();
     TestResources::extract_in("raw/", "extract_with_substitution/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
         "extract_with_substitution/extract_with_substitution.pna",
         "--overwrite",
         "extract_with_substitution/in/",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
     assert!(fs::exists("extract_with_substitution/extract_with_substitution.pna").unwrap());
 
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -29,7 +31,9 @@ fn extract_with_substitution() {
         "-s",
         "#extract_with_substitution/in/##",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff(

--- a/cli/tests/cli/extract/transform.rs
+++ b/cli/tests/cli/extract/transform.rs
@@ -1,24 +1,26 @@
 use crate::utils::{diff::diff, setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 use std::fs;
 
 #[test]
 fn extract_with_transform() {
     setup();
     TestResources::extract_in("raw/", "extract_with_transform/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
         "extract_with_transform/extract_with_transform.pna",
         "--overwrite",
         "extract_with_transform/in/",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
     assert!(fs::exists("extract_with_transform/extract_with_transform.pna").unwrap());
 
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -29,7 +31,9 @@ fn extract_with_transform() {
         "--transform",
         "s,extract_with_transform/in/,,",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff("extract_with_transform/in/", "extract_with_transform/out/").unwrap();

--- a/cli/tests/cli/hardlink.rs
+++ b/cli/tests/cli/hardlink.rs
@@ -1,7 +1,7 @@
 use crate::utils::setup;
 use clap::Parser;
 use pna::{Archive, EntryBuilder, WriteOptions};
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 use std::{fs, io::Write, path::Path};
 
 fn init_resource<P: AsRef<Path>>(path: P) {
@@ -70,7 +70,7 @@ fn init_resource<P: AsRef<Path>>(path: P) {
 fn hardlink() {
     setup();
     init_resource("hardlink/hardlink.pna");
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -78,7 +78,9 @@ fn hardlink() {
         "--overwrite",
         "--out-dir",
         "hardlink/dist",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     assert_eq!(
@@ -103,7 +105,7 @@ fn hardlink() {
 fn hardlink_allow_unsafe_links() {
     setup();
     init_resource("hardlink_allow_unsafe_links/hardlink.pna");
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -112,7 +114,9 @@ fn hardlink_allow_unsafe_links() {
         "--overwrite",
         "--out-dir",
         "hardlink_allow_unsafe_links/dist",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     assert_eq!(

--- a/cli/tests/cli/keep_acl.rs
+++ b/cli/tests/cli/keep_acl.rs
@@ -1,13 +1,13 @@
 #![cfg(feature = "acl")]
 use crate::utils::{components_count, diff::diff, setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 
 #[test]
 fn archive_keep_acl() {
     setup();
     TestResources::extract_in("raw/", "keep_acl/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -16,9 +16,11 @@ fn archive_keep_acl() {
         "keep_acl/in/",
         "--keep-acl",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -30,7 +32,9 @@ fn archive_keep_acl() {
         "--unstable",
         "--strip-components",
         &components_count("keep_acl/in/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff("keep_acl/in/", "keep_acl/out/").unwrap();

--- a/cli/tests/cli/keep_all.rs
+++ b/cli/tests/cli/keep_all.rs
@@ -1,13 +1,13 @@
 use crate::utils::{components_count, diff::diff, setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 use std::fs;
 
 #[test]
 fn archive_keep_all() {
     setup();
     TestResources::extract_in("raw/", "archive_keep_all/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -20,10 +20,12 @@ fn archive_keep_all() {
         "--keep-permission",
         #[cfg(windows)]
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
     assert!(fs::exists("archive_keep_all/keep_all.pna").unwrap());
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -39,7 +41,9 @@ fn archive_keep_all() {
         &components_count("archive_keep_all/in/").to_string(),
         #[cfg(windows)]
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff("archive_keep_all/in/", "archive_keep_all/out/").unwrap();

--- a/cli/tests/cli/list.rs
+++ b/cli/tests/cli/list.rs
@@ -1,28 +1,33 @@
 use crate::utils::{setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 
 #[test]
 fn archive_list() {
     setup();
     TestResources::extract_in("raw/", "list/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
         "list/list.pna",
         "--overwrite",
         "list/in/",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from(["pna", "list", "list/list.pna"])).unwrap();
+    cli::Cli::try_parse_from(["pna", "list", "list/list.pna"])
+        .unwrap()
+        .execute()
+        .unwrap();
 }
 
 #[test]
 fn archive_list_solid() {
     setup();
     TestResources::extract_in("raw/", "list_solid/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -30,22 +35,21 @@ fn archive_list_solid() {
         "--overwrite",
         "list_solid/in/",
         "--solid",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
-        "pna",
-        "list",
-        "list_solid/list_solid.pna",
-        "--solid",
-    ]))
-    .unwrap();
+    cli::Cli::try_parse_from(["pna", "list", "list_solid/list_solid.pna", "--solid"])
+        .unwrap()
+        .execute()
+        .unwrap();
 }
 
 #[test]
 fn archive_list_detail() {
     setup();
     TestResources::extract_in("raw/", "list_detail/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -64,16 +68,20 @@ fn archive_list_detail() {
         "t=1,m=50",
         #[cfg(windows)]
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "list",
         "-l",
         "list_detail/list_detail.pna",
         "--password",
         "password",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 }
 
@@ -81,7 +89,7 @@ fn archive_list_detail() {
 fn archive_list_solid_detail() {
     setup();
     TestResources::extract_in("raw/", "list_solid_detail/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -100,9 +108,11 @@ fn archive_list_solid_detail() {
         "--argon2",
         "t=1,m=50",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "list",
         "-l",
@@ -110,7 +120,9 @@ fn archive_list_solid_detail() {
         "--solid",
         "--password",
         "password",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 }
 
@@ -118,7 +130,7 @@ fn archive_list_solid_detail() {
 fn archive_list_jsonl() {
     setup();
     TestResources::extract_in("raw/", "list_jsonl/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -138,9 +150,11 @@ fn archive_list_jsonl() {
         "--argon2",
         "t=1,m=50",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "list",
         "-l",
@@ -150,7 +164,9 @@ fn archive_list_jsonl() {
         "--password",
         "password",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 }
 
@@ -158,7 +174,7 @@ fn archive_list_jsonl() {
 fn archive_list_solid_jsonl() {
     setup();
     TestResources::extract_in("raw/", "list_solid_jsonl/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -179,9 +195,11 @@ fn archive_list_solid_jsonl() {
         "--argon2",
         "t=1,m=50",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "list",
         "-l",
@@ -192,7 +210,9 @@ fn archive_list_solid_jsonl() {
         "--password",
         "password",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 }
 
@@ -200,7 +220,7 @@ fn archive_list_solid_jsonl() {
 fn archive_list_tree() {
     setup();
     TestResources::extract_in("raw/", "list_tree/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -220,9 +240,11 @@ fn archive_list_tree() {
         "--argon2",
         "t=1,m=50",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "list",
         "-l",
@@ -232,7 +254,9 @@ fn archive_list_tree() {
         "--password",
         "password",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 }
 
@@ -240,7 +264,7 @@ fn archive_list_tree() {
 fn archive_list_solid_tree() {
     setup();
     TestResources::extract_in("raw/", "list_solid_tree/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -261,9 +285,11 @@ fn archive_list_solid_tree() {
         "--argon2",
         "t=1,m=50",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "list",
         "-l",
@@ -274,6 +300,8 @@ fn archive_list_solid_tree() {
         "--password",
         "password",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 }

--- a/cli/tests/cli/multipart.rs
+++ b/cli/tests/cli/multipart.rs
@@ -1,12 +1,12 @@
 use crate::utils::{diff::diff, setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 
 #[test]
 fn multipart_archive() {
     setup();
     TestResources::extract_in("multipart_test.txt", "./multipart_archive/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -16,9 +16,11 @@ fn multipart_archive() {
         "--unstable",
         "--split",
         "110",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -28,7 +30,9 @@ fn multipart_archive() {
         "./multipart_archive/out/",
         "--strip-components",
         "2",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff("./multipart_archive/in/", "./multipart_archive/out/").unwrap();

--- a/cli/tests/cli/restore_acl.rs
+++ b/cli/tests/cli/restore_acl.rs
@@ -1,13 +1,13 @@
 #![cfg(feature = "acl")]
 use crate::utils::{setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 
 #[test]
 fn extract_windows_acl() {
     setup();
     TestResources::extract_in("windows_acl.pna", ".").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -17,7 +17,9 @@ fn extract_windows_acl() {
         "windows_acl/out/",
         "--keep-acl",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 }
 
@@ -25,7 +27,7 @@ fn extract_windows_acl() {
 fn extract_linux_acl() {
     setup();
     TestResources::extract_in("linux_acl.pna", ".").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -35,7 +37,9 @@ fn extract_linux_acl() {
         "linux_acl/out/",
         "--keep-acl",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 }
 
@@ -43,7 +47,7 @@ fn extract_linux_acl() {
 fn extract_macos_acl() {
     setup();
     TestResources::extract_in("macos_acl.pna", ".").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -53,7 +57,9 @@ fn extract_macos_acl() {
         "macos_acl/out/",
         "--keep-acl",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 }
 
@@ -61,7 +67,7 @@ fn extract_macos_acl() {
 fn extract_freebsd_acl() {
     setup();
     TestResources::extract_in("freebsd_acl.pna", ".").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -71,7 +77,9 @@ fn extract_freebsd_acl() {
         "freebsd_acl/out/",
         "--keep-acl",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 }
 
@@ -79,7 +87,7 @@ fn extract_freebsd_acl() {
 fn extract_generic_acl() {
     setup();
     TestResources::extract_in("generic_acl.pna", ".").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -89,6 +97,8 @@ fn extract_generic_acl() {
         "generic_acl/out/",
         "--keep-acl",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 }

--- a/cli/tests/cli/restore_acl_0_19_1.rs
+++ b/cli/tests/cli/restore_acl_0_19_1.rs
@@ -2,13 +2,13 @@
 #![cfg(feature = "acl")]
 use crate::utils::{setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 
 #[test]
 fn extract_windows_acl() {
     setup();
     TestResources::extract_in("0.19.1/windows_acl.pna", ".").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -18,7 +18,9 @@ fn extract_windows_acl() {
         "0.19.1/windows_acl/out/",
         "--keep-acl",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 }
 
@@ -26,7 +28,7 @@ fn extract_windows_acl() {
 fn extract_linux_acl() {
     setup();
     TestResources::extract_in("0.19.1/linux_acl.pna", ".").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -36,7 +38,9 @@ fn extract_linux_acl() {
         "0.19.1/linux_acl/out/",
         "--keep-acl",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 }
 
@@ -44,7 +48,7 @@ fn extract_linux_acl() {
 fn extract_macos_acl() {
     setup();
     TestResources::extract_in("0.19.1/macos_acl.pna", ".").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -54,7 +58,9 @@ fn extract_macos_acl() {
         "0.19.1/macos_acl/out/",
         "--keep-acl",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 }
 
@@ -62,7 +68,7 @@ fn extract_macos_acl() {
 fn extract_freebsd_acl() {
     setup();
     TestResources::extract_in("0.19.1/freebsd_acl.pna", ".").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -72,6 +78,8 @@ fn extract_freebsd_acl() {
         "0.19.1/freebsd_acl/out/",
         "--keep-acl",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 }

--- a/cli/tests/cli/solid_mode.rs
+++ b/cli/tests/cli/solid_mode.rs
@@ -1,12 +1,12 @@
 use crate::utils::{components_count, diff::diff, setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 
 #[test]
 fn solid_store_archive() {
     setup();
     TestResources::extract_in("raw/", "solid_store/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -15,9 +15,11 @@ fn solid_store_archive() {
         "--overwrite",
         "solid_store/in/",
         "--solid",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -27,7 +29,9 @@ fn solid_store_archive() {
         "solid_store/out/",
         "--strip-components",
         &components_count("solid_store/out/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
     diff("solid_store/in/", "solid_store/out/").unwrap();
 }
@@ -36,7 +40,7 @@ fn solid_store_archive() {
 fn solid_zstd_archive() {
     setup();
     TestResources::extract_in("raw/", "solid_zstd/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -45,9 +49,11 @@ fn solid_zstd_archive() {
         "--overwrite",
         "solid_zstd/in/",
         "--solid",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -57,7 +63,9 @@ fn solid_zstd_archive() {
         "solid_zstd/out/",
         "--strip-components",
         &components_count("solid_zstd/in/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff("solid_zstd/in/", "solid_zstd/out/").unwrap();
@@ -67,7 +75,7 @@ fn solid_zstd_archive() {
 fn solid_xz_archive() {
     setup();
     TestResources::extract_in("raw/", "solid_xz/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -76,9 +84,11 @@ fn solid_xz_archive() {
         "--overwrite",
         "solid_xz/in/",
         "--solid",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -88,7 +98,9 @@ fn solid_xz_archive() {
         "solid_xz/out/",
         "--strip-components",
         &components_count("solid_xz/in/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff("solid_xz/in/", "solid_xz/out/").unwrap();
@@ -98,7 +110,7 @@ fn solid_xz_archive() {
 fn solid_deflate_archive() {
     setup();
     TestResources::extract_in("raw/", "solid_deflate/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -107,9 +119,11 @@ fn solid_deflate_archive() {
         "--overwrite",
         "solid_deflate/in/",
         "--solid",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -119,7 +133,9 @@ fn solid_deflate_archive() {
         "solid_deflate/out/",
         "--strip-components",
         &components_count("solid_deflate/in/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
     diff("solid_deflate/in/", "solid_deflate/out/").unwrap();
 }

--- a/cli/tests/cli/split.rs
+++ b/cli/tests/cli/split.rs
@@ -1,22 +1,24 @@
 use crate::utils::{components_count, diff::diff, setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 use std::fs;
 
 #[test]
 fn split_archive() {
     setup();
     TestResources::extract_in("raw/", "split_archive/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "create",
         "split_archive/split.pna",
         "--overwrite",
         "split_archive/in/",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "split",
@@ -26,7 +28,9 @@ fn split_archive() {
         "100kb",
         "--out-dir",
         "split_archive/split/",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     // check split file size
@@ -34,7 +38,7 @@ fn split_archive() {
         assert!(fs::metadata(entry.unwrap().path()).unwrap().len() <= 100 * 1000);
     }
 
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -44,7 +48,9 @@ fn split_archive() {
         "split_archive/out/",
         "--strip-components",
         &components_count("split_archive/in/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     // check completely extracted

--- a/cli/tests/cli/strip.rs
+++ b/cli/tests/cli/strip.rs
@@ -1,12 +1,12 @@
 use crate::utils::{components_count, diff::diff, setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 
 #[test]
 fn archive_strip_metadata() {
     setup();
     TestResources::extract_in("raw/", "archive_strip_metadata/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -19,9 +19,11 @@ fn archive_strip_metadata() {
         "--keep-permission",
         #[cfg(windows)]
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "strip",
@@ -31,9 +33,11 @@ fn archive_strip_metadata() {
         "--keep-permission",
         #[cfg(windows)]
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -49,7 +53,9 @@ fn archive_strip_metadata() {
         &components_count("archive_strip_metadata/in/").to_string(),
         #[cfg(windows)]
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff("archive_strip_metadata/in/", "archive_strip_metadata/out/").unwrap();

--- a/cli/tests/cli/update.rs
+++ b/cli/tests/cli/update.rs
@@ -2,7 +2,7 @@ mod exclude;
 
 use crate::utils::{components_count, diff::diff, setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 use std::{fs, io::prelude::*, time};
 
 const DURATION_24_HOURS: time::Duration = time::Duration::from_secs(24 * 60 * 60);
@@ -11,7 +11,7 @@ const DURATION_24_HOURS: time::Duration = time::Duration::from_secs(24 * 60 * 60
 fn archive_update_newer_mtime() {
     setup();
     TestResources::extract_in("raw/", "archive_update_newer_mtime/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -19,7 +19,9 @@ fn archive_update_newer_mtime() {
         "--overwrite",
         "archive_update_newer_mtime/in/",
         "--keep-timestamp",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     let mut file = fs::File::options()
@@ -41,7 +43,7 @@ fn archive_update_newer_mtime() {
     file.set_modified(time::SystemTime::now() + DURATION_24_HOURS)
         .unwrap();
 
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "experimental",
@@ -50,13 +52,15 @@ fn archive_update_newer_mtime() {
         "archive_update_newer_mtime/update_newer_mtime.pna",
         "archive_update_newer_mtime/in/",
         "--keep-timestamp",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     // restore original empty.txt
     TestResources::extract_in("raw/empty.txt", "archive_update_newer_mtime/in/").unwrap();
 
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -67,7 +71,9 @@ fn archive_update_newer_mtime() {
         "--keep-timestamp",
         "--strip-components",
         &components_count("archive_update_newer_mtime/in/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff(
@@ -82,7 +88,7 @@ fn archive_update_older_mtime() {
     setup();
     TestResources::extract_in("raw/", "archive_update_older_mtime/in/").unwrap();
     TestResources::extract_in("raw/", "archive_update_older_mtime/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -90,7 +96,9 @@ fn archive_update_older_mtime() {
         "--overwrite",
         "archive_update_older_mtime/in/",
         "--keep-timestamp",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     let mut file = fs::File::options()
@@ -112,7 +120,7 @@ fn archive_update_older_mtime() {
     file.set_modified(time::SystemTime::now() - DURATION_24_HOURS)
         .unwrap();
 
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "experimental",
@@ -121,13 +129,15 @@ fn archive_update_older_mtime() {
         "archive_update_older_mtime/update_older_mtime.pna",
         "archive_update_older_mtime/in/",
         "--keep-timestamp",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     // restore original empty.txt
     TestResources::extract_in("raw/empty.txt", "archive_update_older_mtime/in/").unwrap();
 
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -138,7 +148,9 @@ fn archive_update_older_mtime() {
         "--keep-timestamp",
         "--strip-components",
         &components_count("archive_update_older_mtime/in/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff(
@@ -152,7 +164,7 @@ fn archive_update_older_mtime() {
 fn archive_update_deletion() {
     setup();
     TestResources::extract_in("raw/", "archive_update_deletion/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -160,12 +172,14 @@ fn archive_update_deletion() {
         "--overwrite",
         "archive_update_deletion/in/",
         "--keep-timestamp",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     fs::remove_file("archive_update_deletion/in/raw/empty.txt").unwrap();
 
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "experimental",
@@ -174,10 +188,12 @@ fn archive_update_deletion() {
         "archive_update_deletion/update_deletion.pna",
         "archive_update_deletion/in/",
         "--keep-timestamp",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -188,7 +204,9 @@ fn archive_update_deletion() {
         "--keep-timestamp",
         "--strip-components",
         &components_count("archive_update_deletion/in/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     // restore original empty.txt

--- a/cli/tests/cli/update/exclude.rs
+++ b/cli/tests/cli/update/exclude.rs
@@ -1,14 +1,14 @@
 use super::DURATION_24_HOURS;
 use crate::utils::{components_count, diff::diff, setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 use std::{fs, io::prelude::*, time};
 
 #[test]
 fn archive_update_newer_mtime_with_exclude() {
     setup();
     TestResources::extract_in("raw/", "archive_update_newer_mtime_with_exclude/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -16,7 +16,9 @@ fn archive_update_newer_mtime_with_exclude() {
         "--overwrite",
         "archive_update_newer_mtime_with_exclude/in/",
         "--keep-timestamp",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     let mut file = fs::File::options()
@@ -38,7 +40,7 @@ fn archive_update_newer_mtime_with_exclude() {
     file.set_modified(time::SystemTime::now() + DURATION_24_HOURS)
         .unwrap();
 
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "experimental",
@@ -50,7 +52,9 @@ fn archive_update_newer_mtime_with_exclude() {
         "--exclude",
         "archive_update_newer_mtime_with_exclude/in/raw/empty.txt",
         "--unstable",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     // restore original empty.txt
@@ -60,7 +64,7 @@ fn archive_update_newer_mtime_with_exclude() {
     )
     .unwrap();
 
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -71,7 +75,9 @@ fn archive_update_newer_mtime_with_exclude() {
         "--keep-timestamp",
         "--strip-components",
         &components_count("archive_update_newer_mtime_with_exclude/in/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff(

--- a/cli/tests/cli/user_group.rs
+++ b/cli/tests/cli/user_group.rs
@@ -1,13 +1,13 @@
 #![cfg(unix)]
 use crate::utils::{components_count, diff::diff, setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::{cli, command::Command};
 
 #[test]
 fn archive_create_uname_gname() {
     setup();
     TestResources::extract_in("raw/", "archive_create_uname_gname/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -19,16 +19,20 @@ fn archive_create_uname_gname() {
         "test_user",
         "--gname",
         "test_group",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "ls",
         "-lh",
         "archive_create_uname_gname/create_uname_gname.pna",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -39,7 +43,9 @@ fn archive_create_uname_gname() {
         "--keep-permission",
         "--strip-components",
         &components_count("archive_create_uname_gname/in/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff(
@@ -53,7 +59,7 @@ fn archive_create_uname_gname() {
 fn archive_create_uid_gid() {
     setup();
     TestResources::extract_in("raw/", "archive_create_uid_gid/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -65,17 +71,21 @@ fn archive_create_uid_gid() {
         "0",
         "--gid",
         "2",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "ls",
         "-lh",
         "--numeric-owner",
         "archive_create_uid_gid/create_uid_gid.pna",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -86,7 +96,9 @@ fn archive_create_uid_gid() {
         "--keep-permission",
         "--strip-components",
         &components_count("archive_create_uid_gid/in/").to_string(),
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff("archive_create_uid_gid/in/", "archive_create_uid_gid/out/").unwrap();

--- a/cli/tests/cli/xattr.rs
+++ b/cli/tests/cli/xattr.rs
@@ -5,14 +5,15 @@ mod restore;
 
 use crate::utils::{diff::diff, setup, TestResources};
 use clap::Parser;
-use portable_network_archive::{cli, command};
+use portable_network_archive::cli;
+use portable_network_archive::command::Command;
 
 #[test]
 fn archive_xattr_set() {
     setup();
     TestResources::extract_in("raw/", "xattr_set/in/").unwrap();
 
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -21,9 +22,11 @@ fn archive_xattr_set() {
         "xattr_set/in/",
         #[cfg(not(target_os = "netbsd"))]
         "--keep-xattr",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "experimental",
@@ -35,9 +38,11 @@ fn archive_xattr_set() {
         "--value",
         "pna developers!",
         "xattr_set/in/raw/empty.txt",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "experimental",
@@ -47,9 +52,11 @@ fn archive_xattr_set() {
         "xattr_set/in/raw/empty.txt",
         "--name",
         "user.name",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -61,7 +68,9 @@ fn archive_xattr_set() {
         "--keep-xattr",
         "--strip-components",
         "2",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff("xattr_set/in/", "xattr_set/out/").unwrap();
@@ -81,7 +90,7 @@ fn archive_xattr_set() {
 fn archive_xattr_remove() {
     setup();
     TestResources::extract_in("raw/", "xattr_remove/in/").unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -90,9 +99,11 @@ fn archive_xattr_remove() {
         "xattr_remove/in/",
         #[cfg(not(target_os = "netbsd"))]
         "--keep-xattr",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "experimental",
@@ -104,9 +115,11 @@ fn archive_xattr_remove() {
         "--value",
         "pna developers!",
         "xattr_remove/in/raw/empty.txt",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "experimental",
@@ -116,9 +129,11 @@ fn archive_xattr_remove() {
         "--remove",
         "user.name",
         "xattr_remove/in/raw/empty.txt",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "experimental",
@@ -128,9 +143,11 @@ fn archive_xattr_remove() {
         "xattr_remove/in/raw/empty.txt",
         "--name",
         "user.name",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
-    command::entry(cli::Cli::parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "x",
@@ -142,7 +159,9 @@ fn archive_xattr_remove() {
         "--keep-xattr",
         "--strip-components",
         "2",
-    ]))
+    ])
+    .unwrap()
+    .execute()
     .unwrap();
 
     diff("xattr_remove/in/", "xattr_remove/out/").unwrap();


### PR DESCRIPTION
Refine: Optimize imports in CLI test files

Optimized `use` statements in CLI test files by grouping imports from `portable_network_archive::{cli, command::Command}`.

This change follows up on the previous refactoring of CLI test command execution. All workspace tests pass and code formatting is verified.

Output:
I've optimized the imports in the CLI test files.

Specifically, I grouped the `use` statements for imports from `portable_network_archive::{cli, command::Command}`.

This builds upon the previous refactoring of the CLI test command execution. I've confirmed that all workspace tests are passing and the code formatting is correct.