### PR TITLE
:memo: Add shell installer instructions to README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,20 @@ Additionally, the PNA specification includes a rationale appendix to help develo
 
 ## Installation
 
+### Via Shell (Prebuilt Binary)
+
+#### On Linux or MacOS
+
+```sh
+curl --proto '=https' --tlsv1.2 -LsSf 'https://github.com/ChanTsune/Portable-Network-Archive/releases/latest/download/portable-network-archive-installer.sh' | sh
+```
+
+#### On Windows
+
+```sh
+powershell -ExecutionPolicy Bypass -c "irm https://github.com/ChanTsune/Portable-Network-Archive/releases/latest/download/portable-network-archive-installer.ps1 | iex"
+```
+
 ### Via Cargo
 
 ```sh

--- a/cli/README.md
+++ b/cli/README.md
@@ -10,6 +10,20 @@ Also, its data structure is inspired by the PNG data structure.
 
 ## Installation
 
+### Via Shell (Prebuilt Binary)
+
+#### On Linux or MacOS
+
+```sh
+curl --proto '=https' --tlsv1.2 -LsSf 'https://github.com/ChanTsune/Portable-Network-Archive/releases/latest/download/portable-network-archive-installer.sh' | sh
+```
+
+#### On Windows
+
+```sh
+powershell -ExecutionPolicy Bypass -c "irm https://github.com/ChanTsune/Portable-Network-Archive/releases/latest/download/portable-network-archive-installer.ps1 | iex"
+```
+
 ### Via Cargo
 
 ```sh


### PR DESCRIPTION
Updated both the main and CLI README files to include installation instructions for prebuilt binaries via shell scripts for Linux, MacOS, and Windows. This provides users with an easier installation option in addition to Cargo.