### PR TITLE
Cli/bsdtar/positional cd

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -2,7 +2,7 @@ mod old_style;
 pub mod value;
 
 #[doc(hidden)]
-pub use old_style::{expand_bsdtar_old_style_args, expand_bsdtar_w_option};
+pub use old_style::{encode_bsdtar_cd_args, expand_bsdtar_old_style_args, expand_bsdtar_w_option};
 
 use crate::{
     command::{

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1,6 +1,7 @@
 mod old_style;
 pub mod value;
 
+pub(crate) use old_style::CD_SENTINEL;
 #[doc(hidden)]
 pub use old_style::{encode_bsdtar_cd_args, expand_bsdtar_old_style_args, expand_bsdtar_w_option};
 

--- a/cli/src/cli/old_style.rs
+++ b/cli/src/cli/old_style.rs
@@ -10,7 +10,7 @@ pub(crate) const CD_SENTINEL: &str = "\0CD\0";
 /// it never takes an argument. (In new-style mode, clap handles the optional
 /// compression level via `Option<Option<XzLevel>>`.)
 /// Kept in sync with `BsdtarCommand` clap definition via unit test.
-const SHORT_OPTIONS_WITH_ARG: &[char] = &['b', 'C', 'f', 'I', 's', 'T', 'W', 'X'];
+const SHORT_OPTIONS_WITH_ARG: &[char] = &['b', 'f', 'I', 's', 'T', 'W', 'X'];
 
 /// Global long options that take a space-separated value.
 /// `--flag=value` form is already a single token and needs no special handling.

--- a/cli/src/cli/old_style.rs
+++ b/cli/src/cli/old_style.rs
@@ -165,6 +165,13 @@ fn split_w_option(arg: &OsStr) -> Option<(Option<&OsStr>, Option<&OsStr>)> {
 ///
 /// Returns `args` unchanged when the bsdtar subcommand is not detected.
 pub fn encode_bsdtar_cd_args(args: Vec<OsString>) -> Vec<OsString> {
+    fn make_cd_sentinel(value: &std::ffi::OsStr) -> OsString {
+        let mut s = OsString::with_capacity(CD_SENTINEL.len() + value.len());
+        s.push(CD_SENTINEL);
+        s.push(value);
+        s
+    }
+
     let Some(after_subcommand) = find_bsdtar_subcommand(&args) else {
         return args;
     };
@@ -189,25 +196,23 @@ pub fn encode_bsdtar_cd_args(args: Vec<OsString>) -> Vec<OsString> {
 
         // `--cd=value` or `--directory=value`
         if let Some(rest) = bytes.strip_prefix(b"--cd=") {
-            let mut sentinel = OsString::from(CD_SENTINEL);
             // SAFETY: rest comes from valid OsString bytes after stripping an ASCII prefix
-            sentinel.push(unsafe { std::ffi::OsStr::from_encoded_bytes_unchecked(rest) });
-            result.push(sentinel);
+            result.push(make_cd_sentinel(unsafe {
+                std::ffi::OsStr::from_encoded_bytes_unchecked(rest)
+            }));
             continue;
         }
         if let Some(rest) = bytes.strip_prefix(b"--directory=") {
-            let mut sentinel = OsString::from(CD_SENTINEL);
-            sentinel.push(unsafe { std::ffi::OsStr::from_encoded_bytes_unchecked(rest) });
-            result.push(sentinel);
+            result.push(make_cd_sentinel(unsafe {
+                std::ffi::OsStr::from_encoded_bytes_unchecked(rest)
+            }));
             continue;
         }
 
         // `--cd dir` or `--directory dir`
         if arg == "--cd" || arg == "--directory" {
             if let Some(value) = iter.next() {
-                let mut sentinel = OsString::from(CD_SENTINEL);
-                sentinel.push(value);
-                result.push(sentinel);
+                result.push(make_cd_sentinel(value));
             } else {
                 // Trailing `--cd` with no value — pass through for clap to report an error
                 result.push(arg.clone());
@@ -218,9 +223,7 @@ pub fn encode_bsdtar_cd_args(args: Vec<OsString>) -> Vec<OsString> {
         // `-C dir` (exactly `-C`)
         if arg == "-C" {
             if let Some(value) = iter.next() {
-                let mut sentinel = OsString::from(CD_SENTINEL);
-                sentinel.push(value);
-                result.push(sentinel);
+                result.push(make_cd_sentinel(value));
             } else {
                 result.push(arg.clone());
             }
@@ -232,9 +235,9 @@ pub fn encode_bsdtar_cd_args(args: Vec<OsString>) -> Vec<OsString> {
             && !rest.is_empty()
             && !rest.starts_with(b"-")
         {
-            let mut sentinel = OsString::from(CD_SENTINEL);
-            sentinel.push(unsafe { std::ffi::OsStr::from_encoded_bytes_unchecked(rest) });
-            result.push(sentinel);
+            result.push(make_cd_sentinel(unsafe {
+                std::ffi::OsStr::from_encoded_bytes_unchecked(rest)
+            }));
             continue;
         }
 

--- a/cli/src/cli/old_style.rs
+++ b/cli/src/cli/old_style.rs
@@ -149,7 +149,7 @@ fn split_w_option(arg: &OsStr) -> Option<(Option<&OsStr>, Option<&OsStr>)> {
 }
 
 /// Encodes `-C`/`--cd`/`--directory` arguments into sentinel-prefixed positional tokens
-/// for the `compat bsdtar` subcommand (and the deprecated `experimental stdio` subcommand).
+/// for the `compat bsdtar` subcommand.
 ///
 /// This converts directory-change options into `\0CD\0{dir}` tokens so that
 /// later processing stages can treat them as positional arguments that carry
@@ -326,10 +326,11 @@ mod tests {
     #[test]
     fn experimental_stdio_passthrough() {
         // The removed `experimental stdio` sequence is not a bsdtar subcommand;
-        // both helpers leave it untouched so clap rejects it as unknown.
+        // the helpers leave it untouched so clap rejects it as unknown.
         let args = s(&["pna", "experimental", "stdio", "cvf", "archive.pna"]);
         assert_eq!(expand_bsdtar_old_style_args(args.clone()), args);
         assert_eq!(expand_bsdtar_w_option(args.clone()), args);
+        assert_eq!(encode_bsdtar_cd_args(args.clone()), args);
     }
 
     #[test]
@@ -1294,16 +1295,6 @@ mod tests {
         let args = s(&["pna", "create", "-C", "dir", "file"]);
         let result = encode_bsdtar_cd_args(args);
         assert_eq!(result, s(&["pna", "create", "-C", "dir", "file"]));
-    }
-
-    #[test]
-    fn encode_cd_experimental_stdio() {
-        let args = s(&["pna", "experimental", "stdio", "-C", "dir", "file"]);
-        let result = encode_bsdtar_cd_args(args);
-        assert_eq!(
-            result,
-            s(&["pna", "experimental", "stdio", "\0CD\0dir", "file"]),
-        );
     }
 
     #[test]

--- a/cli/src/cli/old_style.rs
+++ b/cli/src/cli/old_style.rs
@@ -1,5 +1,11 @@
 use std::ffi::{OsStr, OsString};
 
+/// Sentinel prefix for encoded `-C`/`--cd`/`--directory` arguments.
+///
+/// NUL bytes cannot appear in file paths, so this prefix unambiguously marks
+/// a positional directory-change argument produced by [`encode_bsdtar_cd_args`].
+pub(crate) const CD_SENTINEL: &str = "\0CD\0";
+
 /// `-J` is excluded from `SHORT_OPTIONS_WITH_ARG` because in bsdtar old-style syntax
 /// it never takes an argument. (In new-style mode, clap handles the optional
 /// compression level via `Option<Option<XzLevel>>`.)
@@ -138,6 +144,102 @@ fn split_w_option(arg: &OsStr) -> Option<(Option<&OsStr>, Option<&OsStr>)> {
         }
     }
     None
+}
+
+/// Encodes `-C`/`--cd`/`--directory` arguments into sentinel-prefixed positional tokens
+/// for the `compat bsdtar` subcommand (and the deprecated `experimental stdio` subcommand).
+///
+/// This converts directory-change options into `\0CD\0{dir}` tokens so that
+/// later processing stages can treat them as positional arguments that carry
+/// their directory value inline.
+///
+/// Recognized forms (after the bsdtar subcommand position):
+/// - `-C dir` (separate tokens)
+/// - `-Cdir` (concatenated short form)
+/// - `--cd dir` / `--directory dir` (long form with separate value)
+/// - `--cd=dir` / `--directory=dir` (long form with `=`)
+///
+/// Arguments after `--` are never encoded.
+///
+/// Returns `args` unchanged when the bsdtar subcommand is not detected.
+pub fn encode_bsdtar_cd_args(args: Vec<OsString>) -> Vec<OsString> {
+    let Some(after_subcommand) = find_bsdtar_subcommand(&args) else {
+        return args;
+    };
+
+    let mut result = args[..after_subcommand].to_vec();
+    let mut iter = args[after_subcommand..].iter();
+    let mut past_double_dash = false;
+
+    while let Some(arg) = iter.next() {
+        if past_double_dash {
+            result.push(arg.clone());
+            continue;
+        }
+
+        if arg == "--" {
+            past_double_dash = true;
+            result.push(arg.clone());
+            continue;
+        }
+
+        let bytes = arg.as_encoded_bytes();
+
+        // `--cd=value` or `--directory=value`
+        if let Some(rest) = bytes.strip_prefix(b"--cd=") {
+            let mut sentinel = OsString::from(CD_SENTINEL);
+            // SAFETY: rest comes from valid OsString bytes after stripping an ASCII prefix
+            sentinel.push(unsafe { std::ffi::OsStr::from_encoded_bytes_unchecked(rest) });
+            result.push(sentinel);
+            continue;
+        }
+        if let Some(rest) = bytes.strip_prefix(b"--directory=") {
+            let mut sentinel = OsString::from(CD_SENTINEL);
+            sentinel.push(unsafe { std::ffi::OsStr::from_encoded_bytes_unchecked(rest) });
+            result.push(sentinel);
+            continue;
+        }
+
+        // `--cd dir` or `--directory dir`
+        if arg == "--cd" || arg == "--directory" {
+            if let Some(value) = iter.next() {
+                let mut sentinel = OsString::from(CD_SENTINEL);
+                sentinel.push(value);
+                result.push(sentinel);
+            } else {
+                // Trailing `--cd` with no value — pass through for clap to report an error
+                result.push(arg.clone());
+            }
+            continue;
+        }
+
+        // `-C dir` (exactly `-C`)
+        if arg == "-C" {
+            if let Some(value) = iter.next() {
+                let mut sentinel = OsString::from(CD_SENTINEL);
+                sentinel.push(value);
+                result.push(sentinel);
+            } else {
+                result.push(arg.clone());
+            }
+            continue;
+        }
+
+        // `-Cdir` (concatenated short form)
+        if let Some(rest) = bytes.strip_prefix(b"-C")
+            && !rest.is_empty()
+            && !rest.starts_with(b"-")
+        {
+            let mut sentinel = OsString::from(CD_SENTINEL);
+            sentinel.push(unsafe { std::ffi::OsStr::from_encoded_bytes_unchecked(rest) });
+            result.push(sentinel);
+            continue;
+        }
+
+        result.push(arg.clone());
+    }
+
+    result
 }
 
 /// Skips leading flags (consuming values for known global options like
@@ -1113,5 +1215,98 @@ mod tests {
     fn compat_bsdtar_w_option_after_double_dash_passthrough() {
         let args = s(&["pna", "compat", "bsdtar", "-x", "--", "-W", "file"]);
         assert_eq!(expand_bsdtar_w_option(args.clone()), args);
+    }
+
+    #[test]
+    fn encode_cd_separate_form() {
+        let args = s(&[
+            "pna", "compat", "bsdtar", "-c", "-f", "out", "-C", "dir", "file",
+        ]);
+        let result = encode_bsdtar_cd_args(args);
+        assert_eq!(
+            result,
+            s(&[
+                "pna",
+                "compat",
+                "bsdtar",
+                "-c",
+                "-f",
+                "out",
+                "\0CD\0dir",
+                "file"
+            ]),
+        );
+    }
+
+    #[test]
+    fn encode_cd_concatenated_form() {
+        let args = s(&["pna", "compat", "bsdtar", "-c", "-Cdir", "file"]);
+        let result = encode_bsdtar_cd_args(args);
+        assert_eq!(
+            result,
+            s(&["pna", "compat", "bsdtar", "-c", "\0CD\0dir", "file"]),
+        );
+    }
+
+    #[test]
+    fn encode_cd_long_form() {
+        let args = s(&["pna", "compat", "bsdtar", "--cd", "dir", "file"]);
+        let result = encode_bsdtar_cd_args(args);
+        assert_eq!(result, s(&["pna", "compat", "bsdtar", "\0CD\0dir", "file"]),);
+    }
+
+    #[test]
+    fn encode_cd_long_eq_form() {
+        let args = s(&["pna", "compat", "bsdtar", "--directory=dir", "file"]);
+        let result = encode_bsdtar_cd_args(args);
+        assert_eq!(result, s(&["pna", "compat", "bsdtar", "\0CD\0dir", "file"]),);
+    }
+
+    #[test]
+    fn encode_cd_multiple() {
+        let args = s(&[
+            "pna", "compat", "bsdtar", "-C", "d1", "f1", "-C", "d2", "f2",
+        ]);
+        let result = encode_bsdtar_cd_args(args);
+        assert_eq!(
+            result,
+            s(&[
+                "pna", "compat", "bsdtar", "\0CD\0d1", "f1", "\0CD\0d2", "f2"
+            ]),
+        );
+    }
+
+    #[test]
+    fn encode_cd_after_double_dash() {
+        let args = s(&["pna", "compat", "bsdtar", "--", "-C", "dir"]);
+        let result = encode_bsdtar_cd_args(args);
+        assert_eq!(result, s(&["pna", "compat", "bsdtar", "--", "-C", "dir"]),);
+    }
+
+    #[test]
+    fn encode_cd_not_bsdtar() {
+        let args = s(&["pna", "create", "-C", "dir", "file"]);
+        let result = encode_bsdtar_cd_args(args);
+        assert_eq!(result, s(&["pna", "create", "-C", "dir", "file"]));
+    }
+
+    #[test]
+    fn encode_cd_experimental_stdio() {
+        let args = s(&["pna", "experimental", "stdio", "-C", "dir", "file"]);
+        let result = encode_bsdtar_cd_args(args);
+        assert_eq!(
+            result,
+            s(&["pna", "experimental", "stdio", "\0CD\0dir", "file"]),
+        );
+    }
+
+    #[test]
+    fn encode_cd_with_unstable_flag() {
+        let args = s(&["pna", "compat", "bsdtar", "--unstable", "-C", "dir", "file"]);
+        let result = encode_bsdtar_cd_args(args);
+        assert_eq!(
+            result,
+            s(&["pna", "compat", "bsdtar", "--unstable", "\0CD\0dir", "file"]),
+        );
     }
 }

--- a/cli/src/cli/old_style.rs
+++ b/cli/src/cli/old_style.rs
@@ -9,8 +9,10 @@ pub(crate) const CD_SENTINEL: &str = "\0CD\0";
 /// `-J` is excluded from `SHORT_OPTIONS_WITH_ARG` because in bsdtar old-style syntax
 /// it never takes an argument. (In new-style mode, clap handles the optional
 /// compression level via `Option<Option<XzLevel>>`.)
+/// `-C` and `-W` are listed here for old-style expansion but are consumed by
+/// `encode_bsdtar_cd_args` / `expand_bsdtar_w_option` before clap sees them.
 /// Kept in sync with `BsdtarCommand` clap definition via unit test.
-const SHORT_OPTIONS_WITH_ARG: &[char] = &['b', 'f', 'I', 's', 'T', 'W', 'X'];
+const SHORT_OPTIONS_WITH_ARG: &[char] = &['b', 'C', 'f', 'I', 's', 'T', 'W', 'X'];
 
 /// Global long options that take a space-separated value.
 /// `--flag=value` form is already a single token and needs no special handling.
@@ -612,11 +614,12 @@ mod tests {
             .collect();
         clap_arg_shorts.sort();
         clap_arg_shorts.dedup();
-        // `W` is handled by expand_bsdtar_w_option preprocessing, not by clap
+        // `C` and `W` are handled by preprocessing (encode_bsdtar_cd_args /
+        // expand_bsdtar_w_option), not by clap
         let mut expected: Vec<char> = SHORT_OPTIONS_WITH_ARG
             .iter()
             .copied()
-            .filter(|&c| c != 'W')
+            .filter(|&c| c != 'C' && c != 'W')
             .collect();
         expected.sort();
         assert_eq!(

--- a/cli/src/cli/old_style.rs
+++ b/cli/src/cli/old_style.rs
@@ -1312,4 +1312,26 @@ mod tests {
             s(&["pna", "compat", "bsdtar", "--unstable", "\0CD\0dir", "file"]),
         );
     }
+
+    #[test]
+    fn encode_cd_after_old_style_c_cf_expansion() {
+        // Simulates output of expand_bsdtar_old_style_args for "cCf dir archive file"
+        let args = s(&[
+            "pna", "compat", "bsdtar", "-c", "-C", "dir", "-f", "archive", "file",
+        ]);
+        let result = encode_bsdtar_cd_args(args);
+        assert_eq!(
+            result,
+            s(&[
+                "pna",
+                "compat",
+                "bsdtar",
+                "-c",
+                "\0CD\0dir",
+                "-f",
+                "archive",
+                "file",
+            ]),
+        );
+    }
 }

--- a/cli/src/command/bsdtar.rs
+++ b/cli/src/command/bsdtar.rs
@@ -883,7 +883,6 @@ fn run_create_archive(args: BsdtarCommand) -> anyhow::Result<()> {
         missing_mtime: MissingTimePolicy::Include,
     }
     .resolve()?;
-    files = utils::expand_bsdtar_windows_globs(files)?;
     let sources = ItemSource::parse_many(&files);
     validate_no_duplicate_stdin(&sources)?;
     let collect_options = CollectOptions {
@@ -1336,7 +1335,6 @@ fn run_append(args: BsdtarCommand) -> anyhow::Result<()> {
         missing_mtime: MissingTimePolicy::Include,
     }
     .resolve()?;
-    files = utils::expand_bsdtar_windows_globs(files)?;
     let sources = ItemSource::parse_many(&files);
     validate_no_duplicate_stdin(&sources)?;
     let collect_options = CollectOptions {
@@ -1499,7 +1497,6 @@ fn run_update(args: BsdtarCommand) -> anyhow::Result<()> {
         exclude.iter().map(|s| s.as_str()).chain(vcs_patterns),
     );
 
-    files = utils::expand_bsdtar_windows_globs(files)?;
     let sources = ItemSource::parse_many(&files);
     validate_no_duplicate_stdin(&sources)?;
     let time_filters = TimeFilterResolver {

--- a/cli/src/command/bsdtar.rs
+++ b/cli/src/command/bsdtar.rs
@@ -8,9 +8,9 @@ use crate::{
         append::{open_archive_then_seek_to_end, run_append_archive},
         ask_password,
         core::{
-            AclStrategy, CollectOptions, CreateOptions, FflagsStrategy, ItemSource, KeepOptions,
-            MacMetadataStrategy, ModeStrategy, OwnerOptions, OwnerStrategy, PathFilter,
-            PathTransformers, PathnameEditor, SplitArchiveReader, StagedArchive,
+            AclStrategy, CollectOptions, CollectedItem, CreateOptions, FflagsStrategy, ItemSource,
+            KeepOptions, MacMetadataStrategy, ModeStrategy, OwnerOptions, OwnerStrategy,
+            PathFilter, PathTransformers, PathnameEditor, SplitArchiveReader, StagedArchive,
             TimeFilterResolver, TimestampStrategyResolver, TransformStrategyUnSolid, Umask,
             XattrStrategy, apply_chroot, collect_items_from_sources, collect_split_archives,
             path_lock::OrderedPathLocks,
@@ -853,7 +853,8 @@ fn run_create_archive(args: BsdtarCommand) -> anyhow::Result<()> {
     if let Some(path) = args.files_from {
         files.extend(read_paths(path, args.null)?);
     }
-    if files.is_empty() {
+    // Check emptiness after filtering out -C sentinel tokens, which are not real inputs
+    if files.iter().all(|f| f.starts_with(crate::cli::CD_SENTINEL)) {
         anyhow::bail!("create mode requires at least one input path or @archive source");
     }
 
@@ -1497,8 +1498,7 @@ fn run_update(args: BsdtarCommand) -> anyhow::Result<()> {
         exclude.iter().map(|s| s.as_str()).chain(vcs_patterns),
     );
 
-    let sources = ItemSource::parse_many(&files);
-    validate_no_duplicate_stdin(&sources)?;
+    let sources = ItemSource::parse_many_no_archives(&files);
     let time_filters = TimeFilterResolver {
         newer_ctime_than: args.newer_ctime_than.as_deref(),
         older_ctime_than: args.older_ctime_than.as_deref(),
@@ -1524,14 +1524,16 @@ fn run_update(args: BsdtarCommand) -> anyhow::Result<()> {
         time_filters: &time_filters,
     };
     let mut resolver = HardlinkResolver::new(collect_options.follow_links);
-    let collected = collect_items_from_sources(sources, &collect_options, &mut resolver)?;
-    let target_items = collected
-        .into_iter()
-        .filter_map(|item| match item {
-            crate::command::core::CollectedItem::Filesystem(entry) => Some(entry),
-            crate::command::core::CollectedItem::ArchiveMarker(_) => None,
-        })
-        .collect();
+    let target_items: Vec<_> =
+        collect_items_from_sources(sources, &collect_options, &mut resolver)?
+            .into_iter()
+            .filter_map(|item| match item {
+                CollectedItem::Filesystem(entry) => Some(entry),
+                // ChangeDir is consumed inline; no ArchiveMarker is produced
+                // because parse_many_no_archives treats @ as filesystem paths.
+                CollectedItem::ArchiveMarker(_) => None,
+            })
+            .collect();
 
     let archives = collect_split_archives(&archive_path)?;
 

--- a/cli/src/command/bsdtar.rs
+++ b/cli/src/command/bsdtar.rs
@@ -12,8 +12,7 @@ use crate::{
             MacMetadataStrategy, ModeStrategy, OwnerOptions, OwnerStrategy, PathFilter,
             PathTransformers, PathnameEditor, SplitArchiveReader, StagedArchive,
             TimeFilterResolver, TimestampStrategyResolver, TransformStrategyUnSolid, Umask,
-            XattrStrategy, apply_chroot, collect_items_from_paths, collect_items_from_sources,
-            collect_split_archives,
+            XattrStrategy, apply_chroot, collect_items_from_sources, collect_split_archives,
             path_lock::OrderedPathLocks,
             re::{bsd::SubstitutionRule, gnu::TransformRule},
             read_paths, run_across_archive, validate_no_duplicate_stdin,
@@ -25,7 +24,9 @@ use crate::{
     },
     utils::{self, BsdGlobMatcher, PathPartExt, VCS_FILES, fs::HardlinkResolver},
 };
+use anyhow::Context;
 use clap::{ArgGroup, Args, Parser, ValueHint};
+use itertools::Itertools;
 use pna::Archive;
 use std::{
     env, io,
@@ -563,15 +564,6 @@ pub(crate) struct BsdtarCommand {
     #[arg(long, help = "Extract files as yourself")]
     no_same_owner: bool,
     #[arg(
-        short = 'C',
-        long = "cd",
-        visible_aliases = ["directory"],
-        value_name = "DIRECTORY",
-        help = "Change directory before adding the following files",
-        value_hint = ValueHint::DirPath
-    )]
-    working_dir: Option<PathBuf>,
-    #[arg(
         short = 'O',
         long = "to-stdout",
         requires = "unstable",
@@ -891,11 +883,7 @@ fn run_create_archive(args: BsdtarCommand) -> anyhow::Result<()> {
         missing_mtime: MissingTimePolicy::Include,
     }
     .resolve()?;
-    if let Some(working_dir) = args.working_dir {
-        env::set_current_dir(working_dir)?;
-    }
     files = utils::expand_bsdtar_windows_globs(files)?;
-    // Parse sources AFTER changing directory so @archive paths are affected by -C
     let sources = ItemSource::parse_many(&files);
     validate_no_duplicate_stdin(&sources)?;
     let collect_options = CollectOptions {
@@ -1121,9 +1109,19 @@ fn run_extract_archive(ctx: &GlobalContext, args: BsdtarCommand) -> anyhow::Resu
     } else {
         None
     };
-    if let Some(working_dir) = args.working_dir {
-        env::set_current_dir(working_dir)?;
+    // Separate -C directory changes from file patterns
+    let (cd_dirs, file_patterns): (Vec<_>, Vec<_>) = files.into_iter().partition_map(|f| {
+        if let Some(dir) = f.strip_prefix(crate::cli::CD_SENTINEL) {
+            itertools::Either::Left(PathBuf::from(dir))
+        } else {
+            itertools::Either::Right(f)
+        }
+    });
+    for dir in &cd_dirs {
+        env::set_current_dir(dir)
+            .with_context(|| format!("changing directory to {}", dir.display()))?;
     }
+    let files = file_patterns;
     apply_chroot(args.chroot)?;
     if let Some(archives) = archives {
         run_extract_archive_reader(
@@ -1195,7 +1193,12 @@ fn run_list_archive(args: BsdtarCommand) -> anyhow::Result<()> {
             LineEnding::Lf
         },
     };
-    let files_globs = BsdGlobMatcher::new(args.files.iter().map(|it| it.as_str()))
+    let files: Vec<_> = args
+        .files
+        .into_iter()
+        .filter(|f| !f.starts_with(crate::cli::CD_SENTINEL))
+        .collect();
+    let files_globs = BsdGlobMatcher::new(files.iter().map(|it| it.as_str()))
         .with_no_recursive(args.no_recursive);
 
     let mut exclude = args.exclude;
@@ -1333,11 +1336,7 @@ fn run_append(args: BsdtarCommand) -> anyhow::Result<()> {
         missing_mtime: MissingTimePolicy::Include,
     }
     .resolve()?;
-    if let Some(working_dir) = args.working_dir {
-        env::set_current_dir(working_dir)?;
-    }
     files = utils::expand_bsdtar_windows_globs(files)?;
-    // Parse sources AFTER changing directory so @archive paths are affected by -C
     let sources = ItemSource::parse_many(&files);
     validate_no_duplicate_stdin(&sources)?;
     let collect_options = CollectOptions {
@@ -1500,10 +1499,9 @@ fn run_update(args: BsdtarCommand) -> anyhow::Result<()> {
         exclude.iter().map(|s| s.as_str()).chain(vcs_patterns),
     );
 
-    if let Some(working_dir) = args.working_dir {
-        env::set_current_dir(working_dir)?;
-    }
     files = utils::expand_bsdtar_windows_globs(files)?;
+    let sources = ItemSource::parse_many(&files);
+    validate_no_duplicate_stdin(&sources)?;
     let time_filters = TimeFilterResolver {
         newer_ctime_than: args.newer_ctime_than.as_deref(),
         older_ctime_than: args.older_ctime_than.as_deref(),
@@ -1529,7 +1527,14 @@ fn run_update(args: BsdtarCommand) -> anyhow::Result<()> {
         time_filters: &time_filters,
     };
     let mut resolver = HardlinkResolver::new(collect_options.follow_links);
-    let target_items = collect_items_from_paths(&files, &collect_options, &mut resolver)?;
+    let collected = collect_items_from_sources(sources, &collect_options, &mut resolver)?;
+    let target_items = collected
+        .into_iter()
+        .filter_map(|item| match item {
+            crate::command::core::CollectedItem::Filesystem(entry) => Some(entry),
+            crate::command::core::CollectedItem::ArchiveMarker(_) => None,
+        })
+        .collect();
 
     let archives = collect_split_archives(&archive_path)?;
 

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -580,13 +580,21 @@ pub(crate) fn collect_items_from_sources(
                     .map_err(|e| io::Error::new(e.kind(), format!("{}: {}", dir.display(), e)))?;
             }
             ItemSource::Filesystem(path) => {
-                let expanded = crate::utils::expand_bsdtar_windows_globs(vec![
-                    path.to_string_lossy().into_owned(),
-                ])
-                .map_err(|e| io::Error::other(e.to_string()))?;
-                for p in expanded {
-                    let items =
-                        collect_items_with_state(Path::new(&p), options, hardlink_resolver)?;
+                #[cfg(windows)]
+                {
+                    let expanded = crate::utils::expand_bsdtar_windows_globs(vec![
+                        path.to_string_lossy().into_owned(),
+                    ])
+                    .map_err(|e| io::Error::other(format!("{e:#}")))?;
+                    for p in expanded {
+                        let items =
+                            collect_items_with_state(Path::new(&p), options, hardlink_resolver)?;
+                        results.extend(items.into_iter().map(CollectedItem::Filesystem));
+                    }
+                }
+                #[cfg(not(windows))]
+                {
+                    let items = collect_items_with_state(&path, options, hardlink_resolver)?;
                     results.extend(items.into_iter().map(CollectedItem::Filesystem));
                 }
             }

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -398,11 +398,14 @@ pub(crate) enum ItemSource {
     Filesystem(PathBuf),
     /// An archive to include entries from.
     Archive(ArchiveSource),
+    /// A directory change instruction encoded by the pre-processing step.
+    ChangeDir(PathBuf),
 }
 
 impl ItemSource {
     /// Parses a single CLI argument into an `ItemSource`.
     ///
+    /// - `\0CD\0path` → `ChangeDir(path)` (internal sentinel from `-C` pre-processing)
     /// - `@` or `@-` → `Archive(Stdin)`
     /// - `@path` → `Archive(File(path))`
     /// - `path` → `Filesystem(path)`
@@ -413,7 +416,9 @@ impl ItemSource {
     /// relative to the current working directory at the time they are accessed,
     /// which means they are affected by the -C option.
     pub(crate) fn parse(arg: &str) -> Self {
-        if let Some(archive_path) = arg.strip_prefix('@') {
+        if let Some(dir) = arg.strip_prefix(crate::cli::CD_SENTINEL) {
+            Self::ChangeDir(PathBuf::from(dir))
+        } else if let Some(archive_path) = arg.strip_prefix('@') {
             if archive_path.is_empty() || archive_path == "-" {
                 Self::Archive(ArchiveSource::Stdin)
             } else {
@@ -577,6 +582,7 @@ pub(crate) fn collect_items_from_sources(
             ItemSource::Archive(archive_source) => {
                 results.push(CollectedItem::ArchiveMarker(archive_source));
             }
+            ItemSource::ChangeDir(_dir) => { /* handled in Task 5 */ }
         }
     }
 
@@ -2923,6 +2929,20 @@ mod tests {
         fn validate_no_duplicate_stdin_empty() {
             let sources: Vec<ItemSource> = vec![];
             assert!(super::validate_no_duplicate_stdin(&sources).is_ok());
+        }
+
+        #[test]
+        fn parse_change_dir() {
+            let item = ItemSource::parse("\0CD\0mydir");
+            assert!(matches!(item, ItemSource::ChangeDir(ref p) if p == Path::new("mydir")));
+        }
+
+        #[test]
+        fn parse_change_dir_absolute() {
+            let item = ItemSource::parse("\0CD\0/absolute/dir");
+            assert!(
+                matches!(item, ItemSource::ChangeDir(ref p) if p == Path::new("/absolute/dir"))
+            );
         }
     }
 

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -358,7 +358,6 @@ pub(crate) struct CreateOptions {
 #[derive(Clone, Debug)]
 pub(crate) struct CollectedEntry {
     pub(crate) path: PathBuf,
-    #[expect(dead_code, reason = "will be consumed in a follow-up commit")]
     pub(crate) fs_path: PathBuf,
     pub(crate) store_as: StoreAs,
     pub(crate) metadata: fs::Metadata,
@@ -938,7 +937,7 @@ pub(crate) fn create_entry(
 ) -> io::Result<Option<NormalEntry>> {
     let CollectedEntry {
         path,
-        fs_path: _,
+        fs_path,
         store_as,
         metadata,
     } = item;
@@ -953,38 +952,38 @@ pub(crate) fn create_entry(
                 return Ok(None);
             };
             let mut entry = HardLinkEntryBuilder::new(entry_name, reference)?;
-            entry.metadata(build_entry_metadata(path, keep_options, metadata)?);
-            for chunk in collect_extra_chunks(path, keep_options, metadata)? {
+            entry.metadata(build_entry_metadata(fs_path, keep_options, metadata)?);
+            for chunk in collect_extra_chunks(fs_path, keep_options, metadata)? {
                 entry.add_extra_chunk(chunk);
             }
             entry.build()
         }
         StoreAs::Symlink(link_target_type) => {
-            let source = fs::read_link(path)?;
+            let source = fs::read_link(fs_path)?;
             let reference = pathname_editor.edit_symlink(&source);
             let mut entry = SymlinkEntryBuilder::new(entry_name, reference)?;
             entry.metadata(
-                build_entry_metadata(path, keep_options, metadata)?
+                build_entry_metadata(fs_path, keep_options, metadata)?
                     .with_link_target_type(Some(*link_target_type)),
             );
-            for chunk in collect_extra_chunks(path, keep_options, metadata)? {
+            for chunk in collect_extra_chunks(fs_path, keep_options, metadata)? {
                 entry.add_extra_chunk(chunk);
             }
             entry.build()
         }
         StoreAs::File => {
             let mut entry = FileEntryBuilder::new_with_options(entry_name, option)?;
-            write_from_path(&mut entry, path)?;
-            entry.metadata(build_entry_metadata(path, keep_options, metadata)?);
-            for chunk in collect_extra_chunks(path, keep_options, metadata)? {
+            write_from_path(&mut entry, fs_path)?;
+            entry.metadata(build_entry_metadata(fs_path, keep_options, metadata)?);
+            for chunk in collect_extra_chunks(fs_path, keep_options, metadata)? {
                 entry.add_extra_chunk(chunk);
             }
             entry.build()
         }
         StoreAs::Dir => {
             let mut entry = DirEntryBuilder::new(entry_name);
-            entry.metadata(build_entry_metadata(path, keep_options, metadata)?);
-            for chunk in collect_extra_chunks(path, keep_options, metadata)? {
+            entry.metadata(build_entry_metadata(fs_path, keep_options, metadata)?);
+            for chunk in collect_extra_chunks(fs_path, keep_options, metadata)? {
                 entry.add_extra_chunk(chunk);
             }
             entry.build()

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -357,7 +357,11 @@ pub(crate) struct CreateOptions {
 
 #[derive(Clone, Debug)]
 pub(crate) struct CollectedEntry {
+    /// Relative path used as the archive entry name (as given on the CLI).
     pub(crate) path: PathBuf,
+    /// Absolute filesystem path for reading file data and metadata.
+    /// Captured as `cwd.join(path)` at collection time so it remains valid
+    /// even after subsequent `-C` directory changes.
     pub(crate) fs_path: PathBuf,
     pub(crate) store_as: StoreAs,
     pub(crate) metadata: fs::Metadata,
@@ -581,20 +585,18 @@ pub(crate) fn collect_items_from_sources(
             }
             ItemSource::Filesystem(path) => {
                 #[cfg(windows)]
-                {
-                    let expanded = crate::utils::expand_bsdtar_windows_globs(vec![
-                        path.to_string_lossy().into_owned(),
-                    ])
-                    .map_err(|e| io::Error::other(format!("{e:#}")))?;
-                    for p in expanded {
-                        let items =
-                            collect_items_with_state(Path::new(&p), options, hardlink_resolver)?;
-                        results.extend(items.into_iter().map(CollectedItem::Filesystem));
-                    }
-                }
+                let paths: Vec<PathBuf> = crate::utils::expand_bsdtar_windows_globs(vec![
+                    path.to_string_lossy().into_owned(),
+                ])
+                .map_err(|e| io::Error::other(format!("{e:#}")))?
+                .into_iter()
+                .map(PathBuf::from)
+                .collect();
                 #[cfg(not(windows))]
-                {
-                    let items = collect_items_with_state(&path, options, hardlink_resolver)?;
+                let paths = [path];
+
+                for p in &paths {
+                    let items = collect_items_with_state(p, options, hardlink_resolver)?;
                     results.extend(items.into_iter().map(CollectedItem::Filesystem));
                 }
             }

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -358,6 +358,8 @@ pub(crate) struct CreateOptions {
 #[derive(Clone, Debug)]
 pub(crate) struct CollectedEntry {
     pub(crate) path: PathBuf,
+    #[expect(dead_code, reason = "will be consumed in a follow-up commit")]
+    pub(crate) fs_path: PathBuf,
     pub(crate) store_as: StoreAs,
     pub(crate) metadata: fs::Metadata,
 }
@@ -682,6 +684,7 @@ pub(crate) fn collect_items_with_state(
     options: &CollectOptions<'_>,
     hardlink_resolver: &mut HardlinkResolver,
 ) -> io::Result<Vec<CollectedEntry>> {
+    let cwd = std::env::current_dir()?;
     let mut ig = ignore::Ignore::default();
     let mut out = Vec::new();
 
@@ -794,6 +797,7 @@ pub(crate) fn collect_items_with_state(
                 {
                     out.push(CollectedEntry {
                         path: archive_path.to_path_buf(),
+                        fs_path: cwd.join(entry_path),
                         store_as,
                         metadata,
                     });
@@ -808,6 +812,7 @@ pub(crate) fn collect_items_with_state(
                         let link_target_type = detect_symlink_target_type(path, &metadata)?;
                         out.push(CollectedEntry {
                             path: path.to_path_buf(),
+                            fs_path: cwd.join(path),
                             store_as: StoreAs::Symlink(link_target_type),
                             metadata,
                         });
@@ -933,6 +938,7 @@ pub(crate) fn create_entry(
 ) -> io::Result<Option<NormalEntry>> {
     let CollectedEntry {
         path,
+        fs_path: _,
         store_as,
         metadata,
     } = item;

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -420,9 +420,18 @@ impl ItemSource {
     /// relative to the current working directory at the time they are accessed,
     /// which means they are affected by the -C option.
     pub(crate) fn parse(arg: &str) -> Self {
+        Self::parse_with(arg, true)
+    }
+
+    /// Parses a single CLI argument with control over `@archive` recognition.
+    ///
+    /// When `recognize_archives` is `false`, the `@` prefix is not treated as
+    /// an archive inclusion marker — the argument becomes a filesystem path.
+    /// This is used by modes (e.g., update) that do not support `@archive`.
+    pub(crate) fn parse_with(arg: &str, recognize_archives: bool) -> Self {
         if let Some(dir) = arg.strip_prefix(crate::cli::CD_SENTINEL) {
             Self::ChangeDir(PathBuf::from(dir))
-        } else if let Some(archive_path) = arg.strip_prefix('@') {
+        } else if recognize_archives && let Some(archive_path) = arg.strip_prefix('@') {
             if archive_path.is_empty() || archive_path == "-" {
                 Self::Archive(ArchiveSource::Stdin)
             } else {
@@ -436,6 +445,11 @@ impl ItemSource {
     /// Parses multiple CLI arguments into `ItemSource` values.
     pub(crate) fn parse_many(args: &[String]) -> Vec<Self> {
         args.iter().map(|s| Self::parse(s)).collect()
+    }
+
+    /// Parses multiple CLI arguments without recognizing `@archive` syntax.
+    pub(crate) fn parse_many_no_archives(args: &[String]) -> Vec<Self> {
+        args.iter().map(|s| Self::parse_with(s, false)).collect()
     }
 }
 

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -367,6 +367,27 @@ pub(crate) struct CollectedEntry {
     pub(crate) metadata: fs::Metadata,
 }
 
+impl CollectedEntry {
+    /// `path` is what the entry is stored as; `fs_path` is what filesystem I/O
+    /// reads, resolved against `cwd`. They differ at a walk root, where `path`
+    /// keeps the trailing separator the caller supplied.
+    pub(crate) fn new(
+        path: PathBuf,
+        fs_path: &Path,
+        cwd: &Path,
+        store_as: StoreAs,
+        metadata: fs::Metadata,
+    ) -> Self {
+        let fs_path = cwd.join(fs_path);
+        Self {
+            path,
+            fs_path,
+            store_as,
+            metadata,
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub(crate) enum StoreAs {
     File,
@@ -390,6 +411,15 @@ impl fmt::Display for ArchiveSource {
             Self::Stdin => f.write_str("-"),
         }
     }
+}
+
+/// Controls how `ItemSource::parse_with` interprets the `@` prefix.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ParseMode {
+    /// Recognizes `@path` as archive inclusion and `@-`/`@` as stdin.
+    Full,
+    /// Treats `@` as a literal character — all arguments become filesystem paths.
+    NoArchives,
 }
 
 /// Represents a CLI file argument that can be either a filesystem path or an archive inclusion.
@@ -420,18 +450,20 @@ impl ItemSource {
     /// relative to the current working directory at the time they are accessed,
     /// which means they are affected by the -C option.
     pub(crate) fn parse(arg: &str) -> Self {
-        Self::parse_with(arg, true)
+        Self::parse_with(arg, ParseMode::Full)
     }
 
     /// Parses a single CLI argument with control over `@archive` recognition.
     ///
-    /// When `recognize_archives` is `false`, the `@` prefix is not treated as
-    /// an archive inclusion marker — the argument becomes a filesystem path.
+    /// When `mode` is [`ParseMode::NoArchives`], the `@` prefix is not treated
+    /// as an archive inclusion marker — the argument becomes a filesystem path.
     /// This is used by modes (e.g., update) that do not support `@archive`.
-    pub(crate) fn parse_with(arg: &str, recognize_archives: bool) -> Self {
+    pub(crate) fn parse_with(arg: &str, mode: ParseMode) -> Self {
         if let Some(dir) = arg.strip_prefix(crate::cli::CD_SENTINEL) {
             Self::ChangeDir(PathBuf::from(dir))
-        } else if recognize_archives && let Some(archive_path) = arg.strip_prefix('@') {
+        } else if mode == ParseMode::Full
+            && let Some(archive_path) = arg.strip_prefix('@')
+        {
             if archive_path.is_empty() || archive_path == "-" {
                 Self::Archive(ArchiveSource::Stdin)
             } else {
@@ -449,7 +481,9 @@ impl ItemSource {
 
     /// Parses multiple CLI arguments without recognizing `@archive` syntax.
     pub(crate) fn parse_many_no_archives(args: &[String]) -> Vec<Self> {
-        args.iter().map(|s| Self::parse_with(s, false)).collect()
+        args.iter()
+            .map(|s| Self::parse_with(s, ParseMode::NoArchives))
+            .collect()
     }
 }
 
@@ -842,12 +876,13 @@ pub(crate) fn collect_items_with_state(
                         .time_filters
                         .matches(metadata.created().ok(), metadata.modified().ok())
                 {
-                    out.push(CollectedEntry {
-                        path: archive_path.to_path_buf(),
-                        fs_path: cwd.join(entry_path),
+                    out.push(CollectedEntry::new(
+                        archive_path.to_path_buf(),
+                        entry_path,
+                        &cwd,
                         store_as,
                         metadata,
-                    });
+                    ));
                 }
             }
             Err(e) => {
@@ -857,12 +892,13 @@ pub(crate) fn collect_items_with_state(
                     let metadata = fs::symlink_metadata(path)?;
                     if is_broken_symlink_error(&metadata, ioe) {
                         let link_target_type = detect_symlink_target_type(path, &metadata)?;
-                        out.push(CollectedEntry {
-                            path: path.to_path_buf(),
-                            fs_path: cwd.join(path),
-                            store_as: StoreAs::Symlink(link_target_type),
+                        out.push(CollectedEntry::new(
+                            path.to_path_buf(),
+                            path,
+                            &cwd,
+                            StoreAs::Symlink(link_target_type),
                             metadata,
-                        });
+                        ));
                         continue;
                     }
                 }

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -37,7 +37,7 @@ use pna::{
 use std::{
     borrow::Cow,
     collections::HashMap,
-    fmt, fs,
+    env, fmt, fs,
     io::{self, prelude::*},
     path::{Path, PathBuf},
     time::SystemTime,
@@ -575,14 +575,25 @@ pub(crate) fn collect_items_from_sources(
 
     for source in sources {
         match source {
+            ItemSource::ChangeDir(dir) => {
+                env::set_current_dir(&dir)
+                    .map_err(|e| io::Error::new(e.kind(), format!("{}: {}", dir.display(), e)))?;
+            }
             ItemSource::Filesystem(path) => {
                 let items = collect_items_with_state(&path, options, hardlink_resolver)?;
                 results.extend(items.into_iter().map(CollectedItem::Filesystem));
             }
-            ItemSource::Archive(archive_source) => {
-                results.push(CollectedItem::ArchiveMarker(archive_source));
+            ItemSource::Archive(ArchiveSource::File(path)) => {
+                let abs = if path.is_relative() {
+                    env::current_dir()?.join(&path)
+                } else {
+                    path
+                };
+                results.push(CollectedItem::ArchiveMarker(ArchiveSource::File(abs)));
             }
-            ItemSource::ChangeDir(_dir) => { /* handled in Task 5 */ }
+            ItemSource::Archive(source @ ArchiveSource::Stdin) => {
+                results.push(CollectedItem::ArchiveMarker(source));
+            }
         }
     }
 

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -580,8 +580,15 @@ pub(crate) fn collect_items_from_sources(
                     .map_err(|e| io::Error::new(e.kind(), format!("{}: {}", dir.display(), e)))?;
             }
             ItemSource::Filesystem(path) => {
-                let items = collect_items_with_state(&path, options, hardlink_resolver)?;
-                results.extend(items.into_iter().map(CollectedItem::Filesystem));
+                let expanded = crate::utils::expand_bsdtar_windows_globs(vec![
+                    path.to_string_lossy().into_owned(),
+                ])
+                .map_err(|e| io::Error::other(e.to_string()))?;
+                for p in expanded {
+                    let items =
+                        collect_items_with_state(Path::new(&p), options, hardlink_resolver)?;
+                    results.extend(items.into_iter().map(CollectedItem::Filesystem));
+                }
             }
             ItemSource::Archive(ArchiveSource::File(path)) => {
                 let abs = if path.is_relative() {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,6 +8,7 @@ fn run() -> anyhow::Result<()> {
     let args: Vec<_> = std::env::args_os().collect();
     let args = cli::expand_bsdtar_old_style_args(args);
     let args = cli::expand_bsdtar_w_option(args);
+    let args = cli::encode_bsdtar_cd_args(args);
     let cli = cli::Cli::parse_from(args);
     cli.init_logger()?;
     cli.execute()

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -12,6 +12,7 @@ pub(crate) mod process;
 pub(crate) mod str;
 mod windows_glob;
 
+#[allow(unused_imports)]
 pub(crate) use {globs::*, path::*, windows_glob::*};
 
 /// Version Control System file names.

--- a/cli/src/utils/windows_glob.rs
+++ b/cli/src/utils/windows_glob.rs
@@ -9,6 +9,7 @@ use std::io;
 ///
 /// bsdtar only performs command-line wildcard expansion on Windows. On Unix,
 /// callers are expected to rely on the shell and operands are left untouched.
+#[cfg_attr(not(windows), allow(dead_code))]
 pub(crate) fn expand_bsdtar_windows_globs(paths: Vec<String>) -> anyhow::Result<Vec<String>> {
     #[cfg(windows)]
     {

--- a/cli/tests/cli/bsdtar/option_cd.rs
+++ b/cli/tests/cli/bsdtar/option_cd.rs
@@ -52,7 +52,7 @@ fn bsdtar_create_extract_with_cd() {
 /// Expectation: Result contains both a.txt (from @source) and b.txt (from sub/).
 ///   @source.pna is resolved from original cwd, not from sub/.
 #[test]
-fn stdio_create_archive_inclusion_before_cd() {
+fn bsdtar_create_archive_inclusion_before_cd() {
     setup();
 
     let base = fs::canonicalize(".")
@@ -78,8 +78,8 @@ fn stdio_create_archive_inclusion_before_cd() {
     cargo_bin_cmd!("pna")
         .args([
             "--quiet",
-            "experimental",
-            "stdio",
+            "compat",
+            "bsdtar",
             "--create",
             "--unstable",
             "--overwrite",
@@ -111,7 +111,7 @@ fn stdio_create_archive_inclusion_before_cd() {
 /// Action: Create with `-C d1 f1.txt -C d2 f2.txt` using absolute -C paths.
 /// Expectation: Both files archived with base names only (no directory prefix).
 #[test]
-fn stdio_create_multiple_cd_absolute_paths() {
+fn bsdtar_create_multiple_cd_absolute_paths() {
     setup();
 
     let base = fs::canonicalize(".")
@@ -136,8 +136,8 @@ fn stdio_create_multiple_cd_absolute_paths() {
     cargo_bin_cmd!("pna")
         .args([
             "--quiet",
-            "experimental",
-            "stdio",
+            "compat",
+            "bsdtar",
             "--create",
             "--unstable",
             "--overwrite",
@@ -166,7 +166,7 @@ fn stdio_create_multiple_cd_absolute_paths() {
 /// Action: Create with `-C` changing into different directories for each file group.
 /// Expectation: Each file is archived relative to its -C directory.
 #[test]
-fn stdio_create_cd_does_not_affect_prior_args() {
+fn bsdtar_create_cd_does_not_affect_prior_args() {
     setup();
 
     let base = fs::canonicalize(".").unwrap().join("stdio_cd_ordering");
@@ -189,8 +189,8 @@ fn stdio_create_cd_does_not_affect_prior_args() {
     cargo_bin_cmd!("pna")
         .args([
             "--quiet",
-            "experimental",
-            "stdio",
+            "compat",
+            "bsdtar",
             "--create",
             "--unstable",
             "--overwrite",
@@ -217,7 +217,7 @@ fn stdio_create_cd_does_not_affect_prior_args() {
 /// Action: Create with `-C src @source.pna -C dir extra.txt`.
 /// Expectation: @source.pna resolves from src/ (the active -C), extra.txt resolves from dir/.
 #[test]
-fn stdio_create_cd_affects_archive_inclusion() {
+fn bsdtar_create_cd_affects_archive_inclusion() {
     setup();
 
     let base = fs::canonicalize(".")
@@ -245,8 +245,8 @@ fn stdio_create_cd_affects_archive_inclusion() {
     cargo_bin_cmd!("pna")
         .args([
             "--quiet",
-            "experimental",
-            "stdio",
+            "compat",
+            "bsdtar",
             "--create",
             "--unstable",
             "--overwrite",
@@ -281,7 +281,7 @@ fn stdio_create_cd_affects_archive_inclusion() {
 /// Action: Extract with `-C <target_dir>` to redirect output.
 /// Expectation: Files appear in the target directory with correct content.
 #[test]
-fn stdio_extract_with_cd() {
+fn bsdtar_extract_with_cd() {
     setup();
 
     let base = fs::canonicalize(".").unwrap().join("stdio_extract_with_cd");
@@ -302,8 +302,8 @@ fn stdio_extract_with_cd() {
     cargo_bin_cmd!("pna")
         .args([
             "--quiet",
-            "experimental",
-            "stdio",
+            "compat",
+            "bsdtar",
             "--extract",
             "--unstable",
             "-f",
@@ -323,7 +323,7 @@ fn stdio_extract_with_cd() {
 /// Action: Update archive with `-C <sub> b.txt`.
 /// Expectation: Archive contains both a.txt and b.txt.
 #[test]
-fn stdio_update_with_cd() {
+fn bsdtar_update_with_cd() {
     setup();
 
     let base = fs::canonicalize(".").unwrap().join("stdio_update_with_cd");
@@ -345,8 +345,8 @@ fn stdio_update_with_cd() {
     cargo_bin_cmd!("pna")
         .args([
             "--quiet",
-            "experimental",
-            "stdio",
+            "compat",
+            "bsdtar",
             "--update",
             "--unstable",
             "-f",
@@ -369,7 +369,7 @@ fn stdio_update_with_cd() {
 /// Action: Append to archive with `-C <sub> b.txt`.
 /// Expectation: Archive contains both a.txt and b.txt.
 #[test]
-fn stdio_append_with_cd() {
+fn bsdtar_append_with_cd() {
     setup();
 
     let base = fs::canonicalize(".").unwrap().join("stdio_append_with_cd");
@@ -391,8 +391,8 @@ fn stdio_append_with_cd() {
     cargo_bin_cmd!("pna")
         .args([
             "--quiet",
-            "experimental",
-            "stdio",
+            "compat",
+            "bsdtar",
             "--append",
             "--unstable",
             "-f",

--- a/cli/tests/cli/bsdtar/option_cd.rs
+++ b/cli/tests/cli/bsdtar/option_cd.rs
@@ -276,3 +276,137 @@ fn stdio_create_cd_affects_archive_inclusion() {
     );
     assert_eq!(entry_names.len(), 2);
 }
+
+/// Precondition: An archive contains entries a.txt and b.txt.
+/// Action: Extract with `-C <target_dir>` to redirect output.
+/// Expectation: Files appear in the target directory with correct content.
+#[test]
+fn stdio_extract_with_cd() {
+    setup();
+
+    let base = fs::canonicalize(".").unwrap().join("stdio_extract_with_cd");
+    if base.exists() {
+        fs::remove_dir_all(&base).unwrap();
+    }
+    fs::create_dir_all(&base).unwrap();
+
+    // Create archive with two entries
+    let archive = base.join("test.pna");
+    create_test_archive(&archive, &[("a.txt", "alpha"), ("b.txt", "beta")]);
+
+    // Create target extraction directory
+    let target = base.join("out");
+    fs::create_dir_all(&target).unwrap();
+
+    // Extract with -C pointing to target directory
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "stdio",
+            "--extract",
+            "--unstable",
+            "-f",
+            archive.to_str().unwrap(),
+            "-C",
+            target.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    // Verify files landed in the target directory
+    assert_eq!(fs::read_to_string(target.join("a.txt")).unwrap(), "alpha");
+    assert_eq!(fs::read_to_string(target.join("b.txt")).unwrap(), "beta");
+}
+
+/// Precondition: Archive contains a.txt. Directory sub/ contains b.txt.
+/// Action: Update archive with `-C <sub> b.txt`.
+/// Expectation: Archive contains both a.txt and b.txt.
+#[test]
+fn stdio_update_with_cd() {
+    setup();
+
+    let base = fs::canonicalize(".").unwrap().join("stdio_update_with_cd");
+    if base.exists() {
+        fs::remove_dir_all(&base).unwrap();
+    }
+    fs::create_dir_all(&base).unwrap();
+
+    // Create initial archive with a.txt
+    let archive = base.join("test.pna");
+    create_test_archive(&archive, &[("a.txt", "content a")]);
+
+    // Create sub directory with b.txt
+    let sub_dir = base.join("sub");
+    fs::create_dir_all(&sub_dir).unwrap();
+    fs::write(sub_dir.join("b.txt"), "content b").unwrap();
+
+    // Update archive: -C sub b.txt
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "stdio",
+            "--update",
+            "--unstable",
+            "-f",
+            archive.to_str().unwrap(),
+            "-C",
+            sub_dir.to_str().unwrap(),
+            "b.txt",
+        ])
+        .assert()
+        .success();
+
+    // Verify the archive now contains both entries
+    let entry_names: HashSet<String> = get_archive_entry_names(&archive).into_iter().collect();
+    assert!(entry_names.contains("a.txt"), "Missing a.txt");
+    assert!(entry_names.contains("b.txt"), "Missing b.txt");
+    assert_eq!(entry_names.len(), 2);
+}
+
+/// Precondition: Archive contains a.txt. Directory sub/ contains b.txt.
+/// Action: Append to archive with `-C <sub> b.txt`.
+/// Expectation: Archive contains both a.txt and b.txt.
+#[test]
+fn stdio_append_with_cd() {
+    setup();
+
+    let base = fs::canonicalize(".").unwrap().join("stdio_append_with_cd");
+    if base.exists() {
+        fs::remove_dir_all(&base).unwrap();
+    }
+    fs::create_dir_all(&base).unwrap();
+
+    // Create initial archive with a.txt
+    let archive = base.join("test.pna");
+    create_test_archive(&archive, &[("a.txt", "content a")]);
+
+    // Create sub directory with b.txt
+    let sub_dir = base.join("sub");
+    fs::create_dir_all(&sub_dir).unwrap();
+    fs::write(sub_dir.join("b.txt"), "content b").unwrap();
+
+    // Append to archive: -C sub b.txt
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "stdio",
+            "--append",
+            "--unstable",
+            "-f",
+            archive.to_str().unwrap(),
+            "-C",
+            sub_dir.to_str().unwrap(),
+            "b.txt",
+        ])
+        .assert()
+        .success();
+
+    // Verify the archive now contains both entries
+    let entry_names: HashSet<String> = get_archive_entry_names(&archive).into_iter().collect();
+    assert!(entry_names.contains("a.txt"), "Missing a.txt");
+    assert!(entry_names.contains("b.txt"), "Missing b.txt");
+    assert_eq!(entry_names.len(), 2);
+}

--- a/cli/tests/cli/bsdtar/option_cd.rs
+++ b/cli/tests/cli/bsdtar/option_cd.rs
@@ -1,5 +1,12 @@
-use crate::utils::{EmbedExt, TestResources, diff::assert_dirs_equal, setup};
+use crate::utils::{
+    EmbedExt, TestResources,
+    archive::{create_test_archive, get_archive_entry_names},
+    diff::assert_dirs_equal,
+    setup,
+};
 use assert_cmd::cargo::cargo_bin_cmd;
+use std::collections::HashSet;
+use std::fs;
 
 /// Precondition: Source tree is available for bsdtar archive creation.
 /// Action: Create an archive via `pna compat bsdtar -c -C <input> .`,
@@ -38,4 +45,234 @@ fn bsdtar_create_extract_with_cd() {
     cmd.assert().success();
 
     assert_dirs_equal("bsdtar_with_cd/in/", "bsdtar_with_cd/out/");
+}
+
+/// Precondition: Archive source.pna contains file a.txt. Directory sub/ contains b.txt.
+/// Action: Create with `@source.pna -C sub b.txt` -- archive inclusion before -C.
+/// Expectation: Result contains both a.txt (from @source) and b.txt (from sub/).
+///   @source.pna is resolved from original cwd, not from sub/.
+#[test]
+fn stdio_create_archive_inclusion_before_cd() {
+    setup();
+
+    let base = fs::canonicalize(".")
+        .unwrap()
+        .join("stdio_cd_archive_before_cd");
+    if base.exists() {
+        fs::remove_dir_all(&base).unwrap();
+    }
+    fs::create_dir_all(&base).unwrap();
+
+    // Create source archive with a.txt
+    let source_archive = base.join("source.pna");
+    create_test_archive(&source_archive, &[("a.txt", "content a")]);
+
+    // Create sub directory with b.txt
+    let sub_dir = base.join("sub");
+    fs::create_dir_all(&sub_dir).unwrap();
+    fs::write(sub_dir.join("b.txt"), "content b").unwrap();
+
+    // Create result archive: @source.pna is before -C, so it resolves from base (cwd).
+    // -C sub applies only to b.txt.
+    let output_archive = base.join("result.pna");
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "stdio",
+            "--create",
+            "--unstable",
+            "--overwrite",
+            "-f",
+            output_archive.to_str().unwrap(),
+            "-C",
+            base.to_str().unwrap(),
+            "@source.pna",
+            "-C",
+            sub_dir.to_str().unwrap(),
+            "b.txt",
+        ])
+        .assert()
+        .success();
+
+    // Verify the output archive contains both entries
+    let entry_names: HashSet<String> = get_archive_entry_names(&output_archive)
+        .into_iter()
+        .collect();
+    assert!(entry_names.contains("a.txt"), "Missing a.txt from @source");
+    assert!(
+        entry_names.contains("b.txt"),
+        "Missing b.txt from sub directory"
+    );
+    assert_eq!(entry_names.len(), 2);
+}
+
+/// Precondition: Directories d1/ and d2/ each contain a file.
+/// Action: Create with `-C d1 f1.txt -C d2 f2.txt` using absolute -C paths.
+/// Expectation: Both files archived with base names only (no directory prefix).
+#[test]
+fn stdio_create_multiple_cd_absolute_paths() {
+    setup();
+
+    let base = fs::canonicalize(".")
+        .unwrap()
+        .join("stdio_cd_multiple_absolute");
+    if base.exists() {
+        fs::remove_dir_all(&base).unwrap();
+    }
+    fs::create_dir_all(&base).unwrap();
+
+    // Create d1 with f1.txt
+    let d1 = base.join("d1");
+    fs::create_dir_all(&d1).unwrap();
+    fs::write(d1.join("f1.txt"), "content f1").unwrap();
+
+    // Create d2 with f2.txt
+    let d2 = base.join("d2");
+    fs::create_dir_all(&d2).unwrap();
+    fs::write(d2.join("f2.txt"), "content f2").unwrap();
+
+    let output_archive = base.join("result.pna");
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "stdio",
+            "--create",
+            "--unstable",
+            "--overwrite",
+            "-f",
+            output_archive.to_str().unwrap(),
+            "-C",
+            d1.to_str().unwrap(),
+            "f1.txt",
+            "-C",
+            d2.to_str().unwrap(),
+            "f2.txt",
+        ])
+        .assert()
+        .success();
+
+    // Verify both files are archived with base names
+    let entry_names: HashSet<String> = get_archive_entry_names(&output_archive)
+        .into_iter()
+        .collect();
+    assert!(entry_names.contains("f1.txt"), "Missing f1.txt");
+    assert!(entry_names.contains("f2.txt"), "Missing f2.txt");
+    assert_eq!(entry_names.len(), 2);
+}
+
+/// Precondition: A directory tree with nested files exists.
+/// Action: Create with `-C` changing into different directories for each file group.
+/// Expectation: Each file is archived relative to its -C directory.
+#[test]
+fn stdio_create_cd_does_not_affect_prior_args() {
+    setup();
+
+    let base = fs::canonicalize(".").unwrap().join("stdio_cd_ordering");
+    if base.exists() {
+        fs::remove_dir_all(&base).unwrap();
+    }
+    fs::create_dir_all(&base).unwrap();
+
+    // Create directories
+    let alpha = base.join("alpha");
+    fs::create_dir_all(&alpha).unwrap();
+    fs::write(alpha.join("first.txt"), "first").unwrap();
+
+    let beta = base.join("beta");
+    fs::create_dir_all(&beta).unwrap();
+    fs::write(beta.join("second.txt"), "second").unwrap();
+
+    // Archive first.txt from alpha, then second.txt from beta
+    let output_archive = base.join("result.pna");
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "stdio",
+            "--create",
+            "--unstable",
+            "--overwrite",
+            "-f",
+            output_archive.to_str().unwrap(),
+            "-C",
+            alpha.to_str().unwrap(),
+            "first.txt",
+            "-C",
+            beta.to_str().unwrap(),
+            "second.txt",
+        ])
+        .assert()
+        .success();
+
+    // Verify entry order matches argument order
+    let entry_names = get_archive_entry_names(&output_archive);
+    assert_eq!(entry_names.len(), 2, "Expected exactly 2 entries");
+    assert_eq!(entry_names[0], "first.txt");
+    assert_eq!(entry_names[1], "second.txt");
+}
+
+/// Precondition: Archive source.pna exists in directory src/. File extra.txt exists in dir/.
+/// Action: Create with `-C src @source.pna -C dir extra.txt`.
+/// Expectation: @source.pna resolves from src/ (the active -C), extra.txt resolves from dir/.
+#[test]
+fn stdio_create_cd_affects_archive_inclusion() {
+    setup();
+
+    let base = fs::canonicalize(".")
+        .unwrap()
+        .join("stdio_cd_archive_resolution");
+    if base.exists() {
+        fs::remove_dir_all(&base).unwrap();
+    }
+    fs::create_dir_all(&base).unwrap();
+
+    // Create source archive inside src/ subdirectory
+    let src_dir = base.join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    let source_archive = src_dir.join("source.pna");
+    create_test_archive(&source_archive, &[("archived.txt", "from archive")]);
+
+    // Create extra file in dir/ subdirectory
+    let dir = base.join("dir");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("extra.txt"), "extra content").unwrap();
+
+    // -C src makes @source.pna resolve from src/
+    // -C dir makes extra.txt resolve from dir/
+    let output_archive = base.join("result.pna");
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "stdio",
+            "--create",
+            "--unstable",
+            "--overwrite",
+            "-f",
+            output_archive.to_str().unwrap(),
+            "-C",
+            src_dir.to_str().unwrap(),
+            "@source.pna",
+            "-C",
+            dir.to_str().unwrap(),
+            "extra.txt",
+        ])
+        .assert()
+        .success();
+
+    // Verify both entries present
+    let entry_names: HashSet<String> = get_archive_entry_names(&output_archive)
+        .into_iter()
+        .collect();
+    assert!(
+        entry_names.contains("archived.txt"),
+        "Missing archived.txt from @source"
+    );
+    assert!(
+        entry_names.contains("extra.txt"),
+        "Missing extra.txt from dir/"
+    );
+    assert_eq!(entry_names.len(), 2);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now preprocesses -C/--cd/--directory forms so directory-change operands can be passed inline in many syntaxes.

* **Bug Fixes**
  * Per-argument directory changes are applied correctly for listing/extraction.
  * Creation/append/update no longer change the global process working directory, yielding more consistent archive resolution.

* **Tests**
  * Added tests for directory-change encodings and archive-resolution/ordering scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->