### PR TITLE
:bug: Fix return value on EOF in block reader

### DIFF
--- a/lib/src/cipher/block/read.rs
+++ b/lib/src/cipher/block/read.rs
@@ -69,7 +69,7 @@ where
             }
         }
         if self.eof {
-            return Ok(0);
+            return Ok(total_written);
         }
         let block_size = cbc::Decryptor::<C>::block_size();
         let mut out_block = Block::<cbc::Decryptor<C>>::default();


### PR DESCRIPTION
Previously, the block reader returned 0 on EOF, which could cause issues if data was written before EOF was reached. Now, it returns the total number of bytes written, ensuring correct behavior when reading blocks.