### PR TITLE
:zap: Add 'dereference' alias for follow_links option

### DIFF
--- a/cli/src/command/append.rs
+++ b/cli/src/command/append.rs
@@ -159,8 +159,8 @@ pub(crate) struct AppendCommand {
     exclude_vcs: bool,
     #[arg(long, help = "Ignore files from .gitignore (unstable)")]
     pub(crate) gitignore: bool,
-    #[arg(long, help = "Follow symbolic links")]
-    pub(crate) follow_links: bool,
+    #[arg(long, visible_aliases = ["dereference"], help = "Follow symbolic links")]
+    follow_links: bool,
     #[arg(
         long,
         help = "Filenames or patterns are separated by null characters, not by newlines"

--- a/cli/src/command/create.rs
+++ b/cli/src/command/create.rs
@@ -176,8 +176,8 @@ pub(crate) struct CreateCommand {
     exclude_vcs: bool,
     #[arg(long, help = "Ignore files from .gitignore (unstable)")]
     pub(crate) gitignore: bool,
-    #[arg(long, help = "Follow symbolic links")]
-    pub(crate) follow_links: bool,
+    #[arg(long, visible_aliases = ["dereference"], help = "Follow symbolic links")]
+    follow_links: bool,
     #[arg(
         long,
         help = "Filenames or patterns are separated by null characters, not by newlines"

--- a/cli/src/command/stdio.rs
+++ b/cli/src/command/stdio.rs
@@ -135,8 +135,8 @@ pub(crate) struct StdioCommand {
     exclude_vcs: bool,
     #[arg(long, help = "Ignore files from .gitignore (unstable)")]
     pub(crate) gitignore: bool,
-    #[arg(long, help = "Follow symbolic links")]
-    pub(crate) follow_links: bool,
+    #[arg(long, visible_aliases = ["dereference"], help = "Follow symbolic links")]
+    follow_links: bool,
     #[arg(long, help = "Output directory of extracted files", value_hint = ValueHint::DirPath)]
     pub(crate) out_dir: Option<PathBuf>,
     #[arg(

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -222,8 +222,8 @@ pub(crate) struct UpdateCommand {
     null: bool,
     #[arg(long, help = "Ignore files from .gitignore (unstable)")]
     pub(crate) gitignore: bool,
-    #[arg(long, help = "Follow symbolic links")]
-    pub(crate) follow_links: bool,
+    #[arg(long, visible_aliases = ["dereference"], help = "Follow symbolic links")]
+    follow_links: bool,
 }
 
 impl Command for UpdateCommand {


### PR DESCRIPTION
The 'follow_links' CLI argument in append, create, stdio, and update commands now has a visible alias 'dereference'. This improves usability by allowing users to specify '--dereference' as an alternative to '--follow-links'.