### PR TITLE
Ci/add riscv runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - ubuntu-24.04-riscv

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,3 +5,6 @@ paths:
   ".github/workflows/*.lock.yml":
     ignore:
       - ".*"
+self-hosted-runner:
+  labels:
+    - ubuntu-24.04-riscv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
           - stable
           - beta
           - nightly
-    timeout-minutes: 60
+    timeout-minutes: ${{ contains(matrix.os, 'riscv') && 120 || 60 }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: git autocrlf false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
         os:
           - ubuntu-latest
           - ubuntu-22.04-arm # TODO: use ubuntu-24.04-arm if https://github.com/rust-lang/rust/issues/135867 resolved
+          - ubuntu-24.04-riscv
           - windows-latest
           - windows-11-arm
           - macos-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,10 +88,12 @@ jobs:
           key: "${{ matrix.os }}-${{ steps.install_rust.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}"
           restore-keys: "${{ matrix.os }}-${{ steps.install_rust.outputs.version }}"
       - name: run test
+        shell: bash
         run: |
-          cargo hack test --locked --release --feature-powerset --exclude-features wasm --exclude portable-network-archive-fuzz --exclude xtask -- --test-threads=1
+          cargo hack test --locked --release --feature-powerset --exclude-features "$EXCLUDE_FEATURES" --exclude portable-network-archive-fuzz --exclude xtask -- --test-threads=1
         env:
           RUST_BACKTRACE: 1
+          EXCLUDE_FEATURES: ${{ contains(matrix.os, 'riscv') && 'wasm,zlib-ng' || 'wasm' }}
       - name: Save rust build cache
         if: github.ref_name == github.event.repository.default_branch && steps.restore-rust-build-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt update
-          sudo apt install -y libacl1-dev
+          sudo apt install -y cmake libacl1-dev
       - name: Install Rustup
         if: ${{ matrix.os == 'windows-11-arm' }}
         shell: pwsh
@@ -191,7 +191,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt update
-          sudo apt install -y libacl1-dev
+          sudo apt install -y cmake libacl1-dev
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt update
-          sudo apt install -y libacl1-dev
+          sudo apt install -y cmake libacl1-dev
       - name: Install Rustup
         if: ${{ matrix.os == 'windows-11-arm' }}
         shell: pwsh
@@ -192,7 +192,7 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt update
-          sudo apt install -y libacl1-dev
+          sudo apt install -y cmake libacl1-dev
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,10 +88,12 @@ jobs:
           key: "${{ matrix.os }}-${{ steps.install_rust.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}"
           restore-keys: "${{ matrix.os }}-${{ steps.install_rust.outputs.version }}"
       - name: run test
+        shell: bash
         run: |
-          cargo hack test --locked --release --feature-powerset --exclude-features wasm --exclude portable-network-archive-fuzz --exclude xtask -- --test-threads=1
+          cargo hack test --locked --release --feature-powerset --exclude-features "$EXCLUDE_FEATURES" --exclude portable-network-archive-fuzz --exclude xtask -- --test-threads=1
         env:
           RUST_BACKTRACE: 1
+          EXCLUDE_FEATURES: ${{ contains(matrix.os, 'riscv') && 'wasm,zlib-ng' || 'wasm' }}
       - name: Save rust build cache
         if: github.ref_name == github.event.repository.default_branch && matrix.rust == 'stable' && steps.restore-rust-build-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added lint configuration to recognize a self-hosted runner label for validation.
  * Expanded workflow triggers to monitor additional CI/configuration files so updates to tooling configs run linters.
  * Expanded the CI test matrix with a new Ubuntu RISC‑V runner and conditional job timeout for RISC‑V jobs.
  * Updated CI setup to install extra build tooling and made feature-exclusion configurable per runner type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->