### PR TITLE
:memo: Include README.md as crate-level documentation

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc = include_str!("../README.md")]
 mod chunk;
 pub mod cli;
 pub mod command;


### PR DESCRIPTION
Added a crate-level doc attribute to include the contents of README.md as documentation for the crate. This improves the visibility and accessibility of project documentation.