### PR TITLE
Fix three bugs in codebase

### DIFF
--- a/cli/src/command/commons.rs
+++ b/cli/src/command/commons.rs
@@ -317,7 +317,7 @@ pub(crate) fn collect_split_archives(first: impl AsRef<Path>) -> io::Result<Vec<
     let mut archives = Vec::new();
     let mut n = 1;
     let mut target_archive = Cow::from(first.as_ref());
-    while fs::exists(&target_archive)? {
+    while fs::try_exists(&target_archive)? {
         archives.push(fs::File::open(&target_archive)?);
         n += 1;
         target_archive = target_archive.with_part(n).expect("").into();

--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -588,7 +588,7 @@ fn detail_list_entries(entries: impl IntoIterator<Item = TableRow>, options: Lis
         );
         let group = content.permission.as_ref().map_or_else(
             || "-".into(),
-            |it| it.owner_display(options.numeric_owner).to_string(),
+            |it| it.group_display(options.numeric_owner).to_string(),
         );
         builder.push_record([
             content.encryption,

--- a/cli/tests/cli/cd_option.rs
+++ b/cli/tests/cli/cd_option.rs
@@ -18,7 +18,7 @@ fn create_extract_with_cd() {
     ]);
     cmd.assert().success();
 
-    assert!(fs::exists("create_extract_with_cd/create_extract_with_cd.pna").unwrap());
+    assert!(fs::try_exists("create_extract_with_cd/create_extract_with_cd.pna").unwrap());
 
     let mut cmd = assert_cmd::Command::cargo_bin("pna").unwrap();
     cmd.args([
@@ -54,7 +54,7 @@ fn append_with_cd() {
     ]);
     cmd.assert().success();
 
-    assert!(fs::exists("append_with_cd/append_with_cd.pna").unwrap());
+    assert!(fs::try_exists("append_with_cd/append_with_cd.pna").unwrap());
 
     // Copy extra input
     TestResources::extract_in("store.pna", "append_with_cd/in/").unwrap();
@@ -106,7 +106,7 @@ fn update_with_cd() {
     ]);
     cmd.assert().success();
 
-    assert!(fs::exists("update_with_cd/update_with_cd.pna").unwrap());
+    assert!(fs::try_exists("update_with_cd/update_with_cd.pna").unwrap());
 
     // Copy extra input
     TestResources::extract_in("store.pna", "update_with_cd/in/").unwrap();

--- a/cli/tests/cli/create/exclude.rs
+++ b/cli/tests/cli/create/exclude.rs
@@ -21,7 +21,7 @@ fn create_with_exclude() {
     .unwrap()
     .execute()
     .unwrap();
-    assert!(fs::exists("create_with_exclude/create_with_exclude.pna").unwrap());
+    assert!(fs::try_exists("create_with_exclude/create_with_exclude.pna").unwrap());
 
     cli::Cli::try_parse_from([
         "pna",

--- a/cli/tests/cli/create/exclude_vcs.rs
+++ b/cli/tests/cli/create/exclude_vcs.rs
@@ -54,7 +54,7 @@ fn create_with_exclude_vcs() {
     .unwrap()
     .execute()
     .unwrap();
-    assert!(fs::exists("create_with_exclude_vcs/create_with_exclude_vcs.pna").unwrap());
+    assert!(fs::try_exists("create_with_exclude_vcs/create_with_exclude_vcs.pna").unwrap());
 
     cli::Cli::try_parse_from([
         "pna",
@@ -133,7 +133,7 @@ fn create_without_exclude_vcs() {
     .unwrap()
     .execute()
     .unwrap();
-    assert!(fs::exists("create_without_exclude_vcs/create_without_exclude_vcs.pna").unwrap());
+    assert!(fs::try_exists("create_without_exclude_vcs/create_without_exclude_vcs.pna").unwrap());
 
     cli::Cli::try_parse_from([
         "pna",

--- a/cli/tests/cli/create/no_recursive.rs
+++ b/cli/tests/cli/create/no_recursive.rs
@@ -19,7 +19,7 @@ fn no_recursive() {
     .unwrap()
     .execute()
     .unwrap();
-    assert!(fs::exists("no_recursive/no_recursive.pna").unwrap());
+    assert!(fs::try_exists("no_recursive/no_recursive.pna").unwrap());
 
     cli::Cli::try_parse_from([
         "pna",

--- a/cli/tests/cli/create/substitution.rs
+++ b/cli/tests/cli/create/substitution.rs
@@ -21,7 +21,7 @@ fn create_with_substitution() {
     .unwrap()
     .execute()
     .unwrap();
-    assert!(fs::exists("create_with_substitution/create_with_substitution.pna").unwrap());
+    assert!(fs::try_exists("create_with_substitution/create_with_substitution.pna").unwrap());
 
     cli::Cli::try_parse_from([
         "pna",

--- a/cli/tests/cli/extract/chroot.rs
+++ b/cli/tests/cli/extract/chroot.rs
@@ -23,7 +23,7 @@ fn archive_extract_chroot() {
     ]);
     cmd.assert().success();
 
-    assert!(fs::exists("extract_chroot/extract_chroot.pna").unwrap());
+    assert!(fs::try_exists("extract_chroot/extract_chroot.pna").unwrap());
 
     let mut cmd = assert_cmd::Command::cargo_bin("pna").unwrap();
     cmd.args([

--- a/cli/tests/cli/extract/exclude.rs
+++ b/cli/tests/cli/extract/exclude.rs
@@ -19,7 +19,7 @@ fn extract_with_exclude() {
     .unwrap()
     .execute()
     .unwrap();
-    assert!(fs::exists("extract_with_exclude/extract_with_exclude.pna").unwrap());
+    assert!(fs::try_exists("extract_with_exclude/extract_with_exclude.pna").unwrap());
 
     cli::Cli::try_parse_from([
         "pna",

--- a/cli/tests/cli/extract/substitution.rs
+++ b/cli/tests/cli/extract/substitution.rs
@@ -18,7 +18,7 @@ fn extract_with_substitution() {
     .unwrap()
     .execute()
     .unwrap();
-    assert!(fs::exists("extract_with_substitution/extract_with_substitution.pna").unwrap());
+    assert!(fs::try_exists("extract_with_substitution/extract_with_substitution.pna").unwrap());
 
     cli::Cli::try_parse_from([
         "pna",

--- a/cli/tests/cli/extract/transform.rs
+++ b/cli/tests/cli/extract/transform.rs
@@ -18,7 +18,7 @@ fn extract_with_transform() {
     .unwrap()
     .execute()
     .unwrap();
-    assert!(fs::exists("extract_with_transform/extract_with_transform.pna").unwrap());
+    assert!(fs::try_exists("extract_with_transform/extract_with_transform.pna").unwrap());
 
     cli::Cli::try_parse_from([
         "pna",

--- a/cli/tests/cli/hardlink.rs
+++ b/cli/tests/cli/hardlink.rs
@@ -89,7 +89,7 @@ fn hardlink() {
     );
 
     // Check skipped extract unsafe link
-    assert!(!fs::exists("hardlink/dist/dir/linked1.txt").unwrap());
+    assert!(!fs::try_exists("hardlink/dist/dir/linked1.txt").unwrap());
 
     assert_eq!(
         "original text text\n",

--- a/cli/tests/cli/keep_all.rs
+++ b/cli/tests/cli/keep_all.rs
@@ -24,7 +24,7 @@ fn archive_keep_all() {
     .unwrap()
     .execute()
     .unwrap();
-    assert!(fs::exists("archive_keep_all/keep_all.pna").unwrap());
+    assert!(fs::try_exists("archive_keep_all/keep_all.pna").unwrap());
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",


### PR DESCRIPTION
Fix three bugs: correct group display in `list` command and update `fs::exists` to `fs::try_exists` in core logic and tests.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab93ef22-f022-49dd-b576-9aff5654b4ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ab93ef22-f022-49dd-b576-9aff5654b4ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

