### PR TITLE
:construction_worker: Enable run cli test for wasip2 target

### DIFF
--- a/.github/workflows/webassembly.yml
+++ b/.github/workflows/webassembly.yml
@@ -80,7 +80,7 @@ jobs:
           cargo test -p libpna --locked --target "$TARGET" -- --nocapture
         env:
           TARGET: ${{ matrix.target }}
-      - if: ${{ startsWith(matrix.target, 'wasm32-wasip1') && startsWith(matrix.rust, 'nightly')}}
+      - if: ${{ startsWith(matrix.target, 'wasm32-wasi') && startsWith(matrix.rust, 'nightly')}}
         name: Run test
         run: |
           cargo test --locked --target "$TARGET" -- --nocapture

--- a/pna/src/lib.rs
+++ b/pna/src/lib.rs
@@ -4,6 +4,7 @@
 //! necessary to manage PNA archives abstracted over a reader or writer hosted by [`libpna`].
 #![doc = include_str!("../README.md")]
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
+#![cfg_attr(all(target_os = "wasi", target_env = "p2"), feature(wasip2))]
 #![doc(html_root_url = "https://docs.rs/pna/0.36.0")]
 #![deny(
     missing_docs,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the CI/CD workflow so that the “Run test” step matches the correct WebAssembly target settings for nightly builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->