### PR TITLE
Find and fix bugs in codebase

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -71,6 +71,7 @@ impl VerbosityArgs {
 }
 
 #[derive(Subcommand, Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum Commands {
     #[command(visible_alias = "c", about = "Create archive")]
     Create(CreateCommand),

--- a/cli/src/command/experimental.rs
+++ b/cli/src/command/experimental.rs
@@ -37,6 +37,7 @@ impl Command for ExperimentalCommand {
 }
 
 #[derive(Subcommand, Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum ExperimentalCommands {
     #[command(about = "Archive manipulation via stdio")]
     Stdio(command::stdio::StdioCommand),

--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -709,7 +709,7 @@ fn datetime(format: TimeFormat, time: SystemTime) -> String {
 }
 
 #[inline]
-fn hide_control_chars<'a>(s: &'a str) -> impl Display + 'a {
+fn hide_control_chars(s: &str) -> impl Display + '_ {
     use core::fmt::Write;
     struct HideControl<'s>(&'s str);
 

--- a/lib/src/chunk.rs
+++ b/lib/src/chunk.rs
@@ -410,9 +410,9 @@ pub fn read_as_chunks<R: Read>(
 /// # Errors
 /// Returns an error if the input is not a PNA archive.
 #[inline]
-pub fn read_chunks_from_slice<'a>(
-    archive: &'a [u8],
-) -> io::Result<impl Iterator<Item = io::Result<impl Chunk + 'a>>> {
+pub fn read_chunks_from_slice(
+    archive: &[u8],
+) -> io::Result<impl Iterator<Item = io::Result<impl Chunk + '_>>> {
     struct Chunks<'a> {
         reader: &'a [u8],
         eoa: bool,


### PR DESCRIPTION
Fix Clippy warnings by eliding needless lifetimes and allowing large enum variants to avoid disruptive refactors.

---
<a href="https://cursor.com/background-agent?bcId=bc-9bbc5406-12a1-488d-9c32-5cf4cb0c283e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9bbc5406-12a1-488d-9c32-5cf4cb0c283e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

