### PR TITLE
:pencil2: Clarify description for Experimental command

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -92,7 +92,9 @@ pub(crate) enum Commands {
     Complete(CompleteCommand),
     #[command(about = "Generate bug report template")]
     BugReport(BugReportCommand),
-    #[command(about = "Unstable experimental commands")]
+    #[command(
+        about = "Unstable experimental commands; behavior and interface may change or be removed"
+    )]
     Experimental(ExperimentalCommand),
 }
 


### PR DESCRIPTION
Expanded the 'Experimental' command's about text to warn users that its behavior and interface may change or be removed.