### PR TITLE
:wrench: Add 'wasi' profile to compose.yml service

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -24,3 +24,5 @@ services:
     command: 'sleep infinity'
     environment:
       CARGO_BUILD_TARGET: wasm32-wasip1
+    profiles:
+      - wasi


### PR DESCRIPTION
Introduces a 'wasi' profile to the relevant service in compose.yml, enabling selective service startup using Docker Compose profiles.