### PR TITLE
:bug: Fix exclusion logic and add is_empty to glob patterns

### DIFF
--- a/cli/src/command/commons.rs
+++ b/cli/src/command/commons.rs
@@ -1006,10 +1006,17 @@ pub(crate) struct Exclude {
 }
 
 impl Exclude {
+    /// Returns `true` if the given path should be excluded.
+    ///
+    /// A path is excluded if:
+    /// 1. It matches any of the `exclude` patterns.
+    /// 2. It does not match any of the `include` patterns (if any are provided).
+    ///
+    /// Note that exclusion patterns take precedence over inclusion patterns.
     #[inline]
     pub(crate) fn excluded(&self, s: impl AsRef<str>) -> bool {
         let s = s.as_ref();
-        !self.include.matches_inclusion(s) && self.exclude.matches_exclusion(s)
+        self.exclude.matches_exclusion(s) || !self.include.matches_inclusion(s)
     }
 }
 
@@ -1066,18 +1073,18 @@ mod tests {
     }
 
     #[test]
-    fn exclude_include() {
+    fn exclude_include_precedence() {
         let exclude = Exclude {
             include: vec!["a/*/c"].into(),
             exclude: vec!["a/*"].into(),
         };
-        assert!(!exclude.excluded("a/b/c"));
+        assert!(exclude.excluded("a/b/c"));
 
         let exclude = Exclude {
             include: vec!["a/*/c"].into(),
             exclude: vec!["a/*/c"].into(),
         };
-        assert!(!exclude.excluded("a/b/c"));
+        assert!(exclude.excluded("a/b/c"));
     }
 
     #[test]

--- a/cli/src/utils/globs.rs
+++ b/cli/src/utils/globs.rs
@@ -83,8 +83,12 @@ impl BsdGlobPatterns {
     }
 
     #[inline]
+    /// Returns `true` if the path should be included.
+    ///
+    /// A path is considered for inclusion if it matches any of the provided glob patterns.
+    /// If no patterns are provided, all paths are considered included (the function returns `true`).
     pub fn matches_inclusion(&self, s: impl AsRef<str>) -> bool {
-        self.0.iter().any(|it| it.match_inclusion(s.as_ref()))
+        self.0.is_empty() || self.0.iter().any(|it| it.match_inclusion(s.as_ref()))
     }
 }
 


### PR DESCRIPTION
Refactored Exclude::excluded to prioritize exclusion patterns and handle empty includes correctly. Added is_empty method to BsdGlobPatterns for improved logic clarity. Updated tests to reflect new exclusion precedence.