### PR TITLE
:bug: Fix symlink substitution to use source path

### DIFF
--- a/cli/src/command/commons.rs
+++ b/cli/src/command/commons.rs
@@ -186,7 +186,7 @@ pub(crate) fn create_entry(
     if !follow_links && path.is_symlink() {
         let source = fs::read_link(path)?;
         let reference = if let Some(substitutions) = substitutions {
-            EntryReference::from(substitutions.apply(path.to_string_lossy(), true, false))
+            EntryReference::from(substitutions.apply(source.to_string_lossy(), true, false))
         } else {
             EntryReference::from_lossy(source)
         };


### PR DESCRIPTION
Corrects the symlink substitution logic to apply substitutions to the symlink's target path instead of the symlink's own path.