### PR TITLE
:shirt: Update deprecation warning for experimental delete

### DIFF
--- a/cli/src/command/experimental.rs
+++ b/cli/src/command/experimental.rs
@@ -26,7 +26,7 @@ impl Command for ExperimentalCommand {
             }
             ExperimentalCommands::Delete(cmd) => {
                 log::warn!(
-                    "`{0} experimental delete` subcommand was stabilized, use `{0} delete` instead.",
+                    "`{0} experimental delete` subcommand was stabilized, use `{0} delete` instead. this command will be removed in the future.",
                     std::env::current_exe()
                         .ok()
                         .and_then(|it| it.file_name().map(|n| n.to_os_string()))
@@ -63,7 +63,9 @@ pub(crate) enum ExperimentalCommands {
         about = "bsdtar-like CLI semantics for PNA archives (stabilized, use `pna compat bsdtar` instead)"
     )]
     Stdio(command::bsdtar::BsdtarCommand),
-    #[command(about = "Delete entry from archive")]
+    #[command(
+        about = "Delete entry from archive (stabilized, use `pna delete` command instead. this command will be removed in the future)"
+    )]
     Delete(command::delete::DeleteCommand),
     #[command(about = "Update entries in archive")]
     Update(command::update::UpdateCommand),


### PR DESCRIPTION
Enhanced the warning message and about text for the `experimental delete` subcommand to indicate it will be removed in the future, guiding users to use the stabilized `delete` command. Mirrors the prior pattern applied to `experimental xattr` (9381433c).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated messaging for the experimental delete subcommand to indicate it is now stabilized. Users are directed to use the standard `pna delete` command instead. The experimental version will be removed in a future release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->