### PR TITLE
:sparkles: Stabilize migrate subcommand

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -9,8 +9,8 @@ use crate::{
         append::AppendCommand, bugreport::BugReportCommand, compat::CompatCommand,
         complete::CompleteCommand, concat::ConcatCommand, core::Umask, create::CreateCommand,
         delete::DeleteCommand, experimental::ExperimentalCommand, extract::ExtractCommand,
-        list::ListCommand, sort::SortCommand, split::SplitCommand, strip::StripCommand,
-        xattr::XattrCommand,
+        list::ListCommand, migrate::MigrateCommand, sort::SortCommand, split::SplitCommand,
+        strip::StripCommand, xattr::XattrCommand,
     },
     utils::{fs::current_umask, process::is_running_as_root},
 };
@@ -195,6 +195,8 @@ pub(crate) enum Commands {
     Strip(StripCommand),
     #[command(about = "Sort entries in archive")]
     Sort(SortCommand),
+    #[command(about = "Upgrade archives created by older PNA versions")]
+    Migrate(MigrateCommand),
     #[command(about = "Manipulate extended attributes")]
     Xattr(XattrCommand),
     #[command(about = "Generate shell auto complete")]

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -15,7 +15,7 @@ pub mod diff;
 pub(super) mod experimental;
 pub mod extract;
 pub mod list;
-mod migrate;
+pub mod migrate;
 pub mod sort;
 pub mod split;
 pub(crate) mod strip;
@@ -74,6 +74,7 @@ impl Cli {
             Commands::Concat(cmd) => cmd.execute(ctx),
             Commands::Strip(cmd) => cmd.execute(ctx),
             Commands::Sort(cmd) => cmd.execute(ctx),
+            Commands::Migrate(cmd) => cmd.execute(ctx),
             Commands::Xattr(cmd) => cmd.execute(ctx),
             Commands::Complete(cmd) => cmd.execute(ctx),
             Commands::BugReport(cmd) => cmd.execute(ctx),

--- a/cli/src/command/experimental.rs
+++ b/cli/src/command/experimental.rs
@@ -39,7 +39,17 @@ impl Command for ExperimentalCommand {
             ExperimentalCommands::Chown(cmd) => cmd.execute(ctx),
             ExperimentalCommands::Chmod(cmd) => cmd.execute(ctx),
             ExperimentalCommands::Acl(cmd) => cmd.execute(ctx),
-            ExperimentalCommands::Migrate(cmd) => cmd.execute(ctx),
+            ExperimentalCommands::Migrate(cmd) => {
+                log::warn!(
+                    "`{0} experimental migrate` subcommand was stabilized, use `{0} migrate` instead. this command will be removed in the future.",
+                    std::env::current_exe()
+                        .ok()
+                        .and_then(|it| it.file_name().map(|n| n.to_os_string()))
+                        .unwrap_or_default()
+                        .to_string_lossy()
+                );
+                cmd.execute(ctx)
+            }
             ExperimentalCommands::Chunk(cmd) => cmd.execute(ctx),
             ExperimentalCommands::Sort(cmd) => {
                 log::warn!(
@@ -75,7 +85,9 @@ pub(crate) enum ExperimentalCommands {
     Chmod(command::chmod::ChmodCommand),
     #[command(about = "Manipulate ACLs of entries")]
     Acl(command::acl::AclCommand),
-    #[command(about = "Migrate old format to latest format")]
+    #[command(
+        about = "Upgrade archives created by older PNA versions (stabilized, use `pna migrate` command instead. this command will be removed in the future)"
+    )]
     Migrate(command::migrate::MigrateCommand),
     #[command(about = "Chunk level operation")]
     Chunk(command::chunk::ChunkCommand),


### PR DESCRIPTION
The migrate command has been moved out of experimental and is now a stable CLI subcommand. A deprecation warning is added to the `experimental migrate` alias to inform users to use the new stable `migrate` command, and related module visibility and command dispatch logic are updated accordingly. Mirrors the prior pattern applied to `sort` (f2f15d38) and `delete` (5417b47b).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `migrate` command to upgrade archives created by previous versions.

* **Deprecations**
  * The experimental `migrate` subcommand is now stabilized; use the standard `migrate` command instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->