### PR TITLE
:bug: Fix archive creation recursion flag logic in stdio subcommand

### DIFF
--- a/cli/src/command/stdio.rs
+++ b/cli/src/command/stdio.rs
@@ -254,7 +254,7 @@ fn run_create_archive(args: StdioCommand) -> anyhow::Result<()> {
     };
     let target_items = collect_items(
         &files,
-        args.recursive,
+        !args.no_recursive,
         args.keep_dir,
         args.gitignore,
         args.follow_links,


### PR DESCRIPTION
Corrects the logic for determining recursive behavior in archive creation by using the negation of the no_recursive argument instead of the recursive argument.