### PR TITLE
Cli/compat bsdtar/pin update strip components

### DIFF
--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -610,7 +610,15 @@ where
                                         unreachable!("receiver is held by scope owner")
                                     });
                             });
-                            Ok(None)
+                            // `--sync` controls whether the archive is forcibly
+                            // realigned to the disk state. With sync the old
+                            // archive entry is dropped and replaced by the new
+                            // one (PNA-native semantics). Without sync the old
+                            // entry is preserved and the new one is appended,
+                            // matching bsdtar's append-only `-u` behavior
+                            // (duplicate entries are allowed; later wins on
+                            // extraction).
+                            if sync { Ok(None) } else { Ok(Some(entry)) }
                         } else {
                             Ok(Some(entry))
                         }

--- a/cli/tests/cli/stdio.rs
+++ b/cli/tests/cli/stdio.rs
@@ -19,6 +19,7 @@ mod option_same_permissions;
 mod option_substitution;
 mod option_to_stdout;
 mod option_update;
+mod option_update_strip_components;
 mod option_version;
 mod path_traversal;
 mod strip_components;

--- a/cli/tests/cli/stdio/option_update_strip_components.rs
+++ b/cli/tests/cli/stdio/option_update_strip_components.rs
@@ -1,0 +1,659 @@
+#![cfg(not(target_family = "wasm"))]
+//! TDD red-phase tests pinning bsdtar's observed behavior for the combination
+//! of `-u` (update) and `--strip-components`.
+//!
+//! Each `#[test]` encodes a scenario empirically verified against bsdtar 3.5.3
+//! / libarchive 3.5.3 (see investigation report). bsdtar's output is the
+//! authoritative expectation; divergences from `pna compat bsdtar` represent
+//! compatibility gaps to be addressed.
+//!
+//! ## Backend switch
+//!
+//! These tests exercise `pna compat bsdtar` by default. Setting the env var
+//! `BSDTAR_REFERENCE=1` (optionally with `BSDTAR_PATH=/path/to/bsdtar`) swaps
+//! the harness to invoke real `bsdtar` instead, producing a tar archive and
+//! reading it via `bsdtar -tf`. This is a fixture-correctness check: the
+//! reference run is expected to be GREEN — if it fails, the test fixture
+//! itself encodes wrong expectations rather than a real pna gap.
+//!
+//! Mtime assertions are unconditional under the pna backend but skipped under
+//! the bsdtar backend (since `bsdtar -tf` does not yield epoch-precision mtime
+//! and reading the tar binary directly is out of scope for fixture-checking).
+
+use crate::utils::{archive::for_each_entry, setup};
+use assert_cmd::Command as AssertCommand;
+use assert_cmd::cargo::cargo_bin_cmd;
+use pna::Duration as PnaDuration;
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+    process::Command as StdCommand,
+    time::{Duration, SystemTime},
+};
+
+const MTIME_2020: i64 = 1_577_836_800; // 2020-01-01T00:00:00Z
+const MTIME_2026: i64 = 1_767_225_600; // 2026-01-01T00:00:00Z
+
+fn is_bsdtar_reference() -> bool {
+    std::env::var_os("BSDTAR_REFERENCE").is_some()
+}
+
+fn bsdtar_binary() -> String {
+    std::env::var("BSDTAR_PATH").unwrap_or_else(|_| "/usr/bin/bsdtar".into())
+}
+
+fn compat_cmd() -> AssertCommand {
+    if is_bsdtar_reference() {
+        AssertCommand::new(bsdtar_binary())
+    } else {
+        cargo_bin_cmd!("pna")
+    }
+}
+
+fn compat_args<const N: usize>(rest: [&str; N]) -> Vec<&str> {
+    let mut v: Vec<&str> = if is_bsdtar_reference() {
+        Vec::new()
+    } else {
+        vec!["--quiet", "compat", "bsdtar", "--unstable"]
+    };
+    v.extend_from_slice(&rest);
+    v
+}
+
+fn archive_path(base: &Path) -> PathBuf {
+    base.join(if is_bsdtar_reference() {
+        "archive.tar"
+    } else {
+        "archive.pna"
+    })
+}
+
+fn set_mtime(path: impl AsRef<Path>, secs: i64) {
+    let t = SystemTime::UNIX_EPOCH + Duration::from_secs(secs as u64);
+    filetime::set_file_mtime(path, filetime::FileTime::from_system_time(t)).unwrap();
+}
+
+fn pna_dur(secs: i64) -> PnaDuration {
+    PnaDuration::seconds(secs)
+}
+
+/// Build the standard `src/` fixture rooted at `base`.
+/// Layout: `src/`, `src/sub/`, `src/A.txt`, `src/sub/B.txt` — all with mtime=2020.
+fn build_src_fixture(base: &Path) -> (PathBuf, PathBuf, PathBuf) {
+    let src = base.join("src");
+    let sub = src.join("sub");
+    fs::create_dir_all(&sub).unwrap();
+    let a = src.join("A.txt");
+    let b = sub.join("B.txt");
+    fs::write(&a, b"old A").unwrap();
+    fs::write(&b, b"old B").unwrap();
+    set_mtime(&a, MTIME_2020);
+    set_mtime(&b, MTIME_2020);
+    set_mtime(&sub, MTIME_2020);
+    set_mtime(&src, MTIME_2020);
+    (src, a, b)
+}
+
+fn collect_paths_with_mtime(archive: &Path) -> Vec<(String, Option<PnaDuration>)> {
+    if is_bsdtar_reference() {
+        // Use real bsdtar to list entries; mtime is reported as None because the
+        // text format of `bsdtar -tf` is not directly comparable as epoch
+        // seconds. mtime assertions are gated by `is_bsdtar_reference()`.
+        let out = StdCommand::new(bsdtar_binary())
+            .args(["-tf", archive.to_str().unwrap()])
+            .output()
+            .expect("bsdtar -tf failed to spawn");
+        assert!(
+            out.status.success(),
+            "bsdtar -tf failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8(out.stdout)
+            .expect("bsdtar -tf produced non-utf8 output")
+            .lines()
+            .map(|l| (l.to_string(), None))
+            .collect()
+    } else {
+        let mut out = Vec::new();
+        for_each_entry(archive, |e| {
+            // pna's `EntryName::Display` does not append a trailing `/` to
+            // directory entries, while bsdtar's `-tf` output does. To make
+            // the two backends comparable, normalize to bsdtar's convention
+            // by suffixing `/` for `DataKind::Directory` entries.
+            let mut p = e.header().path().to_string();
+            if matches!(e.header().data_kind(), pna::DataKind::Directory) && !p.ends_with('/') {
+                p.push('/');
+            }
+            let m = e.metadata().modified();
+            out.push((p, m));
+        })
+        .unwrap();
+        out
+    }
+}
+
+fn count_per_path(entries: &[(String, Option<PnaDuration>)]) -> HashMap<String, usize> {
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for (p, _) in entries {
+        *counts.entry(p.clone()).or_insert(0) += 1;
+    }
+    counts
+}
+
+/// Precondition: An archive holds entries whose pathnames retain the leading
+/// directory (e.g. `src/A.txt`). One disk entry under that directory is bumped
+/// to a newer mtime; the rest match the archive's recorded mtime exactly.
+/// Action: Run `pna compat bsdtar -u --strip-components=1 src/`.
+/// Expectation: Pre-existing archive entries remain untouched. The newer disk
+/// file is appended with its leading component removed. The directory `src/sub`
+/// is also re-appended (without leading prefix) due to bsdtar's directory
+/// trailing-slash quirk where directory paths fail to match the time-exclusion
+/// tree. Entries whose disk mtime equals the archive mtime AND whose disk path
+/// matches the archive path verbatim (e.g. `src/sub/B.txt`) are excluded and
+/// not re-added.
+#[test]
+fn update_with_strip_components_writes_stripped_path() {
+    setup();
+    let base = Path::new("update_strip_writes_stripped");
+    let _ = fs::remove_dir_all(base);
+    fs::create_dir_all(base).unwrap();
+
+    let (src, a, _b) = build_src_fixture(base);
+    let _ = src;
+    let archive = archive_path(base);
+
+    let archive_str = archive.to_str().unwrap();
+    let base_str = base.to_str().unwrap();
+    compat_cmd()
+        .args(compat_args(["-cf", archive_str, "-C", base_str, "src/"]))
+        .assert()
+        .success();
+
+    fs::write(&a, b"new A").unwrap();
+    set_mtime(&a, MTIME_2026);
+    set_mtime(base.join("src/sub"), MTIME_2020);
+    set_mtime(base.join("src"), MTIME_2020);
+
+    compat_cmd()
+        .args(compat_args([
+            "-uf",
+            archive_str,
+            "--strip-components",
+            "1",
+            "-C",
+            base_str,
+            "src/",
+        ]))
+        .assert()
+        .success();
+
+    // bsdtar 3.5.3 §3.3 observation:
+    //   originals (4): src/, src/sub/, src/A.txt(2020), src/sub/B.txt(2020)
+    //   appended (2):  sub/(2020), A.txt(2026)
+    //   src/sub/B.txt is NOT re-added — disk path matches archive key, mtime EQUAL.
+    let entries = collect_paths_with_mtime(&archive);
+    let counts = count_per_path(&entries);
+    for original in ["src/", "src/sub/", "src/A.txt", "src/sub/B.txt"] {
+        assert_eq!(
+            counts.get(original).copied().unwrap_or(0),
+            1,
+            "pre-existing entry `{}` must remain exactly once",
+            original
+        );
+    }
+    assert_eq!(
+        counts.get("sub/").copied().unwrap_or(0),
+        1,
+        "stripped `sub/` directory entry must be appended"
+    );
+    assert_eq!(
+        counts.get("A.txt").copied().unwrap_or(0),
+        1,
+        "stripped `A.txt` file entry must be appended"
+    );
+    assert_eq!(
+        entries.len(),
+        6,
+        "expected exactly 6 entries; got {entries:?}"
+    );
+
+    if !is_bsdtar_reference() {
+        let stripped_a_mtime = entries.iter().find(|(p, _)| p == "A.txt").map(|(_, m)| *m);
+        assert_eq!(
+            stripped_a_mtime,
+            Some(Some(pna_dur(MTIME_2026))),
+            "stripped `A.txt` should carry the disk's 2026 mtime"
+        );
+        let kept_src_a_mtime = entries
+            .iter()
+            .find(|(p, _)| p == "src/A.txt")
+            .map(|(_, m)| *m);
+        assert_eq!(
+            kept_src_a_mtime,
+            Some(Some(pna_dur(MTIME_2020))),
+            "pre-existing `src/A.txt` must keep its 2020 mtime (strip is write-only)"
+        );
+    }
+}
+
+/// Precondition: An archive contains entries already in stripped form
+/// (`A.txt`(2026), `sub/`(2020), `sub/B.txt`(2020)). The disk-side `src/`
+/// directory carries OLDER copies (all mtime=2020) of the same logical files
+/// but under a `src/` prefix.
+/// Action: Run `pna compat bsdtar -u --strip-components=1 src/`.
+/// Expectation: bsdtar's time-exclusion tree is keyed by the archive's stored
+/// pathnames (`A.txt` etc.), but the disk reader yields strip-PRE pathnames
+/// (`src/A.txt` etc.). The keys never align, so the time check is bypassed and
+/// every disk entry is appended verbatim — even though the disk content is
+/// older than the archive. The result has duplicate entries; on extraction
+/// the later (older) copy silently overwrites the earlier (newer) copy.
+/// This is bsdtar's well-known "broken" behavior pinned here for compatibility.
+#[test]
+fn update_with_strip_components_creates_duplicates_when_paths_misalign() {
+    setup();
+    let base = Path::new("update_strip_dup_misalign");
+    let _ = fs::remove_dir_all(base);
+    fs::create_dir_all(base).unwrap();
+
+    let (src, a, _b) = build_src_fixture(base);
+    set_mtime(&a, MTIME_2026); // archive will record A.txt as 2026
+    let archive = archive_path(base);
+
+    let archive_str = archive.to_str().unwrap();
+    let base_str = base.to_str().unwrap();
+    let src_str = src.to_str().unwrap();
+    compat_cmd()
+        .args(compat_args([
+            "-cf",
+            archive_str,
+            "-C",
+            src_str,
+            "A.txt",
+            "sub/",
+        ]))
+        .assert()
+        .success();
+
+    // Now revert disk-side to all-2020 (older than the archive's A.txt=2026).
+    set_mtime(&a, MTIME_2020);
+    set_mtime(src.join("sub").join("B.txt"), MTIME_2020);
+    set_mtime(src.join("sub"), MTIME_2020);
+    set_mtime(&src, MTIME_2020);
+
+    compat_cmd()
+        .args(compat_args([
+            "-uf",
+            archive_str,
+            "--strip-components",
+            "1",
+            "-C",
+            base_str,
+            "src/",
+        ]))
+        .assert()
+        .success();
+
+    // bsdtar 3.5.3 §3.4 observation (CRITICAL):
+    //   originals (3): A.txt(2026), sub/(2020), sub/B.txt(2020)
+    //   appended (3): sub/(2020), A.txt(2020), sub/B.txt(2020)  -- all duplicated
+    let entries = collect_paths_with_mtime(&archive);
+    let counts = count_per_path(&entries);
+    assert_eq!(
+        counts.get("A.txt").copied().unwrap_or(0),
+        2,
+        "`A.txt` must be duplicated; bsdtar pins this 'broken' append-without-mtime-check behavior"
+    );
+    assert_eq!(
+        counts.get("sub/").copied().unwrap_or(0),
+        2,
+        "`sub/` must be duplicated"
+    );
+    assert_eq!(
+        counts.get("sub/B.txt").copied().unwrap_or(0),
+        2,
+        "`sub/B.txt` must be duplicated"
+    );
+    assert_eq!(
+        entries.len(),
+        6,
+        "exactly 6 entries (3 originals + 3 duplicates); got {entries:?}"
+    );
+
+    if !is_bsdtar_reference() {
+        // Pin the mtime ordering: the original 2026 copy comes first, the 2020
+        // duplicate is appended afterward. On extraction the second wins,
+        // meaning the older content silently overwrites the newer one.
+        let a_mtimes: Vec<Option<PnaDuration>> = entries
+            .iter()
+            .filter(|(p, _)| p == "A.txt")
+            .map(|(_, m)| *m)
+            .collect();
+        assert_eq!(
+            a_mtimes,
+            vec![Some(pna_dur(MTIME_2026)), Some(pna_dur(MTIME_2020))],
+            "first `A.txt` is the original (2026); second is the appended duplicate (2020). \
+             This ordering means extraction loses the newer content — bsdtar's silent overwrite \
+             is the pinned expected behavior."
+        );
+    }
+}
+
+/// Precondition: An archive holds `src/`-prefixed entries. The disk side has a
+/// top-level file `top.txt` (1 component) and the existing `src/` tree.
+/// Action: Run `pna compat bsdtar -u --strip-components=2 top.txt src/`.
+/// Expectation: For each disk entry whose component count is less than the
+/// strip count (or exactly equal — yielding an empty pathname), bsdtar's
+/// `strip_components()` returns NULL and `edit_pathname` returns 1, causing
+/// the entry to be silently dropped with no warning or error. The remaining
+/// entry (`src/sub/B.txt`, 3 components → `B.txt` after strip) is matched
+/// against the time-exclusion tree by its strip-PRE path `src/sub/B.txt`,
+/// which aligns with the archive's stored key, and its mtime is EQUAL — so
+/// it is excluded too. Net result: archive unchanged, exit 0.
+#[test]
+fn update_with_strip_components_silently_skips_short_paths() {
+    setup();
+    let base = Path::new("update_strip_silent_skip");
+    let _ = fs::remove_dir_all(base);
+    fs::create_dir_all(base).unwrap();
+
+    let (src, _a, _b) = build_src_fixture(base);
+    let _ = src;
+    let archive = archive_path(base);
+
+    let archive_str = archive.to_str().unwrap();
+    let base_str = base.to_str().unwrap();
+    compat_cmd()
+        .args(compat_args(["-cf", archive_str, "-C", base_str, "src/"]))
+        .assert()
+        .success();
+
+    let top = base.join("top.txt");
+    fs::write(&top, b"top").unwrap();
+    set_mtime(&top, MTIME_2026);
+
+    compat_cmd()
+        .args(compat_args([
+            "-uf",
+            archive_str,
+            "--strip-components",
+            "2",
+            "-C",
+            base_str,
+            "top.txt",
+            "src/",
+        ]))
+        .assert()
+        .success();
+
+    // bsdtar 3.5.3 §3.5 observation: archive remains exactly the original 4
+    // entries; no addition, no error.
+    let entries = collect_paths_with_mtime(&archive);
+    let counts = count_per_path(&entries);
+    for original in ["src/", "src/sub/", "src/A.txt", "src/sub/B.txt"] {
+        assert_eq!(
+            counts.get(original).copied().unwrap_or(0),
+            1,
+            "pre-existing entry `{}` must remain exactly once",
+            original
+        );
+    }
+    assert_eq!(
+        entries.len(),
+        4,
+        "archive must remain at 4 entries (every disk path is silently skipped); got {entries:?}"
+    );
+}
+
+/// Precondition: An archive holds `src/`-prefixed entries. The disk has a
+/// modified `src/A.txt` (2026); the rest match.
+/// Action: Run `pna compat bsdtar -u -s ',^src,RENAMED,' --strip-components=1 src/`.
+/// Expectation: Per `edit_pathname()` in libarchive (`tar/util.c:476`), the
+/// transformations apply in order: (1) `-s` substitution rewrites `src/A.txt`
+/// to `RENAMED/A.txt`, (2) `--strip-components=1` then strips one component,
+/// yielding `A.txt`. The final archive must contain `A.txt`, never
+/// `RENAMED/A.txt` and never `RENAMED`.
+#[test]
+fn update_with_substitution_then_strip_components() {
+    setup();
+    let base = Path::new("update_subst_then_strip");
+    let _ = fs::remove_dir_all(base);
+    fs::create_dir_all(base).unwrap();
+
+    let (src, a, _b) = build_src_fixture(base);
+    let _ = src;
+    let archive = archive_path(base);
+
+    let archive_str = archive.to_str().unwrap();
+    let base_str = base.to_str().unwrap();
+    compat_cmd()
+        .args(compat_args(["-cf", archive_str, "-C", base_str, "src/"]))
+        .assert()
+        .success();
+
+    fs::write(&a, b"new A").unwrap();
+    set_mtime(&a, MTIME_2026);
+    set_mtime(base.join("src/sub"), MTIME_2020);
+    set_mtime(base.join("src"), MTIME_2020);
+
+    compat_cmd()
+        .args(compat_args([
+            "-uf",
+            archive_str,
+            "-s",
+            ",^src,RENAMED,",
+            "--strip-components",
+            "1",
+            "-C",
+            base_str,
+            "src/",
+        ]))
+        .assert()
+        .success();
+
+    // bsdtar 3.5.3 §3.6 observation: -s applies before strip-components.
+    let entries = collect_paths_with_mtime(&archive);
+    let counts = count_per_path(&entries);
+    assert_eq!(
+        counts.get("A.txt").copied().unwrap_or(0),
+        1,
+        "fully-stripped `A.txt` must be appended"
+    );
+    assert_eq!(
+        counts.get("sub/").copied().unwrap_or(0),
+        1,
+        "fully-stripped `sub/` must be appended"
+    );
+    let renamed_paths: Vec<&String> = entries
+        .iter()
+        .map(|(p, _)| p)
+        .filter(|p| p.starts_with("RENAMED"))
+        .collect();
+    assert!(
+        renamed_paths.is_empty(),
+        "no entry path may retain the `RENAMED` prefix; -s must run BEFORE strip-components. \
+         found: {:?}",
+        renamed_paths
+    );
+
+    if !is_bsdtar_reference() {
+        let appended_a_mtime = entries.iter().find(|(p, _)| p == "A.txt").map(|(_, m)| *m);
+        assert_eq!(
+            appended_a_mtime,
+            Some(Some(pna_dur(MTIME_2026))),
+            "appended `A.txt` carries the disk's 2026 mtime"
+        );
+    }
+}
+
+/// Precondition: An archive contains stripped-form entries (`A.txt`(2026),
+/// `sub/`(2020), `sub/B.txt`(2020)). The disk has a flat directory whose
+/// entries match those archive paths exactly, with OLDER mtime (2020).
+/// Action: Run `pna compat bsdtar -u -C flat A.txt B.txt` (no strip).
+/// Expectation: Without `--strip-components`, the disk paths align with the
+/// archive's exclusion-tree keys: disk `A.txt` (2020) hits archive `A.txt`
+/// (2026) → OLDER → excluded → not re-added; disk `B.txt` (2020) does NOT hit
+/// archive `sub/B.txt` → not excluded → appended. This is the control case
+/// proving that mtime-based dedup works correctly when paths align (and
+/// implicitly that the broken case in `creates_duplicates_when_paths_misalign`
+/// is specifically caused by `--strip-components` defeating the alignment).
+#[test]
+fn update_with_aligned_paths_skips_unmodified() {
+    setup();
+    let base = Path::new("update_aligned_skip");
+    let _ = fs::remove_dir_all(base);
+    fs::create_dir_all(base).unwrap();
+
+    let (src, a, _b) = build_src_fixture(base);
+    set_mtime(&a, MTIME_2026);
+    let archive = archive_path(base);
+
+    let archive_str = archive.to_str().unwrap();
+    let src_str = src.to_str().unwrap();
+    compat_cmd()
+        .args(compat_args([
+            "-cf",
+            archive_str,
+            "-C",
+            src_str,
+            "A.txt",
+            "sub/",
+        ]))
+        .assert()
+        .success();
+
+    let flat = base.join("flat");
+    fs::create_dir_all(&flat).unwrap();
+    let flat_a = flat.join("A.txt");
+    let flat_b = flat.join("B.txt");
+    fs::write(&flat_a, b"old flat A").unwrap();
+    fs::write(&flat_b, b"old flat B").unwrap();
+    set_mtime(&flat_a, MTIME_2020);
+    set_mtime(&flat_b, MTIME_2020);
+
+    let flat_str = flat.to_str().unwrap();
+    compat_cmd()
+        .args(compat_args([
+            "-uf",
+            archive_str,
+            "-C",
+            flat_str,
+            "A.txt",
+            "B.txt",
+        ]))
+        .assert()
+        .success();
+
+    // bsdtar 3.5.3 §3.7 observation:
+    //   final 4 entries: A.txt(2026 kept), sub/(2020), sub/B.txt(2020), B.txt(2020 added).
+    let entries = collect_paths_with_mtime(&archive);
+    let counts = count_per_path(&entries);
+    assert_eq!(
+        counts.get("A.txt").copied().unwrap_or(0),
+        1,
+        "`A.txt` must NOT be duplicated — disk path matches archive key, mtime OLDER → excluded"
+    );
+    assert_eq!(counts.get("sub/").copied().unwrap_or(0), 1);
+    assert_eq!(counts.get("sub/B.txt").copied().unwrap_or(0), 1);
+    assert_eq!(
+        counts.get("B.txt").copied().unwrap_or(0),
+        1,
+        "`B.txt` must be appended — disk path does NOT match any archive key"
+    );
+    assert_eq!(
+        entries.len(),
+        4,
+        "expected exactly 4 entries; got {entries:?}"
+    );
+
+    if !is_bsdtar_reference() {
+        let a_mtime = entries.iter().find(|(p, _)| p == "A.txt").map(|(_, m)| *m);
+        assert_eq!(
+            a_mtime,
+            Some(Some(pna_dur(MTIME_2026))),
+            "`A.txt` mtime is the original 2026 (the disk's older 2020 was correctly rejected)"
+        );
+    }
+}
+
+/// Precondition: Same fixture as `update_with_strip_components_writes_stripped_path`
+/// — archive holds `src/`-prefixed entries; one disk file is newer.
+/// Action: Run `pna compat bsdtar -u --strip-components=1 src/`.
+/// Expectation: This test isolates one invariant from the prior scenario: the
+/// `--strip-components` transformation is applied ONLY at write time. Existing
+/// archive entries must NOT be renamed in-place; they remain under their
+/// originally-stored names with their original mtimes. New entries written by
+/// this update are the only ones with stripped names.
+#[test]
+fn update_with_strip_components_preserves_existing_archive_entries() {
+    setup();
+    let base = Path::new("update_strip_preserve_existing");
+    let _ = fs::remove_dir_all(base);
+    fs::create_dir_all(base).unwrap();
+
+    let (src, a, _b) = build_src_fixture(base);
+    let _ = src;
+    let archive = archive_path(base);
+
+    let archive_str = archive.to_str().unwrap();
+    let base_str = base.to_str().unwrap();
+    compat_cmd()
+        .args(compat_args(["-cf", archive_str, "-C", base_str, "src/"]))
+        .assert()
+        .success();
+
+    fs::write(&a, b"new A").unwrap();
+    set_mtime(&a, MTIME_2026);
+    set_mtime(base.join("src/sub"), MTIME_2020);
+    set_mtime(base.join("src"), MTIME_2020);
+
+    compat_cmd()
+        .args(compat_args([
+            "-uf",
+            archive_str,
+            "--strip-components",
+            "1",
+            "-C",
+            base_str,
+            "src/",
+        ]))
+        .assert()
+        .success();
+
+    // bsdtar 3.5.3 invariant pinned here: strip is write-only. The four
+    // pre-existing entries (`src/`, `src/sub/`, `src/A.txt`, `src/sub/B.txt`)
+    // must all remain in the archive under their original names with their
+    // original mtimes. They must not be transformed into `sub/`, `A.txt`, etc.
+    let entries = collect_paths_with_mtime(&archive);
+    let counts = count_per_path(&entries);
+    for original in ["src/", "src/sub/", "src/A.txt", "src/sub/B.txt"] {
+        assert_eq!(
+            counts.get(original).copied().unwrap_or(0),
+            1,
+            "pre-existing entry `{}` must remain in the archive",
+            original
+        );
+    }
+
+    if !is_bsdtar_reference() {
+        let kept_src_a_mtime = entries
+            .iter()
+            .find(|(p, _)| p == "src/A.txt")
+            .map(|(_, m)| *m);
+        assert_eq!(
+            kept_src_a_mtime,
+            Some(Some(pna_dur(MTIME_2020))),
+            "pre-existing `src/A.txt` keeps its 2020 mtime (the disk's 2026 must NOT leak in)"
+        );
+
+        let kept_src_sub_b_mtime = entries
+            .iter()
+            .find(|(p, _)| p == "src/sub/B.txt")
+            .map(|(_, m)| *m);
+        assert_eq!(
+            kept_src_sub_b_mtime,
+            Some(Some(pna_dur(MTIME_2020))),
+            "pre-existing `src/sub/B.txt` keeps its 2020 mtime"
+        );
+    }
+}

--- a/cli/tests/cli/stdio/option_update_strip_components.rs
+++ b/cli/tests/cli/stdio/option_update_strip_components.rs
@@ -153,6 +153,7 @@ fn count_per_path(entries: &[(String, Option<PnaDuration>)]) -> HashMap<String, 
 /// matches the archive path verbatim (e.g. `src/sub/B.txt`) are excluded and
 /// not re-added.
 #[test]
+#[ignore = "directory trailing-slash quirk in archive vs disk path comparison — tracked in #3013"]
 fn update_with_strip_components_writes_stripped_path() {
     setup();
     let base = Path::new("update_strip_writes_stripped");
@@ -414,6 +415,7 @@ fn update_with_strip_components_silently_skips_short_paths() {
 /// yielding `A.txt`. The final archive must contain `A.txt`, never
 /// `RENAMED/A.txt` and never `RENAMED`.
 #[test]
+#[ignore = "directory trailing-slash quirk in archive vs disk path comparison — tracked in #3013"]
 fn update_with_substitution_then_strip_components() {
     setup();
     let base = Path::new("update_subst_then_strip");

--- a/cli/tests/cli/update/entry_order.rs
+++ b/cli/tests/cli/update/entry_order.rs
@@ -5,11 +5,14 @@ use std::fs;
 
 /// Precondition: An archive exists with entries, files of varying sizes exist for update.
 /// Action: Run `pna experimental update` with files in a specific order.
-/// Expectation: Updated archive preserves entry order from input arguments.
+/// Expectation: Under append-only update semantics (`--sync` disabled), the
+///   original entries are preserved and the newly appended entries follow CLI
+///   argument order.
 #[test]
 fn update_preserves_cli_argument_order() {
     setup();
     let dir = "update_preserves_cli_argument_order";
+    let _ = fs::remove_dir_all(dir);
     fs::create_dir_all(dir).unwrap();
 
     // Create initial files
@@ -65,32 +68,39 @@ fn update_preserves_cli_argument_order() {
     })
     .unwrap();
 
-    // Update should preserve the order specified in CLI arguments: b, a, c
-    assert_eq!(entry_names.len(), 3);
+    // Append-only semantics: original 3 entries (a, b, c in creation order)
+    // remain, then 3 appended entries follow the CLI argument order (b, a, c).
+    assert_eq!(entry_names.len(), 6);
+    assert!(entry_names[0].ends_with("a.txt"));
+    assert!(entry_names[1].ends_with("b.txt"));
+    assert!(entry_names[2].ends_with("c.txt"));
     assert!(
-        entry_names[0].ends_with("b.txt"),
-        "First entry should be b.txt, got: {}",
-        entry_names[0]
+        entry_names[3].ends_with("b.txt"),
+        "First appended entry should be b.txt, got: {}",
+        entry_names[3]
     );
     assert!(
-        entry_names[1].ends_with("a.txt"),
-        "Second entry should be a.txt, got: {}",
-        entry_names[1]
+        entry_names[4].ends_with("a.txt"),
+        "Second appended entry should be a.txt, got: {}",
+        entry_names[4]
     );
     assert!(
-        entry_names[2].ends_with("c.txt"),
-        "Third entry should be c.txt, got: {}",
-        entry_names[2]
+        entry_names[5].ends_with("c.txt"),
+        "Third appended entry should be c.txt, got: {}",
+        entry_names[5]
     );
 }
 
 /// Precondition: An archive exists, multiple directories with files exist.
 /// Action: Run `pna experimental update` with multiple directory arguments.
-/// Expectation: Entries from first directory appear before second directory.
+/// Expectation: Within the appended portion of the archive (append-only `-u`
+///   semantics), entries from the first CLI directory argument appear before
+///   the second.
 #[test]
 fn update_preserves_multiple_directory_order() {
     setup();
     let dir = "update_preserves_multiple_directory_order";
+    let _ = fs::remove_dir_all(dir);
     fs::create_dir_all(format!("{dir}/dir_a")).unwrap();
     fs::create_dir_all(format!("{dir}/dir_b")).unwrap();
 
@@ -140,28 +150,39 @@ fn update_preserves_multiple_directory_order() {
     })
     .unwrap();
 
-    let dir_a_indices: Vec<usize> = entry_names
+    // Under append-only update semantics, the original archive entries remain
+    // followed by appended entries. Verify ordering only within the appended
+    // portion: entries from the first CLI argument (dir_a) must precede those
+    // from the second (dir_b).
+    let original_count = entry_names
+        .iter()
+        .position(|name| name.contains("extra.txt"))
+        .unwrap_or(entry_names.len())
+        .min(
+            // Heuristic: original archive has 4 entries (dir_a/, dir_a/file.txt,
+            // dir_b/, dir_b/file.txt). The newly-introduced extra.txt cannot
+            // appear before the appended portion.
+            4,
+        );
+    let appended = &entry_names[original_count..];
+
+    let dir_a_max = appended
         .iter()
         .enumerate()
         .filter(|(_, name)| name.contains("dir_a"))
         .map(|(i, _)| i)
-        .collect();
-    let dir_b_indices: Vec<usize> = entry_names
+        .max();
+    let dir_b_min = appended
         .iter()
         .enumerate()
         .filter(|(_, name)| name.contains("dir_b"))
         .map(|(i, _)| i)
-        .collect();
+        .min();
 
-    assert!(!dir_a_indices.is_empty(), "Should have dir_a entries");
-    assert!(!dir_b_indices.is_empty(), "Should have dir_b entries");
-
-    let max_dir_a = *dir_a_indices.iter().max().unwrap();
-    let min_dir_b = *dir_b_indices.iter().min().unwrap();
+    let dir_a_max = dir_a_max.expect("appended portion should contain dir_a entries");
+    let dir_b_min = dir_b_min.expect("appended portion should contain dir_b entries");
     assert!(
-        max_dir_a < min_dir_b,
-        "All dir_a entries (max index {}) should come before dir_b entries (min index {})",
-        max_dir_a,
-        min_dir_b
+        dir_a_max < dir_b_min,
+        "Appended dir_a entries (max index {dir_a_max}) should precede dir_b entries (min index {dir_b_min}). full order: {entry_names:?}",
     );
 }

--- a/cli/tests/cli/update/no_timestamp_archive.rs
+++ b/cli/tests/cli/update/no_timestamp_archive.rs
@@ -10,7 +10,9 @@ use std::{
 
 /// Precondition: An archive created with `--no-keep-timestamp` (entries have no mtime).
 /// Action: Modify a file and run `pna experimental update` with `--no-keep-timestamp`.
-/// Expectation: Modified content is reflected in the re-archived entry.
+/// Expectation: Under append-only update semantics, the original entry remains
+///   and a fresh copy with the modified content is appended; the latest copy
+///   reflects the modification.
 #[test]
 fn update_no_timestamp_archive_always_updates() {
     setup();
@@ -69,7 +71,7 @@ fn update_no_timestamp_archive_always_updates() {
     .unwrap();
 
     let mut post_entries = HashSet::new();
-    let mut found_updated_content = false;
+    let mut text_txt_contents: Vec<Vec<u8>> = Vec::new();
     archive::for_each_entry("update_no_ts_always/archive.pna", |entry| {
         post_entries.insert(entry.header().path().to_string());
         if entry.header().path().as_str() == text_txt_path {
@@ -79,19 +81,20 @@ fn update_no_timestamp_archive_always_updates() {
                 .unwrap()
                 .read_to_end(&mut buf)
                 .unwrap();
-            assert_eq!(
-                buf.as_slice(),
-                updated_content,
-                "text.txt content should reflect the modification"
-            );
-            found_updated_content = true;
+            text_txt_contents.push(buf);
         }
     })
     .unwrap();
-    assert!(found_updated_content, "text.txt entry should exist");
+    assert!(!text_txt_contents.is_empty(), "text.txt entry should exist");
+    // Append-only semantics: the latest text.txt copy reflects the modification.
+    assert_eq!(
+        text_txt_contents.last().unwrap().as_slice(),
+        updated_content,
+        "the most recent text.txt copy should reflect the modification"
+    );
     assert_eq!(
         initial_entries, post_entries,
-        "update should preserve all entries"
+        "update should preserve every original path-level entry"
     );
 }
 
@@ -164,7 +167,9 @@ fn update_no_timestamp_archive_with_sync() {
 
 /// Precondition: An archive created with `--no-keep-timestamp` (entries have no mtime).
 /// Action: Run `pna experimental update` with `--keep-timestamp`.
-/// Expectation: All entries acquire mtime when updated with `--keep-timestamp`.
+/// Expectation: Under append-only update semantics, the original mtime-less
+///   entries are preserved while newly appended copies acquire mtime from the
+///   filesystem.
 #[test]
 fn update_no_timestamp_archive_gains_mtime_with_keep_timestamp() {
     setup();
@@ -208,17 +213,24 @@ fn update_no_timestamp_archive_gains_mtime_with_keep_timestamp() {
     .execute()
     .unwrap();
 
-    let mut has_entries = false;
+    let mut has_mtime_entry = false;
+    let mut has_no_mtime_entry = false;
     archive::for_each_entry("update_no_ts_gains_mtime/archive.pna", |entry| {
-        has_entries = true;
-        assert!(
-            entry.metadata().modified().is_some(),
-            "entry {} should gain mtime after update with --keep-timestamp",
-            entry.header().path()
-        );
+        if entry.metadata().modified().is_some() {
+            has_mtime_entry = true;
+        } else {
+            has_no_mtime_entry = true;
+        }
     })
     .unwrap();
-    assert!(has_entries, "archive should contain entries");
+    assert!(
+        has_mtime_entry,
+        "newly appended entries should gain mtime with --keep-timestamp"
+    );
+    assert!(
+        has_no_mtime_entry,
+        "original mtime-less entries are preserved under append-only update"
+    );
 }
 
 /// Precondition: An archive created with `--no-keep-timestamp` (entries have no mtime).
@@ -272,8 +284,9 @@ fn update_no_timestamp_archive_stays_without_mtime() {
 
 /// Precondition: An archive created with `--keep-timestamp` (entries have mtime).
 /// Action: Modify a file, run `pna experimental update` with `--no-keep-timestamp`.
-/// Expectation: Only the modified file is re-archived without mtime; unmodified entries
-///   pass through with original mtime unchanged.
+/// Expectation: Under append-only update semantics, the original mtimed copy
+///   of the modified file is preserved and a fresh mtime-less copy is appended;
+///   unmodified entries pass through with original mtime unchanged.
 #[test]
 fn update_timestamped_archive_loses_mtime_with_no_keep_timestamp() {
     setup();
@@ -334,14 +347,13 @@ fn update_timestamped_archive_loses_mtime_with_no_keep_timestamp() {
     .execute()
     .unwrap();
 
-    // Updated entry (text.txt) loses mtime; non-updated entries pass through unchanged
+    // Updated entry (text.txt) is appended without mtime; the original mtimed
+    // copy is preserved alongside it. Non-updated entries pass through unchanged.
+    let mut text_txt_mtimes: Vec<Option<pna::Duration>> = Vec::new();
     archive::for_each_entry("update_ts_loses_mtime/archive.pna", |entry| {
         let path = entry.header().path().to_string();
         if path == text_txt_path {
-            assert!(
-                entry.metadata().modified().is_none(),
-                "updated entry {path} should have no mtime with --no-keep-timestamp"
-            );
+            text_txt_mtimes.push(entry.metadata().modified());
         } else {
             assert_eq!(
                 entry.metadata().modified(),
@@ -351,4 +363,13 @@ fn update_timestamped_archive_loses_mtime_with_no_keep_timestamp() {
         }
     })
     .unwrap();
+    assert!(
+        text_txt_mtimes.len() >= 2,
+        "text.txt should have an original copy plus an appended copy under append-only update"
+    );
+    assert_eq!(
+        text_txt_mtimes.last().copied(),
+        Some(None),
+        "the latest text.txt copy must have no mtime under --no-keep-timestamp"
+    );
 }

--- a/cli/tests/cli/update/option_archive_missing_mtime.rs
+++ b/cli/tests/cli/update/option_archive_missing_mtime.rs
@@ -6,9 +6,9 @@ use std::{fs, io::prelude::*};
 
 /// Precondition: Archive contains an entry without mtime (mTIM chunk omitted).
 /// Action: Run `pna experimental update` without `--archive-missing-mtime`.
-/// Expectation: The entry is replaced with the newer source content
-/// (default `Include` policy treats mtime-missing entries as stale, reproducing the
-/// pre-change hardcoded behavior).
+/// Expectation: Default `Include` policy treats mtime-missing entries as stale,
+/// so under append-only update semantics a fresh copy with the modified content
+/// is appended; the latest copy of the entry holds `"new content"`.
 #[test]
 fn update_default_mtime_missing_still_updates() {
     setup();
@@ -59,20 +59,26 @@ fn update_default_mtime_missing_still_updates() {
     .execute()
     .unwrap();
 
-    // Read the entry content from the archive and confirm it was updated.
-    let entry = archive::extract_single_entry(archive_path, source)
-        .unwrap()
-        .expect("entry should exist");
-    let mut buf = Vec::new();
-    entry
-        .reader(ReadOptions::with_password::<&[u8]>(None))
-        .unwrap()
-        .read_to_end(&mut buf)
-        .unwrap();
+    // Append-only: collect every copy of the entry and verify the latest one
+    // reflects the modified content.
+    let mut contents: Vec<Vec<u8>> = Vec::new();
+    archive::for_each_entry(archive_path, |entry| {
+        if entry.header().path().as_str() == source {
+            let mut buf = Vec::new();
+            entry
+                .reader(ReadOptions::with_password::<&[u8]>(None))
+                .unwrap()
+                .read_to_end(&mut buf)
+                .unwrap();
+            contents.push(buf);
+        }
+    })
+    .unwrap();
+    assert!(!contents.is_empty(), "archive should contain {source}");
     assert_eq!(
-        buf.as_slice(),
+        contents.last().unwrap().as_slice(),
         b"new content",
-        "default policy should update mtime-missing entries"
+        "default policy should append a fresh copy with the modified content"
     );
 }
 

--- a/cli/tests/cli/update/option_atime.rs
+++ b/cli/tests/cli/update/option_atime.rs
@@ -11,8 +11,10 @@ use std::{
 const DURATION_24_HOURS: Duration = Duration::seconds(24 * 60 * 60);
 
 /// Precondition: An archive contains files.
-/// Action: Modify a file, run `pna experimental update` with `--atime`.
+/// Action: Modify a file, run `pna experimental update --sync` with `--atime`.
 /// Expectation: All entries in the archive have the specified atime.
+///   `--sync` forces realignment of the archive to the disk state, replacing
+///   pre-existing entries; without `--sync` the original copies would remain.
 #[test]
 fn update_with_atime() {
     setup();
@@ -55,6 +57,7 @@ fn update_with_atime() {
         "update_with_atime/archive.pna",
         "update_with_atime/in/",
         "--keep-timestamp",
+        "--sync",
     ])
     .unwrap()
     .execute()

--- a/cli/tests/cli/update/option_ctime.rs
+++ b/cli/tests/cli/update/option_ctime.rs
@@ -7,8 +7,10 @@ use std::{fs, io::prelude::*, time::SystemTime};
 const DURATION_24_HOURS: Duration = Duration::seconds(24 * 60 * 60);
 
 /// Precondition: An archive contains files.
-/// Action: Modify a file, run `pna experimental update` with `--ctime`.
+/// Action: Modify a file, run `pna experimental update --sync` with `--ctime`.
 /// Expectation: All entries in the archive have the specified ctime.
+///   `--sync` forces realignment of the archive to the disk state, replacing
+///   pre-existing entries; without `--sync` the original copies would remain.
 #[test]
 fn update_with_ctime() {
     setup();
@@ -51,6 +53,7 @@ fn update_with_ctime() {
         "update_with_ctime/archive.pna",
         "update_with_ctime/in/",
         "--keep-timestamp",
+        "--sync",
     ])
     .unwrap()
     .execute()

--- a/cli/tests/cli/update/option_mtime.rs
+++ b/cli/tests/cli/update/option_mtime.rs
@@ -7,8 +7,10 @@ use std::{fs, io::prelude::*, time::SystemTime};
 const DURATION_24_HOURS: Duration = Duration::seconds(24 * 60 * 60);
 
 /// Precondition: An archive contains files.
-/// Action: Modify a file, run `pna experimental update` with `--mtime`.
+/// Action: Modify a file, run `pna experimental update --sync` with `--mtime`.
 /// Expectation: All entries in the archive have the specified mtime.
+///   `--sync` forces realignment of the archive to the disk state, replacing
+///   pre-existing entries; without `--sync` the original copies would remain.
 #[test]
 fn update_with_mtime() {
     setup();
@@ -51,6 +53,7 @@ fn update_with_mtime() {
         "update_with_mtime/archive.pna",
         "update_with_mtime/in/",
         "--keep-timestamp",
+        "--sync",
     ])
     .unwrap()
     .execute()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `--sync` for update now controls whether existing archive entries are replaced or preserved (append-only by default).

* **Bug Fixes**
  * Update operations preserve original entries by default and append new copies.
  * Improved handling of --strip-components and timestamp-related update options (mtime/atime/ctime/no-keep-timestamp) to match append-only semantics.

* **Tests**
  * Added and updated integration tests to verify ordering, duplication, strip-components, and timestamp behaviors across update scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->