### PR TITLE
Potential fix for code scanning alert no. 531: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,5 +1,8 @@
 name: Fuzzing with cargo fuzz
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/ChanTsune/Portable-Network-Archive/security/code-scanning/531](https://github.com/ChanTsune/Portable-Network-Archive/security/code-scanning/531)

To fix this CodeQL warning, add a `permissions` block at the workflow root (at the same level as `on:` and `jobs:`) or to each job individually (at the same level as `name:`, `runs-on:`, etc.). Since there are two jobs here—`fuzz_target` (which just reads source code) and `fuzz` (which also uploads artifacts)—the minimal starting point is to set `permissions: contents: read` either globally or on both jobs. 

If `upload-artifact` is used, according to GitHub documentation, this also works with `contents: read`. So, setting the workflow-wide permissions to `contents: read` is sufficient and simplest. 

**Where to edit:**  
Insert the following lines after the workflow name and before `on:`:
```yaml
permissions:
  contents: read
```
No new methods, packages, or imports are required—this is a simple YAML edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
