### PR TITLE
Potential fix for code scanning alert no. 545: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: test
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/ChanTsune/Portable-Network-Archive/security/code-scanning/545](https://github.com/ChanTsune/Portable-Network-Archive/security/code-scanning/545)

To fix the problem, add a `permissions` block to the workflow file. This block should be placed at the top level (applies to all jobs), unless specific jobs require elevated permissions for certain API scopes (such as `issues: write`, `pull-requests: write`). Since the shown workflow only appears to check out code, build, and test, and does not attempt any write operations on repository contents, issues, or PRs, the best minimal permissions are likely `contents: read`. This follows GitHub’s recommendation and satisfies CodeQL.

You should add the following block at the top level of .github/workflows/test.yml, immediately below the `name: test` line and above `on:`. If any job later needs write permissions, you could override this in that job, but based on the visible code, this is not necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
