### PR TITLE
:alembic: Add support for sort order in sort command

### DIFF
--- a/cli/tests/cli/sort.rs
+++ b/cli/tests/cli/sort.rs
@@ -2,5 +2,6 @@ mod by_atime;
 mod by_ctime;
 mod by_mtime;
 mod by_name;
+mod by_name_desc;
 mod multiple_keys;
 mod order_combination;

--- a/cli/tests/cli/sort/by_name_desc.rs
+++ b/cli/tests/cli/sort/by_name_desc.rs
@@ -1,0 +1,38 @@
+use crate::utils::{archive::for_each_entry, setup};
+use clap::Parser;
+use pna::{Archive, EntryBuilder, WriteOptions};
+use portable_network_archive::{cli, command::Command};
+use std::fs;
+
+#[test]
+fn sort_by_name_desc() {
+    setup();
+    fs::create_dir_all("sort_by_name_desc").unwrap();
+    let file = fs::File::create("sort_by_name_desc/unsorted.pna").unwrap();
+    let mut archive = Archive::write_header(file).unwrap();
+    let entry_a = EntryBuilder::new_file("a.txt".into(), WriteOptions::store()).unwrap();
+    archive.add_entry(entry_a.build().unwrap()).unwrap();
+    let entry_b = EntryBuilder::new_file("b.txt".into(), WriteOptions::store()).unwrap();
+    archive.add_entry(entry_b.build().unwrap()).unwrap();
+    archive.finalize().unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "sort",
+        "sort_by_name_desc/unsorted.pna",
+        "--by",
+        "name:desc",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut names = Vec::new();
+    for_each_entry("sort_by_name_desc/unsorted.pna", |e| {
+        names.push(e.header().path().as_str().to_string());
+    })
+    .unwrap();
+    assert_eq!(names, ["b.txt", "a.txt"]);
+}


### PR DESCRIPTION
Introduces SortOrder and SortKey to allow specifying ascending or descending order for each sort key in the sort command. Updates argument parsing, sorting logic, and adds tests for parsing and sorting by name in descending order.