### PR TITLE
:sparkles: Add --newer and --older aliases to compat bsdtar

### DIFF
--- a/cli/src/command/bsdtar.rs
+++ b/cli/src/command/bsdtar.rs
@@ -484,6 +484,7 @@ pub(crate) struct BsdtarCommand {
         long,
         value_name = "DATETIME",
         requires = "unstable",
+        visible_alias = "older",
         help_heading = "Unstable Options",
         help = "Only include files and directories older than the specified date. This compares mtime entries."
     )]
@@ -500,6 +501,7 @@ pub(crate) struct BsdtarCommand {
         long,
         value_name = "DATETIME",
         requires = "unstable",
+        visible_alias = "newer",
         help_heading = "Unstable Options",
         help = "Only include files and directories newer than the specified date. This compares mtime entries."
     )]


### PR DESCRIPTION
bsdtar accepts --newer DATE and --older DATE as aliases of --newer-ctime / --older-ctime (libarchive tar/cmdline.c:100,121). Add these aliases in compat bsdtar, mapping them to the mtime variants.

PNA's ctime = birth time (chunk cTIM), while bsdtar's ctime = Unix inode change time. The closest behavioral match in PNA is mtime, which bumps on content changes the same way st_ctime does. This aliasing keeps the bare-form bsdtar-ctime family (--newer, --older, --newer-than, --older-than) consistent: all map to PNA mtime for behavioral approximation of bsdtar's ctime semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shorthand aliases for command-line arguments: `--older` as an alias for `--older_mtime` and `--newer` as an alias for `--newer_mtime`, providing more convenient shortcuts for date filtering operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->