### PR TITLE
:bug: Fix swapped major and minor version in header serialization

### DIFF
--- a/lib/src/entry/header.rs
+++ b/lib/src/entry/header.rs
@@ -102,7 +102,7 @@ impl EntryHeader {
     pub(crate) fn to_bytes(&self) -> Vec<u8> {
         let name = self.path.as_bytes();
         let mut data = Vec::with_capacity(6 + name.len());
-        data.push(self.minor);
+        data.push(self.major);
         data.push(self.minor);
         data.push(self.data_kind as u8);
         data.push(self.compression as u8);


### PR DESCRIPTION
Corrects the order of version bytes in EntryHeader::to_bytes by pushing the major version before the minor version. This ensures that the serialized header format matches the expected specification. However, since both the major and minor versions are always 0, this has no effect on users.