### PR TITLE
:racehorse: Refactor FileInfo and related structs for efficiency

### DIFF
--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -854,7 +854,7 @@ struct FileInfo<'a> {
     modified: String,
     accessed: String,
     acl: Vec<AclEntry>,
-    xattr: Vec<XAttr>,
+    xattr: Vec<XAttr<'a>>,
 }
 
 #[derive(Serialize, Debug)]
@@ -864,8 +864,8 @@ struct AclEntry {
 }
 
 #[derive(Serialize, Debug)]
-struct XAttr {
-    key: String,
+struct XAttr<'a> {
+    key: &'a str,
     value: String,
 }
 
@@ -917,7 +917,7 @@ fn json_line_entries(entries: Vec<TableRow>) {
                     .xattrs
                     .iter()
                     .map(|x| XAttr {
-                        key: x.name().into(),
+                        key: x.name(),
                         value: base64::engine::general_purpose::STANDARD.encode(x.value()),
                     })
                     .collect(),


### PR DESCRIPTION
Removed unnecessary Deserialize derives and switched FileInfo fields to use string references for improved performance. Updated json_line_entries to use Vec and parallel iterator, and adjusted field accesses to avoid unnecessary cloning.