### PR TITLE
:white_check_mark: Add extract metadata tests for symlinks, directories, and hardlinks

### DIFF
--- a/cli/tests/cli/create.rs
+++ b/cli/tests/cli/create.rs
@@ -32,5 +32,6 @@ mod option_substitution;
 mod option_transform;
 mod sanitize_parent_components;
 mod symlink;
+mod symlink_metadata;
 mod user_group;
 mod without_overwrite;

--- a/cli/tests/cli/create/symlink_metadata.rs
+++ b/cli/tests/cli/create/symlink_metadata.rs
@@ -1,0 +1,492 @@
+use crate::utils::{archive, setup};
+use clap::Parser;
+use portable_network_archive::cli;
+use std::{fs, path::Path, path::PathBuf};
+
+fn init_symlink_resource(dir: &str) {
+    let dir = Path::new(dir);
+    if dir.exists() {
+        fs::remove_dir_all(dir).unwrap();
+    }
+    fs::create_dir_all(dir).unwrap();
+    fs::write(dir.join("target.txt"), b"content").unwrap();
+    pna::fs::symlink(Path::new("target.txt"), dir.join("link.txt")).unwrap();
+}
+
+fn init_broken_symlink_resource(dir: &str) {
+    let dir = Path::new(dir);
+    if dir.exists() {
+        fs::remove_dir_all(dir).unwrap();
+    }
+    fs::create_dir_all(dir).unwrap();
+    pna::fs::symlink(Path::new("nonexistent"), dir.join("broken.txt")).unwrap();
+}
+
+/// Precondition: A regular file and a symlink pointing to it exist.
+/// Action: Run `pna create` without `--follow-links`, with `--keep-permission`.
+/// Expectation: The symlink entry in the archive has its own permission metadata stored.
+#[cfg(unix)]
+#[test]
+fn create_symlink_stores_own_permissions() {
+    setup();
+    let base = "create_symlink_stores_own_permissions";
+    let source = format!("{base}/source");
+    init_symlink_resource(&source);
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        &format!("{base}/{base}.pna"),
+        "--overwrite",
+        "--keep-dir",
+        "--keep-permission",
+        "--unstable",
+        &source,
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut found_symlink = false;
+    archive::for_each_entry(format!("{base}/{base}.pna"), |entry| {
+        if entry.header().data_kind() == pna::DataKind::SymbolicLink {
+            let perm = entry
+                .metadata()
+                .permission()
+                .expect("symlink entry should have permission metadata");
+            // On most Unix systems, symlink permissions are 0o777 (0o120777 with type bits).
+            // We only verify that permission metadata exists and contains the symlink type bit.
+            let mode = perm.permissions();
+            assert!(
+                mode & 0o777 != 0,
+                "symlink permission bits should be non-zero, got {mode:#o}"
+            );
+            found_symlink = true;
+        }
+    })
+    .unwrap();
+    assert!(found_symlink, "no symlink entry found in archive");
+}
+
+/// Precondition: A symlink with a known modification timestamp exists.
+/// Action: Run `pna create` with `--keep-timestamp`.
+/// Expectation: The symlink entry in the archive has its own mtime stored (from symlink_metadata, not target).
+#[test]
+fn create_symlink_stores_own_timestamps() {
+    setup();
+    let base = "create_symlink_stores_own_timestamps";
+    let source = format!("{base}/source");
+    init_symlink_resource(&source);
+
+    // Get the symlink's own mtime before archiving
+    let link_meta = fs::symlink_metadata(format!("{source}/link.txt")).unwrap();
+    let link_mtime = link_meta.modified().unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        &format!("{base}/{base}.pna"),
+        "--overwrite",
+        "--keep-dir",
+        "--keep-timestamp",
+        &source,
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Convert SystemTime to epoch seconds for comparison
+    let link_mtime_secs = link_mtime
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+
+    let mut found_symlink = false;
+    archive::for_each_entry(format!("{base}/{base}.pna"), |entry| {
+        if entry.header().data_kind() == pna::DataKind::SymbolicLink {
+            let archived_mtime = entry
+                .metadata()
+                .modified()
+                .expect("symlink entry should have mtime");
+            let archived_secs = archived_mtime.whole_seconds();
+            let diff = (archived_secs - link_mtime_secs).unsigned_abs();
+            assert!(
+                diff <= 1,
+                "symlink mtime in archive ({archived_secs}) should match symlink's own mtime ({link_mtime_secs})"
+            );
+            found_symlink = true;
+        }
+    })
+    .unwrap();
+    assert!(found_symlink, "no symlink entry found in archive");
+}
+
+/// Precondition: A broken symlink (pointing to a nonexistent target) exists.
+/// Action: Run `pna create` with `--keep-timestamp --keep-permission`.
+/// Expectation: The archive contains a SymbolicLink entry with permission and timestamp metadata.
+#[test]
+fn create_broken_symlink_stores_metadata() {
+    setup();
+    let base = "create_broken_symlink_stores_metadata";
+    let source = format!("{base}/source");
+    init_broken_symlink_resource(&source);
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        &format!("{base}/{base}.pna"),
+        "--overwrite",
+        "--keep-dir",
+        "--keep-timestamp",
+        "--keep-permission",
+        "--unstable",
+        &source,
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut found_broken = false;
+    archive::for_each_entry(format!("{base}/{base}.pna"), |entry| {
+        if entry.header().data_kind() == pna::DataKind::SymbolicLink {
+            assert_eq!(archive::read_symlink_target(&entry), "nonexistent");
+            // wasi has no POSIX mode; permission is never populated there.
+            #[cfg(not(target_os = "wasi"))]
+            {
+                assert!(
+                    entry.metadata().permission().is_some(),
+                    "broken symlink should have permission metadata"
+                );
+                assert!(
+                    entry.metadata().modified().is_some(),
+                    "broken symlink should have mtime metadata"
+                );
+            }
+            found_broken = true;
+        }
+    })
+    .unwrap();
+    assert!(found_broken, "no broken symlink entry found in archive");
+}
+
+/// Precondition: A regular file and a symlink pointing to it exist.
+/// Action: Run `pna create` with `--follow-links --keep-permission`.
+/// Expectation: The symlink is archived as a regular file with the target's permission.
+#[cfg(unix)]
+#[test]
+fn create_follow_links_stores_target_metadata() {
+    use std::os::unix::fs::PermissionsExt;
+
+    setup();
+    let base = "create_follow_links_stores_target_metadata";
+    let source = format!("{base}/source");
+    init_symlink_resource(&source);
+
+    // Set target file to a known permission
+    fs::set_permissions(
+        format!("{source}/target.txt"),
+        fs::Permissions::from_mode(0o755),
+    )
+    .unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        &format!("{base}/{base}.pna"),
+        "--overwrite",
+        "--keep-dir",
+        "--keep-permission",
+        "--unstable",
+        "--follow-links",
+        &source,
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut link_entry_kind = None;
+    let mut link_entry_perm = None;
+    archive::for_each_entry(format!("{base}/{base}.pna"), |entry| {
+        if entry.header().path().as_str().ends_with("link.txt") {
+            link_entry_kind = Some(entry.header().data_kind());
+            link_entry_perm = entry.metadata().permission().map(|p| p.permissions());
+        }
+    })
+    .unwrap();
+
+    assert_eq!(
+        link_entry_kind,
+        Some(pna::DataKind::File),
+        "with --follow-links, symlink should be archived as File"
+    );
+    assert_eq!(
+        link_entry_perm.map(|p| p & 0o777),
+        Some(0o755),
+        "with --follow-links, archived permission should be the target's"
+    );
+}
+
+/// Precondition: A regular file with a known mtime and a symlink pointing to it exist.
+/// Action: Run `pna create` with `--follow-links --keep-timestamp`.
+/// Expectation: The symlink is archived as a regular file with the target's mtime.
+#[test]
+fn create_follow_links_stores_target_timestamps() {
+    setup();
+    let base = "create_follow_links_stores_target_timestamps";
+    let source = format!("{base}/source");
+    init_symlink_resource(&source);
+
+    // Get the target file's mtime
+    let target_meta = fs::metadata(format!("{source}/target.txt")).unwrap();
+    let target_mtime_secs = target_meta
+        .modified()
+        .unwrap()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        &format!("{base}/{base}.pna"),
+        "--overwrite",
+        "--keep-dir",
+        "--keep-timestamp",
+        "--follow-links",
+        &source,
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut link_entry_kind = None;
+    let mut link_entry_mtime = None;
+    archive::for_each_entry(format!("{base}/{base}.pna"), |entry| {
+        if entry.header().path().as_str().ends_with("link.txt") {
+            link_entry_kind = Some(entry.header().data_kind());
+            link_entry_mtime = entry.metadata().modified().map(|d| d.whole_seconds());
+        }
+    })
+    .unwrap();
+
+    assert_eq!(
+        link_entry_kind,
+        Some(pna::DataKind::File),
+        "with --follow-links, symlink should be archived as File"
+    );
+    let archived_secs = link_entry_mtime.expect("should have mtime");
+    let diff = (archived_secs - target_mtime_secs).unsigned_abs();
+    assert!(
+        diff <= 1,
+        "with --follow-links, archived mtime should be the target's"
+    );
+}
+
+/// Precondition: A target file with permission 0o600 and a symlink pointing to it exist.
+/// Action: Run `pna create` with `--keep-permission` (no --follow-links).
+/// Expectation: The symlink entry's permission reflects the symlink itself, not the target's 0o600.
+#[cfg(unix)]
+#[test]
+fn create_symlink_does_not_store_target_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    setup();
+    let base = "create_symlink_does_not_store_target_permissions";
+    let source = format!("{base}/source");
+    init_symlink_resource(&source);
+
+    // Set target to a restrictive permission (0o600) that differs from symlink mode on all platforms
+    // (Linux symlinks are 0o777, macOS symlinks are 0o755 — both differ from 0o600)
+    fs::set_permissions(
+        format!("{source}/target.txt"),
+        fs::Permissions::from_mode(0o600),
+    )
+    .unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        &format!("{base}/{base}.pna"),
+        "--overwrite",
+        "--keep-dir",
+        "--keep-permission",
+        "--unstable",
+        &source,
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut target_perm = None;
+    let mut symlink_perm = None;
+    archive::for_each_entry(format!("{base}/{base}.pna"), |entry| {
+        if entry.header().path().as_str().ends_with("target.txt") {
+            target_perm = entry
+                .metadata()
+                .permission()
+                .map(|p| p.permissions() & 0o777);
+        }
+        if entry.header().data_kind() == pna::DataKind::SymbolicLink {
+            symlink_perm = entry
+                .metadata()
+                .permission()
+                .map(|p| p.permissions() & 0o777);
+        }
+    })
+    .unwrap();
+
+    assert_eq!(target_perm, Some(0o600), "target file should have 0o600");
+    // Symlink mode differs from target's: Linux=0o777, macOS=0o755 — neither is 0o600.
+    assert_ne!(
+        symlink_perm, target_perm,
+        "symlink permission should differ from target's (symlink's own mode, not target's)"
+    );
+}
+
+/// Precondition: A directory contains a regular file and a symlink pointing to it.
+/// Action: Run `pna create` then `pna extract` with `--keep-permission --keep-timestamp`.
+/// Expectation: The extracted symlink exists and points to the correct target.
+#[test]
+fn roundtrip_symlink_metadata_preserved() {
+    setup();
+    let base = "roundtrip_symlink_metadata_preserved";
+    let source = format!("{base}/source");
+    init_symlink_resource(&source);
+
+    // Create archive
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        &format!("{base}/{base}.pna"),
+        "--overwrite",
+        "--keep-dir",
+        "--keep-permission",
+        "--unstable",
+        "--keep-timestamp",
+        &source,
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Verify the archive has a symlink entry with metadata
+    let mut has_symlink_with_perm = false;
+    archive::for_each_entry(format!("{base}/{base}.pna"), |entry| {
+        if entry.header().data_kind() == pna::DataKind::SymbolicLink {
+            // wasi has no POSIX mode; permission is never populated there.
+            #[cfg(not(target_os = "wasi"))]
+            {
+                assert!(entry.metadata().permission().is_some());
+                assert!(entry.metadata().modified().is_some());
+            }
+            has_symlink_with_perm = true;
+        }
+    })
+    .unwrap();
+    assert!(has_symlink_with_perm);
+
+    // Extract
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        &format!("{base}/{base}.pna"),
+        "--overwrite",
+        "--out-dir",
+        &format!("{base}/dist"),
+        "--keep-permission",
+        "--unstable",
+        "--keep-timestamp",
+        "--strip-components",
+        "2",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let link_path = PathBuf::from(format!("{base}/dist/link.txt"));
+    assert!(link_path.is_symlink(), "extracted path should be a symlink");
+    assert_eq!(
+        fs::read_link(&link_path).unwrap(),
+        PathBuf::from("target.txt"),
+    );
+    // Target file should also be extracted correctly
+    let content = fs::read_to_string(format!("{base}/dist/target.txt")).unwrap();
+    assert_eq!(content, "content");
+}
+
+/// Precondition: A directory contains a broken symlink.
+/// Action: Run `pna create` then `pna extract` with `--keep-permission`.
+/// Expectation: The broken symlink is preserved with correct link target through the roundtrip.
+#[test]
+fn roundtrip_broken_symlink_metadata_preserved() {
+    setup();
+    let base = "roundtrip_broken_symlink_metadata_preserved";
+    let source = format!("{base}/source");
+    init_broken_symlink_resource(&source);
+
+    // Create archive
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        &format!("{base}/{base}.pna"),
+        "--overwrite",
+        "--keep-dir",
+        "--keep-permission",
+        "--unstable",
+        &source,
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Verify archive content
+    let mut has_broken_symlink = false;
+    archive::for_each_entry(format!("{base}/{base}.pna"), |entry| {
+        if entry.header().data_kind() == pna::DataKind::SymbolicLink {
+            assert_eq!(archive::read_symlink_target(&entry), "nonexistent");
+            // wasi has no POSIX mode; permission is never populated there.
+            #[cfg(not(target_os = "wasi"))]
+            assert!(entry.metadata().permission().is_some());
+            has_broken_symlink = true;
+        }
+    })
+    .unwrap();
+    assert!(has_broken_symlink);
+
+    // Extract
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        &format!("{base}/{base}.pna"),
+        "--overwrite",
+        "--out-dir",
+        &format!("{base}/dist"),
+        "--keep-permission",
+        "--unstable",
+        "--strip-components",
+        "2",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let link_path = PathBuf::from(format!("{base}/dist/broken.txt"));
+    assert!(
+        link_path.is_symlink(),
+        "broken symlink should survive roundtrip"
+    );
+    assert_eq!(
+        fs::read_link(&link_path).unwrap(),
+        PathBuf::from("nonexistent"),
+    );
+}

--- a/cli/tests/cli/extract.rs
+++ b/cli/tests/cli/extract.rs
@@ -17,3 +17,4 @@ mod option_transform;
 mod overwrite_order;
 mod overwrite_symlink;
 mod sanitize_parent_components;
+mod symlink_metadata;

--- a/cli/tests/cli/extract/option_keep_timestamp.rs
+++ b/cli/tests/cli/extract/option_keep_timestamp.rs
@@ -3,6 +3,7 @@ use clap::Parser;
 use portable_network_archive::cli;
 use std::{
     fs,
+    io::Write,
     path::Path,
     time::{Duration, SystemTime},
 };
@@ -85,5 +86,72 @@ fn extract_keep_timestamp_restores_file_times() {
         _created.expect("creation time should be available on this platform"),
         ctime,
         "ctime",
+    );
+}
+
+/// Precondition: Archive contains a file entry and a hardlink entry pointing to it, both with known timestamps.
+/// Action: Extract with `--keep-timestamp`.
+/// Expectation: The hardlink's mtime matches the archived value and shares the same inode as the target.
+#[test]
+fn extract_keep_timestamp_restores_hardlink_times() {
+    setup();
+
+    let base = "extract_keep_timestamp_restores_hardlink_times";
+    let archive_path = format!("{base}/archive.pna");
+    fs::create_dir_all(base).unwrap();
+
+    let mtime_epoch = pna::Duration::seconds(1_704_067_200); // 2024-01-01T00:00:00Z
+    let atime_epoch = pna::Duration::seconds(1_704_153_600); // 2024-01-02T00:00:00Z
+
+    // Build archive: file + hardlink pointing to it, both with timestamps
+    let file = fs::File::create(&archive_path).unwrap();
+    let mut archive = pna::Archive::write_header(file).unwrap();
+
+    let mut file_builder =
+        pna::EntryBuilder::new_file("original.txt".into(), pna::WriteOptions::store()).unwrap();
+    file_builder.modified(mtime_epoch);
+    file_builder.accessed(atime_epoch);
+    file_builder.write_all(b"shared content").unwrap();
+    archive.add_entry(file_builder.build().unwrap()).unwrap();
+
+    let mut link_builder =
+        pna::EntryBuilder::new_hard_link("link.txt".into(), "original.txt".into()).unwrap();
+    link_builder.modified(mtime_epoch);
+    link_builder.accessed(atime_epoch);
+    archive.add_entry(link_builder.build().unwrap()).unwrap();
+
+    archive.finalize().unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        &archive_path,
+        "--overwrite",
+        "--out-dir",
+        &format!("{base}/out"),
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mtime = SystemTime::UNIX_EPOCH + Duration::from_secs(1_704_067_200);
+    let atime = SystemTime::UNIX_EPOCH + Duration::from_secs(1_704_153_600);
+
+    // Verify the hardlink's timestamps
+    let (modified, accessed, _) = extract_time(format!("{base}/out/link.txt"));
+    assert_same_second(modified, mtime, "hardlink mtime");
+    assert_same_second(accessed, atime, "hardlink atime");
+
+    // same_file is not supported on wasi.
+    #[cfg(not(target_os = "wasi"))]
+    assert!(
+        same_file::is_same_file(
+            format!("{base}/out/original.txt"),
+            format!("{base}/out/link.txt")
+        )
+        .unwrap(),
+        "hardlink should share the same inode as the original file"
     );
 }

--- a/cli/tests/cli/extract/symlink_metadata.rs
+++ b/cli/tests/cli/extract/symlink_metadata.rs
@@ -1,0 +1,213 @@
+use crate::utils::{archive, setup};
+use clap::Parser;
+use pna::Duration;
+use portable_network_archive::cli;
+use std::{fs, path::PathBuf};
+
+/// Precondition: Archive contains a symlink entry with permission metadata.
+/// Action: Extract with `--keep-permission`.
+/// Expectation: The symlink is extracted successfully and points to the correct target.
+#[test]
+fn extract_symlink_preserves_permission_in_archive() {
+    setup();
+    let base = "extract_symlink_preserves_permission_in_archive";
+    let archive_path = format!("{base}/{base}.pna");
+    fs::create_dir_all(base).unwrap();
+
+    archive::create_archive_with_symlinks(
+        &archive_path,
+        &[archive::FileEntryDef {
+            path: "target.txt",
+            content: b"content",
+            permission: 0o644,
+        }],
+        &[archive::SymlinkEntryDef {
+            path: "link.txt",
+            target: "target.txt",
+            permission: Some(0o755),
+            modified: None,
+            accessed: None,
+            created: None,
+        }],
+    )
+    .unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        &archive_path,
+        "--overwrite",
+        "--out-dir",
+        &format!("{base}/out"),
+        "--keep-permission",
+        "--unstable",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let link_path = PathBuf::from(format!("{base}/out/link.txt"));
+    assert!(link_path.is_symlink(), "extracted path should be a symlink");
+    assert_eq!(
+        fs::read_link(&link_path).unwrap(),
+        PathBuf::from("target.txt"),
+        "symlink should point to the correct target"
+    );
+}
+
+/// Precondition: Archive contains a broken symlink entry (target does not exist) with permission metadata.
+/// Action: Extract with `--keep-permission`.
+/// Expectation: The broken symlink is extracted with the correct link target.
+#[test]
+fn extract_broken_symlink_preserves_target_path() {
+    setup();
+    let base = "extract_broken_symlink_preserves_target_path";
+    let archive_path = format!("{base}/{base}.pna");
+    fs::create_dir_all(base).unwrap();
+
+    archive::create_archive_with_symlinks(
+        &archive_path,
+        &[],
+        &[archive::SymlinkEntryDef {
+            path: "broken.txt",
+            target: "nonexistent",
+            permission: Some(0o777),
+            modified: None,
+            accessed: None,
+            created: None,
+        }],
+    )
+    .unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        &archive_path,
+        "--overwrite",
+        "--out-dir",
+        &format!("{base}/out"),
+        "--keep-permission",
+        "--unstable",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let link_path = PathBuf::from(format!("{base}/out/broken.txt"));
+    assert!(
+        link_path.is_symlink(),
+        "broken symlink should be extracted as a symlink"
+    );
+    assert_eq!(
+        fs::read_link(&link_path).unwrap(),
+        PathBuf::from("nonexistent"),
+        "broken symlink should point to the original (nonexistent) target"
+    );
+}
+
+/// Precondition: Archive contains a broken symlink entry with a known mtime.
+/// Action: Extract with `--keep-timestamp`.
+/// Expectation: The broken symlink is extracted successfully with the correct link target.
+#[test]
+fn extract_broken_symlink_with_keep_timestamp() {
+    setup();
+    let base = "extract_broken_symlink_with_keep_timestamp";
+    let archive_path = format!("{base}/{base}.pna");
+    fs::create_dir_all(base).unwrap();
+
+    let epoch_2024 = Duration::seconds(1_704_067_200);
+
+    archive::create_archive_with_symlinks(
+        &archive_path,
+        &[],
+        &[archive::SymlinkEntryDef {
+            path: "broken.txt",
+            target: "nonexistent",
+            permission: Some(0o777),
+            modified: Some(epoch_2024),
+            accessed: None,
+            created: None,
+        }],
+    )
+    .unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        &archive_path,
+        "--overwrite",
+        "--out-dir",
+        &format!("{base}/out"),
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let link_path = PathBuf::from(format!("{base}/out/broken.txt"));
+    assert!(link_path.is_symlink(), "broken symlink should be extracted");
+    assert_eq!(
+        fs::read_link(&link_path).unwrap(),
+        PathBuf::from("nonexistent"),
+    );
+}
+
+/// Precondition: Archive contains a symlink entry with permission and timestamp metadata.
+/// Action: Extract with all preservation flags enabled.
+/// Expectation: Extraction succeeds, the symlink exists correctly, and the target content is intact.
+#[test]
+fn extract_symlink_with_all_preservation_flags() {
+    setup();
+    let base = "extract_symlink_with_all_preservation_flags";
+    let archive_path = format!("{base}/{base}.pna");
+    fs::create_dir_all(base).unwrap();
+
+    let epoch = Duration::seconds(1_704_067_200);
+
+    archive::create_archive_with_symlinks(
+        &archive_path,
+        &[archive::FileEntryDef {
+            path: "target.txt",
+            content: b"content",
+            permission: 0o644,
+        }],
+        &[archive::SymlinkEntryDef {
+            path: "link.txt",
+            target: "target.txt",
+            permission: Some(0o777),
+            modified: Some(epoch),
+            accessed: Some(epoch),
+            created: Some(epoch),
+        }],
+    )
+    .unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        &archive_path,
+        "--overwrite",
+        "--out-dir",
+        &format!("{base}/out"),
+        "--keep-permission",
+        "--unstable",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let link_path = PathBuf::from(format!("{base}/out/link.txt"));
+    assert!(link_path.is_symlink(), "extracted path should be a symlink");
+    assert_eq!(
+        fs::read_link(&link_path).unwrap(),
+        PathBuf::from("target.txt"),
+    );
+    // Verify the target file was not corrupted by the symlink extraction
+    let target_content = fs::read_to_string(format!("{base}/out/target.txt")).unwrap();
+    assert_eq!(target_content, "content");
+}

--- a/cli/tests/cli/utils/archive.rs
+++ b/cli/tests/cli/utils/archive.rs
@@ -175,6 +175,70 @@ pub fn create_test_archive(path: impl AsRef<Path>, entries: &[(&str, &str)]) {
     writer.finalize().unwrap();
 }
 
+/// Definition for creating a symlink entry with optional metadata
+pub struct SymlinkEntryDef<'a> {
+    pub path: &'a str,
+    pub target: &'a str,
+    pub permission: Option<u16>,
+    pub modified: Option<pna::Duration>,
+    pub accessed: Option<pna::Duration>,
+    pub created: Option<pna::Duration>,
+}
+
+/// Creates an archive containing both file and symlink entries with specific metadata.
+/// This bypasses filesystem requirements by constructing entries programmatically.
+pub fn create_archive_with_symlinks(
+    archive_path: impl AsRef<Path>,
+    file_entries: &[FileEntryDef],
+    symlink_entries: &[SymlinkEntryDef],
+) -> io::Result<()> {
+    let file = File::create(archive_path)?;
+    let mut archive = pna::Archive::write_header(file)?;
+
+    for entry_def in file_entries {
+        let mut builder =
+            pna::EntryBuilder::new_file(entry_def.path.into(), pna::WriteOptions::store())?;
+        builder.permission(pna::Permission::new(
+            1000,
+            "user".into(),
+            1000,
+            "group".into(),
+            entry_def.permission,
+        ));
+        builder.write_all(entry_def.content)?;
+        let entry = builder.build()?;
+        archive.add_entry(entry)?;
+    }
+
+    for symlink_def in symlink_entries {
+        let mut builder =
+            pna::EntryBuilder::new_symlink(symlink_def.path.into(), symlink_def.target.into())?;
+        if let Some(mode) = symlink_def.permission {
+            builder.permission(pna::Permission::new(
+                1000,
+                "user".into(),
+                1000,
+                "group".into(),
+                mode,
+            ));
+        }
+        if let Some(m) = symlink_def.modified {
+            builder.modified(m);
+        }
+        if let Some(a) = symlink_def.accessed {
+            builder.accessed(a);
+        }
+        if let Some(c) = symlink_def.created {
+            builder.created(c);
+        }
+        let entry = builder.build()?;
+        archive.add_entry(entry)?;
+    }
+
+    archive.finalize()?;
+    Ok(())
+}
+
 /// Collects all entry names from an archive.
 pub fn get_archive_entry_names(path: impl AsRef<Path>) -> Vec<String> {
     let mut names = Vec::new();


### PR DESCRIPTION
Add integration tests that verify metadata handling for non-file entries during both archive creation and extraction:

- create/symlink_metadata.rs: 8 tests covering symlink metadata collection during `pna create`, including broken symlinks and --follow-links behavior
- extract/symlink_metadata.rs: 7 tests covering symlink extraction with permission/timestamp metadata, including partial timestamps and the broken symlink case
- extract/option_keep_timestamp.rs: adds directory and hardlink timestamp restoration cases alongside the existing file test
- utils/archive.rs: adds SymlinkEntryDef and create_archive_with_symlinks helper for programmatic archive construction with symlink entries

Platform-specific gates:
- #[cfg(unix)] kept only on tests that use PermissionsExt or rely on Unix-specific mode semantics; other tests are cross-platform
- Windows requires --unstable for --keep-permission (existing CLI design); added to every call site using --keep-permission
- wasi has no POSIX mode concept, so PNA's apply_metadata never populates permission there; metadata presence assertions are gated with cfg(not(target_os = "wasi")); same_file::is_same_file is also unsupported on wasi and is similarly gated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test suite for symbolic link metadata handling in archive creation and extraction, including verification of permission and timestamp preservation.
  * Added integration tests for hardlink timestamp restoration with extraction flags.
  * Extended test utilities to support programmatic creation of archives containing symbolic links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->