### PR TITLE
:bug: Fix failed to restore permissions on broken symlink

### DIFF
--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -524,7 +524,6 @@ where
     }
     #[cfg(unix)]
     if let Some((p, u, g)) = permissions {
-        use std::os::unix::fs::PermissionsExt;
         if same_owner {
             match chown(&path, u, g) {
                 Err(e) if e.kind() == io::ErrorKind::PermissionDenied => {
@@ -533,7 +532,7 @@ where
                 r => r?,
             }
         }
-        fs::set_permissions(&path, fs::Permissions::from_mode(p.permissions().into()))?;
+        utils::os::unix::fs::chmod(&path, p.permissions())?;
     };
     #[cfg(windows)]
     if let Some((p, u, g)) = permissions {

--- a/cli/src/utils/os/unix/fs.rs
+++ b/cli/src/utils/os/unix/fs.rs
@@ -1,5 +1,21 @@
 #[cfg(not(target_os = "redox"))]
 pub(crate) mod owner;
+
 #[cfg(target_os = "redox")]
 pub(crate) use crate::utils::os::redox::fs::owner;
+use std::{fs, io, os::unix::fs::PermissionsExt, path::Path};
 pub(crate) mod xattrs;
+
+#[inline]
+pub(crate) fn chmod(path: &Path, mode: u16) -> io::Result<()> {
+    match fs::set_permissions(path, fs::Permissions::from_mode(mode.into())) {
+        Err(e)
+            if e.kind() == io::ErrorKind::NotFound
+                && fs::symlink_metadata(path).is_ok_and(|m| m.file_type().is_symlink()) =>
+        {
+            // NOTE: broken symlink will never success set permissions
+            Ok(())
+        }
+        result => result,
+    }
+}


### PR DESCRIPTION
Replaces direct use of fs::set_permissions with a new utils::os::unix::fs::chmod function. This change improves handling of broken symlinks by safely ignoring permission changes on them, preventing errors when setting permissions on non-existent symlink targets.