### PR TITLE
:white_check_mark: replace dynamic strip-components value with fixed "2" in CLI tests

### DIFF
--- a/cli/tests/cli/acl.rs
+++ b/cli/tests/cli/acl.rs
@@ -3,7 +3,7 @@ mod dump;
 #[cfg(not(target_family = "wasm"))]
 mod restore;
 
-use crate::utils::{components_count, diff::diff, setup, TestResources};
+use crate::utils::{diff::diff, setup, TestResources};
 use clap::Parser;
 use portable_network_archive::{cli, command::Command};
 
@@ -85,7 +85,7 @@ fn archive_acl_get_set() {
         "--out-dir",
         "acl_get_set/out/",
         "--strip-components",
-        &components_count("acl_get_set/in/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()

--- a/cli/tests/cli/append.rs
+++ b/cli/tests/cli/append.rs
@@ -1,7 +1,7 @@
 mod exclude;
 mod mtime;
 
-use crate::utils::{components_count, diff::diff, setup, TestResources};
+use crate::utils::{diff::diff, setup, TestResources};
 use clap::Parser;
 use portable_network_archive::{cli, command::Command};
 
@@ -45,7 +45,7 @@ fn archive_append() {
         "--out-dir",
         "archive_append/out/",
         "--strip-components",
-        &components_count("archive_append/in/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()
@@ -96,7 +96,7 @@ fn archive_append_split() {
         "--out-dir",
         "archive_append_split/out/",
         "--strip-components",
-        &components_count("archive_append_split/out/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()

--- a/cli/tests/cli/combination.rs
+++ b/cli/tests/cli/combination.rs
@@ -1,4 +1,4 @@
-use crate::utils::{components_count, diff::diff, setup, LibSourceCode};
+use crate::utils::{diff::diff, setup, LibSourceCode};
 use itertools::Itertools;
 
 // NOTE: Skip `--keep-xattr` option for NetBSD
@@ -61,7 +61,7 @@ fn combination_fs() {
             "--out-dir",
             &format!("combination_fs/out/{joined_options}/"),
             "--strip-components",
-            &components_count("combination_fs/in/").to_string(),
+            "2",
             "--password",
             "password",
             #[cfg(windows)]
@@ -134,7 +134,7 @@ fn combination_stdio() {
             "--out-dir",
             &format!("combination_stdio/out/{joined_options}/"),
             "--strip-components",
-            &components_count("combination_stdio/in/").to_string(),
+            "2",
             "--password",
             "password",
             #[cfg(windows)]

--- a/cli/tests/cli/concat.rs
+++ b/cli/tests/cli/concat.rs
@@ -1,4 +1,4 @@
-use crate::utils::{components_count, diff::diff, setup, TestResources};
+use crate::utils::{diff::diff, setup, TestResources};
 use clap::Parser;
 use portable_network_archive::{cli, command::Command};
 
@@ -49,7 +49,7 @@ fn concat_archive() {
         "--out-dir",
         "concat_archive/out",
         "--strip-components",
-        &components_count("concat_archive/in").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()

--- a/cli/tests/cli/create/files_from.rs
+++ b/cli/tests/cli/create/files_from.rs
@@ -1,4 +1,4 @@
-use crate::utils::{self, components_count, diff::diff, setup, TestResources};
+use crate::utils::{self, diff::diff, setup, TestResources};
 use clap::Parser;
 use portable_network_archive::{cli, command::Command};
 use std::fs;
@@ -42,7 +42,7 @@ fn create_with_files_from() {
         "--out-dir",
         "create_with_files_from/out/",
         "--strip-components",
-        &components_count("create_with_files_from/src/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()

--- a/cli/tests/cli/create/files_from_stdin.rs
+++ b/cli/tests/cli/create/files_from_stdin.rs
@@ -1,5 +1,5 @@
 #![cfg(not(target_family = "wasm"))]
-use crate::utils::{self, components_count, diff::diff, setup, TestResources};
+use crate::utils::{self, diff::diff, setup, TestResources};
 use assert_cmd::Command;
 
 #[test]
@@ -34,7 +34,7 @@ fn create_with_files_from_stdin() {
         "--out-dir",
         "create_with_files_from_stdin/out/",
         "--strip-components",
-        &components_count("create_with_files_from_stdin/src/").to_string(),
+        "2",
     ]);
     cmd.assert().success();
 

--- a/cli/tests/cli/create/numeric_owner.rs
+++ b/cli/tests/cli/create/numeric_owner.rs
@@ -1,5 +1,5 @@
 #![cfg(any(unix, windows))]
-use crate::utils::{archive, components_count, diff::diff, setup, TestResources};
+use crate::utils::{archive, diff::diff, setup, TestResources};
 use clap::Parser;
 use portable_network_archive::{cli, command::Command};
 
@@ -38,7 +38,7 @@ fn create_numeric_owner() {
         "numeric_owner/out/",
         "--keep-permission",
         "--strip-components",
-        &components_count("numeric_owner/in/").to_string(),
+        "2",
         #[cfg(windows)]
         "--unstable",
     ])

--- a/cli/tests/cli/create/password_hash.rs
+++ b/cli/tests/cli/create/password_hash.rs
@@ -1,4 +1,4 @@
-use crate::utils::{components_count, diff::diff, setup, TestResources};
+use crate::utils::{diff::diff, setup, TestResources};
 use clap::Parser;
 use portable_network_archive::{cli, command::Command};
 
@@ -33,7 +33,7 @@ fn aes_ctr_argon2_archive() {
         "--password",
         "password",
         "--strip-components",
-        &components_count("aes_argon2_ctr/in/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()
@@ -76,7 +76,7 @@ fn aes_ctr_argon2_with_params_archive() {
         "--password",
         "password",
         "--strip-components",
-        &components_count("aes_argon2_with_params_ctr/in/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()
@@ -120,7 +120,7 @@ fn aes_ctr_pbkdf2_archive() {
         "--password",
         "password",
         "--strip-components",
-        &components_count("aes_pbkdf2_ctr/in/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()
@@ -161,7 +161,7 @@ fn aes_ctr_pbkdf2_with_params_archive() {
         "--password",
         "password",
         "--strip-components",
-        &components_count("aes_pbkdf2_with_params_ctr/in/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()

--- a/cli/tests/cli/delete.rs
+++ b/cli/tests/cli/delete.rs
@@ -1,6 +1,6 @@
 mod exclude;
 
-use crate::utils::{components_count, diff::diff, setup, TestResources};
+use crate::utils::{diff::diff, setup, TestResources};
 use clap::Parser;
 use portable_network_archive::{cli, command::Command};
 use std::fs;
@@ -41,7 +41,7 @@ fn delete_overwrite() {
         "--out-dir",
         "delete_overwrite/out/",
         "--strip-components",
-        &components_count("delete_overwrite/in/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()
@@ -88,7 +88,7 @@ fn delete_output() {
         "--out-dir",
         "delete_output/out/",
         "--strip-components",
-        &components_count("delete_output/in/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()
@@ -134,7 +134,7 @@ fn delete_solid() {
         "--out-dir",
         "delete_solid/out/",
         "--strip-components",
-        &components_count("delete_solid/in/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()
@@ -180,7 +180,7 @@ fn delete_unsolid() {
         "--out-dir",
         "delete_unsolid/out/",
         "--strip-components",
-        &components_count("delete_unsolid/in/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()

--- a/cli/tests/cli/encrypt.rs
+++ b/cli/tests/cli/encrypt.rs
@@ -1,4 +1,4 @@
-use crate::utils::{components_count, diff::diff, setup, TestResources};
+use crate::utils::{diff::diff, setup, TestResources};
 use clap::Parser;
 use portable_network_archive::{cli, command::Command};
 
@@ -32,7 +32,7 @@ fn aes_ctr_archive() {
         "--password",
         "password",
         "--strip-components",
-        &components_count("zstd_aes_ctr/in/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()
@@ -71,7 +71,7 @@ fn aes_cbc_archive() {
         "--password",
         "password",
         "--strip-components",
-        &components_count("zstd_aes_cbc/in/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()
@@ -110,7 +110,7 @@ fn camellia_ctr_archive() {
         "--password",
         "password",
         "--strip-components",
-        &components_count("zstd_camellia_ctr/in/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()
@@ -149,7 +149,7 @@ fn camellia_cbc_archive() {
         "--password",
         "password",
         "--strip-components",
-        &components_count("zstd_camellia_cbc/in/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()

--- a/cli/tests/cli/keep_acl.rs
+++ b/cli/tests/cli/keep_acl.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "acl")]
-use crate::utils::{components_count, diff::diff, setup, TestResources};
+use crate::utils::{diff::diff, setup, TestResources};
 use clap::Parser;
 use portable_network_archive::{cli, command::Command};
 
@@ -31,7 +31,7 @@ fn archive_keep_acl() {
         "--keep-acl",
         "--unstable",
         "--strip-components",
-        &components_count("keep_acl/in/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()

--- a/cli/tests/cli/keep_all.rs
+++ b/cli/tests/cli/keep_all.rs
@@ -1,4 +1,4 @@
-use crate::utils::{components_count, diff::diff, setup, TestResources};
+use crate::utils::{diff::diff, setup, TestResources};
 use clap::Parser;
 use portable_network_archive::{cli, command::Command};
 use std::fs;
@@ -38,7 +38,7 @@ fn archive_keep_all() {
         "--keep-timestamp",
         "--keep-permission",
         "--strip-components",
-        &components_count("archive_keep_all/in/").to_string(),
+        "2",
         #[cfg(windows)]
         "--unstable",
     ])

--- a/cli/tests/cli/solid_mode.rs
+++ b/cli/tests/cli/solid_mode.rs
@@ -1,4 +1,4 @@
-use crate::utils::{components_count, diff::diff, setup, TestResources};
+use crate::utils::{diff::diff, setup, TestResources};
 use clap::Parser;
 use portable_network_archive::{cli, command::Command};
 
@@ -28,7 +28,7 @@ fn solid_store_archive() {
         "--out-dir",
         "solid_store/out/",
         "--strip-components",
-        &components_count("solid_store/out/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()
@@ -62,7 +62,7 @@ fn solid_zstd_archive() {
         "--out-dir",
         "solid_zstd/out/",
         "--strip-components",
-        &components_count("solid_zstd/in/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()
@@ -97,7 +97,7 @@ fn solid_xz_archive() {
         "--out-dir",
         "solid_xz/out/",
         "--strip-components",
-        &components_count("solid_xz/in/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()
@@ -132,7 +132,7 @@ fn solid_deflate_archive() {
         "--out-dir",
         "solid_deflate/out/",
         "--strip-components",
-        &components_count("solid_deflate/in/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()

--- a/cli/tests/cli/split.rs
+++ b/cli/tests/cli/split.rs
@@ -1,4 +1,4 @@
-use crate::utils::{components_count, diff::diff, setup, TestResources};
+use crate::utils::{diff::diff, setup, TestResources};
 use clap::Parser;
 use portable_network_archive::{cli, command::Command};
 use std::fs;
@@ -47,7 +47,7 @@ fn split_archive() {
         "--out-dir",
         "split_archive/out/",
         "--strip-components",
-        &components_count("split_archive/in/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()

--- a/cli/tests/cli/strip.rs
+++ b/cli/tests/cli/strip.rs
@@ -1,4 +1,4 @@
-use crate::utils::{components_count, diff::diff, setup, TestResources};
+use crate::utils::{diff::diff, setup, TestResources};
 use clap::Parser;
 use portable_network_archive::{cli, command::Command};
 
@@ -50,7 +50,7 @@ fn archive_strip_metadata() {
         "--keep-timestamp",
         "--keep-permission",
         "--strip-components",
-        &components_count("archive_strip_metadata/in/").to_string(),
+        "2",
         #[cfg(windows)]
         "--unstable",
     ])

--- a/cli/tests/cli/update.rs
+++ b/cli/tests/cli/update.rs
@@ -1,7 +1,7 @@
 mod exclude;
 mod mtime;
 
-use crate::utils::{components_count, diff::diff, setup, TestResources};
+use crate::utils::{diff::diff, setup, TestResources};
 use clap::Parser;
 use portable_network_archive::{cli, command::Command};
 use std::{fs, io::prelude::*, time};
@@ -71,7 +71,7 @@ fn archive_update_newer_mtime() {
         "archive_update_newer_mtime/out/",
         "--keep-timestamp",
         "--strip-components",
-        &components_count("archive_update_newer_mtime/in/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()
@@ -148,7 +148,7 @@ fn archive_update_older_mtime() {
         "archive_update_older_mtime/out/",
         "--keep-timestamp",
         "--strip-components",
-        &components_count("archive_update_older_mtime/in/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()
@@ -204,7 +204,7 @@ fn archive_update_deletion() {
         "archive_update_deletion/out/",
         "--keep-timestamp",
         "--strip-components",
-        &components_count("archive_update_deletion/in/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()

--- a/cli/tests/cli/update/exclude.rs
+++ b/cli/tests/cli/update/exclude.rs
@@ -1,5 +1,5 @@
 use super::DURATION_24_HOURS;
-use crate::utils::{components_count, diff::diff, setup, TestResources};
+use crate::utils::{diff::diff, setup, TestResources};
 use clap::Parser;
 use portable_network_archive::{cli, command::Command};
 use std::{fs, io::prelude::*, time};
@@ -74,7 +74,7 @@ fn archive_update_newer_mtime_with_exclude() {
         "archive_update_newer_mtime_with_exclude/out/",
         "--keep-timestamp",
         "--strip-components",
-        &components_count("archive_update_newer_mtime_with_exclude/in/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()


### PR DESCRIPTION
This simplifies test cases by hardcoding the `--strip-components` value to "2" instead of computing it dynamically with `components_count(...)`. Removes unnecessary imports of `components_count` from various test files.