### PR TITLE
:construction_worker: set workflow job timeout to 100 minutes

### DIFF
--- a/.github/workflows/webassembly.yml
+++ b/.github/workflows/webassembly.yml
@@ -31,6 +31,7 @@ jobs:
 
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}
+    timeout-minutes: 100
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
Set the timeout for the webassembly workflow job to 100 minutes.