### PR TITLE
:construction_worker: Restrict setup-rust-toolchain cache save to default branch

### DIFF
--- a/.github/workflows/bsdtar-compat.yml
+++ b/.github/workflows/bsdtar-compat.yml
@@ -227,6 +227,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
           cache-workspaces: "pna -> target"
+          cache-save-if: ${{ github.ref_name == github.event.repository.default_branch }}
 
       - name: Build pna
         if: ${{ matrix.name != 'windows' }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -64,6 +64,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
           toolchain: nightly
+          cache-save-if: ${{ github.ref_name == github.event.repository.default_branch }}
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
       - name: Run fuzzing

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -45,6 +45,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         with:
           toolchain: stable
+          cache-save-if: ${{ github.ref_name == github.event.repository.default_branch }}
 
       - name: Install cargo-release
         run: cargo install -f --git https://github.com/ChanTsune/cargo-release --branch workspace-enable-template-render-when-single-crate --locked cargo-release

--- a/.github/workflows/webassembly.yml
+++ b/.github/workflows/webassembly.yml
@@ -68,6 +68,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           rustflags: ''
           cache-key: ${{ matrix.target }}
+          cache-save-if: ${{ github.ref_name == github.event.repository.default_branch }}
       - if: ${{ startsWith(matrix.target, 'wasm32-wasi') }}
         name: Setup wasmtime
         uses: bytecodealliance/actions/wasmtime/setup@9152e710e9f7182e4c29ad218e4f335a7b203613 # v1.1.3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to optimize caching behavior for build toolchain dependencies, restricting cache saves to the repository's main development branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->