### PR TITLE
:construction_worker: Add RUSTDOCFLAGS for emscripten wasm doc tests

### DIFF
--- a/.github/workflows/webassembly.yml
+++ b/.github/workflows/webassembly.yml
@@ -91,6 +91,7 @@ jobs:
         env:
           TARGET: ${{ matrix.target }}
           RUSTFLAGS: "-C link-arg=-sINITIAL_MEMORY=512MB -C link-arg=-sTOTAL_STACK=16MB"
+          RUSTDOCFLAGS: "-C link-arg=-sINITIAL_MEMORY=512MB -C link-arg=-sTOTAL_STACK=16MB"
       - name: Run on Node.js
         if: ${{ startsWith(matrix.target, 'wasm32-unknown-emscripten') && startsWith(matrix.rust, 'nightly') }}
         run: |


### PR DESCRIPTION
RUSTFLAGS does not propagate to doc test compilation (rustdoc uses RUSTDOCFLAGS instead, see rust-lang/cargo#6650). Without the linker flags, doc test binaries get emscripten's default 16 MiB INITIAL_MEMORY, which is insufficient for Argon2id's ~19 MiB allocation.

Add RUSTDOCFLAGS with the same linker flags as RUSTFLAGS so doc tests are linked with adequate memory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This pull request contains internal build configuration updates only and has no user-facing changes to report in release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->