### PR TITLE
:sparkles: Add --no-keep-dir option to CLI commands

### DIFF
--- a/cli/src/command/append.rs
+++ b/cli/src/command/append.rs
@@ -43,6 +43,7 @@ use std::{
     group(ArgGroup::new("user-flag").args(["numeric_owner", "uname"])),
     group(ArgGroup::new("group-flag").args(["numeric_owner", "gname"])),
     group(ArgGroup::new("recursive-flag").args(["recursive", "no_recursive"])),
+    group(ArgGroup::new("keep-dir-flag").args(["keep_dir", "no_keep_dir"])),
     group(ArgGroup::new("mtime-flag").args(["clamp_mtime"]).requires("mtime")),
     group(ArgGroup::new("atime-flag").args(["clamp_atime"]).requires("atime")),
 )]
@@ -65,7 +66,12 @@ pub(crate) struct AppendCommand {
     )]
     no_recursive: bool,
     #[arg(long, help = "Archiving the directories")]
-    pub(crate) keep_dir: bool,
+    keep_dir: bool,
+    #[arg(
+        long,
+        help = "Do not archive directories. This is the inverse option of --keep-dir"
+    )]
+    no_keep_dir: bool,
     #[arg(
         long,
         visible_alias = "preserve-timestamps",

--- a/cli/src/command/create.rs
+++ b/cli/src/command/create.rs
@@ -46,6 +46,7 @@ use std::{
     group(ArgGroup::new("user-flag").args(["numeric_owner", "uname"])),
     group(ArgGroup::new("group-flag").args(["numeric_owner", "gname"])),
     group(ArgGroup::new("recursive-flag").args(["recursive", "no_recursive"])),
+    group(ArgGroup::new("keep-dir-flag").args(["keep_dir", "no_keep_dir"])),
     group(ArgGroup::new("ctime-flag").args(["clamp_ctime"]).requires("ctime")),
     group(ArgGroup::new("mtime-flag").args(["clamp_mtime"]).requires("mtime")),
     group(ArgGroup::new("atime-flag").args(["clamp_atime"]).requires("atime")),
@@ -71,7 +72,12 @@ pub(crate) struct CreateCommand {
     #[arg(long, help = "Overwrite file")]
     pub(crate) overwrite: bool,
     #[arg(long, help = "Archiving the directories")]
-    pub(crate) keep_dir: bool,
+    keep_dir: bool,
+    #[arg(
+        long,
+        help = "Do not archive directories. This is the inverse option of --keep-dir"
+    )]
+    no_keep_dir: bool,
     #[arg(
         long,
         visible_alias = "preserve-timestamps",

--- a/cli/src/command/stdio.rs
+++ b/cli/src/command/stdio.rs
@@ -40,6 +40,7 @@ use std::{io, path::PathBuf, time::SystemTime};
     group(ArgGroup::new("user-flag").args(["numeric_owner", "uname"])),
     group(ArgGroup::new("group-flag").args(["numeric_owner", "gname"])),
     group(ArgGroup::new("recursive-flag").args(["recursive", "no_recursive"])),
+    group(ArgGroup::new("keep-dir-flag").args(["keep_dir", "no_keep_dir"])),
     group(ArgGroup::new("action-flags").args(["create", "extract", "list", "append"])),
     group(ArgGroup::new("ctime-flag").args(["clamp_ctime"]).requires("ctime")),
     group(ArgGroup::new("mtime-flag").args(["clamp_mtime"]).requires("mtime")),
@@ -75,6 +76,11 @@ pub(crate) struct StdioCommand {
     overwrite: bool,
     #[arg(long, help = "Archiving the directories")]
     keep_dir: bool,
+    #[arg(
+        long,
+        help = "Do not archive directories. This is the inverse option of --keep-dir"
+    )]
+    no_keep_dir: bool,
     #[arg(
         long,
         visible_alias = "preserve-timestamps",

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -47,6 +47,7 @@ use std::{env, fs, io, path::PathBuf, time::SystemTime};
     group(ArgGroup::new("user-flag").args(["numeric_owner", "uname"])),
     group(ArgGroup::new("group-flag").args(["numeric_owner", "gname"])),
     group(ArgGroup::new("recursive-flag").args(["recursive", "no_recursive"])),
+    group(ArgGroup::new("keep-dir-flag").args(["keep_dir", "no_keep_dir"])),
     group(ArgGroup::new("mtime-flag").args(["clamp_mtime"]).requires("mtime")),
     group(ArgGroup::new("atime-flag").args(["clamp_atime"]).requires("atime")),
 )]
@@ -69,7 +70,12 @@ pub(crate) struct UpdateCommand {
     )]
     no_recursive: bool,
     #[arg(long, help = "Archiving the directories")]
-    pub(crate) keep_dir: bool,
+    keep_dir: bool,
+    #[arg(
+        long,
+        help = "Do not archive directories. This is the inverse option of --keep-dir"
+    )]
+    no_keep_dir: bool,
     #[arg(
         long,
         visible_alias = "preserve-timestamps",


### PR DESCRIPTION
Introduces the --no-keep-dir flag as the inverse of --keep-dir for append, create, stdio, and update commands. Updates argument groups to include the new flag, allowing users to explicitly choose not to archive directories.