### PR TITLE
:recycle: Simplify ArchiveHeader::to_bytes using array literal

### DIFF
--- a/lib/src/archive/header.rs
+++ b/lib/src/archive/header.rs
@@ -21,17 +21,17 @@ impl ArchiveHeader {
     }
 
     pub(crate) const fn to_bytes(&self) -> [u8; 8] {
-        let mut data = [0; 8];
-        data[0] = self.major;
-        data[1] = self.minor;
-        data[2] = 0;
-        data[3] = 0;
-        let byte = self.archive_number.to_be_bytes();
-        data[4] = byte[0];
-        data[5] = byte[1];
-        data[6] = byte[2];
-        data[7] = byte[3];
-        data
+        let archive_number = self.archive_number.to_be_bytes();
+        [
+            self.major,
+            self.minor,
+            0,
+            0,
+            archive_number[0],
+            archive_number[1],
+            archive_number[2],
+            archive_number[3],
+        ]
     }
 
     #[inline]


### PR DESCRIPTION
Replaces manual assignment to each index with a single array literal, improving readability without affecting performance.