### PR TITLE
:sparkles: Add --archive-missing-* on update

### DIFF
--- a/cli/src/command/bsdtar.rs
+++ b/cli/src/command/bsdtar.rs
@@ -1551,6 +1551,7 @@ fn run_update(args: BsdtarCommand) -> anyhow::Result<()> {
         &create_options,
         target_items,
         false,
+        MissingTimePolicy::Include,
         &mut out_archive,
         TransformStrategyUnSolid,
         args.verbose,

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -272,6 +272,22 @@ pub(crate) struct UpdateCommand {
     older_mtime_than: Option<PathBuf>,
     #[arg(
         long,
+        visible_alias = "arc-missing-ctime",
+        requires = "unstable",
+        help_heading = "Unstable Options",
+        help = "Behavior for archive entries without ctime during update staleness judgment (unstable). Values: include, exclude, now, epoch, or a datetime. [default: include]"
+    )]
+    archive_missing_ctime: Option<MissingTimePolicy>,
+    #[arg(
+        long,
+        visible_alias = "arc-missing-mtime",
+        requires = "unstable",
+        help_heading = "Unstable Options",
+        help = "Behavior for archive entries without mtime during update staleness judgment (unstable). Values: include, exclude, now, epoch, or a datetime. [default: include]"
+    )]
+    archive_missing_mtime: Option<MissingTimePolicy>,
+    #[arg(
+        long,
         value_name = "FILE",
         requires = "unstable",
         help_heading = "Unstable Options",
@@ -450,6 +466,9 @@ fn update_archive(args: UpdateCommand) -> anyhow::Result<()> {
         missing_mtime: MissingTimePolicy::Include,
     }
     .resolve()?;
+    let archive_missing_mtime = args
+        .archive_missing_mtime
+        .unwrap_or(MissingTimePolicy::Include);
     let create_options = CreateOptions {
         option,
         keep_options,
@@ -515,6 +534,7 @@ fn update_archive(args: UpdateCommand) -> anyhow::Result<()> {
             &create_options,
             target_items,
             sync,
+            archive_missing_mtime,
             &mut out_archive,
             TransformStrategyUnSolid,
             false,
@@ -526,6 +546,7 @@ fn update_archive(args: UpdateCommand) -> anyhow::Result<()> {
             &create_options,
             target_items,
             sync,
+            archive_missing_mtime,
             &mut out_archive,
             TransformStrategyKeepSolid,
             false,
@@ -547,6 +568,7 @@ pub(crate) fn run_update_archive<Strategy, W>(
     create_options: &CreateOptions,
     target_items: Vec<CollectedEntry>,
     sync: bool,
+    archive_missing_mtime: MissingTimePolicy,
     out_archive: &mut Archive<W>,
     _strategy: Strategy,
     verbose: bool,
@@ -572,8 +594,12 @@ where
                     if let Some((idx, item)) =
                         target_files_mapping.shift_remove(entry.header().path())
                     {
-                        let need_update =
-                            is_newer_than_archive(&item.metadata, entry.metadata()).unwrap_or(true);
+                        let need_update = is_newer_than_archive(
+                            archive_missing_mtime,
+                            &item.metadata,
+                            entry.metadata(),
+                        )
+                        .unwrap_or(true);
                         if need_update {
                             let tx = tx.clone();
                             let create_options = create_options.clone();
@@ -626,8 +652,17 @@ where
 }
 
 #[inline]
-fn is_newer_than_archive(fs_meta: &fs::Metadata, metadata: &Metadata) -> Option<bool> {
+fn is_newer_than_archive(
+    archive_missing_mtime: MissingTimePolicy,
+    fs_meta: &fs::Metadata,
+    metadata: &Metadata,
+) -> Option<bool> {
     let fs_mtime = fs_meta.modified().ok()?;
-    let archive_mtime = metadata.modified_time()?;
+    let archive_mtime = match (metadata.modified_time(), archive_missing_mtime) {
+        (Some(t), _) => t,
+        (None, MissingTimePolicy::Include) => return Some(true),
+        (None, MissingTimePolicy::Exclude) => return Some(false),
+        (None, MissingTimePolicy::Assume(t)) => t,
+    };
     Some(archive_mtime < fs_mtime)
 }

--- a/cli/tests/cli/update.rs
+++ b/cli/tests/cli/update.rs
@@ -2,6 +2,7 @@ mod encryption;
 mod entry_order;
 mod error;
 mod no_timestamp_archive;
+mod option_archive_missing_mtime;
 mod option_atime;
 mod option_ctime;
 mod option_exclude;

--- a/cli/tests/cli/update/option_archive_missing_mtime.rs
+++ b/cli/tests/cli/update/option_archive_missing_mtime.rs
@@ -1,0 +1,152 @@
+use crate::utils::{archive, setup};
+use clap::Parser;
+use pna::ReadOptions;
+use portable_network_archive::cli;
+use std::{fs, io::prelude::*};
+
+/// Precondition: Archive contains an entry without mtime (mTIM chunk omitted).
+/// Action: Run `pna experimental update` without `--archive-missing-mtime`.
+/// Expectation: The entry is replaced with the newer source content
+/// (default `Include` policy treats mtime-missing entries as stale, reproducing the
+/// pre-change hardcoded behavior).
+#[test]
+fn update_default_mtime_missing_still_updates() {
+    setup();
+    let _ = fs::remove_dir_all("update_arc_missing_mtime_default");
+    fs::create_dir_all("update_arc_missing_mtime_default").unwrap();
+    let source = "update_arc_missing_mtime_default/file.txt";
+    let archive_path = "update_arc_missing_mtime_default/archive.pna";
+
+    // Create an initial archive whose entry has no mTIM chunk.
+    fs::write(source, "old content").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        archive_path,
+        "--overwrite",
+        source,
+        "--no-keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Sanity check: entry is mTIM-less.
+    archive::for_each_entry(archive_path, |entry| {
+        assert!(
+            entry.metadata().modified().is_none(),
+            "precondition: entry {} must be mTIM-less",
+            entry.header().path()
+        );
+    })
+    .unwrap();
+
+    // Modify the source file.
+    fs::write(source, "new content").unwrap();
+
+    // Default behavior: no `--archive-missing-mtime` flag.
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "-f",
+        archive_path,
+        source,
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Read the entry content from the archive and confirm it was updated.
+    let entry = archive::extract_single_entry(archive_path, source)
+        .unwrap()
+        .expect("entry should exist");
+    let mut buf = Vec::new();
+    entry
+        .reader(ReadOptions::with_password::<&[u8]>(None))
+        .unwrap()
+        .read_to_end(&mut buf)
+        .unwrap();
+    assert_eq!(
+        buf.as_slice(),
+        b"new content",
+        "default policy should update mtime-missing entries"
+    );
+}
+
+/// Precondition: Archive contains an entry without mtime.
+/// Action: Run `pna experimental update --archive-missing-mtime=exclude` on its own
+/// (no time-filter flag). Update's Path B staleness judgment fires for every entry
+/// regardless of time-filter flags, so the archive-missing policy takes effect.
+/// Expectation: The entry is kept (pass-through) because `exclude` treats mtime-missing
+/// archive entries as NOT stale.
+#[test]
+fn update_archive_missing_mtime_exclude_keeps_entry() {
+    setup();
+    let _ = fs::remove_dir_all("update_arc_missing_mtime_exclude");
+    fs::create_dir_all("update_arc_missing_mtime_exclude").unwrap();
+    let source = "update_arc_missing_mtime_exclude/file.txt";
+    let archive_path = "update_arc_missing_mtime_exclude/archive.pna";
+
+    // Create an initial archive whose entry has no mTIM chunk.
+    fs::write(source, "old content").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        archive_path,
+        "--overwrite",
+        source,
+        "--no-keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    archive::for_each_entry(archive_path, |entry| {
+        assert!(
+            entry.metadata().modified().is_none(),
+            "precondition: entry {} must be mTIM-less",
+            entry.header().path()
+        );
+    })
+    .unwrap();
+
+    // Modify the source file.
+    fs::write(source, "new content").unwrap();
+
+    // Run update with --archive-missing-mtime=exclude alone (no time filter);
+    // Path B staleness judgment consults the policy for every entry.
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "--unstable",
+        "--archive-missing-mtime=exclude",
+        "-f",
+        archive_path,
+        source,
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Exclude policy keeps the mtime-less entry untouched: content is OLD.
+    let entry = archive::extract_single_entry(archive_path, source)
+        .unwrap()
+        .expect("entry should exist");
+    let mut buf = Vec::new();
+    entry
+        .reader(ReadOptions::with_password::<&[u8]>(None))
+        .unwrap()
+        .read_to_end(&mut buf)
+        .unwrap();
+    assert_eq!(
+        buf.as_slice(),
+        b"old content",
+        "exclude policy should keep mtime-missing entries"
+    );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental CLI options --archive-missing-mtime and --archive-missing-ctime to control handling of archive entries that lack timestamp metadata; missing timestamps are treated as "include" by default.

* **Tests**
  * Added integration tests validating update behavior when archive entries omit mtime, covering default (include) and explicit exclude behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->