### PR TITLE
Add fltp chunk

### DIFF
--- a/lib/src/chunk/types.rs
+++ b/lib/src/chunk/types.rs
@@ -75,6 +75,7 @@ impl From<ChunkTypeError> for io::Error {
 /// - **Timestamps**: [`cTIM`](Self::cTIM), [`mTIM`](Self::mTIM), [`aTIM`](Self::aTIM)
 ///   (seconds), [`cTNS`](Self::cTNS), [`mTNS`](Self::mTNS), [`aTNS`](Self::aTNS) (nanoseconds)
 /// - **File info**: [`fSIZ`](Self::fSIZ) (size), [`fPRM`](Self::fPRM) (permissions)
+/// - **Link info**: [`fLTP`](Self::fLTP) (link target type)
 /// - **Extended attributes**: [`xATR`](Self::xATR)
 ///
 /// # Creating Private Chunks
@@ -142,6 +143,9 @@ impl ChunkType {
     /// Extended attribute.
     #[allow(non_upper_case_globals)]
     pub const xATR: ChunkType = ChunkType(*b"xATR");
+    /// Link target type.
+    #[allow(non_upper_case_globals)]
+    pub const fLTP: ChunkType = ChunkType(*b"fLTP");
 
     /// Returns the length of the chunk type code.
     ///

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -646,6 +646,7 @@ where
         let mut mtime_ns = None;
         let mut atime_ns = None;
         let mut permission = None;
+        let mut link_target_type = None;
         for chunk in chunks {
             match chunk.ty {
                 ChunkType::FEND => break,
@@ -668,6 +669,7 @@ where
                 ChunkType::aTNS => atime_ns = Some(nanos(chunk.data())?),
                 ChunkType::fPRM => permission = Some(Permission::try_from_bytes(chunk.data())?),
                 ChunkType::xATR => xattrs.push(ExtendedAttribute::try_from_bytes(chunk.data())?),
+                ChunkType::fLTP => link_target_type = LinkTargetType::try_from_bytes(chunk.data())?,
                 _ => {
                     if chunk.ty.is_critical() {
                         return Err(io::Error::new(
@@ -694,6 +696,7 @@ where
                 modified: mtime,
                 accessed: atime,
                 permission,
+                link_target_type,
             },
             data,
             xattrs,
@@ -717,6 +720,7 @@ where
             modified,
             accessed,
             permission,
+            link_target_type,
         } = &self.metadata;
 
         total += (ChunkType::FHED, self.header.to_bytes()).write_chunk_in(writer)?;
@@ -761,6 +765,9 @@ where
         if let Some(p) = permission {
             total += (ChunkType::fPRM, p.to_bytes()).write_chunk_in(writer)?;
         }
+        if let Some(ltp) = link_target_type {
+            total += (ChunkType::fLTP, ltp.to_bytes()).write_chunk_in(writer)?;
+        }
         for xattr in &self.xattrs {
             total += (ChunkType::xATR, xattr.to_bytes()).write_chunk_in(writer)?;
         }
@@ -782,6 +789,7 @@ where
             modified,
             accessed,
             permission,
+            link_target_type,
         } = self.metadata;
         let mut vec = Vec::new();
         vec.push(RawChunk::from_data(ChunkType::FHED, self.header.to_bytes()));
@@ -837,6 +845,9 @@ where
         }
         if let Some(p) = permission {
             vec.push(RawChunk::from_data(ChunkType::fPRM, p.to_bytes()));
+        }
+        if let Some(ltp) = link_target_type {
+            vec.push(RawChunk::from_data(ChunkType::fLTP, ltp.to_bytes()));
         }
         for xattr in self.xattrs {
             vec.push(RawChunk::from_data(ChunkType::xATR, xattr.to_bytes()));

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -7,9 +7,9 @@ use crate::{
     cipher::CipherWriter,
     compress::CompressionWriter,
     entry::{
-        DataKind, Entry, EntryHeader, EntryName, EntryReference, ExtendedAttribute, Metadata,
-        NormalEntry, Permission, SolidEntry, SolidHeader, WriteCipher, WriteOption, WriteOptions,
-        get_writer, get_writer_context, private::SealedEntryExt,
+        DataKind, Entry, EntryHeader, EntryName, EntryReference, ExtendedAttribute, LinkTargetType,
+        Metadata, NormalEntry, Permission, SolidEntry, SolidHeader, WriteCipher, WriteOption,
+        WriteOptions, get_writer, get_writer_context, private::SealedEntryExt,
     },
     io::{FlattenWriter, TryIntoInner},
 };
@@ -145,6 +145,7 @@ pub struct EntryBuilder {
     last_modified: Option<Duration>,
     accessed: Option<Duration>,
     permission: Option<Permission>,
+    link_target_type: Option<LinkTargetType>,
     store_file_size: bool,
     file_size: u128,
     xattrs: Vec<ExtendedAttribute>,
@@ -162,6 +163,7 @@ impl EntryBuilder {
             last_modified: None,
             accessed: None,
             permission: None,
+            link_target_type: None,
             store_file_size: true,
             file_size: 0,
             xattrs: Vec::new(),
@@ -292,6 +294,22 @@ impl EntryBuilder {
         self
     }
 
+    /// Sets the link target type for link entries.
+    ///
+    /// Combined with [`DataKind`](crate::DataKind), this determines the link type:
+    /// - `SymbolicLink` + `File` → file symlink
+    /// - `SymbolicLink` + `Directory` → directory symlink
+    /// - `HardLink` + `File` → file hard link
+    /// - `HardLink` + `Directory` → directory hard link
+    #[inline]
+    pub fn link_target_type(
+        &mut self,
+        link_target_type: impl Into<Option<LinkTargetType>>,
+    ) -> &mut Self {
+        self.link_target_type = link_target_type.into();
+        self
+    }
+
     /// Sets whether to store the raw file size in the entry metadata.
     ///
     /// When `true`, the raw file size is recorded; when `false`, it is omitted.
@@ -370,6 +388,7 @@ impl EntryBuilder {
             modified: self.last_modified,
             accessed: self.accessed,
             permission: self.permission,
+            link_target_type: self.link_target_type,
         };
         Ok(NormalEntry {
             header: self.header,
@@ -680,6 +699,8 @@ impl SolidEntryBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::entry::RawEntry;
+    use crate::entry::private::SealedEntryExt;
     use crate::{ChunkType, ReadOptions};
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
@@ -753,5 +774,60 @@ mod tests {
         reader.read_to_end(&mut buf).unwrap();
 
         assert_eq!("テストデータ".as_bytes(), &buf[..]);
+    }
+
+    #[test]
+    fn fltp_symlink_roundtrip() {
+        let mut builder =
+            EntryBuilder::new_symlink("link_name".into(), "target_dir".into()).unwrap();
+        builder.link_target_type(LinkTargetType::Directory);
+        let entry = builder.build().unwrap();
+        let chunks = entry.into_chunks();
+        let raw = RawEntry(chunks);
+        let restored = NormalEntry::try_from(raw).unwrap();
+        assert_eq!(
+            restored.metadata().link_target_type(),
+            Some(LinkTargetType::Directory)
+        );
+    }
+
+    #[test]
+    fn fltp_hardlink_roundtrip() {
+        let mut builder =
+            EntryBuilder::new_hard_link("dir_hardlink".into(), "target_dir".into()).unwrap();
+        builder.link_target_type(LinkTargetType::Directory);
+        let entry = builder.build().unwrap();
+        let chunks = entry.into_chunks();
+        let raw = RawEntry(chunks);
+        let restored = NormalEntry::try_from(raw).unwrap();
+        assert_eq!(
+            restored.metadata().link_target_type(),
+            Some(LinkTargetType::Directory)
+        );
+    }
+
+    #[test]
+    fn fltp_absent_returns_none() {
+        let builder = EntryBuilder::new_symlink("link_name".into(), "target".into()).unwrap();
+        let entry = builder.build().unwrap();
+        let chunks = entry.into_chunks();
+        let raw = RawEntry(chunks);
+        let restored = NormalEntry::try_from(raw).unwrap();
+        assert_eq!(restored.metadata().link_target_type(), None);
+    }
+
+    #[test]
+    fn fltp_on_regular_file_is_preserved() {
+        let mut builder =
+            EntryBuilder::new_file("regular.txt".into(), WriteOptions::store()).unwrap();
+        builder.link_target_type(LinkTargetType::File);
+        let entry = builder.build().unwrap();
+        let chunks = entry.into_chunks();
+        let raw = RawEntry(chunks);
+        let restored = NormalEntry::try_from(raw).unwrap();
+        assert_eq!(
+            restored.metadata().link_target_type(),
+            Some(LinkTargetType::File)
+        );
     }
 }

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -1,6 +1,6 @@
 //! Metadata and permission types for archive entries.
 
-use crate::Duration;
+use crate::{Duration, UnknownValueError};
 use std::io::{self, Read};
 
 /// Metadata information about an entry.
@@ -26,6 +26,7 @@ pub struct Metadata {
     pub(crate) modified: Option<Duration>,
     pub(crate) accessed: Option<Duration>,
     pub(crate) permission: Option<Permission>,
+    pub(crate) link_target_type: Option<LinkTargetType>,
 }
 
 impl Metadata {
@@ -39,6 +40,7 @@ impl Metadata {
             modified: None,
             accessed: None,
             permission: None,
+            link_target_type: None,
         }
     }
 
@@ -106,6 +108,14 @@ impl Metadata {
         self
     }
 
+    /// Sets the link target type of the entry.
+    /// Only meaningful for symbolic link and hard link entries.
+    #[inline]
+    pub const fn with_link_target_type(mut self, link_target_type: Option<LinkTargetType>) -> Self {
+        self.link_target_type = link_target_type;
+        self
+    }
+
     /// Returns the raw file size of this entry's data in bytes.
     #[inline]
     pub const fn raw_file_size(&self) -> Option<u128> {
@@ -135,6 +145,16 @@ impl Metadata {
     #[inline]
     pub const fn permission(&self) -> Option<&Permission> {
         self.permission.as_ref()
+    }
+
+    /// Returns the link target type for this entry, if present.
+    ///
+    /// - `None`: fLTP chunk was absent.
+    /// - `Some(Unknown)`: fLTP chunk present but target type undetermined.
+    /// - `Some(File)` / `Some(Directory)`: known target type.
+    #[inline]
+    pub const fn link_target_type(&self) -> Option<LinkTargetType> {
+        self.link_target_type
     }
 }
 
@@ -313,6 +333,71 @@ impl Permission {
     }
 }
 
+/// Link target type for link entries.
+///
+/// Stored in the `fLTP` ancillary chunk. Indicates whether the link target
+/// is a file or a directory. The semantic interpretation depends on the
+/// entry's [`DataKind`](crate::DataKind):
+///
+/// | `DataKind` | `Unknown` | `File` | `Directory` |
+/// |---|---|---|---|
+/// | `SymbolicLink` | Symlink (target unknown) | File symlink | Directory symlink |
+/// | `HardLink` | Hard link (target unknown) | File hard link | Directory hard link |
+///
+/// `HardLink` + `Directory` represents a directory hard link — a hard link
+/// whose target is a directory. On systems that prohibit hard links to
+/// directories, implementations may fall back to a symbolic link.
+///
+/// # Value assignments
+///
+/// - `Unknown` (0): Explicit unknown — the target type was not determined.
+/// - `File` (1): Target is a file.
+/// - `Directory` (2): Target is a directory.
+/// - Values 3–63 are reserved for future public extensions.
+/// - Values 64–255 are reserved for private extensions.
+/// - Both ranges are currently unrecognized and fall back to `None`.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[repr(u8)]
+pub enum LinkTargetType {
+    /// Link target type is unknown.
+    Unknown = 0,
+    /// Link target is a file.
+    File = 1,
+    /// Link target is a directory.
+    Directory = 2,
+}
+
+impl TryFrom<u8> for LinkTargetType {
+    type Error = UnknownValueError;
+
+    #[inline]
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Unknown),
+            1 => Ok(Self::File),
+            2 => Ok(Self::Directory),
+            value => Err(UnknownValueError(value)),
+        }
+    }
+}
+
+impl LinkTargetType {
+    pub(crate) fn to_bytes(self) -> [u8; 1] {
+        [self as u8]
+    }
+
+    /// Parse fLTP chunk data.
+    ///
+    /// - Known values (0, 1, 2): `Ok(Some(variant))`
+    /// - Unrecognized values (3-255): `Ok(None)` (graceful fallback)
+    /// - Insufficient data: `Err`
+    pub(crate) fn try_from_bytes(mut bytes: &[u8]) -> io::Result<Option<Self>> {
+        let mut buf = [0u8; 1];
+        bytes.read_exact(&mut buf)?;
+        Ok(Self::try_from(buf[0]).ok())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -323,5 +408,66 @@ mod tests {
     fn permission() {
         let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
         assert_eq!(perm, Permission::try_from_bytes(&perm.to_bytes()).unwrap());
+    }
+
+    #[test]
+    fn link_target_type_roundtrip_unknown() {
+        let ltp = LinkTargetType::Unknown;
+        assert_eq!(
+            Some(ltp),
+            LinkTargetType::try_from_bytes(&ltp.to_bytes()).unwrap()
+        );
+    }
+
+    #[test]
+    fn link_target_type_roundtrip_file() {
+        let ltp = LinkTargetType::File;
+        assert_eq!(
+            Some(ltp),
+            LinkTargetType::try_from_bytes(&ltp.to_bytes()).unwrap()
+        );
+    }
+
+    #[test]
+    fn link_target_type_roundtrip_directory() {
+        let ltp = LinkTargetType::Directory;
+        assert_eq!(
+            Some(ltp),
+            LinkTargetType::try_from_bytes(&ltp.to_bytes()).unwrap()
+        );
+    }
+
+    #[test]
+    fn link_target_type_unknown_values_return_none() {
+        assert_eq!(LinkTargetType::try_from_bytes(&[0x03]).unwrap(), None);
+        assert_eq!(LinkTargetType::try_from_bytes(&[0xFF]).unwrap(), None);
+    }
+
+    #[test]
+    fn link_target_type_empty_bytes() {
+        assert!(LinkTargetType::try_from_bytes(&[]).is_err());
+    }
+
+    #[test]
+    fn link_target_type_try_from_u8() {
+        assert_eq!(
+            LinkTargetType::try_from(0u8).unwrap(),
+            LinkTargetType::Unknown
+        );
+        assert_eq!(LinkTargetType::try_from(1u8).unwrap(), LinkTargetType::File);
+        assert_eq!(
+            LinkTargetType::try_from(2u8).unwrap(),
+            LinkTargetType::Directory
+        );
+        assert!(LinkTargetType::try_from(3u8).is_err());
+    }
+
+    #[test]
+    fn link_target_type_trailing_bytes_ignored() {
+        // read_exact reads only 1 byte; trailing bytes are silently ignored
+        assert_eq!(
+            LinkTargetType::try_from_bytes(&[0x01, 0xFF, 0xFF]).unwrap(),
+            Some(LinkTargetType::File),
+        );
     }
 }

--- a/pna/src/ext/entry_builder.rs
+++ b/pna/src/ext/entry_builder.rs
@@ -57,6 +57,7 @@ impl EntryBuilderExt for EntryBuilder {
             .modified(metadata.modified())
             .accessed(metadata.accessed())
             .permission(metadata.permission().cloned())
+            .link_target_type(metadata.link_target_type())
     }
 
     /// Sets the created time using [`SystemTime`].


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for link-target-type metadata to indicate whether links point to files or directories.
  * Preservation of link-target-type during entry read/write, and emission of a new ancillary chunk for link info.
  * Builder API extended to set or clear link-target-type when constructing entries.

* **Tests**
  * Added unit tests covering round-trip read/write and parsing behavior for link-target-type values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->