### PR TITLE
:truck: Rename symbolic link methods in favor of symlink

### DIFF
--- a/cli/src/command/commons.rs
+++ b/cli/src/command/commons.rs
@@ -289,7 +289,7 @@ pub(crate) fn create_entry(
             } else {
                 EntryReference::from_lossy(source)
             };
-            let entry = EntryBuilder::new_symbolic_link(entry_name, reference)?;
+            let entry = EntryBuilder::new_symlink(entry_name, reference)?;
             apply_metadata(
                 entry,
                 path,

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -110,7 +110,7 @@ impl EntryBuilder {
     /// # Arguments
     ///
     /// * `name` - The name of the entry to create.
-    /// * `link` - The entry reference the symlink points to.
+    /// * `source` - The entry reference the symlink points to.
     ///
     /// # Returns
     ///
@@ -151,7 +151,18 @@ impl EntryBuilder {
 
     /// Creates a new symbolic link with the given name and link.
     ///
-    /// Deprecated: Use [`EntryBuilder::new_symlink`] instead.
+    /// # Deprecated
+    ///
+    /// Use [`EntryBuilder::new_symlink`] instead.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the entry to create.
+    /// * `source` - The entry reference the symlink points to.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if initialization fails.
     #[inline]
     #[deprecated(since = "0.27.3", note = "Use `EntryBuilder::new_symlink` instead")]
     pub fn new_symbolic_link(name: EntryName, source: EntryReference) -> io::Result<Self> {

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -110,7 +110,7 @@ impl EntryBuilder {
     /// # Arguments
     ///
     /// * `name` - The name of the entry to create.
-    /// * `link` - The name of the entry reference.
+    /// * `link` - The entry reference the symlink points to.
     ///
     /// # Returns
     ///
@@ -124,7 +124,7 @@ impl EntryBuilder {
     /// ```
     /// use libpna::{EntryBuilder, EntryName, EntryReference};
     ///
-    /// let builder = EntryBuilder::new_symbolic_link(
+    /// let builder = EntryBuilder::new_symlink(
     ///     EntryName::try_from("path/of/target").unwrap(),
     ///     EntryReference::try_from("path/of/source").unwrap(),
     /// )
@@ -132,7 +132,7 @@ impl EntryBuilder {
     /// let entry = builder.build().unwrap();
     /// ```
     #[inline]
-    pub fn new_symbolic_link(name: EntryName, source: EntryReference) -> io::Result<Self> {
+    pub fn new_symlink(name: EntryName, source: EntryReference) -> io::Result<Self> {
         let option = WriteOptions::store();
         let context = get_writer_context(option)?;
         let mut writer = get_writer(FlattenWriter::new(), &context)?;
@@ -145,8 +145,17 @@ impl EntryBuilder {
             data: Some(writer),
             iv,
             phsf,
-            ..Self::new(EntryHeader::for_symbolic_link(name))
+            ..Self::new(EntryHeader::for_symlink(name))
         })
+    }
+
+    /// Creates a new symbolic link with the given name and link.
+    ///
+    /// Deprecated: Use [`EntryBuilder::new_symlink`] instead.
+    #[inline]
+    #[deprecated(since = "0.27.3", note = "Use `EntryBuilder::new_symlink` instead")]
+    pub fn new_symbolic_link(name: EntryName, source: EntryReference) -> io::Result<Self> {
+        Self::new_symlink(name, source)
     }
 
     /// Creates a new hard link with the given name and link.

--- a/lib/src/entry/header.rs
+++ b/lib/src/entry/header.rs
@@ -59,8 +59,9 @@ impl EntryHeader {
         Self::new(DataKind::Directory, path)
     }
 
+    /// Creates a header for a symbolic link (symlink).
     #[inline]
-    pub(crate) const fn for_symbolic_link(path: EntryName) -> Self {
+    pub(crate) const fn for_symlink(path: EntryName) -> Self {
         Self::new(DataKind::SymbolicLink, path)
     }
 


### PR DESCRIPTION
Replaces usage of EntryBuilder::new_symbolic_link and EntryHeader::for_symbolic_link with new EntryBuilder::new_symlink and EntryHeader::for_symlink methods. Marks the old methods as deprecated and updates documentation and usage accordingly for improved naming consistency.