### PR TITLE
:shirt: Fixed doctest formatting for remove_path_all example

### DIFF
--- a/pna/src/fs.rs
+++ b/pna/src/fs.rs
@@ -63,10 +63,10 @@ pub fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Resu
 /// ```no_run
 /// use pna::fs;
 ///
-/// fn main() -> std::io::Result<()> {
-///     fs::remove_path_all("/some/dir_or_file")?;
-///     Ok(())
-/// }
+/// # fn main() -> std::io::Result<()> {
+/// fs::remove_path_all("/some/dir_or_file")?;
+/// #    Ok(())
+/// # }
 /// ```
 #[inline]
 pub fn remove_path_all<P: AsRef<Path>>(path: P) -> io::Result<()> {


### PR DESCRIPTION
Adjusted the `remove_path_all` usage example to work correctly with `rustdoc` by commenting out the `main` function wrapper using `#`, ensuring the example compiles and runs as a doctest.