### PR TITLE
:bug: Avoid panics when worker results are dropped

### DIFF
--- a/cli/src/command/append.rs
+++ b/cli/src/command/append.rs
@@ -306,7 +306,7 @@ pub(crate) fn run_append_archive(
             s.spawn_fifo(move |_| {
                 log::debug!("Adding: {}", file.0.display());
                 tx.send(create_entry(&file, create_options, path_transformers))
-                    .unwrap_or_else(|e| panic!("{e}: {}", file.0.display()));
+                    .unwrap_or_else(|e| log::error!("{e}: {}", file.0.display()));
             })
         }
 

--- a/cli/src/command/create.rs
+++ b/cli/src/command/create.rs
@@ -384,7 +384,7 @@ where
             s.spawn_fifo(move |_| {
                 log::debug!("Adding: {}", file.0.display());
                 tx.send(create_entry(&file, &create_options, &path_transformers))
-                    .unwrap_or_else(|e| panic!("{e}: {}", file.0.display()));
+                    .unwrap_or_else(|e| log::error!("{e}: {}", file.0.display()));
             })
         }
 
@@ -442,7 +442,7 @@ fn create_archive_with_split(
             s.spawn_fifo(move |_| {
                 log::debug!("Adding: {}", file.0.display());
                 tx.send(create_entry(&file, &create_options, &path_transformers))
-                    .unwrap_or_else(|e| panic!("{e}: {}", file.0.display()));
+                    .unwrap_or_else(|e| log::error!("{e}: {}", file.0.display()));
             })
         }
 

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -309,7 +309,7 @@ where
             let args = args.clone();
             s.spawn_fifo(move |_| {
                 tx.send(extract_entry(item, password, &args))
-                    .unwrap_or_else(|e| panic!("{e}: {item_path}"));
+                    .unwrap_or_else(|e| log::error!("{e}: {item_path}"));
             });
             Ok(())
         })?;
@@ -363,7 +363,7 @@ where
             let args = args.clone();
             s.spawn_fifo(move |_| {
                 tx.send(extract_entry(item, password, &args))
-                    .unwrap_or_else(|e| panic!("{e}: {item_path}"));
+                    .unwrap_or_else(|e| log::error!("{e}: {item_path}"));
             });
             Ok(())
         })?;

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -379,7 +379,7 @@ fn update_archive<Strategy: TransformStrategy>(args: UpdateCommand) -> anyhow::R
                                 &create_options,
                                 &path_transformers,
                             ))
-                            .unwrap_or_else(|e| panic!("{e}: {}", target_path.0.display()));
+                            .unwrap_or_else(|e| log::error!("{e}: {}", target_path.0.display()));
                         });
                         Ok(None)
                     } else {
@@ -400,7 +400,7 @@ fn update_archive<Strategy: TransformStrategy>(args: UpdateCommand) -> anyhow::R
                 log::debug!("Adding: {}", file.display());
                 let file = (file, store);
                 tx.send(create_entry(&file, &create_options, &path_transformers))
-                    .unwrap_or_else(|e| panic!("{e}: {}", file.0.display()));
+                    .unwrap_or_else(|e| log::error!("{e}: {}", file.0.display()));
             });
         }
         drop(tx);


### PR DESCRIPTION
Changed all instances of panic on send errors to log::error in append, create, extract, and update command modules. This improves error handling by logging errors instead of terminating the process.