### PR TITLE
:memo: Lowercase libpna error messages per Rust convention

### DIFF
--- a/lib/src/archive/read.rs
+++ b/lib/src/archive/read.rs
@@ -151,8 +151,9 @@ impl<R: Read> Archive<R> {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!(
-                    "next archive number must be +1 (current: {}, detected: {})",
-                    current_header.archive_number, next.header.archive_number
+                    "next archive number must be {} (expected previous + 1, detected: {})",
+                    current_header.archive_number + 1,
+                    next.header.archive_number
                 ),
             ));
         }

--- a/lib/src/archive/read.rs
+++ b/lib/src/archive/read.rs
@@ -19,7 +19,10 @@ pub(crate) fn read_pna_header<R: Read>(mut reader: R) -> io::Result<()> {
     let mut header = [0u8; PNA_HEADER.len()];
     reader.read_exact(&mut header)?;
     if &header != PNA_HEADER {
-        return Err(io::Error::new(io::ErrorKind::InvalidData, "It's not PNA"));
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "not a PNA archive",
+        ));
     }
     Ok(())
 }
@@ -29,7 +32,10 @@ async fn read_pna_header_async<R: futures_io::AsyncRead + Unpin>(mut reader: R) 
     let mut header = [0u8; PNA_HEADER.len()];
     reader.read_exact(&mut header).await?;
     if &header != PNA_HEADER {
-        return Err(io::Error::new(io::ErrorKind::InvalidData, "It's not PNA"));
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "not a PNA archive",
+        ));
     }
     Ok(())
 }

--- a/lib/src/archive/read.rs
+++ b/lib/src/archive/read.rs
@@ -58,7 +58,7 @@ impl<R: Read> Archive<R> {
         if chunk.ty != ChunkType::AHED {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("Unexpected Chunk `{}`", chunk.ty),
+                format!("unexpected chunk `{}`", chunk.ty),
             ));
         }
         let header = ArchiveHeader::try_from_bytes(chunk.data())?;
@@ -151,7 +151,7 @@ impl<R: Read> Archive<R> {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!(
-                    "Next archive number must be +1 (current: {}, detected: {})",
+                    "next archive number must be +1 (current: {}, detected: {})",
                     current_header.archive_number, next.header.archive_number
                 ),
             ));
@@ -211,7 +211,7 @@ impl<R: futures_io::AsyncRead + Unpin> Archive<R> {
         if chunk.ty != ChunkType::AHED {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("Unexpected Chunk `{}`", chunk.ty),
+                format!("unexpected chunk `{}`", chunk.ty),
             ));
         }
         let header = ArchiveHeader::try_from_bytes(chunk.data())?;

--- a/lib/src/archive/read/slice.rs
+++ b/lib/src/archive/read/slice.rs
@@ -12,7 +12,10 @@ pub(crate) fn read_header_from_slice(bytes: &[u8]) -> io::Result<&[u8]> {
         .split_at_checked(PNA_HEADER.len())
         .ok_or(io::ErrorKind::UnexpectedEof)?;
     if header != PNA_HEADER {
-        return Err(io::Error::new(io::ErrorKind::InvalidData, "It's not PNA"));
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "not a PNA archive",
+        ));
     }
     Ok(body)
 }

--- a/lib/src/archive/read/slice.rs
+++ b/lib/src/archive/read/slice.rs
@@ -157,8 +157,9 @@ impl<'d> Archive<&'d [u8]> {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!(
-                    "next archive number must be +1 (current: {}, detected: {})",
-                    current_header.archive_number, next.header.archive_number
+                    "next archive number must be {} (expected previous + 1, detected: {})",
+                    current_header.archive_number + 1,
+                    next.header.archive_number
                 ),
             ));
         }

--- a/lib/src/archive/read/slice.rs
+++ b/lib/src/archive/read/slice.rs
@@ -38,7 +38,7 @@ impl<'d> Archive<&'d [u8]> {
         if chunk.ty != ChunkType::AHED {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("Unexpected Chunk `{}`", chunk.ty),
+                format!("unexpected chunk `{}`", chunk.ty),
             ));
         }
         let header = ArchiveHeader::try_from_bytes(chunk.data())?;
@@ -157,7 +157,7 @@ impl<'d> Archive<&'d [u8]> {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!(
-                    "Next archive number must be +1 (current: {}, detected: {})",
+                    "next archive number must be +1 (current: {}, detected: {})",
                     current_header.archive_number, next.header.archive_number
                 ),
             ));

--- a/lib/src/chunk/read.rs
+++ b/lib/src/chunk/read.rs
@@ -83,7 +83,7 @@ impl<R: AsyncRead + Unpin> ChunkReader<R> {
         let crc = u32::from_be_bytes(crc);
 
         if crc != crc_hasher.finalize() {
-            return Err(io::Error::new(io::ErrorKind::InvalidData, "Broken chunk"));
+            return Err(io::Error::new(io::ErrorKind::InvalidData, "broken chunk"));
         }
         let ty = ChunkType::new(ty)?;
         Ok(RawChunk {
@@ -146,7 +146,7 @@ pub(crate) fn read_chunk<R: Read>(
     let crc = u32::from_be_bytes(crc);
 
     if crc != crc_hasher.finalize() {
-        return Err(io::Error::new(io::ErrorKind::InvalidData, "Broken chunk"));
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "broken chunk"));
     }
     let ty = ChunkType::new(ty)?;
     Ok(RawChunk {
@@ -185,7 +185,7 @@ pub(crate) fn read_chunk_from_slice(bytes: &[u8]) -> io::Result<(RawChunk<&[u8]>
     let crc = u32::from_be_bytes(*crc);
 
     if crc != crc_hasher.finalize() {
-        return Err(io::Error::new(io::ErrorKind::InvalidData, "Broken chunk"));
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "broken chunk"));
     }
     let ty = ChunkType::new(*ty)?;
     Ok((

--- a/lib/src/chunk/types.rs
+++ b/lib/src/chunk/types.rs
@@ -22,9 +22,9 @@ impl Display for ChunkTypeError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         Display::fmt(
             match self {
-                Self::NonAsciiAlphabetic => "All characters must be ASCII alphabetic",
-                Self::NonPrivateChunkType => "The second character must be lowercase",
-                Self::Reserved => "The third character must be uppercase",
+                Self::NonAsciiAlphabetic => "all characters must be ASCII alphabetic",
+                Self::NonPrivateChunkType => "the second character must be lowercase",
+                Self::Reserved => "the third character must be uppercase",
             },
             f,
         )

--- a/lib/src/cipher/block/read.rs
+++ b/lib/src/cipher/block/read.rs
@@ -89,7 +89,7 @@ where
                     }
                     return Err(io::Error::new(
                         io::ErrorKind::UnexpectedEof,
-                        format!("Expected block size {block_size} but {filled}"),
+                        format!("expected block of {block_size} bytes, got {filled}"),
                     ));
                 }
                 filled += read_len;

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -179,10 +179,10 @@ where
             match first_chunk.ty {
                 ChunkType::SHED => Ok(Self::Solid(SolidEntry::try_from(entry)?)),
                 ChunkType::FHED => Ok(Self::Normal(NormalEntry::try_from(entry)?)),
-                _ => Err(io::Error::new(io::ErrorKind::InvalidData, "Invalid entry")),
+                _ => Err(io::Error::new(io::ErrorKind::InvalidData, "invalid entry")),
             }
         } else {
-            Err(io::Error::new(io::ErrorKind::InvalidData, "Empty entry"))
+            Err(io::Error::new(io::ErrorKind::InvalidData, "empty entry"))
         }
     }
 }
@@ -562,7 +562,7 @@ where
                     if chunk.ty().is_critical() {
                         return Err(io::Error::new(
                             io::ErrorKind::InvalidData,
-                            format!("Unknown critical chunk type: {}", chunk.ty()),
+                            format!("unknown critical chunk type: {}", chunk.ty()),
                         ));
                     }
                     extra.push(chunk);
@@ -666,7 +666,7 @@ where
                     if chunk.ty.is_critical() {
                         return Err(io::Error::new(
                             io::ErrorKind::InvalidData,
-                            format!("Unknown critical chunk type: {}", chunk.ty),
+                            format!("unknown critical chunk type: {}", chunk.ty),
                         ));
                     }
                     extra.push(chunk);

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -534,7 +534,11 @@ where
             if first_chunk.ty != ChunkType::SHED {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
-                    format!("expected {} chunk, got {}", ChunkType::SHED, first_chunk.ty),
+                    format!(
+                        "expected `{}` chunk, got `{}`",
+                        ChunkType::SHED,
+                        first_chunk.ty
+                    ),
                 ));
             } else {
                 SolidHeader::try_from(first_chunk.data())?
@@ -542,7 +546,7 @@ where
         } else {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("{} chunk not found", ChunkType::SHED),
+                format!("`{}` chunk not found", ChunkType::SHED),
             ));
         };
         let mut extra = vec![];
@@ -562,7 +566,7 @@ where
                     if chunk.ty().is_critical() {
                         return Err(io::Error::new(
                             io::ErrorKind::InvalidData,
-                            format!("unknown critical chunk type: {}", chunk.ty()),
+                            format!("unknown critical chunk type: `{}`", chunk.ty()),
                         ));
                     }
                     extra.push(chunk);
@@ -606,14 +610,18 @@ where
             if first_chunk.ty != ChunkType::FHED {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
-                    format!("expected {} chunk, got {}", ChunkType::FHED, first_chunk.ty),
+                    format!(
+                        "expected `{}` chunk, got `{}`",
+                        ChunkType::FHED,
+                        first_chunk.ty
+                    ),
                 ));
             }
             EntryHeader::try_from(first_chunk.data())?
         } else {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("{} chunk not found", ChunkType::FHED),
+                format!("`{}` chunk not found", ChunkType::FHED),
             ));
         };
         if header.major != 0 || header.minor != 0 {
@@ -666,7 +674,7 @@ where
                     if chunk.ty.is_critical() {
                         return Err(io::Error::new(
                             io::ErrorKind::InvalidData,
-                            format!("unknown critical chunk type: {}", chunk.ty),
+                            format!("unknown critical chunk type: `{}`", chunk.ty),
                         ));
                     }
                     extra.push(chunk);

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -534,11 +534,7 @@ where
             if first_chunk.ty != ChunkType::SHED {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
-                    format!(
-                        "Expected {} chunk, but {} chunk was found",
-                        ChunkType::SHED,
-                        first_chunk.ty
-                    ),
+                    format!("expected {} chunk, got {}", ChunkType::SHED, first_chunk.ty),
                 ));
             } else {
                 SolidHeader::try_from(first_chunk.data())?
@@ -610,11 +606,7 @@ where
             if first_chunk.ty != ChunkType::FHED {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
-                    format!(
-                        "Expected {} chunk, but {} chunk was found",
-                        ChunkType::FHED,
-                        first_chunk.ty
-                    ),
+                    format!("expected {} chunk, got {}", ChunkType::FHED, first_chunk.ty),
                 ));
             }
             EntryHeader::try_from(first_chunk.data())?
@@ -628,7 +620,7 @@ where
             return Err(io::Error::new(
                 io::ErrorKind::Unsupported,
                 format!(
-                    "entry version {}.{} is not supported.",
+                    "entry version {}.{} is not supported",
                     header.major, header.minor
                 ),
             ));

--- a/lib/src/entry/read.rs
+++ b/lib/src/entry/read.rs
@@ -28,12 +28,12 @@ pub(crate) fn decrypt_reader<R: Read>(
             let phsf = derive_password_hash(
                 s,
                 password.ok_or_else(|| {
-                    io::Error::new(io::ErrorKind::InvalidInput, "Password was not provided")
+                    io::Error::new(io::ErrorKind::InvalidInput, "password was not provided")
                 })?,
             )?;
             let hash = phsf
                 .hash
-                .ok_or_else(|| io::Error::new(io::ErrorKind::Unsupported, "Failed to get hash"))?;
+                .ok_or_else(|| io::Error::new(io::ErrorKind::Unsupported, "failed to get hash"))?;
             let key = hash.as_bytes();
             match (encryption, cipher_mode) {
                 (Encryption::Aes, CipherMode::CBC) => {

--- a/lib/src/entry/write.rs
+++ b/lib/src/entry/write.rs
@@ -106,7 +106,7 @@ fn hash<'s, 'p: 's>(
     let hash = password_hash
         .hash
         .take()
-        .ok_or_else(|| io::Error::new(io::ErrorKind::Unsupported, "Failed to get hash"))?;
+        .ok_or_else(|| io::Error::new(io::ErrorKind::Unsupported, "failed to get hash"))?;
     Ok((hash, password_hash.to_string()))
 }
 

--- a/lib/src/hash.rs
+++ b/lib/src/hash.rs
@@ -79,7 +79,7 @@ pub(crate) fn derive_password_hash<'a>(
         }
         a => Err(io::Error::new(
             io::ErrorKind::Unsupported,
-            format!("Unsupported algorithm {a:?}"),
+            format!("unsupported algorithm {a:?}"),
         )),
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized and clarified error messages across the app for improved readability and consistency. Messages now use lowercase phrasing, uniform wording patterns, clearer numeric mismatch descriptions, and more consistent chunk/type wording and punctuation. These changes affect validation, CRC/reporting, password/hash, and archive-number messages to make errors easier to read and interpret.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->