### PR TITLE
🛡️ Sentinel: Harden integer arithmetic in archive and entry parsing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Integer Overflow in Archive Metadata and Structure
+**Vulnerability:** Malformed archives could trigger panics during parsing via integer overflows in reachable code paths, specifically in archive part numbering (`archive_number + 1`), chunk size calculations (`MIN_CHUNK_BYTES_SIZE + length`), and timestamp nanosecond additions.
+**Learning:** Standard arithmetic operators (`+`, `sum()`) on untrusted numeric input from archive headers or metadata are dangerous and can lead to Denial-of-Service (DoS) via panics, especially on 32-bit systems or with extreme values.
+**Prevention:** Always use `checked_add` with error propagation for structural fields (like sequence numbers) and `saturating_add` for size/length calculations. For non-critical metadata like sub-second timestamps, use `checked_add` with a safe fallback to the base value.

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -1754,7 +1754,7 @@ where
         )
         .into());
     }
-    let mut part_num = 1;
+    let mut part_num: usize = 1;
     let mut writer = Archive::write_header(initial_writer)?;
 
     // NOTE: max_file_size - (PNA_HEADER + AHED + ANXT + AEND)
@@ -1769,7 +1769,9 @@ where
         )?;
         for part in parts {
             if written_entry_size + part.bytes_len() > max_file_size {
-                part_num += 1;
+                part_num = part_num.checked_add(1).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidInput, "part number overflowed")
+                })?;
                 let file = get_next_writer(part_num)?;
                 writer = writer.split_to_next_archive(file)?;
                 written_entry_size = 0;

--- a/lib/src/archive/read.rs
+++ b/lib/src/archive/read.rs
@@ -147,13 +147,18 @@ impl<R: Read> Archive<R> {
         let current_header = self.header;
         let mut next = Archive::<OR>::read_header_with_buffer(reader, self.buf)?;
         next.max_chunk_size = self.max_chunk_size;
-        if current_header.archive_number + 1 != next.header.archive_number {
+        let expected_next_archive_number = current_header
+            .archive_number
+            .checked_add(1)
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "archive number overflowed")
+            })?;
+        if expected_next_archive_number != next.header.archive_number {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!(
                     "next archive number must be {} (expected previous + 1, detected: {})",
-                    current_header.archive_number + 1,
-                    next.header.archive_number
+                    expected_next_archive_number, next.header.archive_number
                 ),
             ));
         }

--- a/lib/src/archive/write.rs
+++ b/lib/src/archive/write.rs
@@ -243,7 +243,9 @@ impl<W: Write> Archive<W> {
     /// ```
     #[inline]
     pub fn split_to_next_archive<OW: Write>(mut self, writer: OW) -> io::Result<Archive<OW>> {
-        let next_archive_number = self.header.archive_number + 1;
+        let next_archive_number = self.header.archive_number.checked_add(1).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "archive number overflowed")
+        })?;
         let header = ArchiveHeader::new(0, 0, next_archive_number);
         let max_chunk_size = self.max_chunk_size;
         self.add_next_archive_marker()?;

--- a/lib/src/chunk.rs
+++ b/lib/src/chunk.rs
@@ -43,7 +43,7 @@ pub(crate) trait ChunkExt: Chunk {
     /// length, type, and CRC fields.
     #[inline]
     fn bytes_len(&self) -> usize {
-        MIN_CHUNK_BYTES_SIZE + self.data().len()
+        MIN_CHUNK_BYTES_SIZE.saturating_add(self.data().len())
     }
 
     /// Checks if the chunk is a stream chunk.

--- a/lib/src/chunk/read.rs
+++ b/lib/src/chunk/read.rs
@@ -113,7 +113,10 @@ impl<R: Read + Seek> ChunkReader<R> {
         self.r
             .seek(SeekFrom::Current(mem::size_of::<u32>() as i64))?;
 
-        Ok((ChunkType::new(ty)?, MIN_CHUNK_BYTES_SIZE + length as usize))
+        Ok((
+            ChunkType::new(ty)?,
+            MIN_CHUNK_BYTES_SIZE.saturating_add(length as usize),
+        ))
     }
 }
 

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -681,9 +681,18 @@ where
                 }
             }
         }
-        let ctime = ctime.map(|t| t + Duration::nanoseconds(ctime_ns.unwrap_or(0) as _));
-        let mtime = mtime.map(|t| t + Duration::nanoseconds(mtime_ns.unwrap_or(0) as _));
-        let atime = atime.map(|t| t + Duration::nanoseconds(atime_ns.unwrap_or(0) as _));
+        let ctime = ctime.map(|t| {
+            t.checked_add(Duration::nanoseconds(ctime_ns.unwrap_or(0) as _))
+                .unwrap_or(t)
+        });
+        let mtime = mtime.map(|t| {
+            t.checked_add(Duration::nanoseconds(mtime_ns.unwrap_or(0) as _))
+                .unwrap_or(t)
+        });
+        let atime = atime.map(|t| {
+            t.checked_add(Duration::nanoseconds(atime_ns.unwrap_or(0) as _))
+                .unwrap_or(t)
+        });
 
         Ok(Self {
             header,
@@ -1126,7 +1135,9 @@ where
     /// Returns the total length of this entry part in bytes.
     #[inline]
     pub fn bytes_len(&self) -> usize {
-        self.0.iter().map(|chunk| chunk.bytes_len()).sum()
+        self.0
+            .iter()
+            .fold(0, |acc, chunk| acc.saturating_add(chunk.bytes_len()))
     }
 
     /// Get reference.


### PR DESCRIPTION
This change improves the security and robustness of the PNA archiver by replacing potentially panic-inducing standard arithmetic operators with checked or saturating arithmetic in critical code paths. Key areas addressed include archive part numbering, chunk size calculations, and entry timestamp parsing. These improvements mitigate Denial-of-Service (DoS) risks when processing malformed or malicious archive input, especially on 32-bit architectures.

Changes:
- lib/src/archive/read.rs: Use checked_add(1) for archive number validation in read_next_archive.
- lib/src/archive/write.rs: Use checked_add(1) for archive numbering in split_to_next_archive.
- cli/src/command/core.rs: Use checked_add(1) for part numbering in write_split_archive_writer.
- lib/src/chunk.rs: Use saturating_add in ChunkExt::bytes_len.
- lib/src/entry.rs: Use saturating_add in EntryPart::bytes_len.
- lib/src/chunk/read.rs: Use saturating_add in ChunkReader::skip_chunk.
- lib/src/entry.rs: Use checked_add when combining Duration seconds and nanoseconds in NormalEntry::try_from.
- .jules/sentinel.md: Initialized the security journal with these critical learnings.

---
*PR created automatically by Jules for task [14307987386356290784](https://jules.google.com/task/14307987386356290784) started by @ChanTsune*