### PR TITLE
Fix cli bugs

### DIFF
--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -25,7 +25,12 @@ use std::{fs, io};
 
 fn ask_password(args: PasswordArgs) -> io::Result<Option<String>> {
     if let Some(path) = args.password_file {
-        return Ok(Some(fs::read_to_string(path)?));
+        let mut password = fs::read_to_string(path)?;
+        // Trim common line terminators to avoid accidental newline in passwords read from files
+        while password.ends_with('\n') || password.ends_with('\r') {
+            password.pop();
+        }
+        return Ok(Some(password));
     };
     Ok(match args.password {
         Some(password @ Some(_)) => {


### PR DESCRIPTION
Trim trailing newlines from passwords read via `--password-file` to prevent authentication failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-526f1def-49a6-4509-aed9-27edaa7e2b84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-526f1def-49a6-4509-aed9-27edaa7e2b84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

