### PR TITLE
:zap: Use bufread decompressors with unified 32KB buffer

### DIFF
--- a/lib/src/compress.rs
+++ b/lib/src/compress.rs
@@ -1,8 +1,8 @@
 //! Compression and decompression implementations for PNA archives.
 
 use crate::io::TryIntoInner;
-use flate2::{read::ZlibDecoder, write::ZlibEncoder};
-use liblzma::{read::XzDecoder, write::XzEncoder};
+use flate2::{bufread::ZlibDecoder, write::ZlibEncoder};
+use liblzma::{bufread::XzDecoder, write::XzEncoder};
 use std::io::{BufReader, Read, Result, Write};
 use zstd::stream::{read::Decoder as ZStdDecoder, write::Encoder as ZstdEncoder};
 
@@ -85,13 +85,13 @@ impl<W: Write> TryIntoInner<W> for CompressionWriter<W> {
 /// - XZ (LZMA2)
 pub(crate) enum DecompressReader<R: Read> {
     /// No decompression, data is read as-is.
-    No(R),
+    No(BufReader<R>),
     /// Deflate decompression using zlib.
-    Deflate(ZlibDecoder<R>),
+    Deflate(ZlibDecoder<BufReader<R>>),
     /// Zstandard decompression.
     ZStd(ZStdDecoder<'static, BufReader<R>>),
     /// XZ decompression using LZMA2.
-    Xz(XzDecoder<R>),
+    Xz(XzDecoder<BufReader<R>>),
 }
 
 impl<R: Read> Read for DecompressReader<R> {

--- a/lib/src/entry/read.rs
+++ b/lib/src/entry/read.rs
@@ -61,16 +61,21 @@ pub(crate) fn decrypt_reader<R: Read>(
     })
 }
 
+const DECOMPRESS_BUFFER_SIZE: usize = 32 * 1024;
+
 /// Decompress reader according to a compression type.
 pub(crate) fn decompress_reader<R: Read>(
     reader: R,
     compression: Compression,
 ) -> io::Result<DecompressReader<R>> {
+    let reader = io::BufReader::with_capacity(DECOMPRESS_BUFFER_SIZE, reader);
     Ok(match compression {
         Compression::No => DecompressReader::No(reader),
-        Compression::Deflate => DecompressReader::Deflate(flate2::read::ZlibDecoder::new(reader)),
-        Compression::ZStandard => DecompressReader::ZStd(zstd::Decoder::new(reader)?),
-        Compression::XZ => DecompressReader::Xz(liblzma::read::XzDecoder::new(reader)),
+        Compression::Deflate => {
+            DecompressReader::Deflate(flate2::bufread::ZlibDecoder::new(reader))
+        }
+        Compression::ZStandard => DecompressReader::ZStd(zstd::Decoder::with_buffer(reader)?),
+        Compression::XZ => DecompressReader::Xz(liblzma::bufread::XzDecoder::new(reader)),
     })
 }
 


### PR DESCRIPTION
Switch DecompressReader from read-module decompressors to bufread-module variants (flate2::bufread, liblzma::bufread, zstd::Decoder::with_buffer). A single 32KB BufReader is created in decompress_reader() and shared across all compression variants, replacing the inconsistent internal buffers (flate2: 32KB, zstd: 8KB, liblzma: 8KB) and eliminating double-buffering in the zstd path.

Benchmark results (vs before):
- read_zstd_archive: -26% (double BufReader elimination)
- read_deflate_archive: -7%
- read_xz_archive: -4%
- read_store_archive: neutral (no significant change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced decompression performance through buffered I/O optimization. Implemented consistent buffering strategies across all supported compression format handlers to improve memory efficiency and processing throughput, resulting in better responsiveness and reduced overhead when handling compressed archives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->