### PR TITLE
Fix cli codebase bugs

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -117,7 +117,7 @@ pub(crate) struct PasswordArgs {
 }
 
 #[derive(Parser, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[command(group(ArgGroup::new("transform_strategy").args(["password", "password_file"])))]
+#[command(group(ArgGroup::new("transform_strategy").args(["unsolid", "keep_solid"])))]
 pub(crate) struct SolidEntriesTransformStrategyArgs {
     #[arg(long, help = "Unsolid input solid entries.")]
     pub(crate) unsolid: bool,


### PR DESCRIPTION
Fix misconfigured Clap ArgGroup in `SolidEntriesTransformStrategyArgs` to reference correct arguments.

The `SolidEntriesTransformStrategyArgs` struct in `cli/src/cli.rs` had an `ArgGroup` defined that incorrectly referenced `password` and `password_file` arguments. This PR updates the `ArgGroup` to correctly reference `unsolid` and `keep_solid` arguments, resolving a build/test failure.

---
<a href="https://cursor.com/background-agent?bcId=bc-172d8579-bcb9-4342-bddb-e92f434b7dfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-172d8579-bcb9-4342-bddb-e92f434b7dfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

