### PR TITLE
:shirt: Update deprecation warning for experimental xattr

### DIFF
--- a/cli/src/command/experimental.rs
+++ b/cli/src/command/experimental.rs
@@ -19,7 +19,7 @@ impl Command for ExperimentalCommand {
             ExperimentalCommands::Chmod(cmd) => cmd.execute(),
             ExperimentalCommands::Xattr(cmd) => {
                 log::warn!(
-                    "`{0} experimental xattr` subcommand was stabilized, use `{0} xattr` instead.",
+                    "`{0} experimental xattr` subcommand was stabilized, use `{0} xattr` instead. this command will be removed in the future.",
                     std::env::current_exe()
                         .ok()
                         .and_then(|it| it.file_name().map(|n| n.to_os_string()))
@@ -48,7 +48,9 @@ pub(crate) enum ExperimentalCommands {
     Chown(command::chown::ChownCommand),
     #[command(about = "Change mode")]
     Chmod(command::chmod::ChmodCommand),
-    #[command(about = "Manipulate extended attributes")]
+    #[command(
+        about = "Manipulate extended attributes (stabilized, use `pna xattr` command instead. this command will be removed in the future)"
+    )]
     Xattr(command::xattr::XattrCommand),
     #[command(about = "Manipulate ACLs of entries")]
     Acl(command::acl::AclCommand),


### PR DESCRIPTION
Enhanced the warning message for the `experimental xattr` subcommand to indicate it will be removed in the future, guiding users to use the stabilized `xattr` command.