### PR TITLE
:pencil2: Improve documentation and example clarity across library

### DIFF
--- a/lib/src/archive/read.rs
+++ b/lib/src/archive/read.rs
@@ -209,7 +209,7 @@ impl<R> Archive<R> {
     ///
     /// An iterator over the entries in the archive.
     ///
-    /// # Example
+    /// # Examples
     /// ```no_run
     /// use libpna::{Archive, ReadEntry};
     /// use std::fs;
@@ -220,8 +220,12 @@ impl<R> Archive<R> {
     /// let mut archive = Archive::read_header(file)?;
     /// for entry in archive.entries() {
     ///     match entry? {
-    ///         ReadEntry::Solid(solid_entry) => todo!("fill your code"),
-    ///         ReadEntry::Normal(entry) => todo!("fill your code"),
+    ///         ReadEntry::Solid(_solid_entry) => {
+    ///             // handle solid entry
+    ///         }
+    ///         ReadEntry::Normal(_entry) => {
+    ///             // handle normal entry
+    ///         }
     ///     }
     /// }
     /// #    Ok(())
@@ -282,7 +286,7 @@ impl<R: futures_io::AsyncRead + Unpin> Archive<R> {
         Ok(Some(RawEntry(chunks)))
     }
 
-    /// Read a [ReadEntry] from the archive.
+    /// Reads a [`ReadEntry`] from the archive.
     /// This API is unstable.
     ///
     /// # Errors
@@ -338,7 +342,7 @@ impl<'r, R> Entries<'r, R> {
 
     /// Returns an iterator that extracts solid entries from the archive and returns them as normal entries.
     ///
-    /// # Example
+    /// # Examples
     /// ```no_run
     /// use libpna::{Archive, ReadEntry, ReadOptions};
     /// use std::fs;
@@ -349,7 +353,7 @@ impl<'r, R> Entries<'r, R> {
     /// let mut archive = Archive::read_header(file)?;
     /// for entry in archive.entries().extract_solid_entries(Some("password")) {
     ///     let mut reader = entry?.reader(ReadOptions::builder().build());
-    ///     // fill your code
+    ///     // process the entry
     /// }
     /// #    Ok(())
     /// # }

--- a/lib/src/archive/read/slice.rs
+++ b/lib/src/archive/read/slice.rs
@@ -103,7 +103,7 @@ impl<'d> Archive<&'d [u8]> {
     ///
     /// An iterator over the entries in the archive.
     ///
-    /// # Example
+    /// # Examples
     /// ```no_run
     /// use libpna::{Archive, ReadEntry};
     /// use std::fs;
@@ -115,10 +115,10 @@ impl<'d> Archive<&'d [u8]> {
     /// for entry in archive.entries_slice() {
     ///     match entry? {
     ///         ReadEntry::Solid(solid_entry) => {
-    ///             // fill your code
+    ///             // handle solid entry
     ///         }
     ///         ReadEntry::Normal(entry) => {
-    ///             // fill your code
+    ///             // handle normal entry
     ///         }
     ///     }
     /// }
@@ -215,7 +215,7 @@ impl<'a, 'r> Entries<'a, 'r> {
 
     /// Returns an iterator that extracts solid entries from the archive and returns them as normal entries.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// use libpna::{Archive, ReadEntry, ReadOptions};
@@ -230,7 +230,7 @@ impl<'a, 'r> Entries<'a, 'r> {
     ///     .extract_solid_entries(Some("password"))
     /// {
     ///     let mut reader = entry?.reader(ReadOptions::builder().build());
-    ///     // fill your code
+    ///     // process the entry
     /// }
     /// #    Ok(())
     /// # }
@@ -272,7 +272,7 @@ mod tests {
     #[test]
     fn read_header() {
         let result = read_header_from_slice(PNA_HEADER).unwrap();
-        assert_eq!(result, &[]);
+        assert!(result.is_empty());
     }
 
     #[test]

--- a/lib/src/archive/write.rs
+++ b/lib/src/archive/write.rs
@@ -94,13 +94,13 @@ impl<W: Write> Archive<W> {
         Ok(Self::new(write, header))
     }
 
-    /// Write a regular file as normal entry into archive.
+    /// Writes a regular file as a normal entry into the archive.
     ///
     /// # Errors
     ///
-    /// Returns an error if an I/O error occurs while writing an entry, or if the given closure returns an error return it.
+    /// Returns an error if an I/O error occurs while writing the entry, or if the closure returns an error.
     ///
-    /// # Example
+    /// # Examples
     /// ```no_run
     /// use libpna::{Archive, Metadata, WriteOptions};
     /// # use std::error::Error;
@@ -251,17 +251,17 @@ impl<W: Write> Archive<W> {
         Archive::write_header_with(writer, header)
     }
 
-    /// Write an end marker to finalize the archive.
+    /// Writes the end-of-archive marker and finalizes the archive.
     ///
     /// Marks that the PNA archive contains no more entries.
     /// Normally, a PNA archive reader will continue reading entries in the hope that the entry exists until it encounters this end marker.
     /// This end marker should always be recorded at the end of the file unless there is a special reason to do so.
     ///
     /// # Errors
-    /// Returns an error if failed to write archive end marker.
+    /// Returns an error if writing the end-of-archive marker fails.
     ///
     /// # Examples
-    /// Create an empty archive.
+    /// Creates an empty archive.
     /// ```no_run
     /// # use std::io;
     /// # use std::fs::File;
@@ -319,12 +319,12 @@ impl<W: AsyncWrite + Unpin> Archive<W> {
         Ok(bytes.len())
     }
 
-    /// Write an end marker to finalize the archive.
+    /// Writes the end-of-archive marker and finalizes the archive.
     /// This API is unstable.
     ///
     /// # Errors
     ///
-    /// Returns an error if failed to write archive end marker.
+    /// Returns an error if writing the end-of-archive marker fails.
     #[inline]
     pub async fn finalize_async(mut self) -> io::Result<W> {
         let mut chunk_writer = crate::chunk::ChunkWriter::new(&mut self.inner);
@@ -435,13 +435,13 @@ impl<W: Write> SolidArchive<W> {
         entry.write_in(&mut self.inner)
     }
 
-    /// Write a regular file as solid entry into archive.
+    /// Writes a regular file as a solid entry into the archive.
     ///
     /// # Errors
     ///
-    /// Returns an error if an I/O error occurs while writing an entry, or if the given closure returns an error return it.
+    /// Returns an error if an I/O error occurs while writing the entry, or if the closure returns an error.
     ///
-    /// # Example
+    /// # Examples
     /// ```no_run
     /// use libpna::{Archive, Metadata, WriteOptions};
     /// # use std::error::Error;
@@ -472,17 +472,17 @@ impl<W: Write> SolidArchive<W> {
         })
     }
 
-    /// Write an end marker to finalize the archive.
+    /// Writes the end-of-archive marker and finalizes the archive.
     ///
     /// Marks that the PNA archive contains no more entries.
     /// Normally, a PNA archive reader will continue reading entries in the hope that the entry exists until it encounters this end marker.
     /// This end marker should always be recorded at the end of the file unless there is a special reason to do so.
     ///
     /// # Errors
-    /// Returns an error if failed to write archive end marker.
+    /// Returns an error if writing the end-of-archive marker fails.
     ///
     /// # Examples
-    /// Create an empty archive.
+    /// Creates an empty archive.
     /// ```no_run
     /// use libpna::{Archive, WriteOptions};
     /// use std::fs::File;

--- a/lib/src/chunk.rs
+++ b/lib/src/chunk.rs
@@ -33,7 +33,7 @@ pub(crate) trait ChunkExt: Chunk {
         MIN_CHUNK_BYTES_SIZE + self.data().len()
     }
 
-    /// check the chunk type is stream chunk
+    /// Returns `true` if this is a stream chunk.
     #[inline]
     fn is_stream_chunk(&self) -> bool {
         self.ty() == ChunkType::FDAT || self.ty() == ChunkType::SDAT
@@ -61,7 +61,7 @@ pub(crate) trait ChunkExt: Chunk {
         Ok(self.bytes_len())
     }
 
-    /// Convert the provided `Chunk` instance into a `Vec<u8>`.
+    /// Converts the provided `Chunk` instance into a `Vec<u8>`.
     ///
     /// # Returns
     ///
@@ -239,7 +239,7 @@ impl<T: AsRef<[u8]>> Chunk for RawChunk<T> {
 }
 
 impl RawChunk {
-    /// Create a new [`RawChunk`] from given [`ChunkType`] and bytes.
+    /// Creates a new [`RawChunk`] from the given [`ChunkType`] and bytes.
     ///
     /// # Examples
     /// ```
@@ -325,14 +325,14 @@ pub(crate) fn chunk_data_split(
     }
 }
 
-/// Read archive as chunks from given reader.
+/// Reads an archive as chunks from the given reader.
 ///
-/// Reads a PNA archive from the given reader and return an iterator of chunks.
+/// Reads a PNA archive from the given reader and returns an iterator of chunks.
 ///
 /// # Errors
-/// Returns error if it is not a PNA file.
+/// Returns an error if the input is not a PNA archive.
 ///
-/// # Example
+/// # Examples
 ///
 /// ```no_run
 /// # use std::{io, fs};
@@ -378,14 +378,14 @@ pub fn read_as_chunks<R: Read>(
     })
 }
 
-/// Read archive as chunks from given bytes.
+/// Reads an archive as chunks from the given bytes.
 ///
-/// Reads a PNA archive from the given byte slice and return an iterator of chunks.
+/// Reads a PNA archive from the given byte slice and returns an iterator of chunks.
 ///
 /// # Errors
-/// Returns error if it is not a PNA file.
+/// Returns an error if the input is not a PNA archive.
 ///
-/// # Example
+/// # Examples
 ///
 /// ```
 /// # use std::{io, fs};

--- a/lib/src/chunk/types.rs
+++ b/lib/src/chunk/types.rs
@@ -92,7 +92,7 @@ impl ChunkType {
     ///
     /// An integer value representing the length of the chunk type code.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```
     /// use libpna::ChunkType;
@@ -153,7 +153,7 @@ impl ChunkType {
         Ok(Self(ty))
     }
 
-    /// Creates custom [ChunkType] without any check.
+    /// Creates a custom [`ChunkType`] without validation.
     ///
     /// # Panic
     /// Printing ChunkType that contains non-utf8 characters will be panicked.

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -381,7 +381,7 @@ impl<T: AsRef<[u8]>> SolidEntry<T> {
     ///
     /// Returns an error if an I/O error occurs while reading from the [SolidEntry].
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```no_run
     /// use libpna::{Archive, ReadEntry, ReadOptions};
@@ -397,11 +397,11 @@ impl<T: AsRef<[u8]>> SolidEntry<T> {
     ///             for entry in solid_entry.entries(Some("password"))? {
     ///                 let entry = entry?;
     ///                 let mut reader = entry.reader(ReadOptions::builder().build());
-    ///                 // fill your code
+    ///                 // process the entry
     ///             }
     ///         }
-    ///         ReadEntry::Normal(entry) => {
-    ///             // fill your code
+    ///         ReadEntry::Normal(_entry) => {
+    ///             // process the entry
     ///         }
     ///     }
     /// }
@@ -841,9 +841,9 @@ impl<T> NormalEntry<T> {
         &self.extra
     }
 
-    /// Apply metadata to the entry.
+    /// Applies metadata to the entry.
     ///
-    /// # Example
+    /// # Examples
     /// ```
     /// # use std::io;
     /// use libpna::{EntryBuilder, Metadata};
@@ -862,9 +862,9 @@ impl<T> NormalEntry<T> {
         self
     }
 
-    /// Apply extended attributes to the entry.
+    /// Applies extended attributes to the entry.
     ///
-    /// # Example
+    /// # Examples
     /// ```
     /// # use std::io;
     /// use libpna::{EntryBuilder, ExtendedAttribute};
@@ -883,9 +883,9 @@ impl<T> NormalEntry<T> {
 }
 
 impl<T: Clone> NormalEntry<T> {
-    /// Apply extra chunks to the entry.
+    /// Applies extra chunks to the entry.
     ///
-    /// # Example
+    /// # Examples
     /// ```
     /// # use std::io;
     /// use libpna::{ChunkType, EntryBuilder, RawChunk};
@@ -907,7 +907,7 @@ impl<T: Clone> NormalEntry<T> {
 }
 
 impl<T: AsRef<[u8]>> NormalEntry<T> {
-    /// Return the reader of this [`NormalEntry`].
+    /// Returns the reader of this [`NormalEntry`].
     ///
     /// # Errors
     ///

--- a/lib/src/entry/attr.rs
+++ b/lib/src/entry/attr.rs
@@ -8,9 +8,9 @@ pub struct ExtendedAttribute {
 }
 
 impl ExtendedAttribute {
-    /// Create new [ExtendedAttribute].
+    /// Creates a new [`ExtendedAttribute`].
     ///
-    /// # Example
+    /// # Examples
     /// ```
     /// use libpna::ExtendedAttribute;
     ///
@@ -23,7 +23,7 @@ impl ExtendedAttribute {
 
     /// Attribute name
     ///
-    /// # Example
+    /// # Examples
     /// ```
     /// use libpna::ExtendedAttribute;
     ///
@@ -37,7 +37,7 @@ impl ExtendedAttribute {
 
     /// Attribute value
     ///
-    /// # Example
+    /// # Examples
     /// ```
     /// use libpna::ExtendedAttribute;
     ///

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -82,7 +82,7 @@ impl EntryBuilder {
     ///
     /// # Errors
     ///
-    /// Returns an error if failed to initialize context.
+    /// Returns an error if initialization fails.
     #[inline]
     pub fn new_file(name: EntryName, option: impl WriteOption) -> io::Result<Self> {
         let header = EntryHeader::for_file(
@@ -118,7 +118,7 @@ impl EntryBuilder {
     ///
     /// # Errors
     ///
-    /// Returns an error if failed to initialize context.
+    /// Returns an error if initialization fails.
     ///
     /// # Examples
     /// ```
@@ -162,7 +162,7 @@ impl EntryBuilder {
     ///
     /// # Errors
     ///
-    /// Returns an error if failed to initialize context.
+    /// Returns an error if initialization fails.
     ///
     /// # Examples
     /// ```
@@ -418,7 +418,7 @@ impl SolidEntryBuilder {
     ///
     /// # Errors
     ///
-    /// Returns an error if failed to initialize context.
+    /// Returns an error if initialization fails.
     #[inline]
     pub fn new(option: impl WriteOption) -> io::Result<Self> {
         let header = SolidHeader::new(
@@ -479,14 +479,14 @@ impl SolidEntryBuilder {
         entry.write_in(&mut self.data)
     }
 
-    /// Write a regular file to the solid entry.
+    /// Writes a regular file to the solid entry.
     ///
     /// # Errors
     ///
-    /// Returns an error if an I/O error occurs while writing an entry,
-    /// or if the given closure returns an error return it.
+    /// Returns an error if an I/O error occurs while writing the entry,
+    /// or if the closure returns an error.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```
     /// use libpna::{Metadata, SolidEntryBuilder, WriteOptions};

--- a/lib/src/entry/header.rs
+++ b/lib/src/entry/header.rs
@@ -190,7 +190,7 @@ impl SolidHeader {
         self.cipher_mode
     }
 
-    /// Convert to [ChunkType::SHED](crate::ChunkType::SHED) body bytes.
+    /// Converts to [`ChunkType::SHED`](crate::ChunkType::SHED) body bytes.
     #[inline]
     pub const fn to_bytes(&self) -> [u8; 5] {
         [

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -27,7 +27,7 @@ pub struct Metadata {
 }
 
 impl Metadata {
-    /// Create a new [Metadata].
+    /// Creates a new [`Metadata`].
     #[inline]
     pub const fn new() -> Self {
         Self {
@@ -40,7 +40,7 @@ impl Metadata {
         }
     }
 
-    /// Set created time that as duration since unix epoch time.
+    /// Sets the created time as the duration since the Unix epoch.
     ///
     /// # Examples
     /// ```
@@ -59,7 +59,7 @@ impl Metadata {
         self
     }
 
-    /// Set modified time that as duration since unix epoch time.
+    /// Sets the modified time as the duration since the Unix epoch.
     ///
     /// # Examples
     /// ```
@@ -78,7 +78,7 @@ impl Metadata {
         self
     }
 
-    /// Set accessed time that as duration since unix epoch time.
+    /// Sets the accessed time as the duration since the Unix epoch.
     ///
     /// # Examples
     /// ```
@@ -97,7 +97,7 @@ impl Metadata {
         self
     }
 
-    /// Set permission of entry.
+    /// Sets the permission of the entry.
     #[inline]
     pub fn with_permission(mut self, permission: Option<Permission>) -> Self {
         self.permission = permission;
@@ -114,17 +114,17 @@ impl Metadata {
     pub const fn compressed_size(&self) -> usize {
         self.compressed_size
     }
-    /// Created time since unix epoch time of entry
+    /// Returns the created time since the Unix epoch for the entry.
     #[inline]
     pub const fn created(&self) -> Option<Duration> {
         self.created
     }
-    /// Modified time since unix epoch time of entry
+    /// Returns the modified time since the Unix epoch for the entry.
     #[inline]
     pub const fn modified(&self) -> Option<Duration> {
         self.modified
     }
-    /// Accessed time since unix epoch time of entry
+    /// Returns the accessed time since the Unix epoch for the entry.
     #[inline]
     pub const fn accessed(&self) -> Option<Duration> {
         self.accessed
@@ -154,7 +154,7 @@ pub struct Permission {
 }
 
 impl Permission {
-    /// Create a new permission instance with the given values.
+    /// Creates a new permission instance with the given values.
     ///
     /// # Arguments
     ///

--- a/lib/src/entry/name.rs
+++ b/lib/src/entry/name.rs
@@ -47,7 +47,7 @@ impl EntryName {
         Ok(Self::new_from_utf8path(Utf8Path::new(name)))
     }
 
-    /// Create an [`EntryName`] from a struct impl <code>[Into]<[PathBuf]></code>.
+    /// Creates an [`EntryName`] from a struct impl <code>[Into]<[PathBuf]></code>.
     ///
     /// Any non-Unicode sequences are replaced with
     /// [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD] and

--- a/lib/src/entry/options.rs
+++ b/lib/src/entry/options.rs
@@ -45,7 +45,7 @@ mod private {
         }
     }
 
-    /// Write option getter trait.
+    /// Accessors for write options.
     pub trait WriteOption {
         fn compress(&self) -> Compress;
         fn cipher(&self) -> Option<&Cipher>;
@@ -560,49 +560,49 @@ impl WriteOptionsBuilder {
         }
     }
 
-    /// Set [Compression] to this builder.
+    /// Sets the [`Compression`].
     #[inline]
     pub fn compression(&mut self, compression: Compression) -> &mut Self {
         self.compression = compression;
         self
     }
 
-    /// Set [CompressionLevel] to this builder.
+    /// Sets the [`CompressionLevel`].
     #[inline]
     pub fn compression_level(&mut self, compression_level: CompressionLevel) -> &mut Self {
         self.compression_level = compression_level;
         self
     }
 
-    /// Set [Encryption] to this builder.
+    /// Sets the [`Encryption`].
     #[inline]
     pub fn encryption(&mut self, encryption: Encryption) -> &mut Self {
         self.encryption = encryption;
         self
     }
 
-    /// Set [CipherMode] to this builder.
+    /// Sets the [`CipherMode`].
     #[inline]
     pub fn cipher_mode(&mut self, cipher_mode: CipherMode) -> &mut Self {
         self.cipher_mode = cipher_mode;
         self
     }
 
-    /// Set [HashAlgorithm] to this builder.
+    /// Sets the [`HashAlgorithm`].
     #[inline]
     pub fn hash_algorithm(&mut self, algorithm: HashAlgorithm) -> &mut Self {
         self.hash_algorithm = algorithm;
         self
     }
 
-    /// Set the password to this builder.
+    /// Sets the password.
     #[inline]
     pub fn password<S: AsRef<str>>(&mut self, password: Option<S>) -> &mut Self {
         self.password = password.map(|it| it.as_ref().into());
         self
     }
 
-    /// Create new [WriteOptions] parameters set from this builder.
+    /// Creates a new [`WriteOptions`] from this builder.
     ///
     /// ## Panics
     ///
@@ -645,7 +645,7 @@ pub struct ReadOptions {
 }
 
 impl ReadOptions {
-    /// Create a new [`ReadOptions`] with an optional password.
+    /// Creates a new [`ReadOptions`] with an optional password.
     ///
     /// # Examples
     /// ```
@@ -717,7 +717,7 @@ impl ReadOptionsBuilder {
         Self { password: None }
     }
 
-    /// Create a new [`ReadOptions`]
+    /// Creates a new [`ReadOptions`].
     #[inline]
     pub fn build(&self) -> ReadOptions {
         ReadOptions {

--- a/lib/src/entry/reference.rs
+++ b/lib/src/entry/reference.rs
@@ -54,7 +54,7 @@ impl EntryReference {
         Ok(Self::new_from_utf8path(Utf8Path::new(path)))
     }
 
-    /// Create an [`EntryReference`] from a struct impl <code>[Into]<[PathBuf]></code>.
+    /// Creates an [`EntryReference`] from a struct impl <code>[Into]<[PathBuf]></code>.
     ///
     /// Any non-Unicode sequences are replaced with
     /// [`U+FFFD REPLACEMENT CHARACTER`][U+FFFD].

--- a/lib/src/ext/time.rs
+++ b/lib/src/ext/time.rs
@@ -3,12 +3,12 @@ use std::time::SystemTime;
 
 /// [`SystemTime`] extension trait.
 pub trait SystemTimeExt {
-    /// Get [`Duration`] since unix epoch.
+    /// Returns the duration since the Unix epoch.
     fn duration_since_unix_epoch_signed(&self) -> Duration;
 }
 
 impl SystemTimeExt for SystemTime {
-    /// Get [`Duration`] since unix epoch.
+    /// Returns the duration since the Unix epoch.
     #[inline]
     fn duration_since_unix_epoch_signed(&self) -> Duration {
         time::OffsetDateTime::from(*self) - time::OffsetDateTime::UNIX_EPOCH


### PR DESCRIPTION
This commit updates doc comments throughout the codebase for improved clarity, consistency, and accuracy. Changes include rewording method descriptions, standardizing the use of 'Examples' sections, clarifying error messages, and updating code examples to use more descriptive comments. No functional code changes were made.