### PR TITLE
:boom: Change `stdio -x` default overwrite behavior

### DIFF
--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -252,8 +252,13 @@ fn extract_archive(args: ExtractCommand) -> anyhow::Result<()> {
         files.extend(read_paths(path, args.null)?);
     }
 
-    let overwrite_strategy =
-        OverwriteStrategy::from_flags(args.overwrite, args.keep_newer_files, args.keep_old_files);
+    let overwrite_strategy = OverwriteStrategy::from_flags(
+        args.overwrite,
+        args.no_overwrite,
+        args.keep_newer_files,
+        args.keep_old_files,
+        OverwriteStrategy::Never,
+    );
     let keep_options = KeepOptions {
         timestamp_strategy: TimestampStrategy::from_flags(
             args.keep_timestamp,
@@ -333,15 +338,23 @@ pub(crate) enum OverwriteStrategy {
 }
 
 impl OverwriteStrategy {
-    pub(crate) const fn from_flags(overwrite: bool, keep_newer: bool, keep_older: bool) -> Self {
+    pub(crate) const fn from_flags(
+        overwrite: bool,
+        no_overwrite: bool,
+        keep_newer: bool,
+        keep_older: bool,
+        default_strategy: Self,
+    ) -> Self {
         if overwrite {
             Self::Always
+        } else if no_overwrite {
+            Self::Never
         } else if keep_newer {
             Self::KeepNewer
         } else if keep_older {
             Self::KeepOlder
         } else {
-            Self::Never
+            default_strategy
         }
     }
 }

--- a/cli/src/command/stdio.rs
+++ b/cli/src/command/stdio.rs
@@ -435,8 +435,13 @@ fn run_extract_archive(args: StdioCommand) -> anyhow::Result<()> {
         }
     };
 
-    let overwrite_strategy =
-        OverwriteStrategy::from_flags(args.overwrite, args.keep_newer_files, args.keep_old_files);
+    let overwrite_strategy = OverwriteStrategy::from_flags(
+        args.overwrite,
+        args.no_overwrite,
+        args.keep_newer_files,
+        args.keep_old_files,
+        OverwriteStrategy::Always,
+    );
     let out_option = OutputOption {
         overwrite_strategy,
         allow_unsafe_links: args.allow_unsafe_links,


### PR DESCRIPTION
Align pna stdio -x’s overwrite strategy with bsdtar so existing files are replaced by default, fixing partial restore jobs that previously stopped at collisions and matching users’ expectations from other tar tools.
Operators who need to retain the legacy “skip on conflict” semantics can still opt out explicitly with the overwrite-suppression flag.