### PR TITLE
:recycle: Rename --missing-* to --archive-missing-* with aliases

### DIFF
--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -272,16 +272,22 @@ pub(crate) struct ExtractCommand {
     older_mtime_than: Option<PathBuf>,
     #[arg(
         long,
+        visible_alias = "arc-missing-ctime",
+        alias = "missing-ctime",
         requires_all = ["unstable", "ctime-filter"],
-        help = "Behavior for entries without ctime when time filtering (unstable). Values: include, exclude, now, epoch, or a datetime. [default: include]"
+        help_heading = "Unstable Options",
+        help = "Behavior for archive entries without ctime when time filtering (unstable). Values: include, exclude, now, epoch, or a datetime. [default: include]"
     )]
-    missing_ctime: Option<MissingTimePolicy>,
+    archive_missing_ctime: Option<MissingTimePolicy>,
     #[arg(
         long,
+        visible_alias = "arc-missing-mtime",
+        alias = "missing-mtime",
         requires_all = ["unstable", "mtime-filter"],
-        help = "Behavior for entries without mtime when time filtering (unstable). Values: include, exclude, now, epoch, or a datetime. [default: include]"
+        help_heading = "Unstable Options",
+        help = "Behavior for archive entries without mtime when time filtering (unstable). Values: include, exclude, now, epoch, or a datetime. [default: include]"
     )]
-    missing_mtime: Option<MissingTimePolicy>,
+    archive_missing_mtime: Option<MissingTimePolicy>,
     #[arg(
         long,
         value_name = "PATTERN",
@@ -452,8 +458,12 @@ fn extract_archive(args: ExtractCommand) -> anyhow::Result<()> {
         older_mtime_than: args.older_mtime_than.as_deref(),
         newer_mtime: args.newer_mtime.map(|it| it.to_system_time()),
         older_mtime: args.older_mtime.map(|it| it.to_system_time()),
-        missing_ctime: args.missing_ctime.unwrap_or(MissingTimePolicy::Include),
-        missing_mtime: args.missing_mtime.unwrap_or(MissingTimePolicy::Include),
+        missing_ctime: args
+            .archive_missing_ctime
+            .unwrap_or(MissingTimePolicy::Include),
+        missing_mtime: args
+            .archive_missing_mtime
+            .unwrap_or(MissingTimePolicy::Include),
     }
     .resolve()?;
     let overwrite_strategy = OverwriteStrategy::from_flags(

--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -165,16 +165,22 @@ pub(crate) struct ListCommand {
     older_mtime_than: Option<PathBuf>,
     #[arg(
         long,
+        visible_alias = "arc-missing-ctime",
+        alias = "missing-ctime",
         requires_all = ["unstable", "ctime-filter"],
-        help = "Behavior for entries without ctime when time filtering (unstable). Values: include, exclude, now, epoch, or a datetime. [default: include]"
+        help_heading = "Unstable Options",
+        help = "Behavior for archive entries without ctime when time filtering (unstable). Values: include, exclude, now, epoch, or a datetime. [default: include]"
     )]
-    missing_ctime: Option<MissingTimePolicy>,
+    archive_missing_ctime: Option<MissingTimePolicy>,
     #[arg(
         long,
+        visible_alias = "arc-missing-mtime",
+        alias = "missing-mtime",
         requires_all = ["unstable", "mtime-filter"],
-        help = "Behavior for entries without mtime when time filtering (unstable). Values: include, exclude, now, epoch, or a datetime. [default: include]"
+        help_heading = "Unstable Options",
+        help = "Behavior for archive entries without mtime when time filtering (unstable). Values: include, exclude, now, epoch, or a datetime. [default: include]"
     )]
-    missing_mtime: Option<MissingTimePolicy>,
+    archive_missing_mtime: Option<MissingTimePolicy>,
     #[arg(
         short = 'q',
         help = "Force printing of non-graphic characters in file names as the character '?'"
@@ -498,8 +504,12 @@ fn list_archive(ctx: &crate::cli::GlobalContext, args: ListCommand) -> anyhow::R
         older_mtime_than: args.older_mtime_than.as_deref(),
         newer_mtime: args.newer_mtime.map(|it| it.to_system_time()),
         older_mtime: args.older_mtime.map(|it| it.to_system_time()),
-        missing_ctime: args.missing_ctime.unwrap_or(MissingTimePolicy::Include),
-        missing_mtime: args.missing_mtime.unwrap_or(MissingTimePolicy::Include),
+        missing_ctime: args
+            .archive_missing_ctime
+            .unwrap_or(MissingTimePolicy::Include),
+        missing_mtime: args
+            .archive_missing_mtime
+            .unwrap_or(MissingTimePolicy::Include),
     }
     .resolve()?;
 


### PR DESCRIPTION
Rename list/extract's --missing-ctime / --missing-mtime flags to --archive-missing-ctime / --archive-missing-mtime, keeping the legacy names as hidden clap aliases. Also add --arc-missing-* short aliases.

This establishes the disambiguating naming convention for archive-side-missing timestamp fallbacks. Future phases will introduce --source-missing-* on write-side commands and staleness-side controls for update. No behavior change; TimeFilterResolver and MissingTimePolicy are unchanged, all existing CLI invocations continue to work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed CLI flags --archive-missing-ctime and --archive-missing-mtime; legacy names (--missing-ctime / --missing-mtime) preserved as aliases for compatibility.
* **Documentation**
  * Updated CLI help to group these options under "Unstable Options" and to explicitly state they apply to archive entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->