### PR TITLE
:pencil2: Fix doc comment grammar in symlink function

### DIFF
--- a/pna/src/fs.rs
+++ b/pna/src/fs.rs
@@ -19,7 +19,7 @@ use std::{fs, io, os, path::Path};
 /// ```
 ///
 /// # Errors
-/// Returns an error if it fails to create the symlink.
+/// Return an error if it fails to create the symlink.
 #[inline]
 pub fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Result<()> {
     #[cfg(unix)]


### PR DESCRIPTION
Updated the documentation comment for the symlink function to improve grammar by changing 'Returns an error' to 'Return an error'.