### PR TITLE
:pencil2: Improve and clarify `pna` documentation comment

### DIFF
--- a/pna/src/ext/archive.rs
+++ b/pna/src/ext/archive.rs
@@ -3,22 +3,22 @@ use libpna::Archive;
 use std::path::Path;
 use std::{fs, io};
 
-/// [Archive] fs extension trait.
+/// [`Archive`] filesystem extension trait.
 pub trait ArchiveFsExt: private::Sealed {
-    /// Create PNA file.
+    /// Creates a PNA file.
     ///
     /// # Errors
     ///
-    /// Returns error when failed to create archive.
+    /// Returns an error if creating the archive fails.
     fn create<P: AsRef<Path>>(path: P) -> io::Result<Self>
     where
         Self: Sized;
 
-    /// Open existing PNA file.
+    /// Opens an existing PNA file.
     ///
     /// # Errors
     ///
-    /// Returns error when failed to open archive.
+    /// Returns an error if opening the archive fails.
     fn open<P: AsRef<Path>>(path: P) -> io::Result<Self>
     where
         Self: Sized;

--- a/pna/src/ext/entry.rs
+++ b/pna/src/ext/entry.rs
@@ -2,32 +2,32 @@ use super::private;
 use libpna::{EntryBuilder, NormalEntry, WriteOptions};
 use std::{fs, io, path::Path};
 
-/// [NormalEntry] extension method trait.
+/// [`NormalEntry`] filesystem extension methods.
 pub trait EntryFsExt: private::Sealed {
-    /// Create an Entry from a given path.
+    /// Creates an entry from the given path.
     ///
     /// # Errors
     ///
-    /// Returns an error if an I/O error occurs while creating entry.
+    /// Returns an error if an I/O error occurs while creating the entry.
     fn from_path<P: AsRef<Path>>(path: P) -> io::Result<Self>
     where
         Self: Sized;
-    /// Create Entry from a given path with option.
+    /// Creates an entry from the given path with options.
     ///
     /// # Errors
     ///
-    /// Returns an error if an I/O error occurs while creating entry.
+    /// Returns an error if an I/O error occurs while creating the entry.
     fn from_path_with<P: AsRef<Path>>(path: P, options: WriteOptions) -> io::Result<Self>
     where
         Self: Sized;
 }
 
 impl EntryFsExt for NormalEntry {
-    /// Create an Entry from a given path.
+    /// Creates an entry from the given path.
     ///
     /// # Errors
     ///
-    /// Returns an error if an I/O error occurs while creating entry.
+    /// Returns an error if an I/O error occurs while creating the entry.
     ///
     /// # Examples
     ///
@@ -46,11 +46,11 @@ impl EntryFsExt for NormalEntry {
         Self::from_path_with(path.as_ref(), WriteOptions::builder().build())
     }
 
-    /// Create Entry from a given path with option.
+    /// Creates an entry from the given path with options.
     ///
     /// # Errors
     ///
-    /// Returns an error if an I/O error occurs while creating entry.
+    /// Returns an error if an I/O error occurs while creating the entry.
     ///
     /// # Examples
     ///

--- a/pna/src/ext/metadata.rs
+++ b/pna/src/ext/metadata.rs
@@ -3,7 +3,7 @@ use crate::prelude::*;
 use libpna::Metadata;
 use std::{fs, io, path::Path, time::SystemTime};
 
-/// [Metadata] extension method trait.
+/// [`Metadata`] time-related extension methods.
 pub trait MetadataTimeExt: private::Sealed {
     /// Returns the created time.
     fn created_time(&self) -> Option<SystemTime>;
@@ -153,19 +153,19 @@ impl MetadataTimeExt for Metadata {
     }
 }
 
-/// [Metadata] filesystem related extension trait.
+/// [`Metadata`] filesystem-related extension methods.
 pub trait MetadataFsExt: private::Sealed {
-    /// Create new [Metadata] from given [fs::Metadata].
+    /// Creates a new [`Metadata`] from the given [`fs::Metadata`].
     ///
     /// # Errors
-    /// Return an error when failed to convert to [fs::Metadata] to [Metadata]
+    /// Returns an error if converting from [`fs::Metadata`] fails.
     fn from_metadata(metadata: &fs::Metadata) -> io::Result<Self>
     where
         Self: Sized;
 }
 
 impl MetadataFsExt for Metadata {
-    /// Create new [Metadata] from given [fs::Metadata].
+    /// Creates a new [`Metadata`] from the given [`fs::Metadata`].
     ///
     /// # Examples
     ///
@@ -181,7 +181,7 @@ impl MetadataFsExt for Metadata {
     /// ```
     ///
     /// # Errors
-    /// Currently never return an error.
+    /// Currently never returns an error.
     #[inline]
     fn from_metadata(metadata: &fs::Metadata) -> io::Result<Self>
     where
@@ -191,29 +191,29 @@ impl MetadataFsExt for Metadata {
     }
 }
 
-/// [Metadata] path related extension trait.
+/// [`Metadata`] path-related extension methods.
 pub trait MetadataPathExt: private::Sealed {
-    /// Create a new [Metadata] from a given path.
+    /// Creates a new [`Metadata`] from the given path.
     ///
     /// # Errors
     ///
-    /// Returns an error when failed to get [std::fs::Metadata] from a given path.
+    /// Returns an error if retrieving [`std::fs::Metadata`] from the path fails.
     fn from_path<P: AsRef<Path>>(path: P) -> io::Result<Self>
     where
         Self: Sized;
 
-    /// Create a new [Metadata] from a given path without following symlinks.
+    /// Creates a new [`Metadata`] from the given path without following symlinks.
     ///
     /// # Errors
     ///
-    /// Returns an error when failed to get [std::fs::Metadata] from a given path.
+    /// Returns an error if retrieving [`std::fs::Metadata`] from the path fails.
     fn from_symlink_path<P: AsRef<Path>>(path: P) -> io::Result<Self>
     where
         Self: Sized;
 }
 
 impl MetadataPathExt for Metadata {
-    /// Create a new [Metadata] from a given path.
+    /// Creates a new [`Metadata`] from the given path.
     ///
     /// # Examples
     ///
@@ -224,7 +224,7 @@ impl MetadataPathExt for Metadata {
     /// ```
     /// # Errors
     ///
-    /// Returns an error when [`std::fs::metadata`] called in the method returns an error. For details, see [`std::fs::metadata`].
+    /// Returns an error if [`std::fs::metadata`] returns an error.
     #[inline]
     fn from_path<P: AsRef<Path>>(path: P) -> io::Result<Self>
     where
@@ -234,7 +234,7 @@ impl MetadataPathExt for Metadata {
         fs_metadata_to_metadata(&meta)
     }
 
-    /// Create a new [Metadata] from a given path without following symlinks.
+    /// Creates a new [`Metadata`] from the given path without following symlinks.
     ///
     /// # Examples
     ///
@@ -245,7 +245,7 @@ impl MetadataPathExt for Metadata {
     /// ```
     /// # Errors
     ///
-    /// Returns an error when [`std::fs::symlink_metadata`] called in the method returns an error. For details, see [`std::fs::symlink_metadata`].
+    /// Returns an error if [`std::fs::symlink_metadata`] returns an error.
     #[inline]
     fn from_symlink_path<P: AsRef<Path>>(path: P) -> io::Result<Self>
     where

--- a/pna/src/fs.rs
+++ b/pna/src/fs.rs
@@ -1,6 +1,6 @@
-//! PNA file system utilities
+//! PNA filesystem utilities
 //!
-//! The purpose of this module is to provide file system utilities for PNA
+//! The purpose of this module is to provide filesystem utilities for PNA.
 use std::{fs, io, os, path::Path};
 
 /// Creates a new symbolic link on the filesystem.
@@ -19,7 +19,7 @@ use std::{fs, io, os, path::Path};
 /// ```
 ///
 /// # Errors
-/// Returns an error if it fails to create the symlink.
+/// Returns an error if creating the symlink fails.
 #[inline]
 pub fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Result<()> {
     #[cfg(unix)]
@@ -41,8 +41,8 @@ pub fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Resu
     inner(original.as_ref(), link.as_ref())
 }
 
-/// Removes an entry from the filesystem. if given path is a directory,
-/// call [`fs::remove_dir_all`] otherwise call [`fs::remove_file`]. Use carefully!
+/// Removes an entry from the filesystem. If the given path is a directory,
+/// calls [`fs::remove_dir_all`], otherwise calls [`fs::remove_file`]. Use carefully!
 ///
 /// This function does **not** follow symbolic links and it will simply remove the
 /// symbolic link itself.

--- a/pna/src/lib.rs
+++ b/pna/src/lib.rs
@@ -1,7 +1,7 @@
 //! A library for more useful reading and writing PNA archives
 //!
-//! This library provides filesystem-related utilities in addition to utilities
-//! necessary to manage PNA archives abstracted over a reader or writer hosted by [libpna].
+//! Provides filesystem-related utilities in addition to the utilities
+//! necessary to manage PNA archives abstracted over a reader or writer hosted by [`libpna`].
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 #![doc(html_root_url = "https://docs.rs/pna/0.27.0")]
 #![deny(


### PR DESCRIPTION
Refines and standardizes documentation comments across archive, entry, metadata, and filesystem modules. Updates phrasing for clarity, consistency, and accuracy, and improves error descriptions and trait explanations. No functional code changes were made.