### PR TITLE
:white_check_mark: Replace dynamic --strip-components value with fixed "2"

### DIFF
--- a/cli/tests/cli/delete/files_from.rs
+++ b/cli/tests/cli/delete/files_from.rs
@@ -1,4 +1,4 @@
-use crate::utils::{components_count, diff::diff, setup, TestResources};
+use crate::utils::{diff::diff, setup, TestResources};
 use clap::Parser;
 use portable_network_archive::{cli, command::Command};
 use std::fs;
@@ -52,7 +52,7 @@ fn delete_with_files_from() {
         "--out-dir",
         "delete_files_from/out/",
         "--strip-components",
-        &components_count("delete_files_from/in/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()

--- a/cli/tests/cli/delete/files_from_stdin.rs
+++ b/cli/tests/cli/delete/files_from_stdin.rs
@@ -1,5 +1,5 @@
 #![cfg(not(target_family = "wasm"))]
-use crate::utils::{components_count, diff::diff, setup, TestResources};
+use crate::utils::{diff::diff, setup, TestResources};
 use assert_cmd::Command as Cmd;
 use clap::Parser;
 use portable_network_archive::{cli, command::Command};
@@ -47,7 +47,7 @@ fn delete_with_files_from_stdin() {
         "--out-dir",
         "delete_files_from_stdin/out/",
         "--strip-components",
-        &components_count("delete_files_from_stdin/in/").to_string(),
+        "2",
     ]);
     cmd.assert().success();
 

--- a/cli/tests/cli/delete/password.rs
+++ b/cli/tests/cli/delete/password.rs
@@ -1,4 +1,4 @@
-use crate::utils::{components_count, diff::diff, setup, TestResources};
+use crate::utils::{diff::diff, setup, TestResources};
 use clap::Parser;
 use portable_network_archive::{cli, command::Command};
 use std::fs;
@@ -47,7 +47,7 @@ fn delete_with_password() {
         "--password",
         "password",
         "--strip-components",
-        &components_count("delete_password/in/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()

--- a/cli/tests/cli/delete/password_file.rs
+++ b/cli/tests/cli/delete/password_file.rs
@@ -1,4 +1,4 @@
-use crate::utils::{components_count, diff::diff, setup, TestResources};
+use crate::utils::{diff::diff, setup, TestResources};
 use clap::Parser;
 use portable_network_archive::{cli, command::Command};
 use std::fs;
@@ -50,7 +50,7 @@ fn delete_with_password_file() {
         "--password-file",
         password_file_path,
         "--strip-components",
-        &components_count("delete_password_file/in/").to_string(),
+        "2",
     ])
     .unwrap()
     .execute()


### PR DESCRIPTION
Replaced all uses of `components_count(...)` with a hardcoded "2" for the `--strip-components` argument in delete-related CLI tests. This simplifies the test logic and removes unnecessary dependency on directory structure inspection.