### PR TITLE
:bug: Treat anchors inside glob patterns as literal

### DIFF
--- a/cli/src/utils/globs.rs
+++ b/cli/src/utils/globs.rs
@@ -421,7 +421,7 @@ fn pm(mut p: &str, mut s: &str, flags: PathMatch) -> bool {
                     return true;
                 }
                 while !s.is_empty() {
-                    if archive_pathmatch(p, s, flags) {
+                    if pm(p, s, flags) {
                         return true;
                     }
                     s = skip_first_char(s);
@@ -1141,6 +1141,48 @@ mod tests {
         assert!(archive_pathmatch(
             "b/c/d$",
             "a/b/c/d",
+            PathMatch::NO_ANCHOR_START | PathMatch::NO_ANCHOR_END
+        ));
+
+        /* Anchor characters within pattern not special. */
+        assert!(!archive_pathmatch(
+            "*^*",
+            "a/b/c",
+            PathMatch::NO_ANCHOR_START | PathMatch::NO_ANCHOR_END
+        ));
+        assert!(archive_pathmatch(
+            "*^*",
+            "a^b",
+            PathMatch::NO_ANCHOR_START | PathMatch::NO_ANCHOR_END
+        ));
+        assert!(!archive_pathmatch(
+            "*$*",
+            "a/b/c",
+            PathMatch::NO_ANCHOR_START | PathMatch::NO_ANCHOR_END
+        ));
+        assert!(archive_pathmatch(
+            "*$*",
+            "a$b",
+            PathMatch::NO_ANCHOR_START | PathMatch::NO_ANCHOR_END
+        ));
+        assert!(!archive_pathmatch(
+            "a*/^b/c",
+            "a/b/c",
+            PathMatch::NO_ANCHOR_START | PathMatch::NO_ANCHOR_END
+        ));
+        assert!(archive_pathmatch(
+            "a*/^b/c",
+            "a/^b/c",
+            PathMatch::NO_ANCHOR_START | PathMatch::NO_ANCHOR_END
+        ));
+        assert!(!archive_pathmatch(
+            "a*/b$/c",
+            "a/b/c",
+            PathMatch::NO_ANCHOR_START | PathMatch::NO_ANCHOR_END
+        ));
+        assert!(archive_pathmatch(
+            "a*/b$/c",
+            "a/b$/c",
             PathMatch::NO_ANCHOR_START | PathMatch::NO_ANCHOR_END
         ));
     }


### PR DESCRIPTION
The '^' and '$' characters have special anchor meaning only at the very start or end of a pattern. When '*' triggered recursion through archive_pathmatch(), the function re-evaluated leading '^' and stripped it as an anchor, causing patterns like '*^*' to spuriously match paths with no literal '^'. Recurse via pm() instead so anchor handling runs only once at the top-level entry.

Ported from libarchive/libarchive#2924.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced wildcard matching behavior in glob patterns for more consistent results.

* **Tests**
  * Expanded test coverage for special character handling within path patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->