### PR TITLE
:construction_worker: Point rust-cache at the pna subdirectory workspace

### DIFF
--- a/.github/workflows/bsdtar-compat.yml
+++ b/.github/workflows/bsdtar-compat.yml
@@ -225,6 +225,8 @@ jobs:
 
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
+        with:
+          cache-workspaces: "pna -> target"
 
       - name: Build pna
         if: ${{ matrix.name != 'windows' }}


### PR DESCRIPTION
The pna-compat-bsdtar job checks out pna into a subdirectory and runs cargo build with working-directory: pna, but setup-rust-toolchain was caching the repository-root target/ instead, producing ~1 KB no-op caches with no build artifacts. Tell the cache where the workspace actually lives so the compiled pna and xtask binaries are reused across runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD build efficiency by enabling workspace-level caching for the Rust toolchain in the compatibility testing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->