### PR TITLE
:construction_worker: Add GITHUB_TOKEN env for wasm-bindgen-cli install

### DIFF
--- a/.github/workflows/webassembly.yml
+++ b/.github/workflows/webassembly.yml
@@ -79,6 +79,8 @@ jobs:
         name: Install wasm-bindgen-cli from crates.io
         run: |
           cargo binstall --no-confirm --force wasm-bindgen-cli --version ${{ steps.get_version.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For ease GitHub API rate limits
       - if: ${{ endsWith(matrix.target, 'unknown') }}
         name: Run test
         run: |


### PR DESCRIPTION
Sets the GITHUB_TOKEN environment variable during wasm-bindgen-cli installation to help avoid GitHub API rate limits.