### PR TITLE
:white_check_mark: Stabilize xattr test output by sorting entries

### DIFF
--- a/cli/tests/cli/xattr/dump.rs
+++ b/cli/tests/cli/xattr/dump.rs
@@ -33,6 +33,17 @@ fn xattr_get_dump() {
         "--keep-xattr",
     ])
     .unwrap();
+
+    // Sort entries for stablize entries order.
+    let mut cmd = assert_cmd::Command::cargo_bin("pna").unwrap();
+    cmd.args([
+        "--quiet",
+        "experimental",
+        "sort",
+        "xattr_get_dump/xattr_get_dump.pna",
+    ])
+    .assert();
+
     let mut cmd = assert_cmd::Command::cargo_bin("pna").unwrap();
     let assert = cmd
         .args([

--- a/cli/tests/cli/xattr/get.rs
+++ b/cli/tests/cli/xattr/get.rs
@@ -19,6 +19,18 @@ fn xattr_get_name_match_encoding() {
     .execute()
     .unwrap();
 
+    // Sort entries for stablize entries order.
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "sort",
+        "xattr_get_opts/archive.pna",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",


### PR DESCRIPTION
Added sorting steps in xattr dump and get tests to ensure stable entry order. This helps prevent test flakiness due to non-deterministic output ordering.