### PR TITLE
:zap: `--directory` that alias of `--cd` option make visible

### DIFF
--- a/cli/src/command/append.rs
+++ b/cli/src/command/append.rs
@@ -163,7 +163,7 @@ pub(crate) struct AppendCommand {
     #[arg(
         short = 'C',
         long = "cd",
-        aliases = ["directory"],
+        visible_aliases = ["directory"],
         value_name = "DIRECTORY",
         help = "changes the directory before adding the following files",
         value_hint = ValueHint::DirPath

--- a/cli/src/command/create.rs
+++ b/cli/src/command/create.rs
@@ -177,7 +177,7 @@ pub(crate) struct CreateCommand {
     #[arg(
         short = 'C',
         long = "cd",
-        aliases = ["directory"],
+        visible_aliases = ["directory"],
         value_name = "DIRECTORY",
         help = "changes the directory before adding the following files",
         value_hint = ValueHint::DirPath

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -137,7 +137,7 @@ pub(crate) struct ExtractCommand {
     #[arg(
         short = 'C',
         long = "cd",
-        aliases = ["directory"],
+        visible_aliases = ["directory"],
         value_name = "DIRECTORY",
         help = "Change directories after opening the archive but before extracting entries from the archive",
         value_hint = ValueHint::DirPath

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -183,7 +183,7 @@ pub(crate) struct UpdateCommand {
     #[arg(
         short = 'C',
         long = "cd",
-        aliases = ["directory"],
+        visible_aliases = ["directory"],
         value_name = "DIRECTORY",
         help = "changes the directory before adding the following files",
         value_hint = ValueHint::DirPath


### PR DESCRIPTION
Updated the command-line argument definition for the --cd/-C option in append, create, extract, and update commands to use 'visible_aliases' instead of 'aliases' for the 'directory' alias. This change improves clarity and aligns with the latest argument attribute conventions.