### PR TITLE
:zap: Add visible aliases for mtime filter options

### DIFF
--- a/cli/src/command/stdio.rs
+++ b/cli/src/command/stdio.rs
@@ -308,6 +308,7 @@ pub(crate) struct StdioCommand {
         long,
         value_name = "file",
         requires = "unstable",
+        visible_alias = "newer-than",
         help = "Only include files and directories newer than the specified file (unstable). This compares mtime entries."
     )]
     newer_mtime_than: Option<PathBuf>,
@@ -322,6 +323,7 @@ pub(crate) struct StdioCommand {
         long,
         value_name = "file",
         requires = "unstable",
+        visible_alias = "older-than",
         help = "Only include files and directories older than the specified file (unstable). This compares mtime entries."
     )]
     older_mtime_than: Option<PathBuf>,


### PR DESCRIPTION
Introduces 'newer-than' and 'older-than' as visible aliases for the 'newer_mtime_than' and 'older_mtime_than' CLI options, improving usability and discoverability.