### PR TITLE
Cli/create/fltp encode

### DIFF
--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -27,8 +27,8 @@ pub(crate) use path_filter::PathFilter;
 use path_slash::*;
 pub(crate) use path_transformer::PathTransformers;
 use pna::{
-    Archive, EntryBuilder, EntryPart, MIN_CHUNK_BYTES_SIZE, NormalEntry, PNA_HEADER, ReadEntry,
-    SolidEntryBuilder, WriteOptions, prelude::*,
+    Archive, EntryBuilder, EntryPart, LinkTargetType, MIN_CHUNK_BYTES_SIZE, NormalEntry,
+    PNA_HEADER, ReadEntry, SolidEntryBuilder, WriteOptions, prelude::*,
 };
 use std::{
     borrow::Cow,
@@ -379,7 +379,7 @@ pub(crate) struct CollectedEntry {
 pub(crate) enum StoreAs {
     File,
     Dir,
-    Symlink,
+    Symlink(LinkTargetType),
     Hardlink(PathBuf),
 }
 
@@ -736,7 +736,9 @@ pub(crate) fn collect_items_with_state(
 
                 // Classify entry and maybe add it to output
                 let store = if is_symlink {
-                    Some((StoreAs::Symlink, fs::symlink_metadata(path)?))
+                    let meta = fs::symlink_metadata(path)?;
+                    let link_target_type = detect_symlink_target_type(path, &meta)?;
+                    Some((StoreAs::Symlink(link_target_type), meta))
                 } else if is_file {
                     if let Some(linked) = hardlink_resolver.resolve(path).ok().flatten() {
                         Some((StoreAs::Hardlink(linked), fs::symlink_metadata(path)?))
@@ -774,9 +776,10 @@ pub(crate) fn collect_items_with_state(
                 {
                     let metadata = fs::symlink_metadata(path)?;
                     if is_broken_symlink_error(&metadata, ioe) {
+                        let link_target_type = detect_symlink_target_type(path, &metadata)?;
                         out.push(CollectedEntry {
                             path: path.to_path_buf(),
-                            store_as: StoreAs::Symlink,
+                            store_as: StoreAs::Symlink(link_target_type),
                             metadata,
                         });
                         continue;
@@ -792,6 +795,48 @@ pub(crate) fn collect_items_with_state(
 #[inline]
 fn is_broken_symlink_error(meta: &fs::Metadata, err: &io::Error) -> bool {
     meta.is_symlink() && err.kind() == io::ErrorKind::NotFound
+}
+
+/// Detects the target type of a symlink for the fLTP chunk.
+///
+/// On Windows, uses `FileTypeExt` on the link's own metadata to classify the
+/// symlink flavor recorded in the reparse point. Reparse points that are
+/// neither `symlink_file` nor `symlink_dir` (junction points, unknown reparse
+/// tags) degrade to `Unknown` for parity with the Unix path. On Unix, calls
+/// `fs::metadata(link_path)` which follows the symlink chain and stats the
+/// final target. A broken symlink (`NotFound`) degrades to `Unknown` since
+/// the target is confirmed absent and cannot be classified as file or
+/// directory. Other stat failures (permission denied, I/O error, etc.) are
+/// propagated — operators need to know when archive metadata is incomplete
+/// for actionable reasons.
+#[cfg(windows)]
+fn detect_symlink_target_type(
+    _link_path: &Path,
+    link_metadata: &fs::Metadata,
+) -> io::Result<LinkTargetType> {
+    use std::os::windows::fs::FileTypeExt;
+    let ft = link_metadata.file_type();
+    Ok(if ft.is_symlink_dir() {
+        LinkTargetType::Directory
+    } else if ft.is_symlink_file() {
+        LinkTargetType::File
+    } else {
+        LinkTargetType::Unknown
+    })
+}
+
+#[cfg(not(windows))]
+fn detect_symlink_target_type(
+    link_path: &Path,
+    _link_metadata: &fs::Metadata,
+) -> io::Result<LinkTargetType> {
+    match fs::metadata(link_path) {
+        Ok(m) if m.is_dir() => Ok(LinkTargetType::Directory),
+        Ok(m) if m.is_file() => Ok(LinkTargetType::File),
+        Ok(_) => Ok(LinkTargetType::Unknown),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(LinkTargetType::Unknown),
+        Err(e) => Err(e),
+    }
 }
 
 pub(crate) fn collect_split_archives(first: impl AsRef<Path>) -> io::Result<Vec<fs::File>> {
@@ -875,10 +920,11 @@ pub(crate) fn create_entry(
             let entry = EntryBuilder::new_hard_link(entry_name, reference)?;
             apply_metadata(entry, path, keep_options, metadata)?.build()
         }
-        StoreAs::Symlink => {
+        StoreAs::Symlink(link_target_type) => {
             let source = fs::read_link(path)?;
             let reference = pathname_editor.edit_symlink(&source);
-            let entry = EntryBuilder::new_symlink(entry_name, reference)?;
+            let mut entry = EntryBuilder::new_symlink(entry_name, reference)?;
+            entry.link_target_type(*link_target_type);
             apply_metadata(entry, path, keep_options, metadata)?.build()
         }
         StoreAs::File => {

--- a/cli/tests/cli/create/symlink.rs
+++ b/cli/tests/cli/create/symlink.rs
@@ -2,6 +2,7 @@ use crate::utils::{archive, setup};
 use clap::Parser;
 use portable_network_archive::cli;
 use std::{
+    collections::HashMap,
     fs,
     path::{Path, PathBuf},
 };
@@ -35,7 +36,7 @@ fn init_broken_resource<P: AsRef<Path>>(dir: P) {
 
     // Create broken symlinks that point to non-existent targets
     pna::fs::symlink(Path::new("missing.txt"), dir.join("broken.txt")).unwrap();
-    pna::fs::symlink(Path::new("missing_dir"), dir.join("broken_dir")).unwrap();
+    pna::fs::symlink(Path::new("missing_target"), dir.join("broken_link")).unwrap();
 }
 
 /// Precondition: The source tree contains regular files, directories, and symlinks (all valid).
@@ -240,9 +241,9 @@ fn broken_symlink_no_follow() {
                 assert_eq!(entry.header().data_kind(), pna::DataKind::SymbolicLink);
                 assert_eq!(archive::read_symlink_target(&entry), "missing.txt");
             }
-            "broken_symlink_no_follow/source/broken_dir" => {
+            "broken_symlink_no_follow/source/broken_link" => {
                 assert_eq!(entry.header().data_kind(), pna::DataKind::SymbolicLink);
-                assert_eq!(archive::read_symlink_target(&entry), "missing_dir");
+                assert_eq!(archive::read_symlink_target(&entry), "missing_target");
             }
             path => unreachable!("unexpected entry found: {path}"),
         },
@@ -265,14 +266,14 @@ fn broken_symlink_no_follow() {
     .unwrap();
 
     assert!(PathBuf::from("broken_symlink_no_follow/dist/broken.txt").is_symlink());
-    assert!(PathBuf::from("broken_symlink_no_follow/dist/broken_dir").is_symlink());
+    assert!(PathBuf::from("broken_symlink_no_follow/dist/broken_link").is_symlink());
     assert_eq!(
         fs::read_link("broken_symlink_no_follow/dist/broken.txt").unwrap(),
         Path::new("missing.txt"),
     );
     assert_eq!(
-        fs::read_link("broken_symlink_no_follow/dist/broken_dir").unwrap(),
-        Path::new("missing_dir"),
+        fs::read_link("broken_symlink_no_follow/dist/broken_link").unwrap(),
+        Path::new("missing_target"),
     );
 }
 
@@ -310,9 +311,9 @@ fn broken_symlink_follow() {
                 assert_eq!(entry.header().data_kind(), pna::DataKind::SymbolicLink);
                 assert_eq!(archive::read_symlink_target(&entry), "missing.txt");
             }
-            "broken_symlink_follow/source/broken_dir" => {
+            "broken_symlink_follow/source/broken_link" => {
                 assert_eq!(entry.header().data_kind(), pna::DataKind::SymbolicLink);
-                assert_eq!(archive::read_symlink_target(&entry), "missing_dir");
+                assert_eq!(archive::read_symlink_target(&entry), "missing_target");
             }
             path => unreachable!("unexpected entry found: {path}"),
         },
@@ -335,14 +336,14 @@ fn broken_symlink_follow() {
     .unwrap();
 
     assert!(PathBuf::from("broken_symlink_follow/dist/broken.txt").is_symlink());
-    assert!(PathBuf::from("broken_symlink_follow/dist/broken_dir").is_symlink());
+    assert!(PathBuf::from("broken_symlink_follow/dist/broken_link").is_symlink());
     assert_eq!(
         fs::read_link("broken_symlink_follow/dist/broken.txt").unwrap(),
         Path::new("missing.txt"),
     );
     assert_eq!(
-        fs::read_link("broken_symlink_follow/dist/broken_dir").unwrap(),
-        Path::new("missing_dir"),
+        fs::read_link("broken_symlink_follow/dist/broken_link").unwrap(),
+        Path::new("missing_target"),
     );
 }
 
@@ -531,4 +532,112 @@ fn symlink_follow_command_line_partial() {
         }
     })
     .unwrap();
+}
+
+/// Precondition: The source tree contains symlinks to both a file and a directory.
+/// Action: Run `pna create` to create an archive.
+/// Expectation: Each symlink entry carries fLTP metadata matching its target type.
+#[test]
+fn create_sets_fltp_on_symlinks() {
+    setup();
+    init_resource("create_sets_fltp_on_symlinks/source");
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "create_sets_fltp_on_symlinks/test.pna",
+        "--overwrite",
+        "--keep-dir",
+        "create_sets_fltp_on_symlinks/source",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut expected: HashMap<&str, Option<pna::LinkTargetType>> = HashMap::from([
+        ("create_sets_fltp_on_symlinks/source", None),
+        ("create_sets_fltp_on_symlinks/source/text.txt", None),
+        ("create_sets_fltp_on_symlinks/source/dir", None),
+        (
+            "create_sets_fltp_on_symlinks/source/dir/in_dir_text.txt",
+            None,
+        ),
+        (
+            "create_sets_fltp_on_symlinks/source/link.txt",
+            Some(pna::LinkTargetType::File),
+        ),
+        (
+            "create_sets_fltp_on_symlinks/source/dir/in_dir_link.txt",
+            Some(pna::LinkTargetType::File),
+        ),
+        (
+            "create_sets_fltp_on_symlinks/source/link_dir",
+            Some(pna::LinkTargetType::Directory),
+        ),
+    ]);
+    archive::for_each_entry("create_sets_fltp_on_symlinks/test.pna", |entry| {
+        let path = entry.header().path().to_string();
+        let expected_ltp = expected
+            .remove(path.as_str())
+            .unwrap_or_else(|| panic!("unexpected entry found: {path}"));
+        assert_eq!(entry.metadata().link_target_type(), expected_ltp, "{path}",);
+    })
+    .unwrap();
+    assert!(
+        expected.is_empty(),
+        "missing expected entries: {expected:?}",
+    );
+}
+
+/// Precondition: The source tree contains broken symlinks (targets do not exist).
+/// Action: Run `pna create` to create an archive.
+/// Expectation: On Unix the stat fallback hits `NotFound`, which degrades to
+/// `Unknown` since the target is confirmed absent. On Windows the link-side
+/// metadata classifies the symlink via its reparse-point flavor (File for
+/// symlink_file, Directory for symlink_dir).
+#[test]
+fn create_broken_symlink_has_unknown_fltp() {
+    setup();
+    init_broken_resource("create_broken_symlink_has_unknown_fltp/source");
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "create_broken_symlink_has_unknown_fltp/test.pna",
+        "--overwrite",
+        "--keep-dir",
+        "create_broken_symlink_has_unknown_fltp/source",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    #[cfg(windows)]
+    let broken_ltp: Option<pna::LinkTargetType> = Some(pna::LinkTargetType::File);
+    #[cfg(not(windows))]
+    let broken_ltp: Option<pna::LinkTargetType> = Some(pna::LinkTargetType::Unknown);
+
+    let mut expected: HashMap<&str, Option<pna::LinkTargetType>> = HashMap::from([
+        ("create_broken_symlink_has_unknown_fltp/source", None),
+        (
+            "create_broken_symlink_has_unknown_fltp/source/broken.txt",
+            broken_ltp,
+        ),
+        (
+            "create_broken_symlink_has_unknown_fltp/source/broken_link",
+            broken_ltp,
+        ),
+    ]);
+    archive::for_each_entry("create_broken_symlink_has_unknown_fltp/test.pna", |entry| {
+        let path = entry.header().path().to_string();
+        let expected_ltp = expected
+            .remove(path.as_str())
+            .unwrap_or_else(|| panic!("unexpected entry found: {path}"));
+        assert_eq!(entry.metadata().link_target_type(), expected_ltp, "{path}",);
+    })
+    .unwrap();
+    assert!(
+        expected.is_empty(),
+        "missing expected entries: {expected:?}",
+    );
 }

--- a/cli/tests/cli/stdio/mtree.rs
+++ b/cli/tests/cli/stdio/mtree.rs
@@ -8,7 +8,7 @@ use crate::utils::{
     setup,
 };
 use assert_cmd::cargo::cargo_bin_cmd;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::PathBuf;
 
@@ -259,9 +259,11 @@ fn stdio_mtree_directory_entry() {
     assert!(entry_names.contains("subdir/file.txt"));
 }
 
-/// Precondition: An mtree manifest specifies symlink entries with link= keyword.
+/// Precondition: An mtree manifest specifies symlink entries with the `link=` keyword.
 /// Action: Create archive from the mtree manifest.
-/// Expectation: The archive contains the symlink entries.
+/// Expectation: The archive contains the symlink entries, and the symlink entry
+/// has no fLTP because the manifest's `link=` directive overrides the on-disk
+/// target — fLTP would otherwise describe a different path than what is archived.
 #[cfg(unix)]
 #[test]
 fn stdio_mtree_symlink_entry() {
@@ -301,11 +303,96 @@ fn stdio_mtree_symlink_entry() {
         .assert()
         .success();
 
-    let entry_names: HashSet<String> = get_archive_entry_names(&output_archive)
-        .into_iter()
-        .collect();
-    assert!(entry_names.contains("target.txt"));
-    assert!(entry_names.contains("link.txt"));
+    // The mtree `link=` directive overrides the on-disk target, so fLTP must
+    // be omitted to keep archive contents and metadata consistent.
+    let mut expected: HashMap<&str, Option<pna::LinkTargetType>> =
+        HashMap::from([("target.txt", None), ("link.txt", None)]);
+    for_each_entry(&output_archive, |entry| {
+        let path = entry.header().path().to_string();
+        let expected_ltp = expected
+            .remove(path.as_str())
+            .unwrap_or_else(|| panic!("unexpected entry found: {path}"));
+        assert_eq!(entry.metadata().link_target_type(), expected_ltp, "{path}",);
+    })
+    .unwrap();
+    assert!(
+        expected.is_empty(),
+        "missing expected entries: {expected:?}",
+    );
+}
+
+/// Precondition: An mtree manifest specifies type=link entries WITHOUT a link= directive,
+/// backed by real filesystem symlinks.
+/// Action: Create archive from the mtree manifest.
+/// Expectation: No symlink entry carries fLTP metadata. The mtree format does
+/// not represent link target type, and `pna compat bsdtar` is for bsdtar
+/// compatibility, so PNA-specific fLTP metadata is intentionally not emitted.
+#[cfg(unix)]
+#[test]
+fn stdio_mtree_symlink_entry_has_no_fltp() {
+    setup();
+
+    let base = PathBuf::from("stdio_mtree_symlink_entry_has_no_fltp");
+    // Clean up from previous runs (symlinks cause AlreadyExists errors)
+    let _ = fs::remove_dir_all(&base);
+    fs::create_dir_all(base.join("dir")).unwrap();
+
+    // Create a regular file, a subdirectory, and symlinks to each.
+    fs::write(base.join("text.txt"), "file content").unwrap();
+    fs::write(base.join("dir/inside.txt"), "nested").unwrap();
+    std::os::unix::fs::symlink("text.txt", base.join("link_to_file")).unwrap();
+    std::os::unix::fs::symlink("dir", base.join("link_to_dir")).unwrap();
+
+    // mtree declares both as type=link without link= directive.
+    // Note: type=dir entry is placed last because mtree2's relative-form parser
+    // pushes a directory entry onto its cwd stack, which would prefix subsequent
+    // relative entries (and mtree2 cannot pop a single-level cwd back to empty).
+    fs::write(
+        base.join("manifest.mtree"),
+        "#mtree\n\
+         text.txt type=file\n\
+         link_to_file type=link\n\
+         link_to_dir type=link\n\
+         dir type=dir\n",
+    )
+    .unwrap();
+
+    let output_archive = base.join("output.pna");
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "stdio",
+            "--create",
+            "--unstable",
+            "--overwrite",
+            "-f",
+            output_archive.to_str().unwrap(),
+            "-C",
+            base.to_str().unwrap(),
+            "@manifest.mtree",
+        ])
+        .assert()
+        .success();
+
+    let mut expected: HashMap<&str, Option<pna::LinkTargetType>> = HashMap::from([
+        ("text.txt", None),
+        ("dir", None),
+        ("link_to_file", None),
+        ("link_to_dir", None),
+    ]);
+    for_each_entry(&output_archive, |entry| {
+        let path = entry.header().path().to_string();
+        let expected_ltp = expected
+            .remove(path.as_str())
+            .unwrap_or_else(|| panic!("unexpected entry found: {path}"));
+        assert_eq!(entry.metadata().link_target_type(), expected_ltp, "{path}",);
+    })
+    .unwrap();
+    assert!(
+        expected.is_empty(),
+        "missing expected entries: {expected:?}",
+    );
 }
 
 /// Precondition: Both an mtree manifest and standalone files exist.

--- a/pna/src/ext/entry.rs
+++ b/pna/src/ext/entry.rs
@@ -176,7 +176,28 @@ impl EntryFsExt for NormalEntry {
         if meta.file_type().is_symlink() {
             let target = fs::read_link(path)?;
             let reference = target.as_path().try_into().map_err(io::Error::other)?;
-            let builder = EntryBuilder::new_symlink(name, reference)?;
+            let mut builder = EntryBuilder::new_symlink(name, reference)?;
+            #[cfg(windows)]
+            let ltp = {
+                use std::os::windows::fs::FileTypeExt;
+                let ft = meta.file_type();
+                if ft.is_symlink_dir() {
+                    libpna::LinkTargetType::Directory
+                } else if ft.is_symlink_file() {
+                    libpna::LinkTargetType::File
+                } else {
+                    libpna::LinkTargetType::Unknown
+                }
+            };
+            #[cfg(not(windows))]
+            let ltp = match fs::metadata(path) {
+                Ok(m) if m.is_dir() => libpna::LinkTargetType::Directory,
+                Ok(m) if m.is_file() => libpna::LinkTargetType::File,
+                Ok(_) => libpna::LinkTargetType::Unknown,
+                Err(e) if e.kind() == io::ErrorKind::NotFound => libpna::LinkTargetType::Unknown,
+                Err(e) => return Err(e),
+            };
+            builder.link_target_type(ltp);
             builder.build()
         } else if meta.is_file() {
             let mut file = fs::File::open(path)?;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Symlinks archived in PNA files now include target type metadata (file, directory, or unknown).
  * Improved handling for broken symlinks across different platforms.

* **Tests**
  * Added tests validating symlink metadata capture during archive creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->