### PR TITLE
:construction_worker: Separate rust-cache per wasm target

### DIFF
--- a/.github/workflows/webassembly.yml
+++ b/.github/workflows/webassembly.yml
@@ -67,6 +67,7 @@ jobs:
           target: ${{ matrix.target }}
           toolchain: ${{ matrix.rust }}
           rustflags: ''
+          cache-key: ${{ matrix.target }}
       - if: ${{ startsWith(matrix.target, 'wasm32-wasi') }}
         name: Setup wasmtime
         uses: bytecodealliance/actions/wasmtime/setup@9152e710e9f7182e4c29ad218e4f335a7b203613 # v1.1.3


### PR DESCRIPTION
The webassembly test matrix builds 4 wasm targets across 3 rust channels, but Swatinem/rust-cache only composes its key from the job name, OS/arch, rust version and workspace file hashes. On the arm64 runner all three wasm32-unknown-unknown / wasm32-wasip1 / wasm32-wasip2 entries therefore collide on a single cache slot per rust channel, and whichever job finishes first wins; any later job loads a target/ populated with artifacts for a different target triple and cannot reuse them.

Forward matrix.target to setup-rust-toolchain's cache-key so each (target, rust channel) combination gets its own cache.