### PR TITLE
:pencil2: Clarify help text for --unstable flag

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -25,7 +25,11 @@ pub struct Cli {
     pub(crate) commands: Commands,
     #[command(flatten)]
     pub(crate) verbosity: VerbosityArgs,
-    #[arg(long, global = true, help = "Declare to use unstable features")]
+    #[arg(
+        long,
+        global = true,
+        help = "Enable experimental options. Required for flags marked as unstable; behavior may change or be removed."
+    )]
     pub(crate) unstable: bool,
 }
 

--- a/cli/src/command/append.rs
+++ b/cli/src/command/append.rs
@@ -87,7 +87,7 @@ pub(crate) struct AppendCommand {
     #[arg(
         long,
         visible_alias = "preserve-permissions",
-        help = "Archiving the permissions of the files"
+        help = "Archiving the permissions of the files (unstable on Windows)"
     )]
     pub(crate) keep_permission: bool,
     #[arg(
@@ -99,7 +99,7 @@ pub(crate) struct AppendCommand {
     #[arg(
         long,
         visible_alias = "preserve-acls",
-        help = "Archiving the acl of the files"
+        help = "Archiving the acl of the files (unstable)"
     )]
     pub(crate) keep_acl: bool,
     #[arg(long, help = "Archiving user to the entries from given name")]
@@ -148,7 +148,7 @@ pub(crate) struct AppendCommand {
     pub(crate) files_from_stdin: bool,
     #[arg(
         long,
-        help = "Process only files or directories that match the specified pattern. Note that exclusions specified with --exclude take precedence over inclusions"
+        help = "Process only files or directories that match the specified pattern. Note that exclusions specified with --exclude take precedence over inclusions (unstable)"
     )]
     include: Option<Vec<String>>,
     #[arg(long, help = "Exclude path glob (unstable)", value_hint = ValueHint::AnyPath)]
@@ -169,14 +169,14 @@ pub(crate) struct AppendCommand {
     #[arg(
         short = 's',
         value_name = "PATTERN",
-        help = "Modify file or archive member names according to pattern that like BSD tar -s option"
+        help = "Modify file or archive member names according to pattern that like BSD tar -s option (unstable)"
     )]
     substitutions: Option<Vec<SubstitutionRule>>,
     #[arg(
         long = "transform",
         visible_alias = "xform",
         value_name = "PATTERN",
-        help = "Modify file or archive member names according to pattern that like GNU tar -transform option"
+        help = "Modify file or archive member names according to pattern that like GNU tar -transform option (unstable)"
     )]
     transforms: Option<Vec<TransformRule>>,
     #[arg(

--- a/cli/src/command/create.rs
+++ b/cli/src/command/create.rs
@@ -96,7 +96,7 @@ pub(crate) struct CreateCommand {
     #[arg(
         long,
         visible_alias = "preserve-permissions",
-        help = "Archiving the permissions of the files"
+        help = "Archiving the permissions of the files (unstable on Windows)"
     )]
     pub(crate) keep_permission: bool,
     #[arg(
@@ -108,7 +108,7 @@ pub(crate) struct CreateCommand {
     #[arg(
         long,
         visible_alias = "preserve-acls",
-        help = "Archiving the acl of the files"
+        help = "Archiving the acl of the files (unstable)"
     )]
     pub(crate) keep_acl: bool,
     #[arg(
@@ -165,7 +165,7 @@ pub(crate) struct CreateCommand {
     pub(crate) files_from_stdin: bool,
     #[arg(
         long,
-        help = "Process only files or directories that match the specified pattern. Note that exclusions specified with --exclude take precedence over inclusions"
+        help = "Process only files or directories that match the specified pattern. Note that exclusions specified with --exclude take precedence over inclusions (unstable)"
     )]
     include: Option<Vec<String>>,
     #[arg(long, help = "Exclude path glob (unstable)", value_hint = ValueHint::AnyPath)]
@@ -186,14 +186,14 @@ pub(crate) struct CreateCommand {
     #[arg(
         short = 's',
         value_name = "PATTERN",
-        help = "Modify file or archive member names according to pattern that like BSD tar -s option"
+        help = "Modify file or archive member names according to pattern that like BSD tar -s option (unstable)"
     )]
     substitutions: Option<Vec<SubstitutionRule>>,
     #[arg(
         long = "transform",
         visible_alias = "xform",
         value_name = "PATTERN",
-        help = "Modify file or archive member names according to pattern that like GNU tar -transform option"
+        help = "Modify file or archive member names according to pattern that like GNU tar -transform option (unstable)"
     )]
     transforms: Option<Vec<TransformRule>>,
     #[arg(

--- a/cli/src/command/delete.rs
+++ b/cli/src/command/delete.rs
@@ -40,7 +40,7 @@ pub(crate) struct DeleteCommand {
     files_from_stdin: bool,
     #[arg(
         long,
-        help = "Process only files or directories that match the specified pattern. Note that exclusions specified with --exclude take precedence over inclusions"
+        help = "Process only files or directories that match the specified pattern. Note that exclusions specified with --exclude take precedence over inclusions (unstable)"
     )]
     include: Option<Vec<String>>,
     #[arg(long, help = "Exclude path glob (unstable)", value_hint = ValueHint::AnyPath)]

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -68,7 +68,7 @@ pub(crate) struct ExtractCommand {
     #[arg(
         long,
         visible_alias = "preserve-permissions",
-        help = "Restore the permissions of the files"
+        help = "Restore the permissions of the files (unstable on Windows)"
     )]
     pub(crate) keep_permission: bool,
     #[arg(
@@ -80,7 +80,7 @@ pub(crate) struct ExtractCommand {
     #[arg(
         long,
         visible_alias = "preserve-acls",
-        help = "Restore the acl of the files"
+        help = "Restore the acl of the files (unstable)"
     )]
     pub(crate) keep_acl: bool,
     #[arg(long, help = "Restore user from given name")]
@@ -104,7 +104,7 @@ pub(crate) struct ExtractCommand {
     pub(crate) numeric_owner: bool,
     #[arg(
         long,
-        help = "Process only files or directories that match the specified pattern. Note that exclusions specified with --exclude take precedence over inclusions"
+        help = "Process only files or directories that match the specified pattern. Note that exclusions specified with --exclude take precedence over inclusions (unstable)"
     )]
     include: Option<Vec<String>>,
     #[arg(long, help = "Exclude path glob (unstable)", value_hint = ValueHint::AnyPath)]
@@ -126,14 +126,14 @@ pub(crate) struct ExtractCommand {
     #[arg(
         short = 's',
         value_name = "PATTERN",
-        help = "Modify file or archive member names according to pattern that like BSD tar -s option"
+        help = "Modify file or archive member names according to pattern that like BSD tar -s option (unstable)"
     )]
     substitutions: Option<Vec<SubstitutionRule>>,
     #[arg(
         long = "transform",
         visible_alias = "xform",
         value_name = "PATTERN",
-        help = "Modify file or archive member names according to pattern that like GNU tar -transform option"
+        help = "Modify file or archive member names according to pattern that like GNU tar -transform option (unstable)"
     )]
     transforms: Option<Vec<TransformRule>>,
     #[arg(

--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -75,7 +75,7 @@ pub(crate) struct ListCommand {
         help = "When used with the -l option, display complete time information for the entry, including month, day, hour, minute, second, and year"
     )]
     pub(crate) long_time: bool,
-    #[arg(long, help = "Display format")]
+    #[arg(long, help = "Display format (unstable)")]
     format: Option<Format>,
     #[arg(
         long,

--- a/cli/src/command/stdio.rs
+++ b/cli/src/command/stdio.rs
@@ -97,7 +97,7 @@ pub(crate) struct StdioCommand {
     #[arg(
         long,
         visible_alias = "preserve-permissions",
-        help = "Archiving the permissions of the files"
+        help = "Archiving the permissions of the files (unstable on Windows)"
     )]
     keep_permission: bool,
     #[arg(
@@ -109,7 +109,7 @@ pub(crate) struct StdioCommand {
     #[arg(
         long,
         visible_alias = "preserve-acls",
-        help = "Archiving the acl of the files"
+        help = "Archiving the acl of the files (unstable)"
     )]
     keep_acl: bool,
     #[arg(long, help = "Solid mode archive")]
@@ -124,7 +124,7 @@ pub(crate) struct StdioCommand {
     pub(crate) password: PasswordArgs,
     #[arg(
         long,
-        help = "Process only files or directories that match the specified pattern. Note that exclusions specified with --exclude take precedence over inclusions"
+        help = "Process only files or directories that match the specified pattern. Note that exclusions specified with --exclude take precedence over inclusions (unstable)"
     )]
     include: Option<Vec<String>>,
     #[arg(long, help = "Exclude path glob (unstable)", value_hint = ValueHint::AnyPath)]
@@ -195,14 +195,14 @@ pub(crate) struct StdioCommand {
     #[arg(
         short = 's',
         value_name = "PATTERN",
-        help = "Modify file or archive member names according to pattern that like BSD tar -s option"
+        help = "Modify file or archive member names according to pattern that like BSD tar -s option (unstable)"
     )]
     substitutions: Option<Vec<SubstitutionRule>>,
     #[arg(
         long = "transform",
         visible_alias = "xform",
         value_name = "PATTERN",
-        help = "Modify file or archive member names according to pattern that like GNU tar -transform option"
+        help = "Modify file or archive member names according to pattern that like GNU tar -transform option (unstable)"
     )]
     transforms: Option<Vec<TransformRule>>,
     #[arg(

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -91,7 +91,7 @@ pub(crate) struct UpdateCommand {
     #[arg(
         long,
         visible_alias = "preserve-permissions",
-        help = "Archiving the permissions of the files"
+        help = "Archiving the permissions of the files (unstable on Windows)"
     )]
     pub(crate) keep_permission: bool,
     #[arg(
@@ -103,7 +103,7 @@ pub(crate) struct UpdateCommand {
     #[arg(
         long,
         visible_alias = "preserve-acls",
-        help = "Archiving the acl of the files"
+        help = "Archiving the acl of the files (unstable)"
     )]
     pub(crate) keep_acl: bool,
     #[arg(long, help = "Archiving user to the entries from given name")]
@@ -172,7 +172,7 @@ pub(crate) struct UpdateCommand {
     pub(crate) files_from_stdin: bool,
     #[arg(
         long,
-        help = "Process only files or directories that match the specified pattern. Note that exclusions specified with --exclude take precedence over inclusions"
+        help = "Process only files or directories that match the specified pattern. Note that exclusions specified with --exclude take precedence over inclusions (unstable)"
     )]
     include: Option<Vec<String>>,
     #[arg(long, help = "Exclude path glob (unstable)", value_hint = ValueHint::AnyPath)]
@@ -184,14 +184,14 @@ pub(crate) struct UpdateCommand {
     #[arg(
         short = 's',
         value_name = "PATTERN",
-        help = "Modify file or archive member names according to pattern that like BSD tar -s option"
+        help = "Modify file or archive member names according to pattern that like BSD tar -s option (unstable)"
     )]
     substitutions: Option<Vec<SubstitutionRule>>,
     #[arg(
         long = "transform",
         visible_alias = "xform",
         value_name = "PATTERN",
-        help = "Modify file or archive member names according to pattern that like GNU tar -transform option"
+        help = "Modify file or archive member names according to pattern that like GNU tar -transform option (unstable)"
     )]
     transforms: Option<Vec<TransformRule>>,
     #[arg(


### PR DESCRIPTION
Updated the help message for the --unstable CLI flag to better explain its purpose and warn users about potential changes or removal of experimental options.