### PR TITLE
:white_check_mark: Refactor xattr_get_dump test to use CLI for xattr setup

### DIFF
--- a/cli/tests/cli/xattr/dump.rs
+++ b/cli/tests/cli/xattr/dump.rs
@@ -1,26 +1,9 @@
-use crate::utils::{diff::diff, setup, TestResources};
+use crate::utils::{setup, TestResources};
 
 #[test]
 fn xattr_get_dump() {
     setup();
     TestResources::extract_in("raw/", "xattr_get_dump/in/").unwrap();
-
-    #[cfg(all(unix, not(target_os = "netbsd")))]
-    if xattr::SUPPORTED_PLATFORM {
-        assert!(xattr::set(
-            "xattr_get_dump/in/raw/empty.txt",
-            "user.meta",
-            &[1, 2, 3, 4, 5]
-        )
-        .is_ok());
-        assert!(xattr::set("xattr_get_dump/in/raw/empty.txt", "user.name", b"pna").is_ok());
-        assert!(xattr::set(
-            "xattr_get_dump/in/raw/empty.txt",
-            "user.value",
-            b"inspired by png data structure"
-        )
-        .is_ok());
-    }
 
     let mut cmd = assert_cmd::Command::cargo_bin("pna").unwrap();
     cmd.args([
@@ -29,11 +12,32 @@ fn xattr_get_dump() {
         "xattr_get_dump/xattr_get_dump.pna",
         "--overwrite",
         "xattr_get_dump/in/",
-        #[cfg(not(target_os = "netbsd"))]
-        "--keep-xattr",
     ])
     .unwrap();
 
+    let archive_path = "xattr_get_dump/xattr_get_dump.pna";
+    let file_to_set_xattr = "xattr_get_dump/in/raw/empty.txt";
+    let xattrs_to_set = [
+        ("user.meta", "0x0102030405"),
+        ("user.name", "pna"),
+        ("user.value", "inspired by png data structure"),
+    ];
+
+    for (name, value) in xattrs_to_set {
+        let mut cmd = assert_cmd::Command::cargo_bin("pna").unwrap();
+        cmd.args([
+            "--quiet",
+            "xattr",
+            "set",
+            archive_path,
+            file_to_set_xattr,
+            "--name",
+            name,
+            "--value",
+            value,
+        ])
+        .unwrap();
+    }
     // Sort entries for stablize entries order.
     let mut cmd = assert_cmd::Command::cargo_bin("pna").unwrap();
     cmd.args([
@@ -57,52 +61,11 @@ fn xattr_get_dump() {
         ])
         .assert();
 
-    #[cfg(all(unix, not(target_os = "netbsd")))]
-    if xattr::SUPPORTED_PLATFORM {
-        assert.stdout(concat!(
-            "# file: xattr_get_dump/in/raw/empty.txt\n",
-            "user.meta=\"\x01\x02\x03\x04\x05\"\n",
-            "user.name=\"pna\"\n",
-            "user.value=\"inspired by png data structure\"\n",
-            "\n",
-        ));
-    }
-    let mut cmd = assert_cmd::Command::cargo_bin("pna").unwrap();
-    cmd.args([
-        "--quiet",
-        "x",
-        "xattr_get_dump/xattr_get_dump.pna",
-        "--overwrite",
-        "--out-dir",
-        "xattr_get_dump/out/",
-        #[cfg(not(target_os = "netbsd"))]
-        "--keep-xattr",
-        "--strip-components",
-        "2",
-    ])
-    .unwrap();
-
-    diff("xattr_get_dump/in/", "xattr_get_dump/out/").unwrap();
-
-    #[cfg(all(unix, not(target_os = "netbsd")))]
-    if xattr::SUPPORTED_PLATFORM {
-        assert_eq!(
-            xattr::get("xattr_get_dump/out/raw/empty.txt", "user.meta")
-                .unwrap()
-                .unwrap(),
-            &[1, 2, 3, 4, 5]
-        );
-        assert_eq!(
-            xattr::get("xattr_get_dump/out/raw/empty.txt", "user.name")
-                .unwrap()
-                .unwrap(),
-            b"pna"
-        );
-        assert_eq!(
-            xattr::get("xattr_get_dump/out/raw/empty.txt", "user.value")
-                .unwrap()
-                .unwrap(),
-            b"inspired by png data structure"
-        );
-    }
+    assert.stdout(concat!(
+        "# file: xattr_get_dump/in/raw/empty.txt\n",
+        "user.meta=\"\x01\x02\x03\x04\x05\"\n",
+        "user.name=\"pna\"\n",
+        "user.value=\"inspired by png data structure\"\n",
+        "\n",
+    ));
 }


### PR DESCRIPTION
Replaces direct xattr crate usage with CLI commands to set extended attributes in the xattr_get_dump test. Removes platform-specific conditional code and simplifies assertions to always check CLI output.