### PR TITLE
:boom: Finalize --password-file to first non-empty UTF-8 line (stage 2/2)

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -233,7 +233,7 @@ pub(crate) struct PasswordArgs {
     #[arg(
         long,
         value_name = "FILE",
-        help = "Read password from the specified file (entire contents). Files containing newlines or non-UTF-8 content emit a warning; use --password-file-raw if the full file content is intentionally the password"
+        help = "Read the password from the specified file. Only the first non-empty line is used, and trailing newlines are ignored"
     )]
     pub(crate) password_file: Option<PathBuf>,
     #[arg(

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -23,7 +23,10 @@ pub mod update;
 pub(crate) mod verify;
 pub mod xattr;
 
-use crate::cli::{Cli, Commands, GlobalContext, PasswordArgs};
+use crate::{
+    cli::{Cli, Commands, GlobalContext, PasswordArgs},
+    utils::fs as utils_fs,
+};
 use std::{fmt, fs, io};
 
 /// Error that maps to a specific process exit code in `main`.
@@ -80,13 +83,13 @@ fn ask_password(args: PasswordArgs) -> io::Result<Option<Vec<u8>>> {
         return Ok(Some(fs::read(path)?));
     }
     if let Some(path) = args.password_file {
-        let password = fs::read(path)?;
-        if password_bytes_need_raw_mode(&password) {
-            log::warn!(
-                "password file contains a newline or is not valid UTF-8; --password-file will change to use only the first non-empty UTF-8 line in a future release. If the full file content is your password, use --password-file-raw instead."
-            );
-        }
-        return Ok(Some(password));
+        return match utils_fs::read_first_non_empty_line(path)? {
+            Some(password) => Ok(Some(password.into_bytes())),
+            None => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "password is empty",
+            )),
+        };
     }
     Ok(match args.password {
         Some(Some(password)) => {
@@ -100,16 +103,6 @@ fn ask_password(args: PasswordArgs) -> io::Result<Option<Vec<u8>>> {
         ),
         None => None,
     })
-}
-
-/// Returns whether `password` will be read differently (or rejected) once
-/// `--password-file` switches to first-non-empty-UTF-8-line semantics.
-#[inline]
-fn password_bytes_need_raw_mode(password: &[u8]) -> bool {
-    match std::str::from_utf8(password) {
-        Ok(text) => text.contains('\n') || text.contains('\r'),
-        Err(_) => true,
-    }
 }
 
 pub(crate) trait Command {
@@ -137,25 +130,5 @@ impl Cli {
             Commands::Compat(cmd) => cmd.execute(ctx),
             Commands::Experimental(cmd) => cmd.execute(ctx),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::password_bytes_need_raw_mode;
-
-    #[test]
-    fn detects_lf_and_cr_as_newline() {
-        assert!(!password_bytes_need_raw_mode(b"secret"));
-        assert!(password_bytes_need_raw_mode(b"secret\n"));
-        assert!(password_bytes_need_raw_mode(b"secret\r\n"));
-        assert!(password_bytes_need_raw_mode(b"secret\r"));
-        assert!(password_bytes_need_raw_mode(b"line1\nline2"));
-    }
-
-    #[test]
-    fn detects_invalid_utf8() {
-        assert!(password_bytes_need_raw_mode(&[0xff, 0xfe, 0xfd]));
-        assert!(!password_bytes_need_raw_mode("secret".as_bytes()));
     }
 }

--- a/cli/src/utils/fs.rs
+++ b/cli/src/utils/fs.rs
@@ -8,7 +8,11 @@ pub(crate) use file_id::HardlinkResolver;
 pub(crate) use nodump::is_nodump;
 pub(crate) use owner::*;
 pub(crate) use pna::fs::*;
-use std::{fs, io, path::Path};
+use std::{
+    fs,
+    io::{self, BufRead},
+    path::Path,
+};
 
 /// Returns the current process umask.
 ///
@@ -160,5 +164,80 @@ pub(crate) fn file_create(path: impl AsRef<Path>, overwrite: bool) -> io::Result
         fs::File::create(path)
     } else {
         fs::File::create_new(path)
+    }
+}
+
+/// Returns the first non-empty line from a file as UTF-8, if any.
+///
+/// Empty lines are skipped. The trailing line terminator (`\n` or `\r\n`)
+/// is not included in the returned string.
+///
+/// # Returns
+///
+/// - `Ok(Some(line))` if a non-empty line was found.
+/// - `Ok(None)` if the file contains no non-empty lines.
+/// - `Err(e)` if an I/O error occurs while opening or reading the file.
+///
+/// # Errors
+///
+/// Propagates any I/O error that occurs while opening or reading the file.
+#[inline]
+pub(crate) fn read_first_non_empty_line<P: AsRef<Path>>(path: P) -> io::Result<Option<String>> {
+    let file = fs::File::open(path)?;
+    let reader = io::BufReader::new(file);
+    for line in reader.lines() {
+        let line = line?;
+        if !line.is_empty() {
+            return Ok(Some(line));
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::read_first_non_empty_line;
+    use crate::utils::env::temp_dir_or_else;
+    use std::{
+        fs,
+        io::Write,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn temp_path(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        temp_dir_or_else(|| ".".as_ref()).join(format!("pna-password-test-{name}-{nanos}"))
+    }
+
+    #[test]
+    fn reads_first_non_empty_line_and_skips_empty_prefix() {
+        let path = temp_path("first-line");
+        let mut file = fs::File::create(&path).unwrap();
+        writeln!(file, "").unwrap();
+        writeln!(file, "secret").unwrap();
+        writeln!(file, "ignored").unwrap();
+
+        let result = read_first_non_empty_line(&path);
+        let _ = fs::remove_file(&path);
+        assert_eq!(result.unwrap().as_deref(), Some("secret"));
+    }
+
+    #[test]
+    fn returns_none_for_empty_or_blank_file() {
+        let empty = temp_path("empty");
+        fs::write(&empty, "").unwrap();
+        let empty_result = read_first_non_empty_line(&empty);
+        let _ = fs::remove_file(&empty);
+        assert_eq!(empty_result.unwrap(), None);
+
+        let blank = temp_path("blank");
+        fs::write(&blank, "\n\n").unwrap();
+        let blank_result = read_first_non_empty_line(&blank);
+        let _ = fs::remove_file(&blank);
+        assert_eq!(blank_result.unwrap(), None);
     }
 }

--- a/cli/tests/cli/create/option_password_from_file_raw.rs
+++ b/cli/tests/cli/create/option_password_from_file_raw.rs
@@ -1,6 +1,5 @@
 use crate::utils::{EmbedExt, TestResources, archive, setup};
 use clap::Parser;
-use pna::prelude::*;
 use portable_network_archive::cli;
 use std::{collections::HashSet, fs};
 
@@ -57,16 +56,16 @@ fn create_with_password_file_raw() {
     }
 }
 
-/// Precondition: Input files and a password file whose content includes a trailing newline.
-/// Action: Create an encrypted archive with `--password-file` (legacy full-file read).
-/// Expectation: The entire file content (including the newline) is still accepted as the password.
+/// Precondition: Input files and a password file with a trailing newline after the password.
+/// Action: Create an encrypted archive with `--password-file`.
+/// Expectation: Only the first non-empty line is used (trailing newline is ignored).
 #[test]
-fn create_with_password_file_including_newline() {
+fn create_with_password_file_ignores_trailing_newline() {
     setup();
     TestResources::extract_in("raw/", "create_with_password_file_newline/in/").unwrap();
     let password_file_path = "create_with_password_file_newline/password_file";
-    let password = "create_with_password_file_newline\n";
-    fs::write(password_file_path, password).unwrap();
+    let password = "create_with_password_file_newline";
+    fs::write(password_file_path, format!("{password}\n")).unwrap();
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -94,25 +93,28 @@ fn create_with_password_file_including_newline() {
     .unwrap();
 }
 
-/// Precondition: Input files and a password file whose content is not valid UTF-8.
-/// Action: Create an encrypted archive with `--password-file` (legacy full-file read).
-/// Expectation: The entire byte sequence is still accepted as the password (only a warning is
-/// emitted; the upcoming first-non-empty-UTF-8-line behavior would reject this file outright).
+/// Precondition: Input files and a multi-line password file.
+/// Action: Create an encrypted archive with `--password-file`.
+/// Expectation: Only the first non-empty line is used as the password.
 #[test]
-fn create_with_password_file_non_utf8() {
+fn create_with_password_file_uses_first_non_empty_line() {
     setup();
-    TestResources::extract_in("raw/", "create_with_password_file_non_utf8/in/").unwrap();
-    let password_file_path = "create_with_password_file_non_utf8/password_file";
-    let password: &[u8] = &[0xff, 0xfe, 0xfd];
-    fs::write(password_file_path, password).unwrap();
+    TestResources::extract_in("raw/", "create_with_password_file_first_line/in/").unwrap();
+    let password_file_path = "create_with_password_file_first_line/password_file";
+    let password = "first-line-password";
+    fs::write(
+        password_file_path,
+        format!("\n{password}\nsecond-line-ignored\n"),
+    )
+    .unwrap();
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
         "-f",
-        "create_with_password_file_non_utf8/password_from_file.pna",
+        "create_with_password_file_first_line/password_from_file.pna",
         "--overwrite",
-        "create_with_password_file_non_utf8/in/",
+        "create_with_password_file_first_line/in/",
         "--password-file",
         password_file_path,
         "--aes",
@@ -124,10 +126,75 @@ fn create_with_password_file_non_utf8() {
     .execute()
     .unwrap();
 
-    let mut archive =
-        pna::Archive::open("create_with_password_file_non_utf8/password_from_file.pna").unwrap();
-    let read_options = pna::ReadOptions::with_password(Some(password));
-    for entry in archive.entries().extract_solid_entries(&read_options) {
-        entry.unwrap();
-    }
+    archive::for_each_entry_with_password(
+        "create_with_password_file_first_line/password_from_file.pna",
+        password,
+        |_entry| {},
+    )
+    .unwrap();
+}
+
+/// Precondition: Input files and an empty password file.
+/// Action: Create an encrypted archive with `--password-file`.
+/// Expectation: The command fails because the password is empty.
+#[test]
+fn create_with_empty_password_file_is_rejected() {
+    setup();
+    TestResources::extract_in("raw/", "create_with_empty_password_file/in/").unwrap();
+    let password_file_path = "create_with_empty_password_file/password_file";
+    fs::write(password_file_path, "\n\n").unwrap();
+    let err = cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "create_with_empty_password_file/password_from_file.pna",
+        "--overwrite",
+        "create_with_empty_password_file/in/",
+        "--password-file",
+        password_file_path,
+        "--aes",
+        "ctr",
+        "--argon2",
+        "t=1,m=50",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap_err();
+
+    let err = format!("{err:?}");
+    assert!(err.contains("password is empty"), "unexpected error: {err}");
+}
+
+/// Precondition: Input files and a password file whose content is not valid UTF-8.
+/// Action: Create an encrypted archive with `--password-file`.
+/// Expectation: The command fails because the password file must be valid UTF-8
+/// (use `--password-file-raw` for arbitrary bytes).
+#[test]
+fn create_with_non_utf8_password_file_is_rejected() {
+    setup();
+    TestResources::extract_in("raw/", "create_with_non_utf8_password_file/in/").unwrap();
+    let password_file_path = "create_with_non_utf8_password_file/password_file";
+    fs::write(password_file_path, [0xff, 0xfe, 0xfd]).unwrap();
+    let err = cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "create_with_non_utf8_password_file/password_from_file.pna",
+        "--overwrite",
+        "create_with_non_utf8_password_file/in/",
+        "--password-file",
+        password_file_path,
+        "--aes",
+        "ctr",
+        "--argon2",
+        "t=1,m=50",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap_err();
+
+    let err = format!("{err:?}");
+    assert!(err.contains("UTF-8"), "unexpected error: {err}");
 }


### PR DESCRIPTION
## Summary
- Stage 2/2 of the `--password-file` behavior migration, stacked on #3276 (stage 1: adds `--password-file-raw` and warns on newline/non-UTF-8 content in `--password-file`).
- Finalizes `--password-file` to read only the first non-empty UTF-8 line, ignoring blank lines and trailing newlines, matching common tool behavior.
- `--password-file-raw` remains available for callers that intentionally want the entire file content (including newlines / non-UTF-8 bytes) as the password.

## Merge order (important)
**Do not merge this before #3276 has merged and shipped in its own release.** The point of splitting these is to give users at least one release cycle to see the stage-1 warning (newline or non-UTF-8 content in `--password-file`) and migrate to `--password-file-raw` before the behavior actually changes here. Merging both in the same release defeats the warning entirely.

## Behavior changes in this stage
- `--password-file` now reads only the first non-empty line (UTF-8), ignoring leading blank lines and trailing newlines.
- A password file containing only blank lines is now rejected with "password is empty" (previously silently accepted as an empty password).
- A password file that is not valid UTF-8 is now rejected (previously accepted as raw bytes); use `--password-file-raw` for binary/non-UTF-8 passwords.

## Test plan
- [x] `cargo test -p portable-network-archive --lib` (576 passed)
- [x] `cargo test -p portable-network-archive --test cli password_file` — covers trailing-newline, first-non-empty-line, empty-file-rejected, and non-UTF-8-rejected cases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `--password-file` now uses the first non-empty line and ignores trailing newlines.
  * Empty or blank-only password files now return an error.
* **Bug Fixes**
  * Non-UTF-8 password files are rejected with guidance to use `--password-file-raw` for arbitrary-byte passwords.
* **Documentation**
  * Updated command-line help to clearly describe the revised password-file behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->