### PR TITLE
:alembic: Add `--fflags` option to cli and add private chunk for store fflags

### DIFF
--- a/cli/src/chunk.rs
+++ b/cli/src/chunk.rs
@@ -1,3 +1,5 @@
 mod acl;
+mod fflag;
 
 pub use acl::*;
+pub use fflag::*;

--- a/cli/src/chunk/fflag.rs
+++ b/cli/src/chunk/fflag.rs
@@ -1,0 +1,14 @@
+use pna::{ChunkType, RawChunk};
+
+/// Private chunk type for file flags (fflags).
+/// Name follows PNA chunk naming convention where case has semantic meaning:
+/// - lowercase first letter: ancillary (not critical)
+/// - lowercase second letter: private (not public)
+/// - uppercase third letter: reserved
+/// - lowercase fourth letter: safe to copy
+#[allow(non_upper_case_globals)]
+pub const ffLg: ChunkType = unsafe { ChunkType::from_unchecked(*b"ffLg") };
+
+pub fn fflag_chunk(flag: &str) -> RawChunk {
+    RawChunk::from_data(ffLg, flag.as_bytes())
+}

--- a/cli/src/command/append.rs
+++ b/cli/src/command/append.rs
@@ -6,10 +6,10 @@ use crate::{
     command::{
         Command, ask_password, check_password,
         core::{
-            AclStrategy, CollectOptions, CollectedItem, CreateOptions, KeepOptions, OwnerOptions,
-            PathFilter, PathTransformers, PathnameEditor, PermissionStrategy, TimeFilterResolver,
-            TimestampStrategyResolver, XattrStrategy, collect_items_from_paths, create_entry,
-            entry_option,
+            AclStrategy, CollectOptions, CollectedItem, CreateOptions, FflagsStrategy, KeepOptions,
+            OwnerOptions, PathFilter, PathTransformers, PathnameEditor, PermissionStrategy,
+            TimeFilterResolver, TimestampStrategyResolver, XattrStrategy, collect_items_from_paths,
+            create_entry, entry_option,
             re::{bsd::SubstitutionRule, gnu::TransformRule},
             read_paths, read_paths_stdin,
         },
@@ -391,6 +391,7 @@ fn append_to_archive(args: AppendCommand) -> anyhow::Result<()> {
         ),
         xattr_strategy: XattrStrategy::from_flags(args.keep_xattr, args.no_keep_xattr),
         acl_strategy: AclStrategy::from_flags(args.keep_acl, args.no_keep_acl),
+        fflags_strategy: FflagsStrategy::Never,
     };
     let owner_options = OwnerOptions::new(
         args.uname,

--- a/cli/src/command/create.rs
+++ b/cli/src/command/create.rs
@@ -6,7 +6,7 @@ use crate::{
     command::{
         Command, ask_password, check_password,
         core::{
-            AclStrategy, CollectOptions, CollectedItem, CreateOptions, KeepOptions,
+            AclStrategy, CollectOptions, CollectedItem, CreateOptions, FflagsStrategy, KeepOptions,
             MIN_SPLIT_PART_BYTES, OwnerOptions, PathFilter, PathTransformers, PathnameEditor,
             PermissionStrategy, TimeFilterResolver, TimestampStrategyResolver, XattrStrategy,
             collect_items_from_paths, create_entry, entry_option,
@@ -477,6 +477,7 @@ fn create_archive(args: CreateCommand) -> anyhow::Result<()> {
         ),
         xattr_strategy: XattrStrategy::from_flags(args.keep_xattr, args.no_keep_xattr),
         acl_strategy: AclStrategy::from_flags(args.keep_acl, args.no_keep_acl),
+        fflags_strategy: FflagsStrategy::Never,
     };
     let owner_options = OwnerOptions::new(
         args.uname,

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -10,11 +10,11 @@ use crate::{
     command::{
         Command, ask_password, check_password,
         core::{
-            AclStrategy, CollectOptions, CollectedItem, CreateOptions, KeepOptions, OwnerOptions,
-            PathFilter, PathTransformers, PathnameEditor, PermissionStrategy, TimeFilterResolver,
-            TimestampStrategyResolver, TransformStrategy, TransformStrategyKeepSolid,
-            TransformStrategyUnSolid, XattrStrategy, collect_items_from_paths,
-            collect_split_archives, create_entry, entry_option,
+            AclStrategy, CollectOptions, CollectedItem, CreateOptions, FflagsStrategy, KeepOptions,
+            OwnerOptions, PathFilter, PathTransformers, PathnameEditor, PermissionStrategy,
+            TimeFilterResolver, TimestampStrategyResolver, TransformStrategy,
+            TransformStrategyKeepSolid, TransformStrategyUnSolid, XattrStrategy,
+            collect_items_from_paths, collect_split_archives, create_entry, entry_option,
             re::{bsd::SubstitutionRule, gnu::TransformRule},
             read_paths, read_paths_stdin,
         },
@@ -400,6 +400,7 @@ fn update_archive(args: UpdateCommand) -> anyhow::Result<()> {
         ),
         xattr_strategy: XattrStrategy::from_flags(args.keep_xattr, args.no_keep_xattr),
         acl_strategy: AclStrategy::from_flags(args.keep_acl, args.no_keep_acl),
+        fflags_strategy: FflagsStrategy::Never,
     };
     let owner_options = OwnerOptions::new(
         args.uname,

--- a/cli/src/ext.rs
+++ b/cli/src/ext.rs
@@ -13,6 +13,7 @@ pub(crate) type Acls = HashMap<AcePlatform, Vec<Ace>>;
 
 pub(crate) trait NormalEntryExt {
     fn acl(&self) -> io::Result<Acls>;
+    fn fflags(&self) -> Vec<String>;
 }
 
 impl<T> NormalEntryExt for NormalEntry<T>
@@ -42,6 +43,20 @@ where
             }
         }
         Ok(acls)
+    }
+
+    #[inline]
+    fn fflags(&self) -> Vec<String> {
+        self.extra_chunks()
+            .iter()
+            .filter_map(|c| {
+                if c.ty() == chunk::ffLg {
+                    std::str::from_utf8(c.data()).ok().map(str::to_string)
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 }
 

--- a/cli/src/utils/fs.rs
+++ b/cli/src/utils/fs.rs
@@ -66,6 +66,50 @@ pub(crate) fn lchown<P: AsRef<Path>>(
     inner(path.as_ref(), owner, group)
 }
 
+pub(crate) fn get_flags<P: AsRef<Path>>(path: P) -> io::Result<Vec<String>> {
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "linux",
+        target_os = "android",
+        target_os = "freebsd"
+    ))]
+    fn inner(path: &Path) -> io::Result<Vec<String>> {
+        crate::utils::os::unix::fs::get_flags(path)
+    }
+    #[cfg(not(any(
+        target_os = "macos",
+        target_os = "linux",
+        target_os = "android",
+        target_os = "freebsd"
+    )))]
+    fn inner(_path: &Path) -> io::Result<Vec<String>> {
+        Ok(Vec::new())
+    }
+    inner(path.as_ref())
+}
+
+pub(crate) fn set_flags<P: AsRef<Path>>(path: P, flags: &[String]) -> io::Result<()> {
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "linux",
+        target_os = "android",
+        target_os = "freebsd"
+    ))]
+    fn inner(path: &Path, flags: &[String]) -> io::Result<()> {
+        crate::utils::os::unix::fs::set_flags(path, flags)
+    }
+    #[cfg(not(any(
+        target_os = "macos",
+        target_os = "linux",
+        target_os = "android",
+        target_os = "freebsd"
+    )))]
+    fn inner(_path: &Path, _flags: &[String]) -> io::Result<()> {
+        Ok(())
+    }
+    inner(path.as_ref(), flags)
+}
+
 #[inline]
 pub(crate) fn file_create(path: impl AsRef<Path>, overwrite: bool) -> io::Result<fs::File> {
     if overwrite {

--- a/cli/src/utils/fs/nodump.rs
+++ b/cli/src/utils/fs/nodump.rs
@@ -1,48 +1,9 @@
-#[cfg(any(target_os = "linux", target_os = "android"))]
-mod platform {
-    use nix::{
-        fcntl::{OFlag, open},
-        ioctl_read_bad,
-        sys::stat::Mode,
-    };
-    use std::os::fd::AsRawFd;
-    use std::{io, path::Path};
+use crate::utils::fs::get_flags;
+use std::{io, path::Path};
 
-    const FS_NODUMP_FL: libc::c_int = 0x00000040;
-
-    ioctl_read_bad!(fs_ioc_getflags, libc::FS_IOC_GETFLAGS, libc::c_int);
-
-    pub(crate) fn is_nodump(path: &Path) -> io::Result<bool> {
-        let fd = open(path, OFlag::O_RDONLY | OFlag::O_NOFOLLOW, Mode::empty())?;
-        let mut flags: libc::c_int = 0;
-        unsafe { fs_ioc_getflags(fd.as_raw_fd(), &mut flags) }?;
-        Ok((flags & FS_NODUMP_FL) != 0)
-    }
+/// Check if the file has the nodump flag set.
+/// This is used to skip files during backup operations.
+pub(crate) fn is_nodump(path: &Path) -> io::Result<bool> {
+    let flags = get_flags(path)?;
+    Ok(flags.iter().any(|f| f == "nodump"))
 }
-
-#[cfg(any(target_os = "macos", target_os = "freebsd"))]
-mod platform {
-    use nix::sys::stat::lstat;
-    use std::{io, path::Path};
-
-    pub(crate) fn is_nodump(path: &Path) -> io::Result<bool> {
-        let stat = lstat(path)?;
-        Ok((stat.st_flags & libc::UF_NODUMP as libc::c_uint) != 0)
-    }
-}
-
-#[cfg(not(any(
-    target_os = "linux",
-    target_os = "android",
-    target_os = "macos",
-    target_os = "freebsd"
-)))]
-mod platform {
-    use std::{io, path::Path};
-
-    pub(crate) fn is_nodump(_path: &Path) -> io::Result<bool> {
-        Ok(false)
-    }
-}
-
-pub(crate) use platform::is_nodump;

--- a/cli/src/utils/os/unix/fs.rs
+++ b/cli/src/utils/os/unix/fs.rs
@@ -19,3 +19,295 @@ pub(crate) fn chmod(path: &Path, mode: u16) -> io::Result<()> {
         result => result,
     }
 }
+
+#[cfg(target_os = "macos")]
+pub(crate) fn get_flags(path: &Path) -> io::Result<Vec<String>> {
+    use std::os::unix::ffi::OsStrExt;
+    let c_path = std::ffi::CString::new(path.as_os_str().as_bytes())?;
+    let mut stat: libc::stat = unsafe { std::mem::zeroed() };
+    if unsafe { libc::lstat(c_path.as_ptr(), &mut stat) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let flags = stat.st_flags;
+    let mut flag_names = Vec::new();
+    if flags & libc::UF_NODUMP != 0 {
+        flag_names.push("nodump".to_string());
+    }
+    if flags & libc::UF_IMMUTABLE != 0 {
+        flag_names.push("uchg".to_string());
+    }
+    if flags & libc::UF_APPEND != 0 {
+        flag_names.push("uappnd".to_string());
+    }
+    if flags & libc::UF_OPAQUE != 0 {
+        flag_names.push("opaque".to_string());
+    }
+    if flags & libc::UF_HIDDEN != 0 {
+        flag_names.push("hidden".to_string());
+    }
+    if flags & libc::SF_ARCHIVED != 0 {
+        flag_names.push("archived".to_string());
+    }
+    if flags & libc::SF_IMMUTABLE != 0 {
+        flag_names.push("schg".to_string());
+    }
+    if flags & libc::SF_APPEND != 0 {
+        flag_names.push("sappnd".to_string());
+    }
+    Ok(flag_names)
+}
+
+/// Sets file flags on macOS.
+///
+/// Note: This implementation overwrites all existing flags rather than merging them,
+/// which matches libarchive/bsdtar behavior. libarchive uses `chflags()` directly on
+/// BSD systems which replaces all flags, while on Linux it uses ioctl to read current
+/// flags first and merge them. This cross-platform inconsistency exists in bsdtar itself.
+/// See: https://github.com/libarchive/libarchive/blob/master/libarchive/archive_write_disk_posix.c
+#[cfg(target_os = "macos")]
+pub(crate) fn set_flags(path: &Path, flags: &[String]) -> io::Result<()> {
+    use std::os::unix::ffi::OsStrExt;
+    let c_path = std::ffi::CString::new(path.as_os_str().as_bytes())?;
+    let mut flag_bits = 0;
+    for flag in flags {
+        match flag.as_str() {
+            "nodump" => flag_bits |= libc::UF_NODUMP,
+            "uchg" => flag_bits |= libc::UF_IMMUTABLE,
+            "uappnd" => flag_bits |= libc::UF_APPEND,
+            "opaque" => flag_bits |= libc::UF_OPAQUE,
+            "hidden" => flag_bits |= libc::UF_HIDDEN,
+            "archived" => flag_bits |= libc::SF_ARCHIVED,
+            "schg" => flag_bits |= libc::SF_IMMUTABLE,
+            "sappnd" => flag_bits |= libc::SF_APPEND,
+            _ => {}
+        }
+    }
+    unsafe extern "C" {
+        fn lchflags(path: *const libc::c_char, flags: libc::c_uint) -> libc::c_int;
+    }
+    if unsafe { lchflags(c_path.as_ptr(), flag_bits) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+// Linux file flags (FS_IOC_GETFLAGS/FS_IOC_SETFLAGS)
+// Reference: https://man7.org/linux/man-pages/man2/ioctl_iflags.2.html
+#[cfg(any(target_os = "linux", target_os = "android"))]
+mod linux_flags {
+    // Linux ext2/ext3/ext4/btrfs file attribute flags
+    pub const FS_COMPR_FL: libc::c_int = 0x00000004; // 'c' - compress file
+    pub const FS_IMMUTABLE_FL: libc::c_int = 0x00000010; // 'i' - immutable file
+    pub const FS_APPEND_FL: libc::c_int = 0x00000020; // 'a' - append only
+    pub const FS_NODUMP_FL: libc::c_int = 0x00000040; // 'd' - no dump
+    pub const FS_NOATIME_FL: libc::c_int = 0x00000080; // 'A' - no atime updates
+    pub const FS_NOCOW_FL: libc::c_int = 0x00800000; // 'C' - no copy on write (btrfs)
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub(crate) fn get_flags(path: &Path) -> io::Result<Vec<String>> {
+    use linux_flags::*;
+    use nix::fcntl::{OFlag, open};
+    use nix::sys::stat::Mode;
+    use std::os::fd::AsRawFd;
+
+    nix::ioctl_read_bad!(fs_ioc_getflags, libc::FS_IOC_GETFLAGS, libc::c_int);
+
+    let fd = match open(path, OFlag::O_RDONLY | OFlag::O_NOFOLLOW, Mode::empty()) {
+        Ok(fd) => fd,
+        Err(nix::errno::Errno::ELOOP) => {
+            // Symlinks don't support file flags on Linux
+            return Ok(Vec::new());
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    let mut flags: libc::c_int = 0;
+    match unsafe { fs_ioc_getflags(fd.as_raw_fd(), &mut flags) } {
+        Ok(_) => {}
+        Err(nix::errno::Errno::ENOTTY | nix::errno::Errno::EOPNOTSUPP) => {
+            // Filesystem does not support flags (e.g., tmpfs, nfs)
+            return Ok(Vec::new());
+        }
+        Err(e) => return Err(e.into()),
+    }
+
+    let mut flag_names = Vec::new();
+
+    // Map Linux flags to libarchive-compatible names
+    if flags & FS_NODUMP_FL != 0 {
+        flag_names.push("nodump".to_string());
+    }
+    if flags & FS_IMMUTABLE_FL != 0 {
+        // Linux FS_IMMUTABLE_FL is equivalent to BSD SF_IMMUTABLE (system-level)
+        flag_names.push("schg".to_string());
+    }
+    if flags & FS_APPEND_FL != 0 {
+        // Linux FS_APPEND_FL is equivalent to BSD SF_APPEND (system-level)
+        flag_names.push("sappnd".to_string());
+    }
+    if flags & FS_NOATIME_FL != 0 {
+        flag_names.push("noatime".to_string());
+    }
+    if flags & FS_COMPR_FL != 0 {
+        flag_names.push("compr".to_string());
+    }
+    if flags & FS_NOCOW_FL != 0 {
+        flag_names.push("nocow".to_string());
+    }
+
+    Ok(flag_names)
+}
+
+/// Sets file flags on Linux.
+///
+/// Note: This implementation reads current flags first and merges them with new flags,
+/// which matches libarchive/bsdtar behavior on Linux. libarchive uses ioctl to read
+/// current flags (`FS_IOC_GETFLAGS`) then computes `newflags = (oldflags & ~clear) | set`
+/// before writing. This differs from BSD systems where `chflags()` overwrites all flags.
+/// This cross-platform inconsistency exists in bsdtar itself.
+/// See: https://github.com/libarchive/libarchive/blob/master/libarchive/archive_write_disk_posix.c
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub(crate) fn set_flags(path: &Path, flags: &[String]) -> io::Result<()> {
+    use linux_flags::*;
+    use nix::fcntl::{OFlag, open};
+    use nix::sys::stat::Mode;
+    use std::os::fd::AsRawFd;
+
+    if flags.is_empty() {
+        return Ok(());
+    }
+
+    nix::ioctl_read_bad!(fs_ioc_getflags, libc::FS_IOC_GETFLAGS, libc::c_int);
+    nix::ioctl_write_ptr_bad!(fs_ioc_setflags, libc::FS_IOC_SETFLAGS, libc::c_int);
+
+    let fd = match open(path, OFlag::O_RDONLY | OFlag::O_NOFOLLOW, Mode::empty()) {
+        Ok(fd) => fd,
+        Err(nix::errno::Errno::ELOOP) => {
+            // Symlinks don't support file flags on Linux
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "symlinks do not support file flags",
+            ));
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    // Get current flags to preserve flags we're not setting
+    let mut current_flags: libc::c_int = 0;
+    match unsafe { fs_ioc_getflags(fd.as_raw_fd(), &mut current_flags) } {
+        Ok(_) => {}
+        Err(nix::errno::Errno::ENOTTY | nix::errno::Errno::EOPNOTSUPP) => {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "filesystem does not support file flags",
+            ));
+        }
+        Err(e) => return Err(e.into()),
+    }
+
+    // Build new flags bitmap
+    let mut new_flags = current_flags;
+    for flag in flags {
+        match flag.as_str() {
+            "nodump" => new_flags |= FS_NODUMP_FL,
+            // Accept both libarchive names and aliases
+            "schg" | "simmutable" => new_flags |= FS_IMMUTABLE_FL,
+            "sappnd" | "sappend" => new_flags |= FS_APPEND_FL,
+            "noatime" => new_flags |= FS_NOATIME_FL,
+            "compr" | "compress" => new_flags |= FS_COMPR_FL,
+            "nocow" => new_flags |= FS_NOCOW_FL,
+            // Ignore flags not supported on Linux (e.g., uchg, uappnd, opaque, hidden, archived)
+            _ => {}
+        }
+    }
+
+    if new_flags != current_flags {
+        unsafe { fs_ioc_setflags(fd.as_raw_fd(), &new_flags) }?;
+    }
+
+    Ok(())
+}
+
+// FreeBSD file flags (same API as macOS, BSD heritage)
+// Reference: https://man.freebsd.org/cgi/man.cgi?query=chflags&sektion=2
+#[cfg(target_os = "freebsd")]
+pub(crate) fn get_flags(path: &Path) -> io::Result<Vec<String>> {
+    use nix::sys::stat::lstat;
+
+    let stat = lstat(path)?;
+    let flags = stat.st_flags as libc::c_ulong;
+
+    let mut flag_names = Vec::new();
+
+    if flags & libc::UF_NODUMP != 0 {
+        flag_names.push("nodump".to_string());
+    }
+    if flags & libc::UF_IMMUTABLE != 0 {
+        flag_names.push("uchg".to_string());
+    }
+    if flags & libc::UF_APPEND != 0 {
+        flag_names.push("uappnd".to_string());
+    }
+    if flags & libc::UF_OPAQUE != 0 {
+        flag_names.push("opaque".to_string());
+    }
+    if flags & libc::UF_NOUNLINK != 0 {
+        flag_names.push("uunlnk".to_string());
+    }
+    if flags & libc::SF_ARCHIVED != 0 {
+        flag_names.push("archived".to_string());
+    }
+    if flags & libc::SF_IMMUTABLE != 0 {
+        flag_names.push("schg".to_string());
+    }
+    if flags & libc::SF_APPEND != 0 {
+        flag_names.push("sappnd".to_string());
+    }
+    if flags & libc::SF_NOUNLINK != 0 {
+        flag_names.push("sunlnk".to_string());
+    }
+
+    Ok(flag_names)
+}
+
+/// Sets file flags on FreeBSD.
+///
+/// Note: This implementation overwrites all existing flags rather than merging them,
+/// which matches libarchive/bsdtar behavior. libarchive uses `chflags()` directly on
+/// BSD systems which replaces all flags, while on Linux it uses ioctl to read current
+/// flags first and merge them. This cross-platform inconsistency exists in bsdtar itself.
+/// See: https://github.com/libarchive/libarchive/blob/master/libarchive/archive_write_disk_posix.c
+#[cfg(target_os = "freebsd")]
+pub(crate) fn set_flags(path: &Path, flags: &[String]) -> io::Result<()> {
+    use std::os::unix::ffi::OsStrExt;
+
+    if flags.is_empty() {
+        return Ok(());
+    }
+
+    let c_path = std::ffi::CString::new(path.as_os_str().as_bytes())?;
+    let mut flag_bits: libc::c_ulong = 0;
+
+    for flag in flags {
+        match flag.as_str() {
+            "nodump" => flag_bits |= libc::UF_NODUMP as libc::c_ulong,
+            "uchg" | "uimmutable" => flag_bits |= libc::UF_IMMUTABLE as libc::c_ulong,
+            "uappnd" | "uappend" => flag_bits |= libc::UF_APPEND as libc::c_ulong,
+            "opaque" => flag_bits |= libc::UF_OPAQUE as libc::c_ulong,
+            "uunlnk" => flag_bits |= libc::UF_NOUNLINK as libc::c_ulong,
+            "archived" => flag_bits |= libc::SF_ARCHIVED as libc::c_ulong,
+            "schg" | "simmutable" => flag_bits |= libc::SF_IMMUTABLE as libc::c_ulong,
+            "sappnd" | "sappend" => flag_bits |= libc::SF_APPEND as libc::c_ulong,
+            "sunlnk" => flag_bits |= libc::SF_NOUNLINK as libc::c_ulong,
+            // Ignore Linux-specific flags (noatime, compr, nocow)
+            _ => {}
+        }
+    }
+
+    if unsafe { libc::lchflags(c_path.as_ptr(), flag_bits) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(())
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File flag preservation added for macOS, Linux, Android and FreeBSD — archive entries can include and restore flags like nodump, hidden and immutable.
  * New CLI options --keep-fflags / --no-keep-fflags to control preserving file flags for create, extract, append and update operations; preservation is off by default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->