### PR TITLE
:alembic: Add experimental sort command

### DIFF
--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -13,6 +13,7 @@ pub(super) mod experimental;
 pub mod extract;
 pub mod list;
 mod migrate;
+mod sort;
 pub mod split;
 pub(crate) mod stdio;
 pub(crate) mod strip;

--- a/cli/src/command/experimental.rs
+++ b/cli/src/command/experimental.rs
@@ -31,6 +31,7 @@ impl Command for ExperimentalCommand {
             ExperimentalCommands::Acl(cmd) => cmd.execute(),
             ExperimentalCommands::Migrate(cmd) => cmd.execute(),
             ExperimentalCommands::Chunk(cmd) => cmd.execute(),
+            ExperimentalCommands::Sort(cmd) => cmd.execute(),
         }
     }
 }
@@ -55,4 +56,6 @@ pub(crate) enum ExperimentalCommands {
     Migrate(command::migrate::MigrateCommand),
     #[command(about = "Chunk level operation")]
     Chunk(command::chunk::ChunkCommand),
+    #[command(about = "Sort entries in archive")]
+    Sort(command::sort::SortCommand),
 }

--- a/cli/src/command/sort.rs
+++ b/cli/src/command/sort.rs
@@ -1,0 +1,93 @@
+use crate::{
+    cli::PasswordArgs,
+    command::{
+        ask_password,
+        commons::{collect_split_archives, run_entries},
+        Command,
+    },
+    utils::{env::NamedTempFile, PathPartExt},
+};
+use clap::{Parser, ValueEnum, ValueHint};
+use pna::{Archive, NormalEntry};
+use std::path::PathBuf;
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, ValueEnum)]
+pub(crate) enum SortBy {
+    Name,
+    Ctime,
+    Mtime,
+    Atime,
+}
+
+#[derive(Parser, Clone, Eq, PartialEq, Hash, Debug)]
+pub(crate) struct SortCommand {
+    #[arg(value_hint = ValueHint::FilePath)]
+    archive: PathBuf,
+    #[arg(long, help = "Output file path", value_hint = ValueHint::FilePath)]
+    output: Option<PathBuf>,
+    #[arg(long = "by", value_enum, num_args = 1.., default_values_t = [SortBy::Name])]
+    by: Vec<SortBy>,
+    #[command(flatten)]
+    password: PasswordArgs,
+}
+
+impl Command for SortCommand {
+    #[inline]
+    fn execute(self) -> anyhow::Result<()> {
+        sort_archive(self)
+    }
+}
+
+fn sort_archive(args: SortCommand) -> anyhow::Result<()> {
+    let password = ask_password(args.password)?;
+    let archives = collect_split_archives(&args.archive)?;
+    #[cfg(feature = "memmap")]
+    let mmaps = archives
+        .into_iter()
+        .map(crate::utils::mmap::Mmap::try_from)
+        .collect::<std::io::Result<Vec<_>>>()?;
+    #[cfg(feature = "memmap")]
+    let archives = mmaps.iter().map(|m| m.as_ref());
+    let mut entries = Vec::<NormalEntry<_>>::new();
+    run_entries(
+        archives,
+        || password.as_deref(),
+        |entry| {
+            entries.push(entry?);
+            Ok(())
+        },
+    )?;
+
+    entries.sort_by(|a, b| {
+        for by in &args.by {
+            let ord = match by {
+                SortBy::Name => a.header().path().cmp(b.header().path()),
+                SortBy::Ctime => a.metadata().created().cmp(&b.metadata().created()),
+                SortBy::Mtime => a.metadata().modified().cmp(&b.metadata().modified()),
+                SortBy::Atime => a.metadata().accessed().cmp(&b.metadata().accessed()),
+            };
+            if ord != std::cmp::Ordering::Equal {
+                return ord;
+            }
+        }
+        std::cmp::Ordering::Equal
+    });
+
+    let mut temp_file =
+        NamedTempFile::new(|| args.archive.parent().unwrap_or_else(|| ".".as_ref()))?;
+    let mut archive = Archive::write_header(temp_file.as_file_mut())?;
+    for entry in entries {
+        archive.add_entry(entry)?;
+    }
+    archive.finalize()?;
+
+    #[cfg(feature = "memmap")]
+    drop(mmaps);
+
+    let output = args
+        .output
+        .unwrap_or_else(|| args.archive.remove_part().unwrap());
+    temp_file.persist(output)?;
+
+    Ok(())
+}

--- a/cli/tests/cli/main.rs
+++ b/cli/tests/cli/main.rs
@@ -20,6 +20,7 @@ mod multipart;
 mod restore_acl;
 mod restore_acl_0_19_1;
 mod solid_mode;
+mod sort;
 mod split;
 mod strip;
 mod update;

--- a/cli/tests/cli/sort.rs
+++ b/cli/tests/cli/sort.rs
@@ -1,0 +1,6 @@
+mod by_atime;
+mod by_ctime;
+mod by_mtime;
+mod by_name;
+mod multiple_keys;
+mod order_combination;

--- a/cli/tests/cli/sort/by_atime.rs
+++ b/cli/tests/cli/sort/by_atime.rs
@@ -1,0 +1,52 @@
+use crate::utils::{archive::for_each_entry, setup};
+use clap::Parser;
+use pna::{Archive, EntryBuilder, WriteOptions};
+use portable_network_archive::{cli, command::Command};
+use std::{fs, time::Duration};
+
+#[test]
+fn sort_by_atime() {
+    setup();
+    fs::create_dir_all("sort_by_atime").unwrap();
+    let file = fs::File::create("sort_by_atime/unsorted.pna").unwrap();
+    let mut archive = Archive::write_header(file).unwrap();
+    let entry1 = {
+        let mut b = EntryBuilder::new_file("c.txt".into(), WriteOptions::store()).unwrap();
+        b.accessed(Duration::from_secs(3000));
+        b.build().unwrap()
+    };
+    let entry2 = {
+        let mut b = EntryBuilder::new_file("a.txt".into(), WriteOptions::store()).unwrap();
+        b.accessed(Duration::from_secs(1000));
+        b.build().unwrap()
+    };
+    let entry3 = {
+        let mut b = EntryBuilder::new_file("b.txt".into(), WriteOptions::store()).unwrap();
+        b.accessed(Duration::from_secs(2000));
+        b.build().unwrap()
+    };
+    archive.add_entry(entry1).unwrap();
+    archive.add_entry(entry2).unwrap();
+    archive.add_entry(entry3).unwrap();
+    archive.finalize().unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "sort",
+        "sort_by_atime/unsorted.pna",
+        "--by",
+        "atime",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut names = Vec::new();
+    for_each_entry("sort_by_atime/unsorted.pna", |e| {
+        names.push(e.header().path().as_str().to_string());
+    })
+    .unwrap();
+    assert_eq!(names, ["a.txt", "b.txt", "c.txt"]);
+}

--- a/cli/tests/cli/sort/by_ctime.rs
+++ b/cli/tests/cli/sort/by_ctime.rs
@@ -1,0 +1,52 @@
+use crate::utils::{archive::for_each_entry, setup};
+use clap::Parser;
+use pna::{Archive, EntryBuilder, WriteOptions};
+use portable_network_archive::{cli, command::Command};
+use std::{fs, time::Duration};
+
+#[test]
+fn sort_by_ctime() {
+    setup();
+    fs::create_dir_all("sort_by_ctime").unwrap();
+    let file = fs::File::create("sort_by_ctime/unsorted.pna").unwrap();
+    let mut archive = Archive::write_header(file).unwrap();
+    let entry1 = {
+        let mut b = EntryBuilder::new_file("c.txt".into(), WriteOptions::store()).unwrap();
+        b.created(Duration::from_secs(3000));
+        b.build().unwrap()
+    };
+    let entry2 = {
+        let mut b = EntryBuilder::new_file("a.txt".into(), WriteOptions::store()).unwrap();
+        b.created(Duration::from_secs(1000));
+        b.build().unwrap()
+    };
+    let entry3 = {
+        let mut b = EntryBuilder::new_file("b.txt".into(), WriteOptions::store()).unwrap();
+        b.created(Duration::from_secs(2000));
+        b.build().unwrap()
+    };
+    archive.add_entry(entry1).unwrap();
+    archive.add_entry(entry2).unwrap();
+    archive.add_entry(entry3).unwrap();
+    archive.finalize().unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "sort",
+        "sort_by_ctime/unsorted.pna",
+        "--by",
+        "ctime",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut names = Vec::new();
+    for_each_entry("sort_by_ctime/unsorted.pna", |e| {
+        names.push(e.header().path().as_str().to_string());
+    })
+    .unwrap();
+    assert_eq!(names, ["a.txt", "b.txt", "c.txt"]);
+}

--- a/cli/tests/cli/sort/by_mtime.rs
+++ b/cli/tests/cli/sort/by_mtime.rs
@@ -1,0 +1,52 @@
+use crate::utils::{archive::for_each_entry, setup};
+use clap::Parser;
+use pna::{Archive, EntryBuilder, WriteOptions};
+use portable_network_archive::{cli, command::Command};
+use std::{fs, time::Duration};
+
+#[test]
+fn sort_by_mtime() {
+    setup();
+    fs::create_dir_all("sort_by_mtime").unwrap();
+    let file = fs::File::create("sort_by_mtime/unsorted.pna").unwrap();
+    let mut archive = Archive::write_header(file).unwrap();
+    let entry1 = {
+        let mut b = EntryBuilder::new_file("c.txt".into(), WriteOptions::store()).unwrap();
+        b.modified(Duration::from_secs(3000));
+        b.build().unwrap()
+    };
+    let entry2 = {
+        let mut b = EntryBuilder::new_file("a.txt".into(), WriteOptions::store()).unwrap();
+        b.modified(Duration::from_secs(1000));
+        b.build().unwrap()
+    };
+    let entry3 = {
+        let mut b = EntryBuilder::new_file("b.txt".into(), WriteOptions::store()).unwrap();
+        b.modified(Duration::from_secs(2000));
+        b.build().unwrap()
+    };
+    archive.add_entry(entry1).unwrap();
+    archive.add_entry(entry2).unwrap();
+    archive.add_entry(entry3).unwrap();
+    archive.finalize().unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "sort",
+        "sort_by_mtime/unsorted.pna",
+        "--by",
+        "mtime",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut names = Vec::new();
+    for_each_entry("sort_by_mtime/unsorted.pna", |e| {
+        names.push(e.header().path().as_str().to_string());
+    })
+    .unwrap();
+    assert_eq!(names, ["a.txt", "b.txt", "c.txt"]);
+}

--- a/cli/tests/cli/sort/by_name.rs
+++ b/cli/tests/cli/sort/by_name.rs
@@ -1,0 +1,36 @@
+use crate::utils::{archive::for_each_entry, setup};
+use clap::Parser;
+use pna::{Archive, EntryBuilder, WriteOptions};
+use portable_network_archive::{cli, command::Command};
+use std::fs;
+
+#[test]
+fn sort_by_name() {
+    setup();
+    fs::create_dir_all("sort_by_name").unwrap();
+    let file = fs::File::create("sort_by_name/unsorted.pna").unwrap();
+    let mut archive = Archive::write_header(file).unwrap();
+    let entry_b = EntryBuilder::new_file("b.txt".into(), WriteOptions::store()).unwrap();
+    archive.add_entry(entry_b.build().unwrap()).unwrap();
+    let entry_a = EntryBuilder::new_file("a.txt".into(), WriteOptions::store()).unwrap();
+    archive.add_entry(entry_a.build().unwrap()).unwrap();
+    archive.finalize().unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "sort",
+        "sort_by_name/unsorted.pna",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut names = Vec::new();
+    for_each_entry("sort_by_name/unsorted.pna", |e| {
+        names.push(e.header().path().as_str().to_string());
+    })
+    .unwrap();
+    assert_eq!(names, ["a.txt", "b.txt"]);
+}

--- a/cli/tests/cli/sort/multiple_keys.rs
+++ b/cli/tests/cli/sort/multiple_keys.rs
@@ -1,0 +1,60 @@
+use crate::utils::{archive::for_each_entry, setup};
+use clap::Parser;
+use pna::{Archive, EntryBuilder, WriteOptions};
+use portable_network_archive::{cli, command::Command};
+use std::{fs, time::Duration};
+
+#[test]
+fn sort_by_multiple_keys() {
+    setup();
+    fs::create_dir_all("sort_by_multi").unwrap();
+    let file = fs::File::create("sort_by_multi/unsorted.pna").unwrap();
+    let mut archive = Archive::write_header(file).unwrap();
+    // a.txt: ctime=1000, mtime=3000
+    let entry1 = {
+        let mut b = EntryBuilder::new_file("a.txt".into(), WriteOptions::store()).unwrap();
+        b.created(Duration::from_secs(1000));
+        b.modified(Duration::from_secs(3000));
+        b.build().unwrap()
+    };
+    // b.txt: ctime=1000, mtime=2000
+    let entry2 = {
+        let mut b = EntryBuilder::new_file("b.txt".into(), WriteOptions::store()).unwrap();
+        b.created(Duration::from_secs(1000));
+        b.modified(Duration::from_secs(2000));
+        b.build().unwrap()
+    };
+    // c.txt: ctime=2000, mtime=1000
+    let entry3 = {
+        let mut b = EntryBuilder::new_file("c.txt".into(), WriteOptions::store()).unwrap();
+        b.created(Duration::from_secs(2000));
+        b.modified(Duration::from_secs(1000));
+        b.build().unwrap()
+    };
+    archive.add_entry(entry1).unwrap();
+    archive.add_entry(entry2).unwrap();
+    archive.add_entry(entry3).unwrap();
+    archive.finalize().unwrap();
+
+    // by=ctime,mtime
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "sort",
+        "sort_by_multi/unsorted.pna",
+        "--by",
+        "ctime",
+        "--by",
+        "mtime",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    let mut names = Vec::new();
+    for_each_entry("sort_by_multi/unsorted.pna", |e| {
+        names.push(e.header().path().as_str().to_string());
+    })
+    .unwrap();
+    assert_eq!(names, ["b.txt", "a.txt", "c.txt"]);
+}

--- a/cli/tests/cli/sort/order_combination.rs
+++ b/cli/tests/cli/sort/order_combination.rs
@@ -1,0 +1,95 @@
+use crate::utils::{archive::for_each_entry, setup};
+use clap::Parser;
+use pna::{Archive, EntryBuilder, WriteOptions};
+use portable_network_archive::{cli, command::Command};
+use std::{fs, time::Duration};
+
+#[test]
+fn sort_by_all_keys() {
+    setup();
+    fs::create_dir_all("sort_by_all").unwrap();
+    let file = fs::File::create("sort_by_all/unsorted.pna").unwrap();
+    let mut archive = Archive::write_header(file).unwrap();
+    // a.txt: ctime=1000, mtime=3000, atime=2000
+    let entry1 = {
+        let mut b = EntryBuilder::new_file("a.txt".into(), WriteOptions::store()).unwrap();
+        b.created(Duration::from_secs(1000));
+        b.modified(Duration::from_secs(3000));
+        b.accessed(Duration::from_secs(2000));
+        b.build().unwrap()
+    };
+    // b.txt: ctime=1000, mtime=2000, atime=3000
+    let entry2 = {
+        let mut b = EntryBuilder::new_file("b.txt".into(), WriteOptions::store()).unwrap();
+        b.created(Duration::from_secs(1000));
+        b.modified(Duration::from_secs(2000));
+        b.accessed(Duration::from_secs(3000));
+        b.build().unwrap()
+    };
+    // c.txt: ctime=2000, mtime=1000, atime=1000
+    let entry3 = {
+        let mut b = EntryBuilder::new_file("c.txt".into(), WriteOptions::store()).unwrap();
+        b.created(Duration::from_secs(2000));
+        b.modified(Duration::from_secs(1000));
+        b.accessed(Duration::from_secs(1000));
+        b.build().unwrap()
+    };
+    archive.add_entry(entry1).unwrap();
+    archive.add_entry(entry2).unwrap();
+    archive.add_entry(entry3).unwrap();
+    archive.finalize().unwrap();
+
+    // by=atime,mtime,ctime,name
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "sort",
+        "sort_by_all/unsorted.pna",
+        "--by",
+        "atime",
+        "--by",
+        "mtime",
+        "--by",
+        "ctime",
+        "--by",
+        "name",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    let mut names = Vec::new();
+    for_each_entry("sort_by_all/unsorted.pna", |e| {
+        names.push(e.header().path().as_str().to_string());
+    })
+    .unwrap();
+    // atime ascending → mtime ascending → ctime ascending → name ascending
+    assert_eq!(names, ["c.txt", "a.txt", "b.txt"]);
+
+    // Reverse order (by=name,ctime,mtime,atime)
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "sort",
+        "sort_by_all/unsorted.pna",
+        "--by",
+        "name",
+        "--by",
+        "ctime",
+        "--by",
+        "mtime",
+        "--by",
+        "atime",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    let mut names = Vec::new();
+    for_each_entry("sort_by_all/unsorted.pna", |e| {
+        names.push(e.header().path().as_str().to_string());
+    })
+    .unwrap();
+    // name ascending → ctime ascending → mtime ascending → atime ascending
+    assert_eq!(names, ["a.txt", "b.txt", "c.txt"]);
+}


### PR DESCRIPTION
Introduces a new experimental 'sort' command to sort entries in an archive by name. Updates the command registry and adds corresponding tests to verify sorting functionality.