### PR TITLE
⚡ Bolt: optimize StreamCipherWriter allocation and I/O

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Argon2 Overhead in Encryption Benchmarks
+**Learning:** Argon2 key derivation has a high constant cost that masks micro-optimizations in the encryption pipeline when using small payloads.
+**Action:** Use larger payloads or separate key derivation when benchmarking encryption micro-optimizations.

--- a/lib/src/cipher/stream/write.rs
+++ b/lib/src/cipher/stream/write.rs
@@ -51,10 +51,20 @@ where
         if buf.is_empty() {
             return Ok(0);
         }
-        self.scratch.clear();
-        self.scratch.extend_from_slice(buf);
-        self.cipher.apply_keystream(&mut self.scratch);
-        self.w.write_all(&self.scratch)?;
+        // For small writes (metadata, headers), use a stack buffer to avoid heap interaction.
+        if buf.len() <= 4096 {
+            let mut out = [0u8; 4096];
+            let out = &mut out[..buf.len()];
+            self.cipher.apply_keystream_b2b(buf, out);
+            self.w.write_all(out)?;
+        } else {
+            // For larger writes, use a reusable scratch buffer and a single write call
+            // to minimize system call overhead for unbuffered writers.
+            self.scratch.clear();
+            self.scratch.extend_from_slice(buf);
+            self.cipher.apply_keystream(&mut self.scratch);
+            self.w.write_all(&self.scratch)?;
+        }
         Ok(buf.len())
     }
 


### PR DESCRIPTION
💡 **What:** Optimized `StreamCipherWriter` to use a 4KB stack-allocated buffer for small writes and the `apply_keystream_b2b` method for out-of-place encryption. For larger writes, it continues to use a reusable heap-allocated `scratch` buffer to ensure single-write I/O performance.

🎯 **Why:** The previous implementation always cloned input data into a heap-allocated `scratch` buffer for in-place encryption. By using a stack buffer for small writes (typical for entry headers and metadata), we eliminate redundant heap interactions. `apply_keystream_b2b` allows for a single-pass transformation, reducing memory bandwidth usage.

📊 **Impact:** Reduces heap allocations for metadata-heavy write patterns. For small entries, encryption now happens entirely on the stack.

🔬 **Measurement:** Verified with `cargo bench -p libpna --bench create_extract -- aes_ctr`. While Argon2 overhead dominates micro-benchmarks with small payloads (~29ms baseline), this change improves the architectural efficiency of the I/O hot path. Correctness verified with `cargo test -p libpna`.

---
*PR created automatically by Jules for task [7019973745035838714](https://jules.google.com/task/7019973745035838714) started by @ChanTsune*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized stream cipher write operations to improve memory efficiency for varying payload sizes.

* **Chores**
  * Added internal notes on encryption benchmarking observations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->