### PR TITLE
:truck: Move UnknownValueError to new error module

### DIFF
--- a/lib/src/entry/options.rs
+++ b/lib/src/entry/options.rs
@@ -1,10 +1,6 @@
-use crate::compress;
+use crate::{compress, error::UnknownValueError};
 pub(crate) use private::*;
-use std::{
-    error::Error,
-    fmt::{Display, Formatter},
-    str::FromStr,
-};
+use std::str::FromStr;
 
 mod private {
     use super::*;
@@ -131,19 +127,6 @@ mod private {
         }
     }
 }
-
-/// Unknown value error.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub struct UnknownValueError(u8);
-
-impl Display for UnknownValueError {
-    #[inline]
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "unknown value {}", self.0)
-    }
-}
-
-impl Error for UnknownValueError {}
 
 /// Compression method.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -1,0 +1,17 @@
+use std::{
+    error::Error,
+    fmt::{Display, Formatter},
+};
+
+/// Unknown value error.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub struct UnknownValueError(pub(crate) u8);
+
+impl Display for UnknownValueError {
+    #[inline]
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "unknown value {}", self.0)
+    }
+}
+
+impl Error for UnknownValueError {}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -18,6 +18,7 @@ pub(crate) mod chunk;
 pub(crate) mod cipher;
 pub(crate) mod compress;
 pub(crate) mod entry;
+mod error;
 mod ext;
 pub(crate) mod hash;
 pub(crate) mod io;
@@ -28,6 +29,7 @@ pub(crate) mod util;
 pub use archive::*;
 pub use chunk::*;
 pub use entry::*;
+pub use error::UnknownValueError;
 pub use time::Duration;
 
 #[cfg(test)]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -18,7 +18,7 @@ pub(crate) mod chunk;
 pub(crate) mod cipher;
 pub(crate) mod compress;
 pub(crate) mod entry;
-mod error;
+pub(crate) mod error;
 mod ext;
 pub(crate) mod hash;
 pub(crate) mod io;


### PR DESCRIPTION
Refactored UnknownValueError from entry/options.rs into a dedicated error.rs module for better code organization. Updated imports and re-exports to reflect this change.