### PR TITLE
:truck: Rename Exclude struct to PathFilter

### DIFF
--- a/cli/src/command/append.rs
+++ b/cli/src/command/append.rs
@@ -7,7 +7,7 @@ use crate::{
         ask_password, check_password,
         commons::{
             collect_items, create_entry, entry_option, read_paths, read_paths_stdin, CreateOptions,
-            Exclude, KeepOptions, OwnerOptions, PathTransformers, StoreAs, TimeOptions,
+            KeepOptions, OwnerOptions, PathFilter, PathTransformers, StoreAs, TimeOptions,
         },
         Command,
     },
@@ -270,7 +270,7 @@ fn append_to_archive(args: AppendCommand) -> anyhow::Result<()> {
     } else if let Some(path) = args.files_from {
         files.extend(read_paths(path, args.null)?);
     }
-    let exclude = {
+    let filter = {
         let mut exclude = args.exclude.unwrap_or_default();
         if let Some(p) = args.exclude_from {
             exclude.extend(read_paths(p, args.null)?);
@@ -278,7 +278,7 @@ fn append_to_archive(args: AppendCommand) -> anyhow::Result<()> {
         if args.exclude_vcs {
             exclude.extend(VCS_FILES.iter().map(|it| String::from(*it)))
         }
-        Exclude {
+        PathFilter {
             include: args.include.unwrap_or_default().into(),
             exclude: exclude.into(),
         }
@@ -294,7 +294,7 @@ fn append_to_archive(args: AppendCommand) -> anyhow::Result<()> {
         args.follow_links,
         args.follow_command_links,
         args.one_file_system,
-        &exclude,
+        &filter,
     )?;
 
     run_append_archive(&create_options, &path_transformers, archive, target_items)

--- a/cli/src/command/create.rs
+++ b/cli/src/command/create.rs
@@ -7,7 +7,7 @@ use crate::{
         ask_password, check_password,
         commons::{
             collect_items, create_entry, entry_option, read_paths, read_paths_stdin,
-            write_split_archive, CreateOptions, Exclude, KeepOptions, OwnerOptions,
+            write_split_archive, CreateOptions, KeepOptions, OwnerOptions, PathFilter,
             PathTransformers, StoreAs, TimeOptions, MIN_SPLIT_PART_BYTES,
         },
         Command,
@@ -268,7 +268,7 @@ fn create_archive(args: CreateCommand) -> anyhow::Result<()> {
     } else if let Some(path) = args.files_from {
         files.extend(read_paths(path, args.null)?);
     }
-    let exclude = {
+    let filter = {
         let mut exclude = args.exclude.unwrap_or_default();
         if let Some(p) = args.exclude_from {
             exclude.extend(read_paths(p, args.null)?);
@@ -276,7 +276,7 @@ fn create_archive(args: CreateCommand) -> anyhow::Result<()> {
         if args.exclude_vcs {
             exclude.extend(VCS_FILES.iter().map(|it| String::from(*it)))
         }
-        Exclude {
+        PathFilter {
             include: args.include.unwrap_or_default().into(),
             exclude: exclude.into(),
         }
@@ -293,7 +293,7 @@ fn create_archive(args: CreateCommand) -> anyhow::Result<()> {
         args.follow_links,
         args.follow_command_links,
         args.one_file_system,
-        &exclude,
+        &filter,
     )?;
 
     if let Some(parent) = archive_path.parent() {

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -11,8 +11,9 @@ use crate::{
         ask_password, check_password,
         commons::{
             collect_items, collect_split_archives, create_entry, entry_option, read_paths,
-            read_paths_stdin, CreateOptions, Exclude, KeepOptions, OwnerOptions, PathTransformers,
-            TimeOptions, TransformStrategy, TransformStrategyKeepSolid, TransformStrategyUnSolid,
+            read_paths_stdin, CreateOptions, KeepOptions, OwnerOptions, PathFilter,
+            PathTransformers, TimeOptions, TransformStrategy, TransformStrategyKeepSolid,
+            TransformStrategyUnSolid,
         },
         Command,
     },
@@ -314,7 +315,7 @@ fn update_archive<Strategy: TransformStrategy>(args: UpdateCommand) -> anyhow::R
     } else if let Some(path) = args.files_from {
         files.extend(read_paths(path, args.null)?);
     }
-    let exclude = {
+    let filter = {
         let mut exclude = args.exclude.unwrap_or_default();
         if let Some(p) = args.exclude_from {
             exclude.extend(read_paths(p, args.null)?);
@@ -322,7 +323,7 @@ fn update_archive<Strategy: TransformStrategy>(args: UpdateCommand) -> anyhow::R
         if args.exclude_vcs {
             exclude.extend(VCS_FILES.iter().map(|it| String::from(*it)))
         }
-        Exclude {
+        PathFilter {
             include: args.include.unwrap_or_default().into(),
             exclude: exclude.into(),
         }
@@ -341,7 +342,7 @@ fn update_archive<Strategy: TransformStrategy>(args: UpdateCommand) -> anyhow::R
         args.follow_links,
         args.follow_command_links,
         args.one_file_system,
-        &exclude,
+        &filter,
     )?;
 
     let (tx, rx) = std::sync::mpsc::channel();


### PR DESCRIPTION
Refactored codebase to replace the Exclude struct with PathFilter for improved clarity and consistency. Updated all references, function signatures, and tests to use the new PathFilter name.