### PR TITLE
:recycle: Refactor FlattenReader to ChainReader for flexible iteration

### DIFF
--- a/lib/src/io.rs
+++ b/lib/src/io.rs
@@ -27,6 +27,11 @@ impl<const N: usize> io::Write for FlattenWriter<N> {
     }
 }
 
+/// A reader that chains an iterator of readers.
+///
+/// This is similar to [`std::io::Chain`] but for an arbitrary number
+/// of readers from an iterator. It reads from the current reader until it
+/// is exhausted and then moves to the next one.
 pub(crate) struct ChainReader<I, R> {
     inner: I,
     current: Option<R>,
@@ -109,7 +114,7 @@ mod tests {
         assert_eq!(reader.read(&mut out).unwrap(), 2);
         assert_eq!(&out, b"ab");
 
-        // 2nd read: next chunk, gets "cd"
+        // 2nd read: next chunk gets "cd"
         assert_eq!(reader.read(&mut out).unwrap(), 2);
         assert_eq!(&out, b"cd");
 

--- a/lib/src/io.rs
+++ b/lib/src/io.rs
@@ -27,28 +27,39 @@ impl<const N: usize> io::Write for FlattenWriter<N> {
     }
 }
 
-pub(crate) struct FlattenReader<'r> {
-    index: usize,
-    inner: Vec<&'r [u8]>,
+pub(crate) struct ChainReader<I, R> {
+    inner: I,
+    current: Option<R>,
 }
 
-impl<'r> FlattenReader<'r> {
+impl<I, R> ChainReader<I, R>
+where
+    I: Iterator<Item = R>,
+{
     #[inline]
-    pub(crate) const fn new(inner: Vec<&'r [u8]>) -> Self {
-        Self { index: 0, inner }
+    pub(crate) fn new<In: IntoIterator<IntoIter = I>>(into_iter: In) -> Self {
+        let mut inner = into_iter.into_iter();
+        Self {
+            current: inner.next(),
+            inner,
+        }
     }
 }
 
-impl io::Read for FlattenReader<'_> {
+impl<I, R> io::Read for ChainReader<I, R>
+where
+    I: Iterator<Item = R>,
+    R: io::Read,
+{
     #[inline]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if buf.is_empty() {
             return Ok(0);
         }
-        while let Some(c) = self.inner.get_mut(self.index) {
+        while let Some(c) = &mut self.current {
             match c.read(buf) {
                 Ok(0) => {
-                    self.index += 1;
+                    self.current = self.inner.next();
                     continue;
                 }
                 other => return other,
@@ -66,31 +77,32 @@ mod tests {
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
     #[test]
-    fn flat_empty() {
-        let reader = FlattenReader::new(vec![]);
-        assert_eq!("", io::read_to_string(reader).unwrap());
-    }
-    #[test]
-    fn flat_empty_in_empty() {
-        let reader = FlattenReader::new(vec![b""]);
+    fn chain_empty() {
+        let reader = ChainReader::new(Vec::<&[u8]>::new());
         assert_eq!("", io::read_to_string(reader).unwrap());
     }
 
     #[test]
-    fn flat_contain_empty() {
-        let reader = FlattenReader::new(vec![b"abc", b"", b"def"]);
+    fn chain_empty_in_empty() {
+        let reader = ChainReader::new([&b""[..]]);
+        assert_eq!("", io::read_to_string(reader).unwrap());
+    }
+
+    #[test]
+    fn chain_contain_empty() {
+        let reader = ChainReader::new([&b"abc"[..], &b""[..], &b"def"[..]]);
         assert_eq!("abcdef", io::read_to_string(reader).unwrap());
     }
 
     #[test]
-    fn flat_consecutive_empty() {
-        let reader = FlattenReader::new(vec![b"abc", b"", b"", b"def"]);
+    fn chain_consecutive_empty() {
+        let reader = ChainReader::new([&b"abc"[..], &b""[..], &b""[..], &b"def"[..]]);
         assert_eq!("abcdef", io::read_to_string(reader).unwrap());
     }
 
     #[test]
-    fn flat_cross_boundary_small_buf() {
-        let mut reader = FlattenReader::new(vec![b"ab", b"", b"cde"]);
+    fn chain_cross_boundary_small_buf() {
+        let mut reader = ChainReader::new([&b"ab"[..], &b""[..], &b"cde"[..]]);
         let mut out = [0u8; 2];
 
         // 1st read: fills with "ab"


### PR DESCRIPTION
Replaces FlattenReader with a more generic ChainReader that can chain any iterator of readers, improving flexibility and composability. Updates EntryDataReader and EntryIterator to use the new ChainReader, and refactors related code and tests accordingly.