### PR TITLE
Cli/extract/restore dir metadata

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -52,6 +52,9 @@ typed-path = "0.12"
 rand = "0.8.5"
 walkdir = "2.5.0"
 
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+filetime = "0.2"
+
 [target.'cfg(unix)'.dependencies]
 mtree2 = "0.6.15"
 nix = { version = "0.31.2", features = ["user"] }
@@ -71,7 +74,6 @@ windows = { version = "0.62.2", features = [
 field-offset = { version = "0.3.6", optional = true }
 
 [dev-dependencies]
-filetime = "0.2"
 maplit = "1.0.2"
 path-slash = "0.2.1"
 rust-embed = { version = "8.11.0", features = ["debug-embed"] }

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -623,6 +623,7 @@ where
         BsdGlobMatcher::new(patterns.iter().map(|it| it.as_str())).with_no_recursive(no_recursive);
 
     let mut link_entries = Vec::new();
+    let mut dir_metadata = Vec::new();
 
     #[cfg(not(target_family = "wasm"))]
     {
@@ -663,9 +664,11 @@ where
                             return Ok(ProcessAction::Continue);
                         }
                         if item.header().data_kind() == DataKind::Directory {
-                            extract_directory_entry(item, &name, &args).map_err(|e| {
-                                io::Error::new(e.kind(), format!("extracting {item_path}: {e}"))
-                            })?;
+                            if extract_directory_structure(&item, &name, &args).map_err(|e| {
+                                io::Error::new(e.kind(), format!("extracting {}: {e}", item.name()))
+                            })? {
+                                dir_metadata.push((name, item));
+                            }
                             if globs.all_matched() {
                                 return Ok(ProcessAction::Stop);
                             }
@@ -717,10 +720,11 @@ where
                             return Ok(());
                         }
                         if item.header().data_kind() == DataKind::Directory {
-                            let item_path = item.name().to_string();
-                            extract_directory_entry(item, &name, &args).map_err(|e| {
-                                io::Error::new(e.kind(), format!("extracting {item_path}: {e}"))
-                            })?;
+                            if extract_directory_structure(&item, &name, &args).map_err(|e| {
+                                io::Error::new(e.kind(), format!("extracting {}: {e}", item.name()))
+                            })? {
+                                dir_metadata.push((name, item));
+                            }
                             return Ok(());
                         }
                         let path = build_output_path(args.out_dir.as_deref(), name.as_path());
@@ -786,9 +790,11 @@ where
                         return Ok(ProcessAction::Continue);
                     }
                     if item.header().data_kind() == DataKind::Directory {
-                        extract_directory_entry(item, &name, &args).map_err(|e| {
-                            io::Error::new(e.kind(), format!("extracting {}: {e}", item_path))
-                        })?;
+                        if extract_directory_structure(&item, &name, &args).map_err(|e| {
+                            io::Error::new(e.kind(), format!("extracting {}: {e}", item.name()))
+                        })? {
+                            dir_metadata.push((name, item));
+                        }
                         if globs.all_matched() {
                             return Ok(ProcessAction::Stop);
                         }
@@ -830,10 +836,11 @@ where
                         return Ok(());
                     }
                     if item.header().data_kind() == DataKind::Directory {
-                        let item_path = item.name().to_string();
-                        extract_directory_entry(item, &name, &args).map_err(|e| {
-                            io::Error::new(e.kind(), format!("extracting {item_path}: {e}"))
-                        })?;
+                        if extract_directory_structure(&item, &name, &args).map_err(|e| {
+                            io::Error::new(e.kind(), format!("extracting {}: {e}", item.name()))
+                        })? {
+                            dir_metadata.push((name, item));
+                        }
                         return Ok(());
                     }
                     extract_file_entry(item, &name, password, &args).map_err(|e| {
@@ -850,6 +857,16 @@ where
     for (name, item) in link_entries {
         extract_link_entry(item, &name, password, &args)
             .with_context(|| format!("extracting deferred link {name}"))?;
+    }
+
+    // Apply deferred directory metadata (deepest paths first, so child metadata
+    // is set before parents — prevents restrictive parent permissions from blocking)
+    dir_metadata
+        .sort_by_cached_key(|(name, _)| std::cmp::Reverse(name.as_path().components().count()));
+    for (name, item) in dir_metadata {
+        let path = build_output_path(args.out_dir.as_deref(), name.as_path());
+        restore_metadata(&item, &path, &args.keep_options)
+            .with_context(|| format!("restoring deferred directory metadata {name}"))?;
     }
 
     globs.ensure_all_matched()?;
@@ -874,6 +891,7 @@ where
         BsdGlobMatcher::new(files.iter().map(|it| it.as_str())).with_no_recursive(no_recursive);
 
     let mut link_entries: Vec<(EntryName, NormalEntry<Vec<u8>>)> = Vec::new();
+    let mut dir_metadata: Vec<(EntryName, NormalEntry<Vec<u8>>)> = Vec::new();
 
     let (tx, rx) = std::sync::mpsc::channel();
 
@@ -909,9 +927,11 @@ where
                     return Ok(ProcessAction::Continue);
                 }
                 if item.header().data_kind() == DataKind::Directory {
-                    extract_directory_entry(item, &name, &args).map_err(|e| {
-                        io::Error::new(e.kind(), format!("extracting {item_path}: {e}"))
-                    })?;
+                    if extract_directory_structure(&item, &name, &args).map_err(|e| {
+                        io::Error::new(e.kind(), format!("extracting {}: {e}", item.name()))
+                    })? {
+                        dir_metadata.push((name, item.into()));
+                    }
                     if globs.all_matched() {
                         return Ok(ProcessAction::Stop);
                     }
@@ -958,10 +978,11 @@ where
                     return Ok(());
                 }
                 if item.header().data_kind() == DataKind::Directory {
-                    let item_path = item.name().to_string();
-                    extract_directory_entry(item, &name, &args).map_err(|e| {
-                        io::Error::new(e.kind(), format!("extracting {item_path}: {e}"))
-                    })?;
+                    if extract_directory_structure(&item, &name, &args).map_err(|e| {
+                        io::Error::new(e.kind(), format!("extracting {}: {e}", item.name()))
+                    })? {
+                        dir_metadata.push((name, item.into()));
+                    }
                     return Ok(());
                 }
                 let path = build_output_path(args.out_dir.as_deref(), name.as_path());
@@ -992,6 +1013,17 @@ where
         extract_link_entry(item, &name, password, &args)
             .with_context(|| format!("extracting deferred link {name}"))?;
     }
+
+    // Apply deferred directory metadata (deepest paths first, so child metadata
+    // is set before parents — prevents restrictive parent permissions from blocking)
+    dir_metadata
+        .sort_by_cached_key(|(name, _)| std::cmp::Reverse(name.as_path().components().count()));
+    for (name, item) in dir_metadata {
+        let path = build_output_path(args.out_dir.as_deref(), name.as_path());
+        restore_metadata(&item, &path, &args.keep_options)
+            .with_context(|| format!("restoring deferred directory metadata {name}"))?;
+    }
+
     globs.ensure_all_matched()?;
     Ok(())
 }
@@ -1192,11 +1224,49 @@ where
     Ok(ExtractionDecision::Proceed { remove_existing })
 }
 
+/// Creates a directory and runs overwrite policy checks, but defers metadata restoration.
+///
+/// Returns `true` if the directory was created and metadata should be deferred.
+/// Returns `false` if the directory was skipped by overwrite policy.
+fn extract_directory_structure<T>(
+    item: &NormalEntry<T>,
+    item_path: &EntryName,
+    args: &OutputOption<'_>,
+) -> io::Result<bool>
+where
+    T: AsRef<[u8]>,
+    pna::RawChunk<T>: Chunk,
+{
+    if item.header().data_kind() != DataKind::Directory {
+        unreachable!(
+            "extract_directory_structure called with {:?}",
+            item.header().data_kind()
+        );
+    }
+    let path = build_output_path(args.out_dir.as_deref(), item_path.as_path());
+    let secure_symlinks = !args.absolute_paths;
+
+    let ExtractionDecision::Proceed { .. } = check_and_prepare_target(
+        &path,
+        DataKind::Directory,
+        item,
+        args.overwrite_strategy,
+        args.unlink_first,
+        secure_symlinks,
+    )?
+    else {
+        return Ok(false);
+    };
+
+    ensure_directory_components(&path, args.unlink_first, secure_symlinks)?;
+    Ok(true)
+}
+
 /// Shared preamble for entry extraction: builds the output path, runs overwrite
 /// policy checks, and prepares the target.
 ///
-/// Returns `None` if the entry should be skipped by overwrite policy, otherwise
-/// returns the resolved output path and the `remove_existing` flag.
+/// Returns `None` if the entry should be skipped by overwrite policy,
+/// otherwise returns the resolved output path and `remove_existing` flag.
 fn prepare_extraction<'a, T>(
     item: &NormalEntry<T>,
     item_path: &'a EntryName,
@@ -1290,46 +1360,6 @@ where
         restore_timestamps(&mut file, item.metadata(), keep_options)?;
     }
 
-    restore_metadata(&item, &path, keep_options)?;
-    log::debug!("end: {}", path.display());
-    Ok(())
-}
-
-/// Extracts a directory entry: ensures the directory exists on disk and restores its metadata.
-pub(crate) fn extract_directory_entry<'a, T>(
-    item: NormalEntry<T>,
-    item_path: &EntryName,
-    OutputOption {
-        overwrite_strategy,
-        out_dir,
-        keep_options,
-        unlink_first,
-        absolute_paths,
-        ..
-    }: &OutputOption<'a>,
-) -> io::Result<()>
-where
-    T: AsRef<[u8]>,
-    pna::RawChunk<T>: Chunk,
-{
-    if item.header().data_kind() != DataKind::Directory {
-        unreachable!(
-            "extract_directory_entry called with {:?}",
-            item.header().data_kind()
-        );
-    }
-    let Some((path, _)) = prepare_extraction(
-        &item,
-        item_path,
-        out_dir.as_deref(),
-        *overwrite_strategy,
-        *unlink_first,
-        *absolute_paths,
-    )?
-    else {
-        return Ok(());
-    };
-    ensure_directory_components(&path, *unlink_first, !absolute_paths)?;
     restore_metadata(&item, &path, keep_options)?;
     log::debug!("end: {}", path.display());
     Ok(())
@@ -1474,10 +1504,70 @@ fn restore_timestamps(
     Ok(())
 }
 
-/// Restores file metadata (permissions, extended attributes, ACLs, and macOS metadata) for an extracted entry according to the provided keep options.
+/// Restores timestamps on a path without requiring an open file handle.
 ///
-/// - Ownership is restored when `owner_strategy` is `Preserve`
-/// - Mode bits are restored when `mode_strategy` is `Preserve`
+/// Uses `filetime::set_symlink_file_times` which does not follow symlinks,
+/// making it suitable for entries where an open file handle is not available.
+///
+/// Note: creation time cannot be set via this API and is silently skipped.
+/// On macOS/Windows, this means non-file entries lose their creation timestamp
+/// — a limitation of the `filetime` crate's path-based interface.
+#[cfg(not(target_family = "wasm"))]
+#[inline]
+fn restore_path_timestamps(
+    path: &Path,
+    metadata: &pna::Metadata,
+    keep_options: &KeepOptions,
+) -> io::Result<()> {
+    if let TimestampStrategy::Preserve {
+        mtime,
+        ctime: _,
+        atime,
+    } = keep_options.timestamp_strategy
+    {
+        let atime = atime
+            .resolve(metadata.accessed_time())
+            .map(filetime::FileTime::from_system_time);
+        let mtime = mtime
+            .resolve(metadata.modified_time())
+            .map(filetime::FileTime::from_system_time);
+        if atime.is_some() || mtime.is_some() {
+            // set_symlink_file_times always sets both timestamps; when one is absent,
+            // read the current value from the filesystem to avoid clobbering it to epoch.
+            let (fallback_atime, fallback_mtime) = if atime.is_none() || mtime.is_none() {
+                let existing = fs::symlink_metadata(path).ok();
+                (
+                    existing
+                        .as_ref()
+                        .map(filetime::FileTime::from_last_access_time),
+                    existing
+                        .as_ref()
+                        .map(filetime::FileTime::from_last_modification_time),
+                )
+            } else {
+                (None, None)
+            };
+            filetime::set_symlink_file_times(
+                path,
+                atime
+                    .or(fallback_atime)
+                    .unwrap_or(filetime::FileTime::zero()),
+                mtime
+                    .or(fallback_mtime)
+                    .unwrap_or(filetime::FileTime::zero()),
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// Restores entry metadata (timestamps for non-file entries, ownership, permissions, extended attributes, ACLs, and macOS metadata) according to the provided keep options.
+///
+/// - Timestamps are restored for non-file entries (symlinks, directories, hardlinks) via path-based API;
+///   regular files are handled earlier by `restore_timestamps()` with an open file handle
+/// - Ownership is restored via `lchown` when `owner_strategy` is `Preserve` (does not follow symlinks)
+/// - Mode bits are restored when `mode_strategy` is `Preserve`, but skipped for symlinks since
+///   `chmod()` follows symlinks and would corrupt the target's permissions
 /// - These are independent: `--keep-permission --no-same-owner` restores mode but not ownership
 fn restore_metadata<T>(
     item: &NormalEntry<T>,
@@ -1487,16 +1577,27 @@ fn restore_metadata<T>(
 where
     T: AsRef<[u8]>,
 {
+    // Restore timestamps for non-file entries (symlinks, directories, hardlinks).
+    // Regular files are handled by restore_timestamps() with an open file handle.
+    // On WASM, path-based timestamp restoration is not supported (filetime limitation).
+    #[cfg(not(target_family = "wasm"))]
+    if item.header().data_kind() != DataKind::File {
+        restore_path_timestamps(path, item.metadata(), keep_options)?;
+    }
     if let Some(p) = item.metadata().permission() {
         // Restore ownership when owner_strategy is Preserve (independent of mode)
         if let OwnerStrategy::Preserve { options } = &keep_options.owner_strategy {
             restore_owner(path, p, options)?;
         }
         // Restore mode bits when configured.
-        match keep_options.mode_strategy {
-            ModeStrategy::Preserve => restore_mode(path, p)?,
-            ModeStrategy::Masked(mask) => restore_mode_masked(path, p, mask)?,
-            ModeStrategy::Never => {}
+        // Skip for symlinks: symlink permissions are not settable via chmod() on most
+        // platforms, and chmod() follows symlinks, which would corrupt the target's permissions.
+        if item.header().data_kind() != DataKind::SymbolicLink {
+            match keep_options.mode_strategy {
+                ModeStrategy::Preserve => restore_mode(path, p)?,
+                ModeStrategy::Masked(mask) => restore_mode_masked(path, p, mask)?,
+                ModeStrategy::Never => {}
+            }
         }
     }
     // On macOS, when mac_metadata_strategy is Always and the entry has mac_metadata,

--- a/cli/tests/cli/extract/option_keep_timestamp.rs
+++ b/cli/tests/cli/extract/option_keep_timestamp.rs
@@ -89,6 +89,139 @@ fn extract_keep_timestamp_restores_file_times() {
     );
 }
 
+/// Precondition: Archive contains a directory entry with known mtime and atime.
+/// Action: Extract with `--keep-timestamp`.
+/// Expectation: The extracted directory's mtime and atime match the archived values.
+#[test]
+fn extract_keep_timestamp_restores_directory_times() {
+    setup();
+
+    let base = "extract_keep_timestamp_restores_directory_times";
+    let archive_path = format!("{base}/archive.pna");
+    fs::create_dir_all(base).unwrap();
+
+    let atime_epoch = pna::Duration::seconds(1_704_067_200); // 2024-01-01T00:00:00Z
+    let mtime_epoch = pna::Duration::seconds(1_704_153_600); // 2024-01-02T00:00:00Z
+
+    // Build archive programmatically with a directory entry having explicit timestamps
+    let file = fs::File::create(&archive_path).unwrap();
+    let mut archive = pna::Archive::write_header(file).unwrap();
+    let mut dir_builder = pna::EntryBuilder::new_dir("mydir".into());
+    dir_builder.modified(mtime_epoch);
+    dir_builder.accessed(atime_epoch);
+    archive.add_entry(dir_builder.build().unwrap()).unwrap();
+    // Add a file inside the directory so extraction creates the directory
+    let mut file_builder =
+        pna::EntryBuilder::new_file("mydir/file.txt".into(), pna::WriteOptions::store()).unwrap();
+    file_builder.write_all(b"content").unwrap();
+    archive.add_entry(file_builder.build().unwrap()).unwrap();
+    archive.finalize().unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        &archive_path,
+        "--overwrite",
+        "--out-dir",
+        &format!("{base}/out"),
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // WASM does not support path-based timestamp restoration (filetime crate
+    // limitation); restore_path_timestamps is gated out for wasm targets.
+    #[cfg(not(target_family = "wasm"))]
+    {
+        let atime = SystemTime::UNIX_EPOCH + Duration::from_secs(1_704_067_200);
+        let mtime = SystemTime::UNIX_EPOCH + Duration::from_secs(1_704_153_600);
+        let (modified, accessed, _) = extract_time(format!("{base}/out/mydir"));
+        assert_same_second(modified, mtime, "directory mtime");
+        assert_same_second(accessed, atime, "directory atime");
+    }
+}
+
+/// Precondition: Archive contains nested directory entries where each level has a distinct recorded mtime and atime.
+/// Action: Extract with `--keep-timestamp`.
+/// Expectation: Every directory level, including intermediates, has its archived timestamps on disk.
+#[test]
+fn extract_with_keep_timestamp_restores_nested_directory_times() {
+    setup();
+
+    let base = "extract_with_keep_timestamp_restores_nested_directory_times";
+    let archive_path = format!("{base}/archive.pna");
+    fs::create_dir_all(base).unwrap();
+
+    let a_mtime_epoch = pna::Duration::seconds(1_577_836_800); // 2020-01-01T00:00:00Z
+    let a_atime_epoch = pna::Duration::seconds(1_577_923_200); // 2020-01-02T00:00:00Z
+    let b_mtime_epoch = pna::Duration::seconds(1_609_459_200); // 2021-01-01T00:00:00Z
+    let b_atime_epoch = pna::Duration::seconds(1_609_545_600); // 2021-01-02T00:00:00Z
+    let c_mtime_epoch = pna::Duration::seconds(1_640_995_200); // 2022-01-01T00:00:00Z
+    let c_atime_epoch = pna::Duration::seconds(1_641_081_600); // 2022-01-02T00:00:00Z
+
+    let file = fs::File::create(&archive_path).unwrap();
+    let mut archive = pna::Archive::write_header(file).unwrap();
+
+    let mut dir_a = pna::EntryBuilder::new_dir("a".into());
+    dir_a.modified(a_mtime_epoch);
+    dir_a.accessed(a_atime_epoch);
+    archive.add_entry(dir_a.build().unwrap()).unwrap();
+
+    let mut dir_b = pna::EntryBuilder::new_dir("a/b".into());
+    dir_b.modified(b_mtime_epoch);
+    dir_b.accessed(b_atime_epoch);
+    archive.add_entry(dir_b.build().unwrap()).unwrap();
+
+    let mut dir_c = pna::EntryBuilder::new_dir("a/b/c".into());
+    dir_c.modified(c_mtime_epoch);
+    dir_c.accessed(c_atime_epoch);
+    archive.add_entry(dir_c.build().unwrap()).unwrap();
+
+    let mut file_builder =
+        pna::EntryBuilder::new_file("a/b/c/file.txt".into(), pna::WriteOptions::store()).unwrap();
+    file_builder.write_all(b"content").unwrap();
+    archive.add_entry(file_builder.build().unwrap()).unwrap();
+    archive.finalize().unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        &archive_path,
+        "--overwrite",
+        "--out-dir",
+        &format!("{base}/out"),
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    #[cfg(not(target_family = "wasm"))]
+    {
+        let a_mtime = SystemTime::UNIX_EPOCH + Duration::from_secs(1_577_836_800);
+        let a_atime = SystemTime::UNIX_EPOCH + Duration::from_secs(1_577_923_200);
+        let b_mtime = SystemTime::UNIX_EPOCH + Duration::from_secs(1_609_459_200);
+        let b_atime = SystemTime::UNIX_EPOCH + Duration::from_secs(1_609_545_600);
+        let c_mtime = SystemTime::UNIX_EPOCH + Duration::from_secs(1_640_995_200);
+        let c_atime = SystemTime::UNIX_EPOCH + Duration::from_secs(1_641_081_600);
+
+        let (a_mod, a_acc, _) = extract_time(format!("{base}/out/a"));
+        assert_same_second(a_mod, a_mtime, "directory a mtime");
+        assert_same_second(a_acc, a_atime, "directory a atime");
+
+        let (b_mod, b_acc, _) = extract_time(format!("{base}/out/a/b"));
+        assert_same_second(b_mod, b_mtime, "directory a/b mtime");
+        assert_same_second(b_acc, b_atime, "directory a/b atime");
+
+        let (c_mod, c_acc, _) = extract_time(format!("{base}/out/a/b/c"));
+        assert_same_second(c_mod, c_mtime, "directory a/b/c mtime");
+        assert_same_second(c_acc, c_atime, "directory a/b/c atime");
+    }
+}
+
 /// Precondition: Archive contains a file entry and a hardlink entry pointing to it, both with known timestamps.
 /// Action: Extract with `--keep-timestamp`.
 /// Expectation: The hardlink's mtime matches the archived value and shares the same inode as the target.
@@ -136,13 +269,18 @@ fn extract_keep_timestamp_restores_hardlink_times() {
     .execute()
     .unwrap();
 
-    let mtime = SystemTime::UNIX_EPOCH + Duration::from_secs(1_704_067_200);
-    let atime = SystemTime::UNIX_EPOCH + Duration::from_secs(1_704_153_600);
+    // WASM does not support path-based timestamp restoration (filetime crate
+    // limitation); restore_path_timestamps is gated out for wasm targets.
+    #[cfg(not(target_family = "wasm"))]
+    {
+        let mtime = SystemTime::UNIX_EPOCH + Duration::from_secs(1_704_067_200);
+        let atime = SystemTime::UNIX_EPOCH + Duration::from_secs(1_704_153_600);
 
-    // Verify the hardlink's timestamps
-    let (modified, accessed, _) = extract_time(format!("{base}/out/link.txt"));
-    assert_same_second(modified, mtime, "hardlink mtime");
-    assert_same_second(accessed, atime, "hardlink atime");
+        // Verify the hardlink's timestamps
+        let (modified, accessed, _) = extract_time(format!("{base}/out/link.txt"));
+        assert_same_second(modified, mtime, "hardlink mtime");
+        assert_same_second(accessed, atime, "hardlink atime");
+    }
 
     // same_file is not supported on wasi.
     #[cfg(not(target_os = "wasi"))]

--- a/cli/tests/cli/extract/symlink_metadata.rs
+++ b/cli/tests/cli/extract/symlink_metadata.rs
@@ -56,6 +56,134 @@ fn extract_symlink_preserves_permission_in_archive() {
     );
 }
 
+/// Precondition: Archive contains a file (0o644) and a symlink (0o777) pointing to that file.
+/// Action: Extract with `--keep-permission`.
+/// Expectation: The target file retains its own permission (0o644); the symlink's permission
+/// must not leak through to the target via chmod following the symlink.
+#[cfg(unix)]
+#[test]
+fn extract_symlink_does_not_modify_target_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    setup();
+    let base = "extract_symlink_does_not_modify_target_permissions";
+    let archive_path = format!("{base}/{base}.pna");
+    fs::create_dir_all(base).unwrap();
+
+    archive::create_archive_with_symlinks(
+        &archive_path,
+        &[archive::FileEntryDef {
+            path: "target.txt",
+            content: b"content",
+            permission: 0o644,
+        }],
+        &[archive::SymlinkEntryDef {
+            path: "link.txt",
+            target: "target.txt",
+            permission: Some(0o755),
+            modified: None,
+            accessed: None,
+            created: None,
+        }],
+    )
+    .unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        &archive_path,
+        "--overwrite",
+        "--out-dir",
+        &format!("{base}/out"),
+        "--keep-permission",
+        "--unstable",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let target_path = PathBuf::from(format!("{base}/out/target.txt"));
+    let target_meta = fs::metadata(&target_path).unwrap();
+    let target_mode = target_meta.permissions().mode() & 0o777;
+    assert_eq!(
+        target_mode, 0o644,
+        "target file permission should remain 0o644, not be changed by symlink's 0o755"
+    );
+}
+
+/// Precondition: Archive contains a symlink entry with mtime=2024-01-01.
+/// Action: Extract with `--keep-timestamp`.
+/// Expectation: The symlink's mtime is restored to 2024-01-01.
+#[test]
+fn extract_symlink_with_keep_timestamp() {
+    setup();
+    let base = "extract_symlink_with_keep_timestamp";
+    let archive_path = format!("{base}/{base}.pna");
+    fs::create_dir_all(base).unwrap();
+
+    let epoch_2024 = Duration::seconds(1_704_067_200); // 2024-01-01T00:00:00Z
+
+    archive::create_archive_with_symlinks(
+        &archive_path,
+        &[archive::FileEntryDef {
+            path: "target.txt",
+            content: b"content",
+            permission: 0o644,
+        }],
+        &[archive::SymlinkEntryDef {
+            path: "link.txt",
+            target: "target.txt",
+            permission: Some(0o777),
+            modified: Some(epoch_2024),
+            accessed: Some(epoch_2024),
+            created: Some(epoch_2024),
+        }],
+    )
+    .unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        &archive_path,
+        "--overwrite",
+        "--out-dir",
+        &format!("{base}/out"),
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let link_path = PathBuf::from(format!("{base}/out/link.txt"));
+    assert!(link_path.is_symlink(), "extracted path should be a symlink");
+    assert_eq!(
+        fs::read_link(&link_path).unwrap(),
+        PathBuf::from("target.txt"),
+    );
+    // WASM does not support path-based timestamp restoration (filetime crate
+    // limitation); restore_path_timestamps is gated out for wasm targets.
+    #[cfg(not(target_family = "wasm"))]
+    {
+        use std::time::{Duration as StdDuration, SystemTime};
+        let link_mtime = fs::symlink_metadata(&link_path)
+            .unwrap()
+            .modified()
+            .unwrap();
+        let expected = SystemTime::UNIX_EPOCH + StdDuration::from_secs(1_704_067_200);
+        let diff = if link_mtime > expected {
+            link_mtime.duration_since(expected).unwrap()
+        } else {
+            expected.duration_since(link_mtime).unwrap()
+        };
+        assert!(
+            diff.as_secs() <= 1,
+            "symlink mtime should be restored to 2024-01-01"
+        );
+    }
+}
+
 /// Precondition: Archive contains a broken symlink entry (target does not exist) with permission metadata.
 /// Action: Extract with `--keep-permission`.
 /// Expectation: The broken symlink is extracted with the correct link target.
@@ -109,7 +237,7 @@ fn extract_broken_symlink_preserves_target_path() {
 
 /// Precondition: Archive contains a broken symlink entry with a known mtime.
 /// Action: Extract with `--keep-timestamp`.
-/// Expectation: The broken symlink is extracted successfully with the correct link target.
+/// Expectation: The broken symlink is extracted with the correct target and its mtime is restored.
 #[test]
 fn extract_broken_symlink_with_keep_timestamp() {
     setup();
@@ -153,9 +281,107 @@ fn extract_broken_symlink_with_keep_timestamp() {
         fs::read_link(&link_path).unwrap(),
         PathBuf::from("nonexistent"),
     );
+    // WASM does not support path-based timestamp restoration (filetime crate
+    // limitation); restore_path_timestamps is gated out for wasm targets.
+    #[cfg(not(target_family = "wasm"))]
+    {
+        use std::time::{Duration as StdDuration, SystemTime};
+        let link_mtime = fs::symlink_metadata(&link_path)
+            .unwrap()
+            .modified()
+            .unwrap();
+        let expected = SystemTime::UNIX_EPOCH + StdDuration::from_secs(1_704_067_200);
+        let diff = if link_mtime > expected {
+            link_mtime.duration_since(expected).unwrap()
+        } else {
+            expected.duration_since(link_mtime).unwrap()
+        };
+        assert!(
+            diff.as_secs() <= 1,
+            "broken symlink mtime should be restored to the archived value"
+        );
+    }
 }
 
-/// Precondition: Archive contains a symlink entry with permission and timestamp metadata.
+/// Precondition: Archive contains a symlink entry with mtime set but atime absent.
+/// Action: Extract with `--keep-timestamp`.
+/// Expectation: The symlink's mtime is restored; the existing atime is not clobbered to epoch.
+#[test]
+fn extract_symlink_with_partial_timestamps() {
+    setup();
+    let base = "extract_symlink_with_partial_timestamps";
+    let archive_path = format!("{base}/{base}.pna");
+    fs::create_dir_all(base).unwrap();
+
+    let epoch_2024 = Duration::seconds(1_704_067_200); // 2024-01-01T00:00:00Z
+
+    // Create archive with symlink that has mtime but NO atime
+    archive::create_archive_with_symlinks(
+        &archive_path,
+        &[archive::FileEntryDef {
+            path: "target.txt",
+            content: b"content",
+            permission: 0o644,
+        }],
+        &[archive::SymlinkEntryDef {
+            path: "link.txt",
+            target: "target.txt",
+            permission: Some(0o777),
+            modified: Some(epoch_2024),
+            accessed: None, // intentionally absent
+            created: None,
+        }],
+    )
+    .unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        &archive_path,
+        "--overwrite",
+        "--out-dir",
+        &format!("{base}/out"),
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let link_path = PathBuf::from(format!("{base}/out/link.txt"));
+    assert!(link_path.is_symlink());
+
+    // WASM does not support path-based timestamp restoration (filetime crate
+    // limitation); restore_path_timestamps is gated out for wasm targets.
+    #[cfg(not(target_family = "wasm"))]
+    {
+        use std::time::{Duration as StdDuration, SystemTime};
+        let link_meta = fs::symlink_metadata(&link_path).unwrap();
+
+        // Verify mtime was restored to 2024-01-01
+        let link_mtime = link_meta.modified().unwrap();
+        let expected_mtime = SystemTime::UNIX_EPOCH + StdDuration::from_secs(1_704_067_200);
+        let mtime_diff = if link_mtime > expected_mtime {
+            link_mtime.duration_since(expected_mtime).unwrap()
+        } else {
+            expected_mtime.duration_since(link_mtime).unwrap()
+        };
+        assert!(
+            mtime_diff.as_secs() <= 1,
+            "symlink mtime should be restored to the archived value"
+        );
+
+        // Verify atime was NOT clobbered to Unix epoch (1970-01-01)
+        let link_atime = link_meta.accessed().unwrap();
+        let epoch_1970 = SystemTime::UNIX_EPOCH + StdDuration::from_secs(86400);
+        assert!(
+            link_atime > epoch_1970,
+            "atime should not be clobbered to Unix epoch when absent from archive"
+        );
+    }
+}
+
+/// Precondition: Archive contains a symlink entry with all metadata (permission, timestamps).
 /// Action: Extract with all preservation flags enabled.
 /// Expectation: Extraction succeeds, the symlink exists correctly, and the target content is intact.
 #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Directory timestamps are correctly restored when using --keep-timestamp during extraction.
  * Symlink extraction no longer alters target permissions and preserves timestamps as expected.

* **Tests**
  * Added/expanded tests to verify directory timestamp preservation, nested directories, hardlinks, and symlink metadata handling with preservation flags.

* **Chores**
  * Adjusted dependency inclusion so a timestamp-handling library is available for non‑WASM builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->