### PR TITLE
:zap: Make ChunkStreamWriter::new a const fn

### DIFF
--- a/lib/src/chunk/write.rs
+++ b/lib/src/chunk/write.rs
@@ -49,7 +49,7 @@ pub(crate) struct ChunkStreamWriter<W> {
 
 impl<W> ChunkStreamWriter<W> {
     #[inline]
-    pub(crate) fn new(ty: ChunkType, inner: W) -> Self {
+    pub(crate) const fn new(ty: ChunkType, inner: W) -> Self {
         Self {
             ty,
             w: ChunkWriter::new(inner),


### PR DESCRIPTION
Changed the new function of ChunkStreamWriter to be a const fn, allowing it to be used in const contexts.