### PR TITLE
Potential fix for code scanning alert no. 534: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,8 @@ concurrency:
 jobs:
   publish:
     name: Publish crate
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
Potential fix for [https://github.com/ChanTsune/Portable-Network-Archive/security/code-scanning/534](https://github.com/ChanTsune/Portable-Network-Archive/security/code-scanning/534)

To fix this issue, add a `permissions:` block specifying the minimal required permissions for this workflow/job. The minimal starting point is `contents: read`, which allows the workflow to read repository content but not write. Since the workflow publishes to crates.io (external to GitHub) and does not interact with pull requests, issues, or require elevated repo access, `contents: read` is sufficient unless future steps require more. You can add this block either at the workflow level (top) or at the job level (inside the `publish` job). Adding it under the job is precise since only one job exists.

**Steps:**
- Insert a `permissions:` block immediately after `name: Publish crate` (line 14).
- The block should look like:
  ```yaml
  permissions:
    contents: read
  ```
No further code changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
