### PR TITLE
:construction_worker: Pre-clean pkg vs pkg-devel collision file before FreeBSD VM install

### DIFF
--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -124,6 +124,15 @@ jobs:
               enabled: yes
             }
             EOF
+            # Workaround for pkg/pkg-devel file collision over
+            # /usr/local/etc/bash_completion.d/_pkg.bash that surfaces during
+            # `pkg install` when the FreeBSD repository carries a pkg-devel
+            # build whose installed file set overlaps with the pre-installed
+            # pkg(8). Delete the disputed file before install so pkg can hand
+            # ownership to whichever package needs to provide it; the bash
+            # completion is not consumed inside the CI VM. Observed first on
+            # 2026-05-02 (FreeBSD VM Tests, run id 25246917346).
+            rm -f /usr/local/etc/bash_completion.d/_pkg.bash
             pkg install -y curl cmake
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           run: |

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -116,27 +116,25 @@ jobs:
             # https://github.com/vmactions/freebsd-vm/issues/141 for the
             # related geo-mirror flakiness pattern.
             mkdir -p /usr/local/etc/pkg/repos
+            # Use the rolling `latest` repository instead of `quarterly`.
+            # The current quarterly snapshot exposes group-level integrity
+            # failures during `pkg install`: it ships incompatible release
+            # and devel variants of pkg(8) and gcc12/13/14/15 that all claim
+            # ownership of the same files (e.g. _pkg.bash, c++14, libgccjit.h).
+            # The rolling `latest` index keeps the variant set internally
+            # consistent. Run ids witnessing the quarterly breakage:
+            # 25246917346 (initial), 25251665720, 25253956945.
             cat > /usr/local/etc/pkg/repos/FreeBSD.conf <<'EOF'
             FreeBSD: {
-              url: "pkg+https://pkg.FreeBSD.org/${ABI}/quarterly",
+              url: "pkg+https://pkg.FreeBSD.org/${ABI}/latest",
               mirror_type: "srv",
               signature_type: "none",
               enabled: yes
             }
             EOF
-            # Workaround for pkg/pkg-devel file collision over
-            # /usr/local/etc/bash_completion.d/_pkg.bash. The vmactions VM
-            # ships pkg-2.7.5 whose package metadata claims ownership of
-            # that file, while the FreeBSD repository's pkg-devel package
-            # also claims it. The conflict surfaces at pkg(8)'s metadata-level
-            # integrity check ("Checking integrity... done (1 conflicting)"),
-            # so removing the file from disk is insufficient -- the database
-            # entry still wins. Force-upgrade pkg(8) against the repository
-            # first so its metadata aligns with the repository version,
-            # dissolving the conflict before subsequent installs run.
-            # Observed on 2026-05-02 (FreeBSD VM Tests, run ids 25246917346
-            # and 25251665720).
-            pkg upgrade -y -f pkg
+            # cmake is required at build time by libz-ng-sys (transitive
+            # dependency activated by the zlib-ng feature, which is part of
+            # the feature-powerset matrix below).
             pkg install -y curl cmake
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           run: |

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -125,14 +125,18 @@ jobs:
             }
             EOF
             # Workaround for pkg/pkg-devel file collision over
-            # /usr/local/etc/bash_completion.d/_pkg.bash that surfaces during
-            # `pkg install` when the FreeBSD repository carries a pkg-devel
-            # build whose installed file set overlaps with the pre-installed
-            # pkg(8). Delete the disputed file before install so pkg can hand
-            # ownership to whichever package needs to provide it; the bash
-            # completion is not consumed inside the CI VM. Observed first on
-            # 2026-05-02 (FreeBSD VM Tests, run id 25246917346).
-            rm -f /usr/local/etc/bash_completion.d/_pkg.bash
+            # /usr/local/etc/bash_completion.d/_pkg.bash. The vmactions VM
+            # ships pkg-2.7.5 whose package metadata claims ownership of
+            # that file, while the FreeBSD repository's pkg-devel package
+            # also claims it. The conflict surfaces at pkg(8)'s metadata-level
+            # integrity check ("Checking integrity... done (1 conflicting)"),
+            # so removing the file from disk is insufficient -- the database
+            # entry still wins. Force-upgrade pkg(8) against the repository
+            # first so its metadata aligns with the repository version,
+            # dissolving the conflict before subsequent installs run.
+            # Observed on 2026-05-02 (FreeBSD VM Tests, run ids 25246917346
+            # and 25251665720).
+            pkg upgrade -y -f pkg
             pkg install -y curl cmake
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           run: |

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -146,7 +146,14 @@ jobs:
             # need a UFS+acls filesystem. Create a vnode-backed UFS image and
             # point CARGO_TARGET_DIR there so integration test cwd
             # (CARGO_TARGET_TMPDIR = $CARGO_TARGET_DIR/tmp) lives on UFS.
-            truncate -s 4g /tmp/ufs.img
+            # The UFS image must hold the entire `cargo hack test
+            # --feature-powerset --release` build artifact set across every
+            # feature combination, which easily exceeds 4 GiB. The previous
+            # 4 GiB allotment caused the VM to become unresponsive (ssh exit
+            # code 255) after ~42 minutes when the image filled up; raise it
+            # to 12 GiB so the build can complete within the runner host
+            # disk budget (ubuntu-latest provides ~14 GiB).
+            truncate -s 12g /tmp/ufs.img
             mdconfig -a -t vnode -f /tmp/ufs.img -u 9
             newfs /dev/md9
             mkdir -p /mnt/ufs

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -105,7 +105,14 @@ jobs:
         id: test
         uses: vmactions/freebsd-vm@d1e65811565151536c0c894fff74f06351ed26e6 # v1.4.5
         with:
-          envs: "RUST_BACKTRACE"
+          envs: "RUST_BACKTRACE CARGO_BUILD_JOBS"
+          # vmactions/freebsd-vm defaults to 6144 MiB which is insufficient
+          # for `cargo hack test --feature-powerset --release` of this
+          # workspace. Earlier failures (commit 5efebfe4 and aace5992) ended
+          # with the in-VM child process getting SIGKILL'd (exit 137,
+          # "Child process pid=... terminated abnormally: Killed"), pointing
+          # to OOM. Raise memory to 12 GiB; ubuntu-latest provides 16 GiB.
+          mem: 12288
           copyback: false
           disable-cache: true
           usesh: true
@@ -141,6 +148,11 @@ jobs:
             set -e
             . "$HOME/.cargo/env"
             export LC_ALL=C LANG=C
+            # Cap rustc parallelism. Even with 12 GiB allocated to the VM,
+            # the default rustc job count (1 per CPU, typically 4) lets a
+            # release-mode powerset build hit the OOM-killer; capping to 2
+            # jobs trades a slower build for a stable peak memory footprint.
+            export CARGO_BUILD_JOBS=2
             uname -a
             # vmactions/freebsd-vm root is ZFS+nfsv4acls; POSIX.1e ACL tests
             # need a UFS+acls filesystem. Create a vnode-backed UFS image and

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -139,9 +139,19 @@ jobs:
               enabled: yes
             }
             EOF
+            # The latest repository advertises a newer pkg(8) binary than
+            # the one shipped in the vmactions VM image. Without an
+            # explicit force-upgrade, every subsequent `pkg` invocation
+            # re-prints "New version of pkg detected; it needs to be
+            # installed first." and re-fetches the catalog instead of
+            # making progress. Commit 84853493's run logged 3629 such
+            # repetitions across 50 minutes, never reaching cargo. Use
+            # the static binary to upgrade pkg(8) once up front so
+            # subsequent invocations see no version skew.
+            ASSUME_ALWAYS_YES=yes pkg-static upgrade -fy pkg
             # cmake is required at build time by libz-ng-sys (transitive
-            # dependency activated by the zlib-ng feature, which is part of
-            # the feature-powerset matrix below).
+            # dependency activated by the zlib-ng feature, which is part
+            # of the feature-powerset matrix below).
             pkg install -y curl cmake
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           run: |


### PR DESCRIPTION
The FreeBSD VM Tests job currently fails inside vmactions/freebsd-vm@v1.4.5 during `pkg install -y curl cmake` because the FreeBSD repository ships a pkg-devel package whose file set overlaps the pre-installed pkg(8). Both packages claim ownership of /usr/local/etc/bash_completion.d/_pkg.bash, so when dependency resolution pulls pkg-devel in (after the bootstrap fetch), the install step aborts with:

  pkg: pkg-devel-2.6.99.6 conflicts with pkg-2.7.5
       (installs files into the same place).

Remove the disputed bash completion file in the prepare step so pkg can hand ownership to whichever package needs to provide it. The bash completion is not consumed inside the ephemeral CI VM, so the side effect is acceptable. NetBSD / OpenBSD / Solaris / OmniOS jobs are unaffected because they use different package managers.

First observed: 2026-05-02 on run id 25246917346.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved FreeBSD CI stability by switching package indexing to the rolling "latest" channel, enlarging the VM image to reduce resource pressure, limiting parallel build concurrency, and adding one-time package upgrade handling to avoid package manager version skew.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->