### PR TITLE
:boom: Return error if file pattern not found in archive

### DIFF
--- a/cli/src/command/acl.rs
+++ b/cli/src/command/acl.rs
@@ -331,6 +331,13 @@ fn archive_get_acl(args: GetAclCommand) -> anyhow::Result<()> {
             Ok(())
         },
     )?;
+    let unmatched_patterns = globs.unmatched_patterns();
+    if !unmatched_patterns.is_empty() {
+        for p in unmatched_patterns {
+            log::error!("{p} not found in archive");
+        }
+        anyhow::bail!("from previous errors");
+    }
     Ok(())
 }
 
@@ -388,6 +395,16 @@ fn archive_set_acl(args: SetAclCommand) -> anyhow::Result<()> {
     drop(mmaps);
 
     temp_file.persist(output_path)?;
+
+    if let SetAclsStrategy::Apply { globs, .. } = set_strategy {
+        let unmatched_patterns = globs.unmatched_patterns();
+        if !unmatched_patterns.is_empty() {
+            for p in unmatched_patterns {
+                log::error!("{p} not found in archive");
+            }
+            anyhow::bail!("from previous errors");
+        }
+    }
     Ok(())
 }
 

--- a/cli/src/command/acl.rs
+++ b/cli/src/command/acl.rs
@@ -331,13 +331,7 @@ fn archive_get_acl(args: GetAclCommand) -> anyhow::Result<()> {
             Ok(())
         },
     )?;
-    let unmatched_patterns = globs.unmatched_patterns();
-    if !unmatched_patterns.is_empty() {
-        for p in unmatched_patterns {
-            log::error!("{p} not found in archive");
-        }
-        anyhow::bail!("from previous errors");
-    }
+    globs.ensure_all_matched()?;
     Ok(())
 }
 
@@ -397,17 +391,12 @@ fn archive_set_acl(args: SetAclCommand) -> anyhow::Result<()> {
     temp_file.persist(output_path)?;
 
     if let SetAclsStrategy::Apply { globs, .. } = set_strategy {
-        let unmatched_patterns = globs.unmatched_patterns();
-        if !unmatched_patterns.is_empty() {
-            for p in unmatched_patterns {
-                log::error!("{p} not found in archive");
-            }
-            anyhow::bail!("from previous errors");
-        }
+        globs.ensure_all_matched()?;
     }
     Ok(())
 }
 
+#[allow(clippy::large_enum_variant)]
 enum SetAclsStrategy<'s> {
     Restore(HashMap<String, Acls>),
     Apply {

--- a/cli/src/command/chmod.rs
+++ b/cli/src/command/chmod.rs
@@ -20,7 +20,7 @@ use nom::{
     Parser as _,
 };
 use pna::NormalEntry;
-use std::{io, ops::BitOr, path::PathBuf, str::FromStr};
+use std::{ops::BitOr, path::PathBuf, str::FromStr};
 
 #[derive(Parser, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub(crate) struct ChmodCommand {
@@ -48,8 +48,7 @@ fn archive_chmod(args: ChmodCommand) -> anyhow::Result<()> {
     if args.files.is_empty() {
         return Ok(());
     }
-    let globs = GlobPatterns::new(args.files)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+    let mut globs = GlobPatterns::new(args.files.iter().map(|p| p.as_str()))?;
 
     let archives = collect_split_archives(&args.archive)?;
 
@@ -57,7 +56,7 @@ fn archive_chmod(args: ChmodCommand) -> anyhow::Result<()> {
     let mmaps = archives
         .into_iter()
         .map(crate::utils::mmap::Mmap::try_from)
-        .collect::<io::Result<Vec<_>>>()?;
+        .collect::<std::io::Result<Vec<_>>>()?;
     #[cfg(feature = "memmap")]
     let archives = mmaps.iter().map(|m| m.as_ref());
 

--- a/cli/src/command/chmod.rs
+++ b/cli/src/command/chmod.rs
@@ -99,6 +99,14 @@ fn archive_chmod(args: ChmodCommand) -> anyhow::Result<()> {
     drop(mmaps);
 
     temp_file.persist(output_path)?;
+
+    let unmatched_patterns = globs.unmatched_patterns();
+    if !unmatched_patterns.is_empty() {
+        for p in unmatched_patterns {
+            log::error!("{p} not found in archive");
+        }
+        anyhow::bail!("from previous errors");
+    }
     Ok(())
 }
 

--- a/cli/src/command/chmod.rs
+++ b/cli/src/command/chmod.rs
@@ -100,13 +100,7 @@ fn archive_chmod(args: ChmodCommand) -> anyhow::Result<()> {
 
     temp_file.persist(output_path)?;
 
-    let unmatched_patterns = globs.unmatched_patterns();
-    if !unmatched_patterns.is_empty() {
-        for p in unmatched_patterns {
-            log::error!("{p} not found in archive");
-        }
-        anyhow::bail!("from previous errors");
-    }
+    globs.ensure_all_matched()?;
     Ok(())
 }
 

--- a/cli/src/command/chown.rs
+++ b/cli/src/command/chown.rs
@@ -108,6 +108,14 @@ fn archive_chown(args: ChownCommand) -> anyhow::Result<()> {
     drop(mmaps);
 
     temp_file.persist(output_path)?;
+
+    let unmatched_patterns = globs.unmatched_patterns();
+    if !unmatched_patterns.is_empty() {
+        for p in unmatched_patterns {
+            log::error!("{p} not found in archive");
+        }
+        anyhow::bail!("from previous errors");
+    }
     Ok(())
 }
 

--- a/cli/src/command/chown.rs
+++ b/cli/src/command/chown.rs
@@ -53,8 +53,7 @@ fn archive_chown(args: ChownCommand) -> anyhow::Result<()> {
     if args.files.is_empty() {
         return Ok(());
     }
-    let globs = GlobPatterns::new(args.files)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+    let mut globs = GlobPatterns::new(args.files.iter().map(|p| p.as_ref()))?;
 
     let owner = args
         .owner

--- a/cli/src/command/chown.rs
+++ b/cli/src/command/chown.rs
@@ -109,13 +109,7 @@ fn archive_chown(args: ChownCommand) -> anyhow::Result<()> {
 
     temp_file.persist(output_path)?;
 
-    let unmatched_patterns = globs.unmatched_patterns();
-    if !unmatched_patterns.is_empty() {
-        for p in unmatched_patterns {
-            log::error!("{p} not found in archive");
-        }
-        anyhow::bail!("from previous errors");
-    }
+    globs.ensure_all_matched()?;
     Ok(())
 }
 

--- a/cli/src/command/delete.rs
+++ b/cli/src/command/delete.rs
@@ -13,7 +13,7 @@ use crate::{
     utils::{env::NamedTempFile, GlobPatterns, PathPartExt, VCS_FILES},
 };
 use clap::{ArgGroup, Parser, ValueHint};
-use std::{io, path::PathBuf};
+use std::path::PathBuf;
 
 #[derive(Parser, Clone, Eq, PartialEq, Hash, Debug)]
 #[command(
@@ -77,8 +77,7 @@ fn delete_file_from_archive(args: DeleteCommand) -> anyhow::Result<()> {
     } else if let Some(path) = args.files_from {
         files.extend(read_paths(path, args.null)?);
     }
-    let globs =
-        GlobPatterns::new(files).map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+    let mut globs = GlobPatterns::new(files.iter().map(|it| it.as_str()))?;
     let exclude = {
         let mut exclude = args.exclude.unwrap_or_default();
         if let Some(p) = args.exclude_from {
@@ -99,7 +98,7 @@ fn delete_file_from_archive(args: DeleteCommand) -> anyhow::Result<()> {
     let mmaps = archives
         .into_iter()
         .map(crate::utils::mmap::Mmap::try_from)
-        .collect::<io::Result<Vec<_>>>()?;
+        .collect::<std::io::Result<Vec<_>>>()?;
     #[cfg(feature = "memmap")]
     let archives = mmaps.iter().map(|m| m.as_ref());
 

--- a/cli/src/command/delete.rs
+++ b/cli/src/command/delete.rs
@@ -143,5 +143,13 @@ fn delete_file_from_archive(args: DeleteCommand) -> anyhow::Result<()> {
     drop(mmaps);
 
     temp_file.persist(output_path)?;
+
+    let unmatched_patterns = globs.unmatched_patterns();
+    if !unmatched_patterns.is_empty() {
+        for p in unmatched_patterns {
+            log::error!("{p} not found in archive");
+        }
+        anyhow::bail!("from previous errors");
+    }
     Ok(())
 }

--- a/cli/src/command/delete.rs
+++ b/cli/src/command/delete.rs
@@ -144,12 +144,6 @@ fn delete_file_from_archive(args: DeleteCommand) -> anyhow::Result<()> {
 
     temp_file.persist(output_path)?;
 
-    let unmatched_patterns = globs.unmatched_patterns();
-    if !unmatched_patterns.is_empty() {
-        for p in unmatched_patterns {
-            log::error!("{p} not found in archive");
-        }
-        anyhow::bail!("from previous errors");
-    }
+    globs.ensure_all_matched()?;
     Ok(())
 }

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -323,13 +323,7 @@ where
         extract_entry(item, password, &args)?;
     }
 
-    let unmatched_patterns = globs.unmatched_patterns();
-    if !unmatched_patterns.is_empty() {
-        for p in unmatched_patterns {
-            log::error!("{p} not found in archive");
-        }
-        anyhow::bail!("from previous errors");
-    }
+    globs.ensure_all_matched()?;
     Ok(())
 }
 
@@ -381,13 +375,7 @@ where
         for item in link_entries {
             extract_entry(item, password, &args)?;
         }
-        let unmatched_patterns = globs.unmatched_patterns();
-        if !unmatched_patterns.is_empty() {
-            for p in unmatched_patterns {
-                log::error!("{p} not found in archive");
-            }
-            anyhow::bail!("from previous errors");
-        }
+        globs.ensure_all_matched()?;
         Ok(())
     })
 }

--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -408,13 +408,7 @@ fn print_entries(
                 && !exclude.excluded(r.entry_type.name())
         })
         .collect::<Vec<_>>();
-    let unmatched_patterns = globs.unmatched_patterns();
-    if !unmatched_patterns.is_empty() {
-        for p in unmatched_patterns {
-            log::error!("{p} not found in archive");
-        }
-        anyhow::bail!("from previous errors");
-    }
+    globs.ensure_all_matched()?;
     match options.format {
         Some(Format::JsonL) => json_line_entries(entries),
         Some(Format::Table) => detail_list_entries(entries, options),

--- a/cli/src/command/stdio.rs
+++ b/cli/src/command/stdio.rs
@@ -422,8 +422,7 @@ fn run_list_archive(args: StdioCommand) -> anyhow::Result<()> {
         classify: false,
         format: None,
     };
-    let files_globs = GlobPatterns::new(&args.files)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+    let files_globs = GlobPatterns::new(args.files.iter().map(|it| it.as_str()))?;
 
     let exclude = {
         let mut exclude = args.exclude.unwrap_or_default();

--- a/cli/src/command/xattr.rs
+++ b/cli/src/command/xattr.rs
@@ -230,13 +230,7 @@ fn archive_get_xattr(args: GetXattrCommand) -> anyhow::Result<()> {
             Ok(())
         },
     )?;
-    let unmatched_patterns = globs.unmatched_patterns();
-    if !unmatched_patterns.is_empty() {
-        for p in unmatched_patterns {
-            log::error!("{p} not found in archive");
-        }
-        anyhow::bail!("from previous errors");
-    }
+    globs.ensure_all_matched()?;
     Ok(())
 }
 
@@ -296,13 +290,7 @@ fn archive_set_xattr(args: SetXattrCommand) -> anyhow::Result<()> {
     temp_file.persist(output_path)?;
 
     if let SetAttrStrategy::Apply { globs, .. } = set_strategy {
-        let unmatched_patterns = globs.unmatched_patterns();
-        if !unmatched_patterns.is_empty() {
-            for p in unmatched_patterns {
-                log::error!("{p} not found in archive");
-            }
-            anyhow::bail!("from previous errors");
-        }
+        globs.ensure_all_matched()?;
     }
     Ok(())
 }

--- a/cli/src/command/xattr.rs
+++ b/cli/src/command/xattr.rs
@@ -230,6 +230,13 @@ fn archive_get_xattr(args: GetXattrCommand) -> anyhow::Result<()> {
             Ok(())
         },
     )?;
+    let unmatched_patterns = globs.unmatched_patterns();
+    if !unmatched_patterns.is_empty() {
+        for p in unmatched_patterns {
+            log::error!("{p} not found in archive");
+        }
+        anyhow::bail!("from previous errors");
+    }
     Ok(())
 }
 
@@ -287,6 +294,16 @@ fn archive_set_xattr(args: SetXattrCommand) -> anyhow::Result<()> {
     drop(mmaps);
 
     temp_file.persist(output_path)?;
+
+    if let SetAttrStrategy::Apply { globs, .. } = set_strategy {
+        let unmatched_patterns = globs.unmatched_patterns();
+        if !unmatched_patterns.is_empty() {
+            for p in unmatched_patterns {
+                log::error!("{p} not found in archive");
+            }
+            anyhow::bail!("from previous errors");
+        }
+    }
     Ok(())
 }
 

--- a/cli/src/utils/globs.rs
+++ b/cli/src/utils/globs.rs
@@ -54,6 +54,17 @@ impl<'s> GlobPatterns<'s> {
         }
         unmatched
     }
+
+    pub(crate) fn ensure_all_matched(&self) -> anyhow::Result<()> {
+        let unmatched = self.unmatched_patterns();
+        if !unmatched.is_empty() {
+            for p in unmatched {
+                log::error!("'{p}' not found in archive");
+            }
+            anyhow::bail!("from previous errors");
+        }
+        Ok(())
+    }
 }
 
 /// BSD tar command like globs.

--- a/cli/tests/cli/acl.rs
+++ b/cli/tests/cli/acl.rs
@@ -1,5 +1,6 @@
 #[cfg(not(target_family = "wasm"))]
 mod dump;
+mod missing_file;
 #[cfg(not(target_family = "wasm"))]
 mod restore;
 

--- a/cli/tests/cli/acl/missing_file.rs
+++ b/cli/tests/cli/acl/missing_file.rs
@@ -1,0 +1,69 @@
+use crate::utils::{setup, TestResources};
+use clap::Parser;
+use portable_network_archive::{cli, command::Command};
+
+#[test]
+fn fail_with_missing_file_get() {
+    setup();
+    TestResources::extract_in("raw/", "acl_missing/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "acl_missing/archive.pna",
+        "--overwrite",
+        "acl_missing/in/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let result = cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "acl",
+        "get",
+        "acl_missing/archive.pna",
+        "acl_missing/in/raw/empty.txt",
+        "acl_missing/in/raw/not_found.txt",
+    ])
+    .unwrap()
+    .execute();
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn fail_with_missing_file_set() {
+    setup();
+    TestResources::extract_in("raw/", "acl_missing_set/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "acl_missing_set/archive.pna",
+        "--overwrite",
+        "acl_missing_set/in/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let result = cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "acl",
+        "set",
+        "acl_missing_set/archive.pna",
+        "--set",
+        "u::rwx",
+        "acl_missing_set/in/raw/empty.txt",
+        "acl_missing_set/in/raw/not_found.txt",
+    ])
+    .unwrap()
+    .execute();
+
+    assert!(result.is_err());
+}

--- a/cli/tests/cli/chmod.rs
+++ b/cli/tests/cli/chmod.rs
@@ -1,4 +1,5 @@
 mod keep_solid;
+mod missing_file;
 mod numeric;
 mod password;
 mod password_file;

--- a/cli/tests/cli/chmod/missing_file.rs
+++ b/cli/tests/cli/chmod/missing_file.rs
@@ -1,0 +1,38 @@
+use crate::utils::{setup, TestResources};
+use clap::Parser;
+use portable_network_archive::{cli, command::Command};
+
+#[test]
+fn fail_with_missing_file() {
+    setup();
+    TestResources::extract_in("raw/", "chmod_missing/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "chmod_missing/archive.pna",
+        "--overwrite",
+        "chmod_missing/in/",
+        "--keep-permission",
+        #[cfg(windows)]
+        "--unstable",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let result = cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "chmod",
+        "chmod_missing/archive.pna",
+        "644",
+        "chmod_missing/in/raw/empty.txt",
+        "chmod_missing/in/raw/not_found.txt",
+    ])
+    .unwrap()
+    .execute();
+
+    assert!(result.is_err());
+}

--- a/cli/tests/cli/chown.rs
+++ b/cli/tests/cli/chown.rs
@@ -1,2 +1,3 @@
+mod missing_file;
 mod no_owner_lookup;
 mod no_owner_lookup_numeric;

--- a/cli/tests/cli/chown/missing_file.rs
+++ b/cli/tests/cli/chown/missing_file.rs
@@ -1,0 +1,39 @@
+use crate::utils::{setup, TestResources};
+use clap::Parser;
+use portable_network_archive::{cli, command::Command};
+
+#[test]
+fn fail_with_missing_file() {
+    setup();
+    TestResources::extract_in("raw/", "chown_missing/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "chown_missing/archive.pna",
+        "--overwrite",
+        "chown_missing/in/",
+        "--keep-permission",
+        #[cfg(windows)]
+        "--unstable",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let result = cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "chown",
+        "chown_missing/archive.pna",
+        "test_user:test_group",
+        "chown_missing/in/raw/empty.txt",
+        "chown_missing/in/raw/not_found.txt",
+        "--no-owner-lookup",
+    ])
+    .unwrap()
+    .execute();
+
+    assert!(result.is_err());
+}

--- a/cli/tests/cli/delete.rs
+++ b/cli/tests/cli/delete.rs
@@ -4,6 +4,7 @@ mod exclude_vcs;
 mod files_from;
 mod files_from_stdin;
 mod include;
+mod missing_file;
 mod password;
 mod password_file;
 

--- a/cli/tests/cli/delete/exclude_vcs.rs
+++ b/cli/tests/cli/delete/exclude_vcs.rs
@@ -46,6 +46,7 @@ fn delete_with_exclude_vcs() {
     .unwrap()
     .execute()
     .unwrap();
+    let delete_file = "delete_with_exclude_vcs/in/raw/regular.txt";
     // delete with exclude-vcs
     cli::Cli::try_parse_from([
         "pna",
@@ -53,7 +54,7 @@ fn delete_with_exclude_vcs() {
         "experimental",
         "delete",
         "delete_with_exclude_vcs/delete_with_exclude_vcs.pna",
-        "raw/",
+        delete_file,
         "--unstable",
         "--exclude-vcs",
     ])
@@ -74,7 +75,7 @@ fn delete_with_exclude_vcs() {
     .unwrap()
     .execute()
     .unwrap();
-    for file in vcs_files {
+    for file in vcs_files.into_iter().chain([delete_file]) {
         utils::remove_with_empty_parents(file).unwrap();
     }
     diff(
@@ -127,6 +128,7 @@ fn delete_without_exclude_vcs() {
     .unwrap()
     .execute()
     .unwrap();
+    let delete_file = "delete_without_exclude_vcs/in/raw/regular.txt";
     // delete without exclude-vcs
     cli::Cli::try_parse_from([
         "pna",
@@ -134,7 +136,7 @@ fn delete_without_exclude_vcs() {
         "experimental",
         "delete",
         "delete_without_exclude_vcs/delete_without_exclude_vcs.pna",
-        "raw/",
+        delete_file,
         "--unstable",
     ])
     .unwrap()
@@ -154,6 +156,8 @@ fn delete_without_exclude_vcs() {
     .unwrap()
     .execute()
     .unwrap();
+
+    utils::remove_with_empty_parents(delete_file).unwrap();
     diff(
         "delete_without_exclude_vcs/in/",
         "delete_without_exclude_vcs/out/",

--- a/cli/tests/cli/delete/missing_file.rs
+++ b/cli/tests/cli/delete/missing_file.rs
@@ -1,0 +1,34 @@
+use crate::utils::{setup, TestResources};
+use clap::Parser;
+use portable_network_archive::{cli, command::Command};
+
+#[test]
+fn fail_with_missing_file() {
+    setup();
+    TestResources::extract_in("raw/", "delete_missing/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "delete_missing/archive.pna",
+        "--overwrite",
+        "delete_missing/in/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let result = cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "delete",
+        "delete_missing/archive.pna",
+        "delete_missing/in/raw/empty.txt",
+        "delete_missing/in/raw/not_found.txt",
+    ])
+    .unwrap()
+    .execute();
+
+    assert!(result.is_err());
+}

--- a/cli/tests/cli/extract.rs
+++ b/cli/tests/cli/extract.rs
@@ -2,6 +2,7 @@ mod chroot;
 mod exclude;
 mod exclude_vcs;
 mod hardlink;
+mod missing_file;
 mod password_from_file;
 mod substitution;
 mod transform;

--- a/cli/tests/cli/extract/missing_file.rs
+++ b/cli/tests/cli/extract/missing_file.rs
@@ -1,0 +1,36 @@
+use crate::utils::{setup, TestResources};
+use clap::Parser;
+use portable_network_archive::{cli, command::Command};
+
+#[test]
+fn fail_with_missing_file() {
+    setup();
+    TestResources::extract_in("raw/", "extract_missing/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "extract_missing/archive.pna",
+        "--overwrite",
+        "extract_missing/in/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let result = cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        "extract_missing/archive.pna",
+        "--overwrite",
+        "--out-dir",
+        "extract_missing/out/",
+        "extract_missing/in/raw/empty.txt",
+        "extract_missing/in/raw/not_found.txt",
+    ])
+    .unwrap()
+    .execute();
+
+    assert!(result.is_err());
+}

--- a/cli/tests/cli/list.rs
+++ b/cli/tests/cli/list.rs
@@ -1,5 +1,6 @@
 #[cfg(not(target_family = "wasm"))]
 mod exclude_vcs;
+mod missing_file;
 #[cfg(not(target_family = "wasm"))]
 mod simple;
 

--- a/cli/tests/cli/list/missing_file.rs
+++ b/cli/tests/cli/list/missing_file.rs
@@ -1,0 +1,33 @@
+use crate::utils::{setup, TestResources};
+use clap::Parser;
+use portable_network_archive::{cli, command::Command};
+
+#[test]
+fn fail_with_missing_file() {
+    setup();
+    TestResources::extract_in("raw/", "list_missing/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "list_missing/archive.pna",
+        "--overwrite",
+        "list_missing/in/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let result = cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "list",
+        "list_missing/archive.pna",
+        "list_missing/in/raw/empty.txt",
+        "list_missing/in/raw/not_found.txt",
+    ])
+    .unwrap()
+    .execute();
+
+    assert!(result.is_err());
+}

--- a/cli/tests/cli/xattr.rs
+++ b/cli/tests/cli/xattr.rs
@@ -2,6 +2,7 @@
 mod dump;
 #[cfg(not(target_family = "wasm"))]
 mod get;
+mod missing_file;
 mod remove;
 #[cfg(not(target_family = "wasm"))]
 mod restore;

--- a/cli/tests/cli/xattr/missing_file.rs
+++ b/cli/tests/cli/xattr/missing_file.rs
@@ -1,0 +1,71 @@
+use crate::utils::{setup, TestResources};
+use clap::Parser;
+use portable_network_archive::{cli, command::Command};
+
+#[test]
+fn fail_with_missing_file_get() {
+    setup();
+    TestResources::extract_in("raw/", "xattr_missing/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "xattr_missing/archive.pna",
+        "--overwrite",
+        "xattr_missing/in/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let result = cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "xattr",
+        "get",
+        "xattr_missing/archive.pna",
+        "xattr_missing/in/raw/empty.txt",
+        "xattr_missing/in/raw/not_found.txt",
+    ])
+    .unwrap()
+    .execute();
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn fail_with_missing_file_set() {
+    setup();
+    TestResources::extract_in("raw/", "xattr_missing_set/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "xattr_missing_set/archive.pna",
+        "--overwrite",
+        "xattr_missing_set/in/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let result = cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "xattr",
+        "set",
+        "xattr_missing_set/archive.pna",
+        "--name",
+        "user.test",
+        "--value",
+        "test_value",
+        "xattr_missing_set/in/raw/empty.txt",
+        "xattr_missing_set/in/raw/not_found.txt",
+    ])
+    .unwrap()
+    .execute();
+
+    assert!(result.is_err());
+}


### PR DESCRIPTION
The extract command now returns an error if any requested file pattern is not found in the archive, instead of silently ignoring missing files. Added tracking of matched patterns and a new test to verify error handling for missing files.