### PR TITLE
:bug: Fixed handling of broken symlinks

### DIFF
--- a/cli/src/command/append.rs
+++ b/cli/src/command/append.rs
@@ -7,7 +7,7 @@ use crate::{
         ask_password, check_password,
         commons::{
             collect_items, create_entry, entry_option, read_paths, read_paths_stdin, CreateOptions,
-            Exclude, KeepOptions, OwnerOptions, PathTransformers, TimeOptions,
+            Exclude, KeepOptions, OwnerOptions, PathTransformers, StoreAs, TimeOptions,
         },
         Command,
     },
@@ -246,7 +246,6 @@ fn append_to_archive(args: AppendCommand) -> anyhow::Result<()> {
         keep_options,
         owner_options,
         time_options,
-        follow_links: args.follow_links,
     };
     let path_transformers = PathTransformers::new(args.substitutions, args.transforms);
 
@@ -290,7 +289,7 @@ pub(crate) fn run_append_archive(
     create_options: &CreateOptions,
     path_transformers: &Option<PathTransformers>,
     mut archive: Archive<impl io::Write>,
-    target_items: Vec<(PathBuf, Option<PathBuf>)>,
+    target_items: Vec<(PathBuf, StoreAs)>,
 ) -> anyhow::Result<()> {
     let (tx, rx) = std::sync::mpsc::channel();
     rayon::scope_fifo(|s| {

--- a/cli/src/command/commons.rs
+++ b/cli/src/command/commons.rs
@@ -188,9 +188,11 @@ pub(crate) fn collect_items(
                         )))
                     }
                 }
-                Err(e) => match &e {
-                    ignore::Error::WithPath { path, err } if is_broken_symlink_error(path, err) => {
-                        Some(Ok((path.to_path_buf(), StoreAs::Symlink)))
+                Err(e) => match e {
+                    ignore::Error::WithPath { path, err }
+                        if is_broken_symlink_error(&path, &err) =>
+                    {
+                        Some(Ok((path, StoreAs::Symlink)))
                     }
                     _ => Some(Err(io::Error::other(e))),
                 },

--- a/cli/src/command/create.rs
+++ b/cli/src/command/create.rs
@@ -8,7 +8,7 @@ use crate::{
         commons::{
             collect_items, create_entry, entry_option, read_paths, read_paths_stdin,
             write_split_archive, CreateOptions, Exclude, KeepOptions, OwnerOptions,
-            PathTransformers, TimeOptions,
+            PathTransformers, StoreAs, TimeOptions,
         },
         Command,
     },
@@ -307,7 +307,6 @@ fn create_archive(args: CreateCommand) -> anyhow::Result<()> {
         owner_options,
         time_options,
         solid: args.solid,
-        follow_links: args.follow_links,
         path_transformers,
     };
     if let Some(size) = max_file_size {
@@ -338,7 +337,6 @@ pub(crate) struct CreationContext {
     pub(crate) owner_options: OwnerOptions,
     pub(crate) time_options: TimeOptions,
     pub(crate) solid: bool,
-    pub(crate) follow_links: bool,
     pub(crate) path_transformers: Option<PathTransformers>,
 }
 
@@ -350,10 +348,9 @@ pub(crate) fn create_archive_file<W, F>(
         owner_options,
         time_options,
         solid,
-        follow_links,
         path_transformers,
     }: CreationContext,
-    target_items: Vec<(PathBuf, Option<PathBuf>)>,
+    target_items: Vec<(PathBuf, StoreAs)>,
 ) -> anyhow::Result<()>
 where
     W: Write,
@@ -370,7 +367,6 @@ where
         keep_options,
         owner_options,
         time_options,
-        follow_links,
     };
     rayon::scope_fifo(|s| {
         for file in target_items {
@@ -412,10 +408,9 @@ fn create_archive_with_split(
         owner_options,
         time_options,
         solid,
-        follow_links,
         path_transformers,
     }: CreationContext,
-    target_items: Vec<(PathBuf, Option<PathBuf>)>,
+    target_items: Vec<(PathBuf, StoreAs)>,
     max_file_size: usize,
     overwrite: bool,
 ) -> anyhow::Result<()> {
@@ -430,7 +425,6 @@ fn create_archive_with_split(
         keep_options,
         owner_options,
         time_options,
-        follow_links,
     };
     rayon::scope_fifo(|s| -> anyhow::Result<()> {
         for file in target_items {

--- a/cli/src/command/stdio.rs
+++ b/cli/src/command/stdio.rs
@@ -329,7 +329,6 @@ fn run_create_archive(args: StdioCommand) -> anyhow::Result<()> {
         owner_options,
         time_options,
         solid: args.solid,
-        follow_links: args.follow_links,
         path_transformers,
     };
     if let Some(file) = archive_file {
@@ -498,7 +497,6 @@ fn run_append(args: StdioCommand) -> anyhow::Result<()> {
         keep_options,
         owner_options,
         time_options,
-        follow_links: args.follow_links,
     };
     let path_transformers = PathTransformers::new(args.substitutions, args.transforms);
 


### PR DESCRIPTION
Introduces a StoreAs enum to explicitly represent how files, directories, symlinks, and hardlinks are stored. Refactors item collection and entry creation to use StoreAs, improving clarity and correctness, especially for symlink and hardlink handling. Removes the follow_links option from CreateOptions and related code. Adds tests to verify correct handling of broken symlinks.