### PR TITLE
:construction_worker: Update Rust setup in format workflow

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: ./.github/actions/setup-rust
+      - uses: actions-rust-lang/setup-rust-toolchain@02be93da58aa71fb456aa9c43b301149248829d8 # v1.15.1
+        with:
+          components: "rustfmt,rust-docs"
       - name: run check format
         run: cargo fmt --check
         env:
@@ -18,7 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: ./.github/actions/setup-rust
+      - uses: actions-rust-lang/setup-rust-toolchain@02be93da58aa71fb456aa9c43b301149248829d8 # v1.15.1
+        with:
+          components: "rustfmt,rust-docs"
       - name: run check doc
         run: cargo doc --no-deps -p libpna -p pna
         env:


### PR DESCRIPTION
Replaces the local setup-rust action with actions-rust-lang/setup-rust-toolchain@v1.15.1 in the format workflow. Also specifies the installation of rustfmt and rust-docs components.