### PR TITLE
:recycle: Handle cipher init errors in block read/write

### DIFF
--- a/lib/src/cipher/block/read.rs
+++ b/lib/src/cipher/block/read.rs
@@ -38,7 +38,8 @@ where
         }
         Ok(Self {
             r,
-            c: cbc::Decryptor::<C>::new_from_slices(key, iv).unwrap(),
+            c: cbc::Decryptor::<C>::new_from_slices(key, iv)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
             padding: PhantomData,
             remaining: ArrayVec::new(),
             buf,

--- a/lib/src/cipher/block/read.rs
+++ b/lib/src/cipher/block/read.rs
@@ -39,7 +39,7 @@ where
         Ok(Self {
             r,
             c: cbc::Decryptor::<C>::new_from_slices(key, iv)
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?,
             padding: PhantomData,
             remaining: ArrayVec::new(),
             buf,

--- a/lib/src/cipher/block/write.rs
+++ b/lib/src/cipher/block/write.rs
@@ -26,7 +26,8 @@ where
         debug_assert_eq!(cbc::Encryptor::<C>::block_size(), 16);
         Ok(Self {
             w,
-            c: cbc::Encryptor::<C>::new_from_slices(key, iv).unwrap(),
+            c: cbc::Encryptor::<C>::new_from_slices(key, iv)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
             padding: PhantomData,
             buf: ArrayVec::new(),
         })

--- a/lib/src/cipher/block/write.rs
+++ b/lib/src/cipher/block/write.rs
@@ -27,7 +27,7 @@ where
         Ok(Self {
             w,
             c: cbc::Encryptor::<C>::new_from_slices(key, iv)
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?,
             padding: PhantomData,
             buf: ArrayVec::new(),
         })

--- a/lib/src/cipher/stream/read.rs
+++ b/lib/src/cipher/stream/read.rs
@@ -26,7 +26,7 @@ where
         Ok(Self {
             r,
             cipher: StreamCipherCoreWrapper::<T>::new_from_slices(key, iv)
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?,
         })
     }
 }

--- a/lib/src/cipher/stream/write.rs
+++ b/lib/src/cipher/stream/write.rs
@@ -26,7 +26,7 @@ where
         Ok(Self {
             w,
             cipher: StreamCipherCoreWrapper::<T>::new_from_slices(key, iv)
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?,
         })
     }
 


### PR DESCRIPTION
Replaces unwrap() with proper error handling when initializing CBC encryptor/decryptor in block read and write modules. This prevents panics and returns an io::Error if key or IV are invalid.