### PR TITLE
Potential fix for code scanning alert no. 542: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["*"]
 
+permissions:
+  contents: read
+
 env:
   RUST_BACKTRACE: 1
 


### PR DESCRIPTION
Potential fix for [https://github.com/ChanTsune/Portable-Network-Archive/security/code-scanning/542](https://github.com/ChanTsune/Portable-Network-Archive/security/code-scanning/542)

**General fix:**  
Explicitly add a `permissions:` block with the minimum permissions needed to the workflow. If no write operations against the GitHub API are performed, as in this case, `permissions: contents: read` is the minimal and safest setting. This can go at the top level (applies to all jobs), or per-job.

**Detailed fix:**  
Add a `permissions:` block at the root level of `.github/workflows/vm.yml`, immediately after the `name:` or `on:` block. Set the `contents` permission to `read`. No additional permissions are necessary for jobs that only check out code and run tests. Existing functionality will not be affected, as this change only restricts the scope of `GITHUB_TOKEN`.

- **File/lines to change:** `.github/workflows/vm.yml`, after the `name:` or `on:` block (before `env:`).
- **Methods/definitions/imports needed:** None.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
