### PR TITLE
:recycle: Move command dispatch logic into Cli::execute()

### DIFF
--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -23,19 +23,7 @@ use crate::cli::{CipherAlgorithmArgs, Cli, Commands, PasswordArgs};
 use std::{fs, io};
 
 pub fn entry(cli: Cli) -> io::Result<()> {
-    match cli.commands {
-        Commands::Create(cmd) => cmd.execute(),
-        Commands::Append(cmd) => cmd.execute(),
-        Commands::Extract(cmd) => cmd.execute(),
-        Commands::List(cmd) => cmd.execute(),
-        Commands::Split(cmd) => cmd.execute(),
-        Commands::Concat(cmd) => cmd.execute(),
-        Commands::Strip(cmd) => cmd.execute(),
-        Commands::Xattr(cmd) => cmd.execute(),
-        Commands::Complete(cmd) => cmd.execute(),
-        Commands::BugReport(cmd) => cmd.execute(),
-        Commands::Experimental(cmd) => cmd.execute(),
-    }
+    cli.execute()
 }
 
 fn ask_password(args: PasswordArgs) -> io::Result<Option<String>> {
@@ -72,6 +60,18 @@ pub trait Command {
 impl Command for Cli {
     #[inline]
     fn execute(self) -> io::Result<()> {
-        entry(self)
+        match self.commands {
+            Commands::Create(cmd) => cmd.execute(),
+            Commands::Append(cmd) => cmd.execute(),
+            Commands::Extract(cmd) => cmd.execute(),
+            Commands::List(cmd) => cmd.execute(),
+            Commands::Split(cmd) => cmd.execute(),
+            Commands::Concat(cmd) => cmd.execute(),
+            Commands::Strip(cmd) => cmd.execute(),
+            Commands::Xattr(cmd) => cmd.execute(),
+            Commands::Complete(cmd) => cmd.execute(),
+            Commands::BugReport(cmd) => cmd.execute(),
+            Commands::Experimental(cmd) => cmd.execute(),
+        }
     }
 }


### PR DESCRIPTION
Simplified the `entry` function by delegating command matching to the `Cli::execute()` method. This makes `entry()` cleaner and better separates concerns, improving readability and testability.