### PR TITLE
Potential fix for code scanning alert no. 535: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   semver-checks:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/ChanTsune/Portable-Network-Archive/security/code-scanning/535](https://github.com/ChanTsune/Portable-Network-Archive/security/code-scanning/535)

To fix this issue, we should add an explicit `permissions` block scoped to the minimum needed for the job. The required permissions for this workflow are:
- `contents: read` to allow actions like `actions/checkout`.
- `pull-requests: write` because the workflow directly edits PR labels using the GitHub CLI (`gh pr edit`).

Add a `permissions` block at the job level (i.e., under `semver-checks:` and above `runs-on:`) in `.github/workflows/semver-checks.yml`:

```yaml
permissions:
  contents: read
  pull-requests: write
```

No other changes are needed; no imports or method changes are required since this is a declarative YAML workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
