### PR TITLE
:construction_worker: Disable ineffective rust cache in format workflow

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -39,6 +39,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           components: "rustfmt,rust-docs"
+          cache: false
       - name: run check format
         run: cargo fmt --check
         env:
@@ -54,6 +55,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           components: "rustfmt,rust-docs"
+          cache: false
       - name: run check doc
         run: cargo doc --no-deps -p libpna -p pna
         env:


### PR DESCRIPTION
cargo fmt --check does not invoke the compiler, and cargo doc --no-deps only rebuilds the two listed crates' metadata, so the automatic Swatinem/rust-cache caches (~75 MB and ~90 MB respectively) add more upload/download overhead than they save. Disable the automatic cache in actions-rust-lang/setup-rust-toolchain for both jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for consistency in toolchain setup steps during format checks and documentation validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->