### PR TITLE
:sparkles: Restrict -O / --to-stdout to extract and list modes

### DIFF
--- a/cli/src/command/bsdtar.rs
+++ b/cli/src/command/bsdtar.rs
@@ -691,6 +691,9 @@ fn run_bsdtar(ctx: &GlobalContext, args: BsdtarCommand) -> anyhow::Result<()> {
             "Option '--block-size {block_size}' is accepted for compatibility but will be ignored."
         );
     }
+    if args.to_stdout && (args.create || args.append || args.update) {
+        anyhow::bail!("-O / --to-stdout is only valid in extract (-x) or list (-t) modes");
+    }
     if args.create {
         run_create_archive(args)
     } else if args.extract {

--- a/tests/bats/test_to_stdout_mode_restriction.bats
+++ b/tests/bats/test_to_stdout_mode_restriction.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+
+# Verify that -O / --to-stdout is only valid in extract (-x) and list (-t)
+# modes, matching bsdtar's `only_mode(bsdtar, "-O", "xt")` check
+# (libarchive tar/bsdtar.c:935).
+# pna's BsdtarCommand modes are: create, extract, list, append, update.
+
+load 'test_helper.bash'
+
+EXECUTABLE="pna --log-level error compat bsdtar --unstable --keep-dir --overwrite"
+
+setup_file() {
+  pushd "$BATS_FILE_TMPDIR" || exit 1
+
+  assert_make_file file1 0644 "file1"
+  run bash -c "$EXECUTABLE -cf archive.tar file1"
+  assert_success
+}
+
+teardown_file() {
+  popd || exit 1
+}
+
+setup() {
+  TEST_DIR="test$BATS_TEST_NUMBER"
+  assert_make_dir "$TEST_DIR" 0755
+  pushd "$TEST_DIR" || exit 1
+}
+
+teardown() {
+  popd || exit 1
+}
+
+@test "-c with -O is rejected" {
+  cp ../file1 .
+  run bash -c "$EXECUTABLE -cOf out.tar file1 2>test.err"
+  assert_failure
+  assert_file_not_empty test.err
+}
+
+@test "-r with -O is rejected" {
+  cp ../archive.tar copy.tar
+  cp ../file1 .
+  run bash -c "$EXECUTABLE -rOf copy.tar file1 2>test.err"
+  assert_failure
+  assert_file_not_empty test.err
+}
+
+@test "-u with -O is rejected" {
+  cp ../archive.tar copy.tar
+  cp ../file1 .
+  run bash -c "$EXECUTABLE -uOf copy.tar file1 2>test.err"
+  assert_failure
+  assert_file_not_empty test.err
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `bsdtar` command now rejects invalid combinations of the `--to-stdout` flag with create, append, and update operation modes.

* **Tests**
  * Added test cases verifying the rejection of `--to-stdout` when used with non-compatible operation modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->