### PR TITLE
:zap: Add symlink-aware entry creation methods

### DIFF
--- a/pna/src/ext/entry.rs
+++ b/pna/src/ext/entry.rs
@@ -12,12 +12,31 @@ pub trait EntryFsExt: private::Sealed {
     fn from_path<P: AsRef<Path>>(path: P) -> io::Result<Self>
     where
         Self: Sized;
+
     /// Creates an entry from the given path with options.
     ///
     /// # Errors
     ///
     /// Returns an error if an I/O error occurs while creating the entry.
     fn from_path_with<P: AsRef<Path>>(path: P, options: WriteOptions) -> io::Result<Self>
+    where
+        Self: Sized;
+
+    /// Creates an entry from the given path without following symlinks.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an I/O error occurs while creating the entry.
+    fn from_path_symlink<P: AsRef<Path>>(path: P) -> io::Result<Self>
+    where
+        Self: Sized;
+
+    /// Creates an entry from the given path with options, without following symlinks.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an I/O error occurs while creating the entry.
+    fn from_path_symlink_with<P: AsRef<Path>>(path: P, options: WriteOptions) -> io::Result<Self>
     where
         Self: Sized;
 }
@@ -73,6 +92,83 @@ impl EntryFsExt for NormalEntry {
         let meta = fs::metadata(path)?;
         let name = path.try_into().map_err(io::Error::other)?;
         if meta.is_file() {
+            let mut file = fs::File::open(path)?;
+            let mut builder = EntryBuilder::new_file(name, options)?;
+            io::copy(&mut file, &mut builder)?;
+            builder.build()
+        } else {
+            let builder = EntryBuilder::new_dir(name);
+            builder.build()
+        }
+    }
+
+    /// Creates an entry from the given path without following symlinks.
+    ///
+    /// This behaves like [`EntryFsExt::from_path`], but uses
+    /// [`std::fs::symlink_metadata`] to avoid following symbolic links.
+    /// When `path` is a symbolic link, a symbolic-link entry is created using
+    /// [`EntryBuilder::new_symlink`], with the link target captured via
+    /// [`std::fs::read_link`]. For regular files and directories, behavior is
+    /// identical to [`EntryFsExt::from_path`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use pna::prelude::*;
+    /// use pna::NormalEntry;
+    ///
+    /// # fn main() -> std::io::Result<()> {
+    /// NormalEntry::from_path_symlink("path/to/file")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an I/O error occurs while creating the entry.
+    #[inline]
+    fn from_path_symlink<P: AsRef<Path>>(path: P) -> io::Result<Self>
+    where
+        Self: Sized,
+    {
+        Self::from_path_symlink_with(path, WriteOptions::builder().build())
+    }
+
+    /// Creates an entry from the given path with options, without following symlinks.
+    ///
+    /// Behaves like [`EntryFsExt::from_path_with`], but uses
+    /// [`std::fs::symlink_metadata`] and creates a symbolic-link entry for
+    /// symlinks instead of following them.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use pna::prelude::*;
+    /// use pna::{NormalEntry, WriteOptions};
+    ///
+    /// # fn main() -> std::io::Result<()> {
+    /// NormalEntry::from_path_symlink_with("path/to/file", WriteOptions::store())?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an I/O error occurs while creating the entry.
+    #[inline]
+    fn from_path_symlink_with<P: AsRef<Path>>(path: P, options: WriteOptions) -> io::Result<Self>
+    where
+        Self: Sized,
+    {
+        let path = path.as_ref();
+        let meta = fs::symlink_metadata(path)?;
+        let name = path.try_into().map_err(io::Error::other)?;
+        if meta.file_type().is_symlink() {
+            let target = fs::read_link(path)?;
+            let reference = target.as_path().try_into().map_err(io::Error::other)?;
+            let builder = EntryBuilder::new_symlink(name, reference)?;
+            builder.build()
+        } else if meta.is_file() {
             let mut file = fs::File::open(path)?;
             let mut builder = EntryBuilder::new_file(name, options)?;
             io::copy(&mut file, &mut builder)?;


### PR DESCRIPTION
Introduces `from_path_symlink` and `from_path_symlink_with` to EntryFsExt and implements them for NormalEntry. These methods create entries without following symlinks, allowing symbolic-link entries to be created when the path is a symlink.