### PR TITLE
Potential fix for code scanning alert no. 539: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/webassembly.yml
+++ b/.github/workflows/webassembly.yml
@@ -1,4 +1,6 @@
 name: Build Webassembly
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/ChanTsune/Portable-Network-Archive/security/code-scanning/539](https://github.com/ChanTsune/Portable-Network-Archive/security/code-scanning/539)

To fix the problem, add an explicit `permissions` block to the workflow. Since the workflow appears only to require the ability to check out the code (read access to repository contents) and does not interact with issues, pull requests or other privileged GitHub API endpoints, setting `permissions: { contents: read }` at the top workflow/root level is sufficient and safe. This ensures that all jobs within the workflow run with the minimal required permissions, thus improving security and adhering to best practices.  
The change is to add the following lines near the top (after `name:` or `on:`):

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
