### PR TITLE
Cli/fflag/introduce fflag get set

### DIFF
--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -14,6 +14,7 @@ pub mod delete;
 pub mod diff;
 pub(super) mod experimental;
 pub mod extract;
+mod fflag;
 pub mod list;
 mod migrate;
 pub mod sort;

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -14,6 +14,7 @@ pub mod delete;
 pub mod diff;
 pub(super) mod experimental;
 pub mod extract;
+mod fflag;
 pub mod list;
 pub mod migrate;
 pub mod sort;

--- a/cli/src/command/experimental.rs
+++ b/cli/src/command/experimental.rs
@@ -39,6 +39,7 @@ impl Command for ExperimentalCommand {
             ExperimentalCommands::Chown(cmd) => cmd.execute(ctx),
             ExperimentalCommands::Chmod(cmd) => cmd.execute(ctx),
             ExperimentalCommands::Acl(cmd) => cmd.execute(ctx),
+            ExperimentalCommands::Fflag(cmd) => cmd.execute(ctx),
             ExperimentalCommands::Migrate(cmd) => cmd.execute(ctx),
             ExperimentalCommands::Chunk(cmd) => cmd.execute(ctx),
             ExperimentalCommands::Sort(cmd) => {
@@ -75,6 +76,8 @@ pub(crate) enum ExperimentalCommands {
     Chmod(command::chmod::ChmodCommand),
     #[command(about = "Manipulate ACLs of entries")]
     Acl(command::acl::AclCommand),
+    #[command(about = "Manipulate file flags of entries")]
+    Fflag(command::fflag::FflagCommand),
     #[command(about = "Migrate old format to latest format")]
     Migrate(command::migrate::MigrateCommand),
     #[command(about = "Chunk level operation")]

--- a/cli/src/command/experimental.rs
+++ b/cli/src/command/experimental.rs
@@ -16,6 +16,7 @@ impl Command for ExperimentalCommand {
             ExperimentalCommands::Chown(cmd) => cmd.execute(ctx),
             ExperimentalCommands::Chmod(cmd) => cmd.execute(ctx),
             ExperimentalCommands::Acl(cmd) => cmd.execute(ctx),
+            ExperimentalCommands::Fflag(cmd) => cmd.execute(ctx),
             ExperimentalCommands::Chunk(cmd) => cmd.execute(ctx),
             ExperimentalCommands::Diff(cmd) => cmd.execute(ctx),
             ExperimentalCommands::Verify(cmd) => cmd.execute(ctx),
@@ -34,6 +35,8 @@ pub(crate) enum ExperimentalCommands {
     Chmod(command::chmod::ChmodCommand),
     #[command(about = "Manipulate ACLs of entries")]
     Acl(command::acl::AclCommand),
+    #[command(about = "Manipulate file flags of entries")]
+    Fflag(command::fflag::FflagCommand),
     #[command(about = "Chunk level operation")]
     Chunk(command::chunk::ChunkCommand),
     #[command(about = "Compare archive entries with filesystem")]

--- a/cli/src/command/fflag.rs
+++ b/cli/src/command/fflag.rs
@@ -1,0 +1,574 @@
+use crate::{
+    chunk,
+    cli::{
+        FileArgs, PasswordArgs, SolidEntriesTransformStrategy, SolidEntriesTransformStrategyArgs,
+    },
+    command::{
+        Command, ask_password,
+        core::{
+            TransformStrategyKeepSolid, TransformStrategyUnSolid, collect_split_archives,
+            run_entries, run_transform_entry,
+        },
+    },
+    ext::NormalEntryExt,
+    utils::{GlobPatterns, PathPartExt, env::NamedTempFile},
+};
+use clap::{Parser, ValueHint};
+use pna::{Chunk, NormalEntry, RawChunk};
+use regex::Regex;
+use std::{
+    collections::{HashMap, HashSet},
+    fs, io,
+    str::FromStr,
+};
+
+#[derive(Parser, Clone, Eq, PartialEq, Hash, Debug)]
+#[command(args_conflicts_with_subcommands = true, arg_required_else_help = true)]
+pub(crate) struct FflagCommand {
+    #[command(subcommand)]
+    command: FflagCommands,
+}
+
+impl Command for FflagCommand {
+    #[inline]
+    fn execute(self, ctx: &crate::cli::GlobalArgs) -> anyhow::Result<()> {
+        match self.command {
+            FflagCommands::Get(cmd) => cmd.execute(ctx),
+            FflagCommands::Set(cmd) => cmd.execute(ctx),
+        }
+    }
+}
+
+#[derive(Parser, Clone, Eq, PartialEq, Hash, Debug)]
+pub(crate) enum FflagCommands {
+    #[command(about = "Get file flags of entries")]
+    Get(GetFflagCommand),
+    #[command(about = "Set file flags of entries")]
+    Set(SetFflagCommand),
+}
+
+#[derive(Parser, Clone, Eq, PartialEq, Hash, Debug)]
+pub(crate) struct GetFflagCommand {
+    #[command(flatten)]
+    file: FileArgs,
+    #[arg(short, long, help = "Show only if entry has this specific flag")]
+    name: Option<String>,
+    #[arg(short, long, help = "Output in restorable format")]
+    dump: bool,
+    #[arg(
+        short = 'm',
+        long = "match",
+        value_name = "PATTERN",
+        help = "Filter flags by regex pattern. Specify '-' for all flags"
+    )]
+    regex_match: Option<String>,
+    #[arg(short, long, help = "Show verbose output with flag descriptions")]
+    long: bool,
+    #[command(flatten)]
+    password: PasswordArgs,
+}
+
+impl Command for GetFflagCommand {
+    #[inline]
+    fn execute(self, _ctx: &crate::cli::GlobalArgs) -> anyhow::Result<()> {
+        archive_get_fflag(self)
+    }
+}
+
+#[derive(Parser, Clone, Eq, PartialEq, Hash, Debug)]
+pub(crate) struct SetFflagCommand {
+    #[arg(
+        short = 'f',
+        long = "file",
+        value_name = "ARCHIVE",
+        help = "Archive file path",
+        value_hint = ValueHint::FilePath
+    )]
+    archive: std::path::PathBuf,
+    #[arg(
+        value_name = "FLAGS",
+        help = "Comma-separated flags to set/clear (chflags-style: uchg, nouchg, nodump, dump, etc.)"
+    )]
+    flags: Option<FlagOperations>,
+    #[arg(value_name = "FILES", help = "Entry paths to modify (supports globs)")]
+    files: Vec<String>,
+    #[arg(
+        long,
+        value_name = "FILE",
+        help = "Restore flags from dump file. Use '-' for stdin",
+        value_hint = ValueHint::FilePath
+    )]
+    restore: Option<String>,
+    #[command(flatten)]
+    transform_strategy: SolidEntriesTransformStrategyArgs,
+    #[command(flatten)]
+    password: PasswordArgs,
+}
+
+impl Command for SetFflagCommand {
+    #[inline]
+    fn execute(self, _ctx: &crate::cli::GlobalArgs) -> anyhow::Result<()> {
+        archive_set_fflag(self)
+    }
+}
+
+/// Known file flags with their canonical names, aliases, and descriptions.
+const KNOWN_FLAGS: &[(&str, &[&str], &str)] = &[
+    // BSD/macOS user-level flags
+    ("uchg", &["uimmutable", "uchange"], "user immutable"),
+    ("uappnd", &["uappend"], "user append-only"),
+    ("nodump", &[], "no dump"),
+    ("hidden", &["uhidden"], "hidden file"),
+    ("opaque", &[], "opaque directory"),
+    ("uunlnk", &["uunlink"], "user undeletable"),
+    // BSD/macOS system-level flags
+    ("schg", &["simmutable", "schange"], "system immutable"),
+    ("sappnd", &["sappend"], "system append-only"),
+    ("archived", &["arch"], "archived"),
+    ("sunlnk", &["sunlink"], "system undeletable"),
+    // Linux-specific flags
+    ("noatime", &[], "no atime updates"),
+    ("compr", &["compress"], "compress file"),
+    ("nocow", &[], "no copy-on-write"),
+];
+
+fn get_flag_description(flag: &str) -> Option<&'static str> {
+    KNOWN_FLAGS
+        .iter()
+        .find(|(canonical, aliases, _)| *canonical == flag || aliases.contains(&flag))
+        .map(|(_, _, desc)| *desc)
+}
+
+fn normalize_flag_name(flag: &str) -> String {
+    // Find canonical name for aliases
+    for (canonical, aliases, _) in KNOWN_FLAGS {
+        if *canonical == flag {
+            return flag.to_string();
+        }
+        if aliases.contains(&flag) {
+            return (*canonical).to_string();
+        }
+    }
+    // Unknown flag, return as-is
+    flag.to_string()
+}
+
+fn is_known_flag(flag: &str) -> bool {
+    KNOWN_FLAGS
+        .iter()
+        .any(|(canonical, aliases, _)| *canonical == flag || aliases.contains(&flag))
+}
+
+/// A single flag operation: set or clear.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+enum FlagOp {
+    Set(String),
+    Clear(String),
+}
+
+/// A collection of flag operations parsed from chflags-style input.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash)]
+pub(crate) struct FlagOperations(Vec<FlagOp>);
+
+impl FromStr for FlagOperations {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let ops = s
+            .split(',')
+            .map(|f| f.trim().to_lowercase())
+            .filter(|f| !f.is_empty())
+            .map(|f| parse_flag_op(&f))
+            .collect::<Vec<_>>();
+        Ok(Self(ops))
+    }
+}
+
+fn parse_flag_op(flag: &str) -> FlagOp {
+    // Special case: "dump" clears "nodump"
+    if flag == "dump" {
+        return FlagOp::Clear("nodump".into());
+    }
+    // "no" prefix clears the flag (except for "nodump" which sets the flag)
+    if let Some(base) = flag.strip_prefix("no") {
+        // "nodump" is a flag itself, not "no" + "dump"
+        if base == "dump" {
+            return FlagOp::Set(normalize_flag_name(flag));
+        }
+        if is_known_flag(base) || is_known_flag(flag) {
+            // If base is known, it's a clear operation
+            if is_known_flag(base) {
+                return FlagOp::Clear(normalize_flag_name(base));
+            }
+        }
+        // Check if the full "no*" form is itself a known flag
+        if is_known_flag(flag) {
+            return FlagOp::Set(normalize_flag_name(flag));
+        }
+        // Unknown but has "no" prefix - treat as clear
+        log::warn!("Unknown flag: {}", base);
+        return FlagOp::Clear(base.into());
+    }
+    // No "no" prefix - set the flag
+    if !is_known_flag(flag) {
+        log::warn!("Unknown flag: {}", flag);
+    }
+    FlagOp::Set(normalize_flag_name(flag))
+}
+
+impl FlagOperations {
+    fn apply(&self, current_flags: &[String]) -> Vec<String> {
+        let mut flags: HashSet<String> = current_flags.iter().cloned().collect();
+
+        // Apply clears first, then sets
+        for op in &self.0 {
+            if let FlagOp::Clear(flag) = op {
+                flags.remove(flag);
+            }
+        }
+        for op in &self.0 {
+            if let FlagOp::Set(flag) = op {
+                flags.insert(flag.clone());
+            }
+        }
+
+        let mut result: Vec<_> = flags.into_iter().collect();
+        result.sort();
+        result
+    }
+}
+
+enum MatchStrategy<'s> {
+    All,
+    Named(&'s str),
+    Regex(Regex),
+}
+
+struct FilterOption<'s> {
+    dump: bool,
+    long: bool,
+    matcher: MatchStrategy<'s>,
+}
+
+impl<'a> FilterOption<'a> {
+    fn new(
+        dump: bool,
+        long: bool,
+        name: Option<&'a str>,
+        regex_match: Option<&'a str>,
+    ) -> Result<Self, regex::Error> {
+        Ok(match (name, regex_match) {
+            (None, None) | (None, Some("-")) => Self {
+                dump,
+                long,
+                matcher: MatchStrategy::All,
+            },
+            (None, Some(re)) => Self {
+                dump,
+                long,
+                matcher: MatchStrategy::Regex(Regex::new(re)?),
+            },
+            (Some(name), _) => Self {
+                dump,
+                long,
+                matcher: MatchStrategy::Named(name),
+            },
+        })
+    }
+
+    fn is_match(&self, flag: &str) -> bool {
+        match &self.matcher {
+            MatchStrategy::All => true,
+            MatchStrategy::Named(n) => *n == flag,
+            MatchStrategy::Regex(re) => re.is_match(flag),
+        }
+    }
+}
+
+#[hooq::hooq(anyhow)]
+fn archive_get_fflag(args: GetFflagCommand) -> anyhow::Result<()> {
+    let password = ask_password(args.password)?;
+    if args.file.files.is_empty() {
+        return Ok(());
+    }
+    let files = &args.file.files;
+    let mut globs = GlobPatterns::new(files.iter().map(|it| it.as_str()))?;
+    let filter = FilterOption::new(
+        args.dump,
+        args.long,
+        args.name.as_deref(),
+        args.regex_match.as_deref(),
+    )
+    .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+
+    let archives = collect_split_archives(&args.file.archive)?;
+
+    #[cfg(feature = "memmap")]
+    let mmaps = archives
+        .into_iter()
+        .map(crate::utils::mmap::Mmap::try_from)
+        .collect::<io::Result<Vec<_>>>()?;
+    #[cfg(feature = "memmap")]
+    let archives = mmaps.iter().map(|m| m.as_ref());
+
+    run_entries(
+        archives,
+        || password.as_deref(),
+        #[hooq::skip_all]
+        |entry| {
+            let entry = entry?;
+            let name = entry.name();
+            if globs.matches_any(name) {
+                let flags: Vec<_> = entry
+                    .fflags()
+                    .into_iter()
+                    .filter(|f| filter.is_match(f))
+                    .collect();
+
+                if !flags.is_empty() || filter.dump {
+                    println!("# file: {name}");
+                    if filter.dump {
+                        // Dump format: flags=flag1,flag2,...
+                        println!("flags={}", flags.join(","));
+                    } else if filter.long {
+                        // Long format with descriptions
+                        for flag in &flags {
+                            if let Some(desc) = get_flag_description(flag) {
+                                println!("{:<12} {}", flag, desc);
+                            } else {
+                                println!("{}", flag);
+                            }
+                        }
+                    } else {
+                        // Simple format: one flag per line
+                        for flag in &flags {
+                            println!("{}", flag);
+                        }
+                    }
+                    println!();
+                }
+            }
+            Ok(())
+        },
+    )?;
+    globs.ensure_all_matched()?;
+    Ok(())
+}
+
+#[hooq::hooq(anyhow)]
+fn archive_set_fflag(args: SetFflagCommand) -> anyhow::Result<()> {
+    let password = ask_password(args.password)?;
+    let files = &args.files;
+
+    let mut set_strategy = if let Some("-") = args.restore.as_deref() {
+        SetFflagStrategy::Restore(parse_fflag_dump(io::stdin().lock())?)
+    } else if let Some(path) = args.restore.as_deref() {
+        SetFflagStrategy::Restore(parse_fflag_dump(io::BufReader::new(fs::File::open(path)?))?)
+    } else if files.is_empty() {
+        return Ok(());
+    } else {
+        let globs = GlobPatterns::new(files.iter().map(|it| it.as_str()))?;
+        SetFflagStrategy::Apply {
+            globs,
+            operations: args.flags.unwrap_or_default(),
+        }
+    };
+
+    let archives = collect_split_archives(&args.archive)?;
+
+    #[cfg(feature = "memmap")]
+    let mmaps = archives
+        .into_iter()
+        .map(crate::utils::mmap::Mmap::try_from)
+        .collect::<io::Result<Vec<_>>>()?;
+    #[cfg(feature = "memmap")]
+    let archives = mmaps.iter().map(|m| m.as_ref());
+
+    let output_path = args.archive.remove_part();
+    let mut temp_file =
+        NamedTempFile::new(|| output_path.parent().unwrap_or_else(|| ".".as_ref()))?;
+
+    match args.transform_strategy.strategy() {
+        SolidEntriesTransformStrategy::UnSolid => run_transform_entry(
+            temp_file.as_file_mut(),
+            archives,
+            || password.as_deref(),
+            #[hooq::skip_all]
+            |entry| Ok(Some(set_strategy.transform_entry(entry?))),
+            TransformStrategyUnSolid,
+        ),
+        SolidEntriesTransformStrategy::KeepSolid => run_transform_entry(
+            temp_file.as_file_mut(),
+            archives,
+            || password.as_deref(),
+            #[hooq::skip_all]
+            |entry| Ok(Some(set_strategy.transform_entry(entry?))),
+            TransformStrategyKeepSolid,
+        ),
+    }?;
+
+    #[cfg(feature = "memmap")]
+    drop(mmaps);
+
+    temp_file.persist(output_path)?;
+
+    if let SetFflagStrategy::Apply { globs, .. } = set_strategy {
+        globs.ensure_all_matched()?;
+    }
+    Ok(())
+}
+
+enum SetFflagStrategy<'s> {
+    Restore(HashMap<String, Vec<String>>),
+    Apply {
+        globs: GlobPatterns<'s>,
+        operations: FlagOperations,
+    },
+}
+
+impl SetFflagStrategy<'_> {
+    fn transform_entry<T>(&mut self, entry: NormalEntry<T>) -> NormalEntry<T>
+    where
+        T: Clone,
+        RawChunk<T>: Chunk,
+        RawChunk<T>: From<RawChunk>,
+    {
+        match self {
+            Self::Restore(restore) => {
+                if let Some(flags) = restore.get(entry.name().as_str()) {
+                    transform_entry_flags(entry, flags)
+                } else {
+                    entry
+                }
+            }
+            Self::Apply { globs, operations } => {
+                if globs.matches_any(entry.name()) {
+                    let current_flags = entry.fflags();
+                    let new_flags = operations.apply(&current_flags);
+                    transform_entry_flags(entry, &new_flags)
+                } else {
+                    entry
+                }
+            }
+        }
+    }
+}
+
+fn transform_entry_flags<T>(entry: NormalEntry<T>, flags: &[String]) -> NormalEntry<T>
+where
+    T: Clone,
+    RawChunk<T>: Chunk,
+    RawChunk<T>: From<RawChunk>,
+{
+    // Remove existing ffLg chunks
+    let extra_without_fflags: Vec<_> = entry
+        .extra_chunks()
+        .iter()
+        .filter(|c| c.ty() != chunk::ffLg)
+        .cloned()
+        .collect();
+
+    // Add new ffLg chunks
+    let mut extra_chunks = extra_without_fflags;
+    for flag in flags {
+        extra_chunks.push(chunk::fflag_chunk(flag).into());
+    }
+
+    entry.with_extra_chunks(extra_chunks)
+}
+
+fn parse_fflag_dump(reader: impl io::BufRead) -> io::Result<HashMap<String, Vec<String>>> {
+    let mut result = HashMap::new();
+    let mut current_file: Option<String> = None;
+
+    for line in reader.lines() {
+        let line = line?;
+        if line.is_empty() {
+            continue;
+        }
+        if let Some(path) = line.strip_prefix("# file: ") {
+            current_file = Some(path.to_string());
+        } else if let Some(file) = &current_file {
+            if let Some(flags_str) = line.strip_prefix("flags=") {
+                let flags: Vec<String> = flags_str
+                    .split(',')
+                    .map(|f| f.trim().to_string())
+                    .filter(|f| !f.is_empty())
+                    .collect();
+                result.insert(file.clone(), flags);
+            }
+        }
+    }
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_flag_op_set() {
+        assert_eq!(parse_flag_op("uchg"), FlagOp::Set("uchg".into()));
+        assert_eq!(parse_flag_op("schg"), FlagOp::Set("schg".into()));
+        assert_eq!(parse_flag_op("hidden"), FlagOp::Set("hidden".into()));
+    }
+
+    #[test]
+    fn parse_flag_op_clear() {
+        assert_eq!(parse_flag_op("nouchg"), FlagOp::Clear("uchg".into()));
+        assert_eq!(parse_flag_op("noschg"), FlagOp::Clear("schg".into()));
+        assert_eq!(parse_flag_op("nohidden"), FlagOp::Clear("hidden".into()));
+    }
+
+    #[test]
+    fn parse_flag_op_nodump_special() {
+        // "nodump" is a flag itself
+        assert_eq!(parse_flag_op("nodump"), FlagOp::Set("nodump".into()));
+        // "dump" clears "nodump"
+        assert_eq!(parse_flag_op("dump"), FlagOp::Clear("nodump".into()));
+    }
+
+    #[test]
+    fn parse_flag_operations() {
+        let ops: FlagOperations = "uchg,nodump,nohidden".parse().unwrap();
+        assert_eq!(ops.0.len(), 3);
+        assert_eq!(ops.0[0], FlagOp::Set("uchg".into()));
+        assert_eq!(ops.0[1], FlagOp::Set("nodump".into()));
+        assert_eq!(ops.0[2], FlagOp::Clear("hidden".into()));
+    }
+
+    #[test]
+    fn apply_flag_operations() {
+        let ops: FlagOperations = "uchg,nodump".parse().unwrap();
+        let result = ops.apply(&[]);
+        assert!(result.contains(&"uchg".to_string()));
+        assert!(result.contains(&"nodump".to_string()));
+    }
+
+    #[test]
+    fn apply_flag_operations_clear() {
+        let ops: FlagOperations = "nouchg".parse().unwrap();
+        let current = vec!["uchg".to_string(), "nodump".to_string()];
+        let result = ops.apply(&current);
+        assert!(!result.contains(&"uchg".to_string()));
+        assert!(result.contains(&"nodump".to_string()));
+    }
+
+    #[test]
+    fn apply_flag_operations_mixed() {
+        let ops: FlagOperations = "schg,nouchg,nodump".parse().unwrap();
+        let current = vec!["uchg".to_string()];
+        let result = ops.apply(&current);
+        assert!(!result.contains(&"uchg".to_string()));
+        assert!(result.contains(&"schg".to_string()));
+        assert!(result.contains(&"nodump".to_string()));
+    }
+
+    #[test]
+    fn normalize_aliases() {
+        assert_eq!(normalize_flag_name("uimmutable"), "uchg");
+        assert_eq!(normalize_flag_name("simmutable"), "schg");
+        assert_eq!(normalize_flag_name("uhidden"), "hidden");
+        assert_eq!(normalize_flag_name("uappend"), "uappnd");
+    }
+}

--- a/cli/src/command/fflag.rs
+++ b/cli/src/command/fflag.rs
@@ -6,8 +6,8 @@ use crate::{
     command::{
         Command, ask_password,
         core::{
-            TransformStrategyKeepSolid, TransformStrategyUnSolid, collect_split_archives,
-            run_entries, run_transform_entry,
+            SplitArchiveReader, TransformStrategyKeepSolid, TransformStrategyUnSolid,
+            collect_split_archives,
         },
     },
     ext::NormalEntryExt,
@@ -31,7 +31,7 @@ pub(crate) struct FflagCommand {
 
 impl Command for FflagCommand {
     #[inline]
-    fn execute(self, ctx: &crate::cli::GlobalArgs) -> anyhow::Result<()> {
+    fn execute(self, ctx: &crate::cli::GlobalContext) -> anyhow::Result<()> {
         match self.command {
             FflagCommands::Get(cmd) => cmd.execute(ctx),
             FflagCommands::Set(cmd) => cmd.execute(ctx),
@@ -70,7 +70,7 @@ pub(crate) struct GetFflagCommand {
 
 impl Command for GetFflagCommand {
     #[inline]
-    fn execute(self, _ctx: &crate::cli::GlobalArgs) -> anyhow::Result<()> {
+    fn execute(self, _ctx: &crate::cli::GlobalContext) -> anyhow::Result<()> {
         archive_get_fflag(self)
     }
 }
@@ -107,7 +107,7 @@ pub(crate) struct SetFflagCommand {
 
 impl Command for SetFflagCommand {
     #[inline]
-    fn execute(self, _ctx: &crate::cli::GlobalArgs) -> anyhow::Result<()> {
+    fn execute(self, _ctx: &crate::cli::GlobalContext) -> anyhow::Result<()> {
         archive_set_fflag(self)
     }
 }
@@ -290,33 +290,32 @@ impl<'a> FilterOption<'a> {
 
 #[hooq::hooq(anyhow)]
 fn archive_get_fflag(args: GetFflagCommand) -> anyhow::Result<()> {
-    let password = ask_password(args.password)?;
-    if args.file.files.is_empty() {
+    let GetFflagCommand {
+        file,
+        name,
+        dump,
+        regex_match,
+        long,
+        password,
+    } = args;
+    let password = ask_password(password)?;
+    if file.files.is_empty() {
         return Ok(());
     }
-    let files = &args.file.files;
+    let FileArgs { archive, files } = file;
     let mut globs = GlobPatterns::new(files.iter().map(|it| it.as_str()))?;
     let filter = FilterOption::new(
-        args.dump,
-        args.long,
-        args.name.as_deref(),
-        args.regex_match.as_deref(),
+        dump,
+        long,
+        name.as_deref(),
+        regex_match.as_deref(),
     )
     .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
 
-    let archives = collect_split_archives(&args.file.archive)?;
+    let mut source = SplitArchiveReader::new(collect_split_archives(archive)?)?;
 
-    #[cfg(feature = "memmap")]
-    let mmaps = archives
-        .into_iter()
-        .map(crate::utils::mmap::Mmap::try_from)
-        .collect::<io::Result<Vec<_>>>()?;
-    #[cfg(feature = "memmap")]
-    let archives = mmaps.iter().map(|m| m.as_ref());
-
-    run_entries(
-        archives,
-        || password.as_deref(),
+    source.for_each_entry(
+        password.as_deref(),
         #[hooq::skip_all]
         |entry| {
             let entry = entry?;
@@ -377,41 +376,30 @@ fn archive_set_fflag(args: SetFflagCommand) -> anyhow::Result<()> {
         }
     };
 
-    let archives = collect_split_archives(&args.archive)?;
-
-    #[cfg(feature = "memmap")]
-    let mmaps = archives
-        .into_iter()
-        .map(crate::utils::mmap::Mmap::try_from)
-        .collect::<io::Result<Vec<_>>>()?;
-    #[cfg(feature = "memmap")]
-    let archives = mmaps.iter().map(|m| m.as_ref());
+    let mut source = SplitArchiveReader::new(collect_split_archives(&args.archive)?)?;
 
     let output_path = args.archive.remove_part();
     let mut temp_file =
         NamedTempFile::new(|| output_path.parent().unwrap_or_else(|| ".".as_ref()))?;
 
     match args.transform_strategy.strategy() {
-        SolidEntriesTransformStrategy::UnSolid => run_transform_entry(
+        SolidEntriesTransformStrategy::UnSolid => source.transform_entries(
             temp_file.as_file_mut(),
-            archives,
-            || password.as_deref(),
+            password.as_deref(),
             #[hooq::skip_all]
             |entry| Ok(Some(set_strategy.transform_entry(entry?))),
             TransformStrategyUnSolid,
         ),
-        SolidEntriesTransformStrategy::KeepSolid => run_transform_entry(
+        SolidEntriesTransformStrategy::KeepSolid => source.transform_entries(
             temp_file.as_file_mut(),
-            archives,
-            || password.as_deref(),
+            password.as_deref(),
             #[hooq::skip_all]
             |entry| Ok(Some(set_strategy.transform_entry(entry?))),
             TransformStrategyKeepSolid,
         ),
     }?;
 
-    #[cfg(feature = "memmap")]
-    drop(mmaps);
+    drop(source);
 
     temp_file.persist(output_path)?;
 

--- a/cli/src/command/fflag.rs
+++ b/cli/src/command/fflag.rs
@@ -304,13 +304,8 @@ fn archive_get_fflag(args: GetFflagCommand) -> anyhow::Result<()> {
     }
     let FileArgs { archive, files } = file;
     let mut globs = GlobPatterns::new(files.iter().map(|it| it.as_str()))?;
-    let filter = FilterOption::new(
-        dump,
-        long,
-        name.as_deref(),
-        regex_match.as_deref(),
-    )
-    .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+    let filter = FilterOption::new(dump, long, name.as_deref(), regex_match.as_deref())
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
 
     let mut source = SplitArchiveReader::new(collect_split_archives(archive)?)?;
 

--- a/cli/src/command/fflag.rs
+++ b/cli/src/command/fflag.rs
@@ -218,17 +218,20 @@ fn parse_flag_op(flag: &str) -> FlagOp {
 
 impl FlagOperations {
     fn apply(&self, current_flags: &[String]) -> Vec<String> {
-        let mut flags: HashSet<String> = current_flags.iter().cloned().collect();
+        let mut flags: HashSet<String> = current_flags
+            .iter()
+            .map(|flag| normalize_flag_name(flag))
+            .collect();
 
         // Apply clears first, then sets
         for op in &self.0 {
             if let FlagOp::Clear(flag) = op {
-                flags.remove(flag);
+                flags.remove(&normalize_flag_name(flag));
             }
         }
         for op in &self.0 {
             if let FlagOp::Set(flag) = op {
-                flags.insert(flag.clone());
+                flags.insert(normalize_flag_name(flag));
             }
         }
 
@@ -561,6 +564,16 @@ mod tests {
         let result = ops.apply(&current);
         assert!(!result.contains(&"uchg".to_string()));
         assert!(result.contains(&"schg".to_string()));
+        assert!(result.contains(&"nodump".to_string()));
+    }
+
+    #[test]
+    fn apply_flag_operations_normalizes_existing_aliases() {
+        let ops: FlagOperations = "nouchg".parse().unwrap();
+        let current = vec!["uimmutable".to_string(), "nodump".to_string()];
+        let result = ops.apply(&current);
+        assert!(!result.contains(&"uimmutable".to_string()));
+        assert!(!result.contains(&"uchg".to_string()));
         assert!(result.contains(&"nodump".to_string()));
     }
 

--- a/cli/src/command/fflag.rs
+++ b/cli/src/command/fflag.rs
@@ -179,41 +179,35 @@ impl FromStr for FlagOperations {
             .map(|f| f.trim().to_lowercase())
             .filter(|f| !f.is_empty())
             .map(|f| parse_flag_op(&f))
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>, _>>()?;
         Ok(Self(ops))
     }
 }
 
-fn parse_flag_op(flag: &str) -> FlagOp {
+fn parse_flag_op(flag: &str) -> Result<FlagOp, String> {
     // Special case: "dump" clears "nodump"
     if flag == "dump" {
-        return FlagOp::Clear("nodump".into());
+        return Ok(FlagOp::Clear("nodump".into()));
     }
     // "no" prefix clears the flag (except for "nodump" which sets the flag)
     if let Some(base) = flag.strip_prefix("no") {
         // "nodump" is a flag itself, not "no" + "dump"
         if base == "dump" {
-            return FlagOp::Set(normalize_flag_name(flag));
+            return Ok(FlagOp::Set(normalize_flag_name(flag)));
         }
-        if is_known_flag(base) || is_known_flag(flag) {
-            // If base is known, it's a clear operation
-            if is_known_flag(base) {
-                return FlagOp::Clear(normalize_flag_name(base));
-            }
+        if is_known_flag(base) {
+            return Ok(FlagOp::Clear(normalize_flag_name(base)));
         }
-        // Check if the full "no*" form is itself a known flag
         if is_known_flag(flag) {
-            return FlagOp::Set(normalize_flag_name(flag));
+            return Ok(FlagOp::Set(normalize_flag_name(flag)));
         }
-        // Unknown but has "no" prefix - treat as clear
-        log::warn!("Unknown flag: {}", base);
-        return FlagOp::Clear(base.into());
+        return Err(format!("Unknown flag: '{base}'"));
     }
     // No "no" prefix - set the flag
     if !is_known_flag(flag) {
-        log::warn!("Unknown flag: {}", flag);
+        return Err(format!("Unknown flag: '{flag}'"));
     }
-    FlagOp::Set(normalize_flag_name(flag))
+    Ok(FlagOp::Set(normalize_flag_name(flag)))
 }
 
 impl FlagOperations {
@@ -365,10 +359,11 @@ fn archive_set_fflag(args: SetFflagCommand) -> anyhow::Result<()> {
         return Ok(());
     } else {
         let globs = GlobPatterns::new(files.iter().map(|it| it.as_str()))?;
-        SetFflagStrategy::Apply {
-            globs,
-            operations: args.flags.unwrap_or_default(),
+        let operations = args.flags.unwrap_or_default();
+        if operations.0.is_empty() {
+            anyhow::bail!("No flag operations specified");
         }
+        SetFflagStrategy::Apply { globs, operations }
     };
 
     let mut source = SplitArchiveReader::new(collect_split_archives(&args.archive)?)?;
@@ -482,7 +477,17 @@ fn parse_fflag_dump(reader: impl io::BufRead) -> io::Result<HashMap<String, Vec<
                     .filter(|f| !f.is_empty())
                     .collect();
                 result.insert(file.clone(), flags);
+            } else {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Expected 'flags=...' but got: '{line}'"),
+                ));
             }
+        } else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Unexpected line before '# file:' header: '{line}'"),
+            ));
         }
     }
     Ok(result)
@@ -494,24 +499,49 @@ mod tests {
 
     #[test]
     fn parse_flag_op_set() {
-        assert_eq!(parse_flag_op("uchg"), FlagOp::Set("uchg".into()));
-        assert_eq!(parse_flag_op("schg"), FlagOp::Set("schg".into()));
-        assert_eq!(parse_flag_op("hidden"), FlagOp::Set("hidden".into()));
+        assert_eq!(parse_flag_op("uchg").unwrap(), FlagOp::Set("uchg".into()));
+        assert_eq!(parse_flag_op("schg").unwrap(), FlagOp::Set("schg".into()));
+        assert_eq!(
+            parse_flag_op("hidden").unwrap(),
+            FlagOp::Set("hidden".into())
+        );
     }
 
     #[test]
     fn parse_flag_op_clear() {
-        assert_eq!(parse_flag_op("nouchg"), FlagOp::Clear("uchg".into()));
-        assert_eq!(parse_flag_op("noschg"), FlagOp::Clear("schg".into()));
-        assert_eq!(parse_flag_op("nohidden"), FlagOp::Clear("hidden".into()));
+        assert_eq!(
+            parse_flag_op("nouchg").unwrap(),
+            FlagOp::Clear("uchg".into())
+        );
+        assert_eq!(
+            parse_flag_op("noschg").unwrap(),
+            FlagOp::Clear("schg".into())
+        );
+        assert_eq!(
+            parse_flag_op("nohidden").unwrap(),
+            FlagOp::Clear("hidden".into())
+        );
     }
 
     #[test]
     fn parse_flag_op_nodump_special() {
         // "nodump" is a flag itself
-        assert_eq!(parse_flag_op("nodump"), FlagOp::Set("nodump".into()));
+        assert_eq!(
+            parse_flag_op("nodump").unwrap(),
+            FlagOp::Set("nodump".into())
+        );
         // "dump" clears "nodump"
-        assert_eq!(parse_flag_op("dump"), FlagOp::Clear("nodump".into()));
+        assert_eq!(
+            parse_flag_op("dump").unwrap(),
+            FlagOp::Clear("nodump".into())
+        );
+    }
+
+    #[test]
+    fn parse_flag_op_unknown_flag() {
+        assert!(parse_flag_op("xyzzy").is_err());
+        assert!(parse_flag_op("file.txt").is_err());
+        assert!(parse_flag_op("noxyzzy").is_err());
     }
 
     #[test]

--- a/cli/src/command/fflag.rs
+++ b/cli/src/command/fflag.rs
@@ -6,15 +6,15 @@ use crate::{
     command::{
         Command, ask_password,
         core::{
-            SplitArchiveReader, TransformStrategyKeepSolid, TransformStrategyUnSolid,
-            collect_split_archives,
+            SplitArchiveReader, StagedArchive, TransformStrategyKeepSolid,
+            TransformStrategyUnSolid, collect_split_archives,
         },
     },
     ext::NormalEntryExt,
-    utils::{GlobPatterns, PathPartExt, env::NamedTempFile},
+    utils::{GlobPatterns, PathPartExt},
 };
 use clap::{Parser, ValueHint};
-use pna::{Chunk, NormalEntry, RawChunk};
+use pna::{Chunk, NormalEntry, RawChunk, ReadOptions};
 use regex::Regex;
 use std::{
     collections::{HashMap, HashSet},
@@ -302,9 +302,10 @@ fn archive_get_fflag(args: GetFflagCommand) -> anyhow::Result<()> {
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
 
     let mut source = SplitArchiveReader::new(collect_split_archives(archive)?)?;
+    let read_options = ReadOptions::with_password(password.as_deref());
 
     source.for_each_entry(
-        password.as_deref(),
+        &read_options,
         #[hooq::skip_all]
         |entry| {
             let entry = entry?;
@@ -369,19 +370,18 @@ fn archive_set_fflag(args: SetFflagCommand) -> anyhow::Result<()> {
     let mut source = SplitArchiveReader::new(collect_split_archives(&args.archive)?)?;
 
     let output_path = args.archive.remove_part();
-    let mut temp_file =
-        NamedTempFile::new(|| output_path.parent().unwrap_or_else(|| ".".as_ref()))?;
+    let mut staged = StagedArchive::new(output_path)?;
 
     match args.transform_strategy.strategy() {
         SolidEntriesTransformStrategy::UnSolid => source.transform_entries(
-            temp_file.as_file_mut(),
+            staged.as_file_mut(),
             password.as_deref(),
             #[hooq::skip_all]
             |entry| Ok(Some(set_strategy.transform_entry(entry?))),
             TransformStrategyUnSolid,
         ),
         SolidEntriesTransformStrategy::KeepSolid => source.transform_entries(
-            temp_file.as_file_mut(),
+            staged.as_file_mut(),
             password.as_deref(),
             #[hooq::skip_all]
             |entry| Ok(Some(set_strategy.transform_entry(entry?))),
@@ -391,12 +391,10 @@ fn archive_set_fflag(args: SetFflagCommand) -> anyhow::Result<()> {
 
     drop(source);
 
-    temp_file.persist(output_path)?;
-
-    if let SetFflagStrategy::Apply { globs, .. } = set_strategy {
-        globs.ensure_all_matched()?;
+    match set_strategy {
+        SetFflagStrategy::Apply { globs, .. } => staged.commit(Some(&globs)),
+        SetFflagStrategy::Restore(_) => staged.commit(None),
     }
-    Ok(())
 }
 
 enum SetFflagStrategy<'s> {

--- a/cli/tests/cli/fflag.rs
+++ b/cli/tests/cli/fflag.rs
@@ -1,0 +1,4 @@
+mod compatibility;
+#[cfg(not(target_family = "wasm"))]
+mod get;
+mod set;

--- a/cli/tests/cli/fflag/compatibility.rs
+++ b/cli/tests/cli/fflag/compatibility.rs
@@ -1,0 +1,187 @@
+use crate::utils::{EmbedExt, TestResources, setup};
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::PredicateBooleanExt;
+
+/// Precondition: A snapshot archive with a single flag (uchg).
+/// Action: Run `pna experimental fflag get` to read the flag.
+/// Expectation: The uchg flag is correctly read from the archive.
+#[test]
+fn fflag_compatibility_single_flag() {
+    setup();
+    TestResources::extract_in("fflag_single.pna", ".").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_single.pna",
+            "*",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("testfile.txt"))
+        .stdout(predicates::str::contains("uchg"));
+}
+
+/// Precondition: A snapshot archive with multiple flags (uchg, nodump, hidden).
+/// Action: Run `pna experimental fflag get` to read the flags.
+/// Expectation: All flags are correctly read from the archive.
+#[test]
+fn fflag_compatibility_multi_flag() {
+    setup();
+    TestResources::extract_in("fflag_multi.pna", ".").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_multi.pna",
+            "*",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("testfile.txt"))
+        .stdout(predicates::str::contains("uchg"))
+        .stdout(predicates::str::contains("nodump"))
+        .stdout(predicates::str::contains("hidden"));
+}
+
+/// Precondition: A snapshot archive with multiple entries having different flags.
+/// Action: Run `pna experimental fflag get` to read all flags.
+/// Expectation: Each entry's flags are correctly read.
+#[test]
+fn fflag_compatibility_multi_entry() {
+    setup();
+    TestResources::extract_in("fflag_multi_entry.pna", ".").unwrap();
+
+    let output = cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_multi_entry.pna",
+            "--long",
+            "*",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let output_str = String::from_utf8_lossy(&output);
+
+    // Verify file1.txt has uchg
+    assert!(output_str.contains("file1.txt"));
+    assert!(output_str.contains("uchg"));
+
+    // Verify file2.txt has nodump
+    assert!(output_str.contains("file2.txt"));
+    assert!(output_str.contains("nodump"));
+
+    // Verify file3.txt has hidden and schg
+    assert!(output_str.contains("file3.txt"));
+    assert!(output_str.contains("hidden"));
+    assert!(output_str.contains("schg"));
+}
+
+/// Precondition: A snapshot archive with fflags.
+/// Action: Run `pna experimental fflag get --dump` to output restorable format.
+/// Expectation: Output is in the correct dump format.
+#[test]
+fn fflag_compatibility_dump_format() {
+    setup();
+    TestResources::extract_in("fflag_multi.pna", ".").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_multi.pna",
+            "--dump",
+            "*",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("# file: testfile.txt"))
+        .stdout(predicates::str::contains("flags="));
+}
+
+/// Precondition: A snapshot archive with fflags.
+/// Action: Run `pna experimental fflag get --name <flag>` to filter.
+/// Expectation: Only entries with the specified flag are shown.
+#[test]
+fn fflag_compatibility_filter_by_name() {
+    setup();
+    TestResources::extract_in("fflag_multi_entry.pna", ".").unwrap();
+
+    // Filter for uchg - should only show file1.txt
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_multi_entry.pna",
+            "--name",
+            "uchg",
+            "*",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("file1.txt"))
+        .stdout(predicates::str::contains("file2.txt").not())
+        .stdout(predicates::str::contains("file3.txt").not());
+}
+
+/// Precondition: A snapshot archive with fflags.
+/// Action: Set additional flags on the snapshot archive.
+/// Expectation: New flags are added without removing existing ones.
+#[test]
+fn fflag_compatibility_add_flags() {
+    setup();
+    TestResources::extract_in("fflag_single.pna", ".").unwrap();
+
+    // Add nodump to existing uchg
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_single.pna",
+            "nodump",
+            "testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Verify both flags are present
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_single.pna",
+            "testfile.txt",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("uchg"))
+        .stdout(predicates::str::contains("nodump"));
+}

--- a/cli/tests/cli/fflag/compatibility.rs
+++ b/cli/tests/cli/fflag/compatibility.rs
@@ -8,7 +8,7 @@ use predicates::prelude::PredicateBooleanExt;
 #[test]
 fn fflag_compatibility_single_flag() {
     setup();
-    TestResources::extract_in("zstd_keep_fflags.pna", ".").unwrap();
+    TestResources::extract_in("zstd_keep_fflags.pna", "fflag_compat_single_flag/").unwrap();
 
     cargo_bin_cmd!("pna")
         .args([
@@ -17,7 +17,7 @@ fn fflag_compatibility_single_flag() {
             "fflag",
             "get",
             "-f",
-            "zstd_keep_fflags.pna",
+            "fflag_compat_single_flag/zstd_keep_fflags.pna",
             "file1.txt",
         ])
         .assert()
@@ -32,7 +32,7 @@ fn fflag_compatibility_single_flag() {
 #[test]
 fn fflag_compatibility_multi_flag() {
     setup();
-    TestResources::extract_in("zstd_keep_fflags.pna", ".").unwrap();
+    TestResources::extract_in("zstd_keep_fflags.pna", "fflag_compat_multi_flag/").unwrap();
 
     cargo_bin_cmd!("pna")
         .args([
@@ -41,7 +41,7 @@ fn fflag_compatibility_multi_flag() {
             "fflag",
             "get",
             "-f",
-            "zstd_keep_fflags.pna",
+            "fflag_compat_multi_flag/zstd_keep_fflags.pna",
             "testfile.txt",
         ])
         .assert()
@@ -58,7 +58,7 @@ fn fflag_compatibility_multi_flag() {
 #[test]
 fn fflag_compatibility_multi_entry() {
     setup();
-    TestResources::extract_in("zstd_keep_fflags.pna", ".").unwrap();
+    TestResources::extract_in("zstd_keep_fflags.pna", "fflag_compat_multi_entry/").unwrap();
 
     let output = cargo_bin_cmd!("pna")
         .args([
@@ -67,7 +67,7 @@ fn fflag_compatibility_multi_entry() {
             "fflag",
             "get",
             "-f",
-            "zstd_keep_fflags.pna",
+            "fflag_compat_multi_entry/zstd_keep_fflags.pna",
             "--long",
             "*",
         ])
@@ -99,7 +99,7 @@ fn fflag_compatibility_multi_entry() {
 #[test]
 fn fflag_compatibility_dump_format() {
     setup();
-    TestResources::extract_in("zstd_keep_fflags.pna", ".").unwrap();
+    TestResources::extract_in("zstd_keep_fflags.pna", "fflag_compat_dump_format/").unwrap();
 
     cargo_bin_cmd!("pna")
         .args([
@@ -108,7 +108,7 @@ fn fflag_compatibility_dump_format() {
             "fflag",
             "get",
             "-f",
-            "zstd_keep_fflags.pna",
+            "fflag_compat_dump_format/zstd_keep_fflags.pna",
             "--dump",
             "testfile.txt",
         ])
@@ -124,7 +124,7 @@ fn fflag_compatibility_dump_format() {
 #[test]
 fn fflag_compatibility_filter_by_name() {
     setup();
-    TestResources::extract_in("zstd_keep_fflags.pna", ".").unwrap();
+    TestResources::extract_in("zstd_keep_fflags.pna", "fflag_compat_filter_by_name/").unwrap();
 
     // Filter for schg - should only show file3.txt
     cargo_bin_cmd!("pna")
@@ -134,7 +134,7 @@ fn fflag_compatibility_filter_by_name() {
             "fflag",
             "get",
             "-f",
-            "zstd_keep_fflags.pna",
+            "fflag_compat_filter_by_name/zstd_keep_fflags.pna",
             "--name",
             "schg",
             "*",

--- a/cli/tests/cli/fflag/compatibility.rs
+++ b/cli/tests/cli/fflag/compatibility.rs
@@ -8,7 +8,7 @@ use predicates::prelude::PredicateBooleanExt;
 #[test]
 fn fflag_compatibility_single_flag() {
     setup();
-    TestResources::extract_in("fflag_single.pna", ".").unwrap();
+    TestResources::extract_in("zstd_keep_fflags.pna", ".").unwrap();
 
     cargo_bin_cmd!("pna")
         .args([
@@ -17,12 +17,12 @@ fn fflag_compatibility_single_flag() {
             "fflag",
             "get",
             "-f",
-            "fflag_single.pna",
-            "*",
+            "zstd_keep_fflags.pna",
+            "file1.txt",
         ])
         .assert()
         .success()
-        .stdout(predicates::str::contains("testfile.txt"))
+        .stdout(predicates::str::contains("file1.txt"))
         .stdout(predicates::str::contains("uchg"));
 }
 
@@ -32,7 +32,7 @@ fn fflag_compatibility_single_flag() {
 #[test]
 fn fflag_compatibility_multi_flag() {
     setup();
-    TestResources::extract_in("fflag_multi.pna", ".").unwrap();
+    TestResources::extract_in("zstd_keep_fflags.pna", ".").unwrap();
 
     cargo_bin_cmd!("pna")
         .args([
@@ -41,8 +41,8 @@ fn fflag_compatibility_multi_flag() {
             "fflag",
             "get",
             "-f",
-            "fflag_multi.pna",
-            "*",
+            "zstd_keep_fflags.pna",
+            "testfile.txt",
         ])
         .assert()
         .success()
@@ -58,7 +58,7 @@ fn fflag_compatibility_multi_flag() {
 #[test]
 fn fflag_compatibility_multi_entry() {
     setup();
-    TestResources::extract_in("fflag_multi_entry.pna", ".").unwrap();
+    TestResources::extract_in("zstd_keep_fflags.pna", ".").unwrap();
 
     let output = cargo_bin_cmd!("pna")
         .args([
@@ -67,7 +67,7 @@ fn fflag_compatibility_multi_entry() {
             "fflag",
             "get",
             "-f",
-            "fflag_multi_entry.pna",
+            "zstd_keep_fflags.pna",
             "--long",
             "*",
         ])
@@ -99,7 +99,7 @@ fn fflag_compatibility_multi_entry() {
 #[test]
 fn fflag_compatibility_dump_format() {
     setup();
-    TestResources::extract_in("fflag_multi.pna", ".").unwrap();
+    TestResources::extract_in("zstd_keep_fflags.pna", ".").unwrap();
 
     cargo_bin_cmd!("pna")
         .args([
@@ -108,9 +108,9 @@ fn fflag_compatibility_dump_format() {
             "fflag",
             "get",
             "-f",
-            "fflag_multi.pna",
+            "zstd_keep_fflags.pna",
             "--dump",
-            "*",
+            "testfile.txt",
         ])
         .assert()
         .success()
@@ -124,9 +124,9 @@ fn fflag_compatibility_dump_format() {
 #[test]
 fn fflag_compatibility_filter_by_name() {
     setup();
-    TestResources::extract_in("fflag_multi_entry.pna", ".").unwrap();
+    TestResources::extract_in("zstd_keep_fflags.pna", ".").unwrap();
 
-    // Filter for uchg - should only show file1.txt
+    // Filter for schg - should only show file3.txt
     cargo_bin_cmd!("pna")
         .args([
             "--quiet",
@@ -134,16 +134,17 @@ fn fflag_compatibility_filter_by_name() {
             "fflag",
             "get",
             "-f",
-            "fflag_multi_entry.pna",
+            "zstd_keep_fflags.pna",
             "--name",
-            "uchg",
+            "schg",
             "*",
         ])
         .assert()
         .success()
-        .stdout(predicates::str::contains("file1.txt"))
+        .stdout(predicates::str::contains("file3.txt"))
+        .stdout(predicates::str::contains("file1.txt").not())
         .stdout(predicates::str::contains("file2.txt").not())
-        .stdout(predicates::str::contains("file3.txt").not());
+        .stdout(predicates::str::contains("testfile.txt").not());
 }
 
 /// Precondition: A snapshot archive with fflags.
@@ -152,9 +153,9 @@ fn fflag_compatibility_filter_by_name() {
 #[test]
 fn fflag_compatibility_add_flags() {
     setup();
-    TestResources::extract_in("fflag_single.pna", ".").unwrap();
+    TestResources::extract_in("zstd_keep_fflags.pna", ".").unwrap();
 
-    // Add nodump to existing uchg
+    // Add nodump to existing uchg on file1
     cargo_bin_cmd!("pna")
         .args([
             "--quiet",
@@ -162,9 +163,9 @@ fn fflag_compatibility_add_flags() {
             "fflag",
             "set",
             "-f",
-            "fflag_single.pna",
+            "zstd_keep_fflags.pna",
             "nodump",
-            "testfile.txt",
+            "file1.txt",
         ])
         .assert()
         .success();
@@ -177,8 +178,8 @@ fn fflag_compatibility_add_flags() {
             "fflag",
             "get",
             "-f",
-            "fflag_single.pna",
-            "testfile.txt",
+            "zstd_keep_fflags.pna",
+            "file1.txt",
         ])
         .assert()
         .success()

--- a/cli/tests/cli/fflag/compatibility.rs
+++ b/cli/tests/cli/fflag/compatibility.rs
@@ -153,7 +153,7 @@ fn fflag_compatibility_filter_by_name() {
 #[test]
 fn fflag_compatibility_add_flags() {
     setup();
-    TestResources::extract_in("zstd_keep_fflags.pna", ".").unwrap();
+    TestResources::extract_in("zstd_keep_fflags.pna", "fflag_compat_add_flags/").unwrap();
 
     // Add nodump to existing uchg on file1
     cargo_bin_cmd!("pna")
@@ -163,7 +163,7 @@ fn fflag_compatibility_add_flags() {
             "fflag",
             "set",
             "-f",
-            "zstd_keep_fflags.pna",
+            "fflag_compat_add_flags/zstd_keep_fflags.pna",
             "nodump",
             "file1.txt",
         ])
@@ -178,7 +178,7 @@ fn fflag_compatibility_add_flags() {
             "fflag",
             "get",
             "-f",
-            "zstd_keep_fflags.pna",
+            "fflag_compat_add_flags/zstd_keep_fflags.pna",
             "file1.txt",
         ])
         .assert()

--- a/cli/tests/cli/fflag/get.rs
+++ b/cli/tests/cli/fflag/get.rs
@@ -1,0 +1,6 @@
+mod basic;
+mod missing_file;
+mod option_dump;
+mod option_long;
+mod option_match;
+mod option_name;

--- a/cli/tests/cli/fflag/get/basic.rs
+++ b/cli/tests/cli/fflag/get/basic.rs
@@ -1,0 +1,148 @@
+use crate::utils::setup;
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::PredicateBooleanExt;
+use std::fs;
+
+/// Precondition: An archive with entries that have file flags set.
+/// Action: Run `pna experimental fflag get` to list flags.
+/// Expectation: Flags are displayed for entries that have them.
+#[test]
+fn fflag_get_basic() {
+    setup();
+    fs::create_dir_all("fflag_get_basic").unwrap();
+
+    fs::write("fflag_get_basic/testfile.txt", "test content").unwrap();
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_get_basic/test.pna",
+            "--overwrite",
+            "fflag_get_basic/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set flags on the entry
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_get_basic/test.pna",
+            "uchg,nodump",
+            "fflag_get_basic/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Get flags
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_get_basic/test.pna",
+            "fflag_get_basic/testfile.txt",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("nodump"))
+        .stdout(predicates::str::contains("uchg"));
+}
+
+/// Precondition: An archive with entries that have no file flags.
+/// Action: Run `pna experimental fflag get` to list flags.
+/// Expectation: No output for entries without flags.
+#[test]
+fn fflag_get_no_flags() {
+    setup();
+    fs::create_dir_all("fflag_get_no_flags").unwrap();
+
+    fs::write("fflag_get_no_flags/testfile.txt", "test content").unwrap();
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_get_no_flags/test.pna",
+            "--overwrite",
+            "fflag_get_no_flags/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Get flags - should have no output since no flags are set
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_get_no_flags/test.pna",
+            "*",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::is_empty());
+}
+
+/// Precondition: An archive with multiple entries, some with flags.
+/// Action: Run `pna experimental fflag get *` to list all flags.
+/// Expectation: Only entries with flags are shown.
+#[test]
+fn fflag_get_wildcard() {
+    setup();
+    fs::create_dir_all("fflag_get_wildcard").unwrap();
+
+    fs::write("fflag_get_wildcard/file1.txt", "content 1").unwrap();
+    fs::write("fflag_get_wildcard/file2.txt", "content 2").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_get_wildcard/test.pna",
+            "--overwrite",
+            "fflag_get_wildcard/file1.txt",
+            "fflag_get_wildcard/file2.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set flags only on file1
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_get_wildcard/test.pna",
+            "hidden",
+            "fflag_get_wildcard/file1.txt",
+        ])
+        .assert()
+        .success();
+
+    // Get all flags with wildcard
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_get_wildcard/test.pna",
+            "*",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("file1.txt"))
+        .stdout(predicates::str::contains("hidden"))
+        .stdout(predicates::str::contains("file2.txt").not());
+}

--- a/cli/tests/cli/fflag/get/basic.rs
+++ b/cli/tests/cli/fflag/get/basic.rs
@@ -16,6 +16,7 @@ fn fflag_get_basic() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_get_basic/test.pna",
             "--overwrite",
             "fflag_get_basic/testfile.txt",
@@ -68,6 +69,7 @@ fn fflag_get_no_flags() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_get_no_flags/test.pna",
             "--overwrite",
             "fflag_get_no_flags/testfile.txt",
@@ -106,6 +108,7 @@ fn fflag_get_wildcard() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_get_wildcard/test.pna",
             "--overwrite",
             "fflag_get_wildcard/file1.txt",

--- a/cli/tests/cli/fflag/get/missing_file.rs
+++ b/cli/tests/cli/fflag/get/missing_file.rs
@@ -1,0 +1,57 @@
+use crate::utils::setup;
+use assert_cmd::cargo::cargo_bin_cmd;
+
+/// Precondition: Archive file does not exist.
+/// Action: Run `pna experimental fflag get` on non-existent archive.
+/// Expectation: Command fails with appropriate error.
+#[test]
+fn fflag_get_missing_archive() {
+    setup();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "nonexistent.pna",
+            "*",
+        ])
+        .assert()
+        .failure();
+}
+
+/// Precondition: Archive exists but entry does not.
+/// Action: Run `pna experimental fflag get` on non-existent entry.
+/// Expectation: Command fails with appropriate error.
+#[test]
+fn fflag_get_missing_entry() {
+    setup();
+    std::fs::create_dir_all("fflag_get_missing_entry").unwrap();
+    std::fs::write("fflag_get_missing_entry/file.txt", "content").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_get_missing_entry/test.pna",
+            "--overwrite",
+            "fflag_get_missing_entry/file.txt",
+        ])
+        .assert()
+        .success();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_get_missing_entry/test.pna",
+            "nonexistent.txt",
+        ])
+        .assert()
+        .failure();
+}

--- a/cli/tests/cli/fflag/get/missing_file.rs
+++ b/cli/tests/cli/fflag/get/missing_file.rs
@@ -35,6 +35,7 @@ fn fflag_get_missing_entry() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_get_missing_entry/test.pna",
             "--overwrite",
             "fflag_get_missing_entry/file.txt",

--- a/cli/tests/cli/fflag/get/option_dump.rs
+++ b/cli/tests/cli/fflag/get/option_dump.rs
@@ -1,0 +1,96 @@
+use crate::utils::setup;
+use assert_cmd::cargo::cargo_bin_cmd;
+use std::fs;
+
+/// Precondition: An archive with entries that have file flags set.
+/// Action: Run `pna experimental fflag get --dump` to output restorable format.
+/// Expectation: Output is in the format `# file: path\nflags=flag1,flag2`.
+#[test]
+fn fflag_get_dump_format() {
+    setup();
+    fs::create_dir_all("fflag_get_dump").unwrap();
+
+    fs::write("fflag_get_dump/testfile.txt", "test content").unwrap();
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_get_dump/test.pna",
+            "--overwrite",
+            "fflag_get_dump/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set multiple flags
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_get_dump/test.pna",
+            "uchg,nodump,hidden",
+            "fflag_get_dump/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Get with dump format
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_get_dump/test.pna",
+            "--dump",
+            "*",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains(
+            "# file: fflag_get_dump/testfile.txt",
+        ))
+        .stdout(predicates::str::contains("flags="));
+}
+
+/// Precondition: An archive with entries that have no flags.
+/// Action: Run `pna experimental fflag get --dump`.
+/// Expectation: Output shows file header with empty flags.
+#[test]
+fn fflag_get_dump_empty_flags() {
+    setup();
+    fs::create_dir_all("fflag_get_dump_empty").unwrap();
+
+    fs::write("fflag_get_dump_empty/testfile.txt", "test content").unwrap();
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_get_dump_empty/test.pna",
+            "--overwrite",
+            "fflag_get_dump_empty/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Get with dump format - should show file with empty flags
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_get_dump_empty/test.pna",
+            "--dump",
+            "*",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("# file:"))
+        .stdout(predicates::str::contains("flags="));
+}

--- a/cli/tests/cli/fflag/get/option_dump.rs
+++ b/cli/tests/cli/fflag/get/option_dump.rs
@@ -15,6 +15,7 @@ fn fflag_get_dump_format() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_get_dump/test.pna",
             "--overwrite",
             "fflag_get_dump/testfile.txt",
@@ -70,6 +71,7 @@ fn fflag_get_dump_empty_flags() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_get_dump_empty/test.pna",
             "--overwrite",
             "fflag_get_dump_empty/testfile.txt",

--- a/cli/tests/cli/fflag/get/option_long.rs
+++ b/cli/tests/cli/fflag/get/option_long.rs
@@ -1,0 +1,134 @@
+use crate::utils::setup;
+use assert_cmd::cargo::cargo_bin_cmd;
+use std::fs;
+
+/// Precondition: An archive with entries that have file flags set.
+/// Action: Run `pna experimental fflag get --long` to get verbose output.
+/// Expectation: Output includes detailed information about flags.
+#[test]
+fn fflag_get_long_format() {
+    setup();
+    fs::create_dir_all("fflag_get_long").unwrap();
+
+    fs::write("fflag_get_long/testfile.txt", "test content").unwrap();
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_get_long/test.pna",
+            "--overwrite",
+            "fflag_get_long/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set flags
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_get_long/test.pna",
+            "uchg,nodump",
+            "fflag_get_long/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Get with long format
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_get_long/test.pna",
+            "--long",
+            "fflag_get_long/testfile.txt",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("fflag_get_long/testfile.txt"))
+        .stdout(predicates::str::contains("nodump"))
+        .stdout(predicates::str::contains("uchg"));
+}
+
+/// Precondition: An archive with multiple entries having different flags.
+/// Action: Run `pna experimental fflag get --long *` to list all flags.
+/// Expectation: All entries with flags are displayed with paths.
+#[test]
+fn fflag_get_long_multiple_entries() {
+    setup();
+    fs::create_dir_all("fflag_get_long_multi").unwrap();
+
+    fs::write("fflag_get_long_multi/file1.txt", "content 1").unwrap();
+    fs::write("fflag_get_long_multi/file2.txt", "content 2").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_get_long_multi/test.pna",
+            "--overwrite",
+            "fflag_get_long_multi/file1.txt",
+            "fflag_get_long_multi/file2.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set different flags on different files
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_get_long_multi/test.pna",
+            "uchg",
+            "fflag_get_long_multi/file1.txt",
+        ])
+        .assert()
+        .success();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_get_long_multi/test.pna",
+            "hidden",
+            "fflag_get_long_multi/file2.txt",
+        ])
+        .assert()
+        .success();
+
+    // Get with long format for all
+    let output = cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_get_long_multi/test.pna",
+            "--long",
+            "*",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let output_str = String::from_utf8_lossy(&output);
+    assert!(output_str.contains("file1.txt"));
+    assert!(output_str.contains("uchg"));
+    assert!(output_str.contains("file2.txt"));
+    assert!(output_str.contains("hidden"));
+}

--- a/cli/tests/cli/fflag/get/option_long.rs
+++ b/cli/tests/cli/fflag/get/option_long.rs
@@ -15,6 +15,7 @@ fn fflag_get_long_format() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_get_long/test.pna",
             "--overwrite",
             "fflag_get_long/testfile.txt",
@@ -71,6 +72,7 @@ fn fflag_get_long_multiple_entries() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_get_long_multi/test.pna",
             "--overwrite",
             "fflag_get_long_multi/file1.txt",

--- a/cli/tests/cli/fflag/get/option_match.rs
+++ b/cli/tests/cli/fflag/get/option_match.rs
@@ -1,0 +1,130 @@
+use crate::utils::setup;
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::PredicateBooleanExt;
+use std::fs;
+
+/// Precondition: An archive with entries that have different flags.
+/// Action: Run `pna experimental fflag get --match` to filter by flag name.
+/// Expectation: Only entries with matching flags are displayed.
+#[test]
+fn fflag_get_match_single_flag() {
+    setup();
+    fs::create_dir_all("fflag_get_match").unwrap();
+
+    fs::write("fflag_get_match/file1.txt", "content 1").unwrap();
+    fs::write("fflag_get_match/file2.txt", "content 2").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_get_match/test.pna",
+            "--overwrite",
+            "fflag_get_match/file1.txt",
+            "fflag_get_match/file2.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set uchg on file1
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_get_match/test.pna",
+            "uchg",
+            "fflag_get_match/file1.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set hidden on file2
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_get_match/test.pna",
+            "hidden",
+            "fflag_get_match/file2.txt",
+        ])
+        .assert()
+        .success();
+
+    // Match only uchg
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_get_match/test.pna",
+            "--match",
+            "uchg",
+            "*",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("file1.txt"))
+        .stdout(predicates::str::contains("file2.txt").not());
+}
+
+/// Precondition: An archive with entries that have multiple flags.
+/// Action: Run `pna experimental fflag get --match` with multiple flags.
+/// Expectation: Entries matching any of the flags are displayed.
+#[test]
+fn fflag_get_match_no_matches() {
+    setup();
+    fs::create_dir_all("fflag_get_match_none").unwrap();
+
+    fs::write("fflag_get_match_none/file.txt", "content").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_get_match_none/test.pna",
+            "--overwrite",
+            "fflag_get_match_none/file.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set uchg
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_get_match_none/test.pna",
+            "uchg",
+            "fflag_get_match_none/file.txt",
+        ])
+        .assert()
+        .success();
+
+    // Match nodump - should find no entries
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_get_match_none/test.pna",
+            "--match",
+            "nodump",
+            "*",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::is_empty());
+}

--- a/cli/tests/cli/fflag/get/option_match.rs
+++ b/cli/tests/cli/fflag/get/option_match.rs
@@ -18,6 +18,7 @@ fn fflag_get_match_single_flag() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_get_match/test.pna",
             "--overwrite",
             "fflag_get_match/file1.txt",
@@ -89,6 +90,7 @@ fn fflag_get_match_no_matches() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_get_match_none/test.pna",
             "--overwrite",
             "fflag_get_match_none/file.txt",

--- a/cli/tests/cli/fflag/get/option_name.rs
+++ b/cli/tests/cli/fflag/get/option_name.rs
@@ -1,0 +1,130 @@
+use crate::utils::setup;
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::PredicateBooleanExt;
+use std::fs;
+
+/// Precondition: An archive with entries that have multiple flags set.
+/// Action: Run `pna experimental fflag get --name <flag>` to filter by flag name.
+/// Expectation: Only entries with that specific flag are shown.
+#[test]
+fn fflag_get_filter_by_name() {
+    setup();
+    fs::create_dir_all("fflag_get_filter_name").unwrap();
+
+    fs::write("fflag_get_filter_name/file1.txt", "content 1").unwrap();
+    fs::write("fflag_get_filter_name/file2.txt", "content 2").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_get_filter_name/test.pna",
+            "--overwrite",
+            "fflag_get_filter_name/file1.txt",
+            "fflag_get_filter_name/file2.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set uchg on file1
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_get_filter_name/test.pna",
+            "uchg",
+            "fflag_get_filter_name/file1.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set nodump on file2
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_get_filter_name/test.pna",
+            "nodump",
+            "fflag_get_filter_name/file2.txt",
+        ])
+        .assert()
+        .success();
+
+    // Filter by name "uchg" - should only show file1
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_get_filter_name/test.pna",
+            "--name",
+            "uchg",
+            "*",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("file1.txt"))
+        .stdout(predicates::str::contains("uchg"))
+        .stdout(predicates::str::contains("file2.txt").not());
+}
+
+/// Precondition: An archive with entries that have flags.
+/// Action: Run `pna experimental fflag get --name <flag>` with no matching entries.
+/// Expectation: Empty output.
+#[test]
+fn fflag_get_filter_by_name_no_match() {
+    setup();
+    fs::create_dir_all("fflag_get_filter_name_empty").unwrap();
+
+    fs::write("fflag_get_filter_name_empty/testfile.txt", "test content").unwrap();
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_get_filter_name_empty/test.pna",
+            "--overwrite",
+            "fflag_get_filter_name_empty/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set nodump
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_get_filter_name_empty/test.pna",
+            "nodump",
+            "fflag_get_filter_name_empty/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Filter by name "uchg" - no entries have this flag
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_get_filter_name_empty/test.pna",
+            "--name",
+            "uchg",
+            "*",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::is_empty());
+}

--- a/cli/tests/cli/fflag/get/option_name.rs
+++ b/cli/tests/cli/fflag/get/option_name.rs
@@ -18,6 +18,7 @@ fn fflag_get_filter_by_name() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_get_filter_name/test.pna",
             "--overwrite",
             "fflag_get_filter_name/file1.txt",
@@ -89,6 +90,7 @@ fn fflag_get_filter_by_name_no_match() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_get_filter_name_empty/test.pna",
             "--overwrite",
             "fflag_get_filter_name_empty/testfile.txt",

--- a/cli/tests/cli/fflag/set.rs
+++ b/cli/tests/cli/fflag/set.rs
@@ -1,0 +1,8 @@
+mod basic;
+mod chflags_style;
+mod clear_flags;
+mod missing_file;
+mod mixed_operations;
+mod multiple_entries;
+#[cfg(not(target_family = "wasm"))]
+mod option_restore;

--- a/cli/tests/cli/fflag/set/basic.rs
+++ b/cli/tests/cli/fflag/set/basic.rs
@@ -1,0 +1,174 @@
+use crate::utils::setup;
+use assert_cmd::cargo::cargo_bin_cmd;
+use std::fs;
+
+/// Precondition: An archive with entries.
+/// Action: Run `pna experimental fflag set` to set flags on an entry.
+/// Expectation: Flags are stored in the archive.
+#[test]
+fn fflag_set_basic() {
+    setup();
+    fs::create_dir_all("fflag_set_basic").unwrap();
+
+    fs::write("fflag_set_basic/testfile.txt", "test content").unwrap();
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_set_basic/test.pna",
+            "--overwrite",
+            "fflag_set_basic/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set a single flag
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_set_basic/test.pna",
+            "uchg",
+            "fflag_set_basic/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Verify flag is set
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_set_basic/test.pna",
+            "fflag_set_basic/testfile.txt",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("uchg"));
+}
+
+/// Precondition: An archive with entries.
+/// Action: Set multiple flags with comma-separated values.
+/// Expectation: All specified flags are stored.
+#[test]
+fn fflag_set_multiple_flags() {
+    setup();
+    fs::create_dir_all("fflag_set_multi").unwrap();
+
+    fs::write("fflag_set_multi/testfile.txt", "test content").unwrap();
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_set_multi/test.pna",
+            "--overwrite",
+            "fflag_set_multi/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set multiple flags at once
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_set_multi/test.pna",
+            "uchg,nodump,hidden",
+            "fflag_set_multi/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Verify all flags are set
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_set_multi/test.pna",
+            "fflag_set_multi/testfile.txt",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("uchg"))
+        .stdout(predicates::str::contains("nodump"))
+        .stdout(predicates::str::contains("hidden"));
+}
+
+/// Precondition: An archive entry already has flags.
+/// Action: Set additional flags.
+/// Expectation: New flags are added, existing flags remain.
+#[test]
+fn fflag_set_additive() {
+    setup();
+    fs::create_dir_all("fflag_set_additive").unwrap();
+
+    fs::write("fflag_set_additive/testfile.txt", "test content").unwrap();
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_set_additive/test.pna",
+            "--overwrite",
+            "fflag_set_additive/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set first flag
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_set_additive/test.pna",
+            "uchg",
+            "fflag_set_additive/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set another flag
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_set_additive/test.pna",
+            "nodump",
+            "fflag_set_additive/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Verify both flags are present
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_set_additive/test.pna",
+            "fflag_set_additive/testfile.txt",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("uchg"))
+        .stdout(predicates::str::contains("nodump"));
+}

--- a/cli/tests/cli/fflag/set/basic.rs
+++ b/cli/tests/cli/fflag/set/basic.rs
@@ -15,6 +15,7 @@ fn fflag_set_basic() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_set_basic/test.pna",
             "--overwrite",
             "fflag_set_basic/testfile.txt",
@@ -66,6 +67,7 @@ fn fflag_set_multiple_flags() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_set_multi/test.pna",
             "--overwrite",
             "fflag_set_multi/testfile.txt",
@@ -119,6 +121,7 @@ fn fflag_set_additive() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_set_additive/test.pna",
             "--overwrite",
             "fflag_set_additive/testfile.txt",

--- a/cli/tests/cli/fflag/set/chflags_style.rs
+++ b/cli/tests/cli/fflag/set/chflags_style.rs
@@ -1,0 +1,188 @@
+use crate::utils::setup;
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::PredicateBooleanExt;
+use std::fs;
+
+/// Precondition: An archive with entries.
+/// Action: Use chflags-style flag syntax like "uchg" and "nouchg".
+/// Expectation: Flags are correctly set and cleared based on syntax.
+#[test]
+fn fflag_set_chflags_style_set() {
+    setup();
+    fs::create_dir_all("fflag_chflags_set").unwrap();
+
+    fs::write("fflag_chflags_set/testfile.txt", "test content").unwrap();
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_chflags_set/test.pna",
+            "--overwrite",
+            "fflag_chflags_set/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set flag using chflags-style syntax
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_chflags_set/test.pna",
+            "uchg",
+            "fflag_chflags_set/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Verify flag is set
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_chflags_set/test.pna",
+            "fflag_chflags_set/testfile.txt",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("uchg"));
+}
+
+/// Precondition: An archive with entry having flags set.
+/// Action: Use "no" prefix to clear a flag (e.g., "nouchg").
+/// Expectation: Flag is removed from the entry.
+#[test]
+fn fflag_set_chflags_style_clear() {
+    setup();
+    fs::create_dir_all("fflag_chflags_clear").unwrap();
+
+    fs::write("fflag_chflags_clear/testfile.txt", "test content").unwrap();
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_chflags_clear/test.pna",
+            "--overwrite",
+            "fflag_chflags_clear/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set multiple flags
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_chflags_clear/test.pna",
+            "uchg,nodump",
+            "fflag_chflags_clear/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Clear uchg using "nouchg"
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_chflags_clear/test.pna",
+            "nouchg",
+            "fflag_chflags_clear/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Verify uchg is cleared but nodump remains
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_chflags_clear/test.pna",
+            "fflag_chflags_clear/testfile.txt",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("uchg").not())
+        .stdout(predicates::str::contains("nodump"));
+}
+
+/// Precondition: nodump flag uses special syntax "dump" to clear.
+/// Action: Use "dump" to clear nodump flag.
+/// Expectation: nodump flag is removed.
+#[test]
+fn fflag_set_dump_clears_nodump() {
+    setup();
+    fs::create_dir_all("fflag_dump_clear").unwrap();
+
+    fs::write("fflag_dump_clear/testfile.txt", "test content").unwrap();
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_dump_clear/test.pna",
+            "--overwrite",
+            "fflag_dump_clear/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set nodump flag
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_dump_clear/test.pna",
+            "nodump",
+            "fflag_dump_clear/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Clear using "dump"
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_dump_clear/test.pna",
+            "dump",
+            "fflag_dump_clear/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Verify nodump is cleared
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_dump_clear/test.pna",
+            "fflag_dump_clear/testfile.txt",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("nodump").not());
+}

--- a/cli/tests/cli/fflag/set/chflags_style.rs
+++ b/cli/tests/cli/fflag/set/chflags_style.rs
@@ -16,6 +16,7 @@ fn fflag_set_chflags_style_set() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_chflags_set/test.pna",
             "--overwrite",
             "fflag_chflags_set/testfile.txt",
@@ -67,6 +68,7 @@ fn fflag_set_chflags_style_clear() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_chflags_clear/test.pna",
             "--overwrite",
             "fflag_chflags_clear/testfile.txt",
@@ -134,6 +136,7 @@ fn fflag_set_dump_clears_nodump() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_dump_clear/test.pna",
             "--overwrite",
             "fflag_dump_clear/testfile.txt",

--- a/cli/tests/cli/fflag/set/clear_flags.rs
+++ b/cli/tests/cli/fflag/set/clear_flags.rs
@@ -1,0 +1,175 @@
+use crate::utils::setup;
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::PredicateBooleanExt;
+use std::fs;
+
+/// Precondition: An archive entry with multiple flags.
+/// Action: Clear all flags by setting empty or using no-prefixes.
+/// Expectation: All specified flags are cleared.
+#[test]
+fn fflag_clear_single_flag() {
+    setup();
+    fs::create_dir_all("fflag_clear_single").unwrap();
+
+    fs::write("fflag_clear_single/testfile.txt", "test content").unwrap();
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_clear_single/test.pna",
+            "--overwrite",
+            "fflag_clear_single/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set flags
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_clear_single/test.pna",
+            "uchg,hidden",
+            "fflag_clear_single/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Clear single flag
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_clear_single/test.pna",
+            "nouchg",
+            "fflag_clear_single/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Verify only hidden remains
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_clear_single/test.pna",
+            "fflag_clear_single/testfile.txt",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("uchg").not())
+        .stdout(predicates::str::contains("hidden"));
+}
+
+/// Precondition: An archive entry with multiple flags.
+/// Action: Clear multiple flags at once.
+/// Expectation: All specified flags are cleared.
+#[test]
+fn fflag_clear_multiple_flags() {
+    setup();
+    fs::create_dir_all("fflag_clear_multi").unwrap();
+
+    fs::write("fflag_clear_multi/testfile.txt", "test content").unwrap();
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_clear_multi/test.pna",
+            "--overwrite",
+            "fflag_clear_multi/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set flags
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_clear_multi/test.pna",
+            "uchg,nodump,hidden",
+            "fflag_clear_multi/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Clear multiple flags
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_clear_multi/test.pna",
+            "nouchg,nohidden",
+            "fflag_clear_multi/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Verify only nodump remains
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_clear_multi/test.pna",
+            "fflag_clear_multi/testfile.txt",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("uchg").not())
+        .stdout(predicates::str::contains("hidden").not())
+        .stdout(predicates::str::contains("nodump"));
+}
+
+/// Precondition: An archive entry.
+/// Action: Try to clear a flag that's not set.
+/// Expectation: Command succeeds (no-op).
+#[test]
+fn fflag_clear_nonexistent_flag() {
+    setup();
+    fs::create_dir_all("fflag_clear_nonexistent").unwrap();
+
+    fs::write("fflag_clear_nonexistent/testfile.txt", "test content").unwrap();
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_clear_nonexistent/test.pna",
+            "--overwrite",
+            "fflag_clear_nonexistent/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Try to clear a flag that doesn't exist
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_clear_nonexistent/test.pna",
+            "nouchg",
+            "fflag_clear_nonexistent/testfile.txt",
+        ])
+        .assert()
+        .success();
+}

--- a/cli/tests/cli/fflag/set/clear_flags.rs
+++ b/cli/tests/cli/fflag/set/clear_flags.rs
@@ -16,6 +16,7 @@ fn fflag_clear_single_flag() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_clear_single/test.pna",
             "--overwrite",
             "fflag_clear_single/testfile.txt",
@@ -83,6 +84,7 @@ fn fflag_clear_multiple_flags() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_clear_multi/test.pna",
             "--overwrite",
             "fflag_clear_multi/testfile.txt",
@@ -151,6 +153,7 @@ fn fflag_clear_nonexistent_flag() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_clear_nonexistent/test.pna",
             "--overwrite",
             "fflag_clear_nonexistent/testfile.txt",

--- a/cli/tests/cli/fflag/set/missing_file.rs
+++ b/cli/tests/cli/fflag/set/missing_file.rs
@@ -1,0 +1,59 @@
+use crate::utils::setup;
+use assert_cmd::cargo::cargo_bin_cmd;
+
+/// Precondition: Archive file does not exist.
+/// Action: Run `pna experimental fflag set` on non-existent archive.
+/// Expectation: Command fails with appropriate error.
+#[test]
+fn fflag_set_missing_archive() {
+    setup();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "nonexistent.pna",
+            "uchg",
+            "somefile.txt",
+        ])
+        .assert()
+        .failure();
+}
+
+/// Precondition: Archive exists but entry does not.
+/// Action: Run `pna experimental fflag set` on non-existent entry.
+/// Expectation: Command fails with appropriate error.
+#[test]
+fn fflag_set_missing_entry() {
+    setup();
+    std::fs::create_dir_all("fflag_set_missing_entry").unwrap();
+    std::fs::write("fflag_set_missing_entry/file.txt", "content").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_set_missing_entry/test.pna",
+            "--overwrite",
+            "fflag_set_missing_entry/file.txt",
+        ])
+        .assert()
+        .success();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_set_missing_entry/test.pna",
+            "uchg",
+            "nonexistent.txt",
+        ])
+        .assert()
+        .failure();
+}

--- a/cli/tests/cli/fflag/set/missing_file.rs
+++ b/cli/tests/cli/fflag/set/missing_file.rs
@@ -36,6 +36,7 @@ fn fflag_set_missing_entry() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_set_missing_entry/test.pna",
             "--overwrite",
             "fflag_set_missing_entry/file.txt",

--- a/cli/tests/cli/fflag/set/mixed_operations.rs
+++ b/cli/tests/cli/fflag/set/mixed_operations.rs
@@ -1,0 +1,176 @@
+use crate::utils::setup;
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::PredicateBooleanExt;
+use std::fs;
+
+/// Precondition: An archive with entry having some flags.
+/// Action: Set and clear flags in the same command.
+/// Expectation: Both set and clear operations are applied.
+#[test]
+fn fflag_set_and_clear_in_one_command() {
+    setup();
+    fs::create_dir_all("fflag_mixed_ops").unwrap();
+
+    fs::write("fflag_mixed_ops/testfile.txt", "test content").unwrap();
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_mixed_ops/test.pna",
+            "--overwrite",
+            "fflag_mixed_ops/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set initial flags
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_mixed_ops/test.pna",
+            "uchg,hidden",
+            "fflag_mixed_ops/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Mixed operation: clear uchg, set nodump
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_mixed_ops/test.pna",
+            "nouchg,nodump",
+            "fflag_mixed_ops/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Verify: uchg cleared, hidden unchanged, nodump added
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_mixed_ops/test.pna",
+            "fflag_mixed_ops/testfile.txt",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("uchg").not())
+        .stdout(predicates::str::contains("hidden"))
+        .stdout(predicates::str::contains("nodump"));
+}
+
+/// Precondition: An archive entry.
+/// Action: Set a flag, then toggle it using no-prefix in same invocation.
+/// Expectation: Final state depends on processing order.
+#[test]
+fn fflag_set_same_flag_twice() {
+    setup();
+    fs::create_dir_all("fflag_same_twice").unwrap();
+
+    fs::write("fflag_same_twice/testfile.txt", "test content").unwrap();
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_same_twice/test.pna",
+            "--overwrite",
+            "fflag_same_twice/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set the same flag twice (should be idempotent)
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_same_twice/test.pna",
+            "uchg,uchg",
+            "fflag_same_twice/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Verify flag is set
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_same_twice/test.pna",
+            "fflag_same_twice/testfile.txt",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("uchg"));
+}
+
+/// Precondition: An archive entry with mixed flag operations.
+/// Action: Set and clear the same flag in one command.
+/// Expectation: Set operations take precedence over clear operations
+///              (implementation applies clears first, then sets).
+#[test]
+fn fflag_set_then_clear_same_flag() {
+    setup();
+    fs::create_dir_all("fflag_set_clear_same").unwrap();
+
+    fs::write("fflag_set_clear_same/testfile.txt", "test content").unwrap();
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_set_clear_same/test.pna",
+            "--overwrite",
+            "fflag_set_clear_same/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set then clear in same command - set takes precedence
+    // (implementation applies clears first, then sets)
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_set_clear_same/test.pna",
+            "uchg,nouchg",
+            "fflag_set_clear_same/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Verify flag is set (set takes precedence over clear)
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_set_clear_same/test.pna",
+            "fflag_set_clear_same/testfile.txt",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("uchg"));
+}

--- a/cli/tests/cli/fflag/set/mixed_operations.rs
+++ b/cli/tests/cli/fflag/set/mixed_operations.rs
@@ -16,6 +16,7 @@ fn fflag_set_and_clear_in_one_command() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_mixed_ops/test.pna",
             "--overwrite",
             "fflag_mixed_ops/testfile.txt",
@@ -84,6 +85,7 @@ fn fflag_set_same_flag_twice() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_same_twice/test.pna",
             "--overwrite",
             "fflag_same_twice/testfile.txt",
@@ -136,6 +138,7 @@ fn fflag_set_then_clear_same_flag() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_set_clear_same/test.pna",
             "--overwrite",
             "fflag_set_clear_same/testfile.txt",

--- a/cli/tests/cli/fflag/set/multiple_entries.rs
+++ b/cli/tests/cli/fflag/set/multiple_entries.rs
@@ -1,0 +1,217 @@
+use crate::utils::setup;
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::PredicateBooleanExt;
+use std::fs;
+
+/// Precondition: An archive with multiple entries.
+/// Action: Set flags on multiple entries using glob pattern.
+/// Expectation: All matching entries get the flags.
+#[test]
+fn fflag_set_multiple_entries_glob() {
+    setup();
+    fs::create_dir_all("fflag_set_glob").unwrap();
+
+    fs::write("fflag_set_glob/file1.txt", "content 1").unwrap();
+    fs::write("fflag_set_glob/file2.txt", "content 2").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_set_glob/test.pna",
+            "--overwrite",
+            "fflag_set_glob/file1.txt",
+            "fflag_set_glob/file2.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set flags on all entries using glob
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_set_glob/test.pna",
+            "nodump",
+            "*",
+        ])
+        .assert()
+        .success();
+
+    // Verify both entries have the flag
+    let output = cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_set_glob/test.pna",
+            "--long",
+            "*",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let output_str = String::from_utf8_lossy(&output);
+    assert!(output_str.contains("file1.txt"));
+    assert!(output_str.contains("file2.txt"));
+    assert!(output_str.matches("nodump").count() >= 2);
+}
+
+/// Precondition: An archive with multiple entries.
+/// Action: Set different flags on different entries.
+/// Expectation: Each entry has its own flags.
+#[test]
+fn fflag_set_different_flags_per_entry() {
+    setup();
+    fs::create_dir_all("fflag_set_different").unwrap();
+
+    fs::write("fflag_set_different/file1.txt", "content 1").unwrap();
+    fs::write("fflag_set_different/file2.txt", "content 2").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_set_different/test.pna",
+            "--overwrite",
+            "fflag_set_different/file1.txt",
+            "fflag_set_different/file2.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set uchg on file1
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_set_different/test.pna",
+            "uchg",
+            "fflag_set_different/file1.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set hidden on file2
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_set_different/test.pna",
+            "hidden",
+            "fflag_set_different/file2.txt",
+        ])
+        .assert()
+        .success();
+
+    // Verify file1 has uchg
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_set_different/test.pna",
+            "fflag_set_different/file1.txt",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("uchg"))
+        .stdout(predicates::str::contains("hidden").not());
+
+    // Verify file2 has hidden
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_set_different/test.pna",
+            "fflag_set_different/file2.txt",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("hidden"))
+        .stdout(predicates::str::contains("uchg").not());
+}
+
+/// Precondition: An archive with multiple entries.
+/// Action: Set flags on specific entries by name.
+/// Expectation: Only named entries are modified.
+#[test]
+fn fflag_set_specific_entries_only() {
+    setup();
+    fs::create_dir_all("fflag_set_specific").unwrap();
+
+    fs::write("fflag_set_specific/file1.txt", "content 1").unwrap();
+    fs::write("fflag_set_specific/file2.txt", "content 2").unwrap();
+    fs::write("fflag_set_specific/file3.txt", "content 3").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_set_specific/test.pna",
+            "--overwrite",
+            "fflag_set_specific/file1.txt",
+            "fflag_set_specific/file2.txt",
+            "fflag_set_specific/file3.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set flag on file1 and file3 only
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_set_specific/test.pna",
+            "nodump",
+            "fflag_set_specific/file1.txt",
+            "fflag_set_specific/file3.txt",
+        ])
+        .assert()
+        .success();
+
+    // Get all flags
+    let output = cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_set_specific/test.pna",
+            "--long",
+            "*",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let output_str = String::from_utf8_lossy(&output);
+    assert!(output_str.contains("file1.txt"));
+    assert!(!output_str.contains("file2.txt")); // file2 should not appear (no flags)
+    assert!(output_str.contains("file3.txt"));
+}

--- a/cli/tests/cli/fflag/set/multiple_entries.rs
+++ b/cli/tests/cli/fflag/set/multiple_entries.rs
@@ -18,6 +18,7 @@ fn fflag_set_multiple_entries_glob() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_set_glob/test.pna",
             "--overwrite",
             "fflag_set_glob/file1.txt",
@@ -80,6 +81,7 @@ fn fflag_set_different_flags_per_entry() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_set_different/test.pna",
             "--overwrite",
             "fflag_set_different/file1.txt",
@@ -167,6 +169,7 @@ fn fflag_set_specific_entries_only() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_set_specific/test.pna",
             "--overwrite",
             "fflag_set_specific/file1.txt",

--- a/cli/tests/cli/fflag/set/option_restore.rs
+++ b/cli/tests/cli/fflag/set/option_restore.rs
@@ -1,0 +1,222 @@
+use crate::utils::setup;
+use assert_cmd::cargo::cargo_bin_cmd;
+use std::fs;
+use std::io::Write;
+
+/// Precondition: A dump file with flags for multiple entries.
+/// Action: Run `pna experimental fflag set --restore` to restore flags.
+/// Expectation: Flags are restored from the dump file.
+#[test]
+fn fflag_set_restore_from_dump() {
+    setup();
+    fs::create_dir_all("fflag_restore").unwrap();
+
+    fs::write("fflag_restore/file1.txt", "content 1").unwrap();
+    fs::write("fflag_restore/file2.txt", "content 2").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_restore/test.pna",
+            "--overwrite",
+            "fflag_restore/file1.txt",
+            "fflag_restore/file2.txt",
+        ])
+        .assert()
+        .success();
+
+    // Create a dump file
+    let dump_content = "# file: fflag_restore/file1.txt\nflags=uchg,nodump\n\n# file: fflag_restore/file2.txt\nflags=hidden\n";
+    fs::write("fflag_restore/flags.dump", dump_content).unwrap();
+
+    // Restore from dump
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_restore/test.pna",
+            "--restore",
+            "fflag_restore/flags.dump",
+        ])
+        .assert()
+        .success();
+
+    // Verify file1 has uchg and nodump
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_restore/test.pna",
+            "fflag_restore/file1.txt",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("uchg"))
+        .stdout(predicates::str::contains("nodump"));
+
+    // Verify file2 has hidden
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_restore/test.pna",
+            "fflag_restore/file2.txt",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("hidden"));
+}
+
+/// Precondition: An archive with flags set.
+/// Action: Dump flags and restore them to another archive.
+/// Expectation: Round-trip preserves flags exactly.
+#[test]
+fn fflag_dump_and_restore_roundtrip() {
+    setup();
+    fs::create_dir_all("fflag_roundtrip").unwrap();
+
+    fs::write("fflag_roundtrip/testfile.txt", "test content").unwrap();
+
+    // Create source archive
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_roundtrip/source.pna",
+            "--overwrite",
+            "fflag_roundtrip/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Set flags on source
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_roundtrip/source.pna",
+            "uchg,nodump,hidden",
+            "fflag_roundtrip/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Dump flags to file
+    let output = cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_roundtrip/source.pna",
+            "--dump",
+            "*",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let mut dump_file = fs::File::create("fflag_roundtrip/flags.dump").unwrap();
+    dump_file.write_all(&output).unwrap();
+
+    // Create target archive
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_roundtrip/target.pna",
+            "--overwrite",
+            "fflag_roundtrip/testfile.txt",
+        ])
+        .assert()
+        .success();
+
+    // Restore flags to target
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_roundtrip/target.pna",
+            "--restore",
+            "fflag_roundtrip/flags.dump",
+        ])
+        .assert()
+        .success();
+
+    // Verify target has same flags as source
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "get",
+            "-f",
+            "fflag_roundtrip/target.pna",
+            "fflag_roundtrip/testfile.txt",
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("uchg"))
+        .stdout(predicates::str::contains("nodump"))
+        .stdout(predicates::str::contains("hidden"));
+}
+
+/// Precondition: A dump file with flags for an entry that doesn't exist.
+/// Action: Run `pna experimental fflag set --restore`.
+/// Expectation: Command succeeds silently ignoring missing entries.
+#[test]
+fn fflag_restore_missing_entry() {
+    setup();
+    fs::create_dir_all("fflag_restore_missing").unwrap();
+
+    fs::write("fflag_restore_missing/file.txt", "content").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "fflag_restore_missing/test.pna",
+            "--overwrite",
+            "fflag_restore_missing/file.txt",
+        ])
+        .assert()
+        .success();
+
+    // Create dump file referencing non-existent entry
+    let dump_content = "# file: nonexistent.txt\nflags=uchg\n";
+    fs::write("fflag_restore_missing/flags.dump", dump_content).unwrap();
+
+    // Restore succeeds but silently ignores missing entries
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "fflag",
+            "set",
+            "-f",
+            "fflag_restore_missing/test.pna",
+            "--restore",
+            "fflag_restore_missing/flags.dump",
+        ])
+        .assert()
+        .success();
+}

--- a/cli/tests/cli/fflag/set/option_restore.rs
+++ b/cli/tests/cli/fflag/set/option_restore.rs
@@ -18,6 +18,7 @@ fn fflag_set_restore_from_dump() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_restore/test.pna",
             "--overwrite",
             "fflag_restore/file1.txt",
@@ -92,6 +93,7 @@ fn fflag_dump_and_restore_roundtrip() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_roundtrip/source.pna",
             "--overwrite",
             "fflag_roundtrip/testfile.txt",
@@ -140,6 +142,7 @@ fn fflag_dump_and_restore_roundtrip() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_roundtrip/target.pna",
             "--overwrite",
             "fflag_roundtrip/testfile.txt",
@@ -194,6 +197,7 @@ fn fflag_restore_missing_entry() {
         .args([
             "--quiet",
             "c",
+            "-f",
             "fflag_restore_missing/test.pna",
             "--overwrite",
             "fflag_restore_missing/file.txt",

--- a/cli/tests/cli/main.rs
+++ b/cli/tests/cli/main.rs
@@ -19,6 +19,7 @@ mod delete;
 mod diff;
 mod encrypt;
 mod extract;
+mod fflag;
 mod hardlink;
 mod keep_acl;
 mod keep_all;

--- a/cli/tests/cli/main.rs
+++ b/cli/tests/cli/main.rs
@@ -19,6 +19,7 @@ mod delete;
 mod diff;
 mod encrypt;
 mod extract;
+#[cfg(not(target_family = "wasm"))]
 mod fflag;
 mod hardlink;
 mod keep_acl;

--- a/cli/tests/cli/main.rs
+++ b/cli/tests/cli/main.rs
@@ -19,6 +19,7 @@ mod delete;
 mod diff;
 mod encrypt;
 mod extract;
+#[cfg(not(target_family = "wasm"))]
 mod fflag;
 mod flag_pairs;
 mod hardlink;

--- a/cli/tests/cli/main.rs
+++ b/cli/tests/cli/main.rs
@@ -19,6 +19,7 @@ mod delete;
 mod diff;
 mod encrypt;
 mod extract;
+mod fflag;
 mod flag_pairs;
 mod hardlink;
 mod keep_acl;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental "fflag" CLI to view and modify per-entry file flags in archives; includes wired `get` and `set` subcommands with dump, long, name/regex filtering, chflags-style ops, glob targets, and restore-from-dump support.

* **Tests**
  * Added extensive integration tests covering get/set behaviors, formats, filtering, clearing, mixed operations, restore roundtrips, and compatibility (non-WASM).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->