### PR TITLE
Potential fix for code scanning alert no. 530: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -2,6 +2,8 @@ name: format
 on:
   pull_request:
   push:
+permissions:
+  contents: read
 jobs:
   rust_check_format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ChanTsune/Portable-Network-Archive/security/code-scanning/530](https://github.com/ChanTsune/Portable-Network-Archive/security/code-scanning/530)

To fix the problem, set an explicit `permissions` block restricting the job or workflow to the least privilege required. In this case, both jobs (`rust_check_format`, `rust_check_doc`) only check formatting or build documentation; they do not modify the repository or interact externally. The minimal needed privilege is `contents: read`.

Apply the fix at the root of the workflow (top-level), just after the workflow `name` and `on` triggers, to cover all jobs in this workflow. Add the following block:
```yaml
permissions:
  contents: read
```
This ensures that all jobs in the workflow only get read access to repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
