### PR TITLE
:bug: Capitalize time field string representations

### DIFF
--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -321,9 +321,9 @@ impl TimeField {
     #[inline]
     const fn as_str(&self) -> &'static str {
         match self {
-            TimeField::Created => "created",
-            TimeField::Modified => "modified",
-            TimeField::Accessed => "accessed",
+            TimeField::Created => "Created",
+            TimeField::Modified => "Modified",
+            TimeField::Accessed => "Accessed",
         }
     }
 }


### PR DESCRIPTION
Updated the as_str() method in TimeField to return capitalized strings for 'Created', 'Modified', and 'Accessed' instead of lowercase. This improves consistency with other output formatting.