### PR TITLE
Harden archive part number validation against integer overflow

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-05 - Harden archive part number validation
+**Vulnerability:** Potential panic in multi-part archive handling due to integer overflow.
+**Learning:** Malformed archives or extremely large split sets could trigger panics when incrementing part numbers (e.g., `archive_number + 1`). While `u32::MAX` parts are unlikely, safe arithmetic is required for robustness against untrusted input.
+**Prevention:** Use `checked_add` for all counters derived from archive headers or used in loop increments that determine archive structure.

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -844,11 +844,13 @@ fn detect_symlink_target_type(
 pub(crate) fn collect_split_archives(first: impl AsRef<Path>) -> io::Result<Vec<fs::File>> {
     let first = first.as_ref();
     let mut archives = Vec::new();
-    let mut n = 1;
+    let mut n: usize = 1;
     let mut target_archive = Cow::from(first);
     while fs::exists(&target_archive)? {
         archives.push(fs::File::open(&target_archive)?);
-        n += 1;
+        n = n
+            .checked_add(1)
+            .ok_or_else(|| io::Error::other("too many archive parts"))?;
         target_archive = target_archive.with_part(n).into();
     }
     if archives.is_empty() {
@@ -1754,7 +1756,7 @@ where
         )
         .into());
     }
-    let mut part_num = 1;
+    let mut part_num: usize = 1;
     let mut writer = Archive::write_header(initial_writer)?;
 
     // NOTE: max_file_size - (PNA_HEADER + AHED + ANXT + AEND)
@@ -1769,7 +1771,9 @@ where
         )?;
         for part in parts {
             if written_entry_size + part.bytes_len() > max_file_size {
-                part_num += 1;
+                part_num = part_num
+                    .checked_add(1)
+                    .ok_or_else(|| anyhow::anyhow!("too many archive parts"))?;
                 let file = get_next_writer(part_num)?;
                 writer = writer.split_to_next_archive(file)?;
                 written_entry_size = 0;

--- a/lib/src/archive/read.rs
+++ b/lib/src/archive/read.rs
@@ -147,12 +147,15 @@ impl<R: Read> Archive<R> {
         let current_header = self.header;
         let mut next = Archive::<OR>::read_header_with_buffer(reader, self.buf)?;
         next.max_chunk_size = self.max_chunk_size;
-        if current_header.archive_number + 1 != next.header.archive_number {
+        let expected_next_number = current_header
+            .archive_number
+            .checked_add(1)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "archive number overflow"))?;
+        if expected_next_number != next.header.archive_number {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!(
-                    "next archive number must be {} (expected previous + 1, detected: {})",
-                    current_header.archive_number + 1,
+                    "next archive number must be {expected_next_number} (expected previous + 1, detected: {})",
                     next.header.archive_number
                 ),
             ));


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Harden archive part number validation against integer overflow

* 🚨 Severity: HIGH
* 💡 Vulnerability: Potential panic in multi-part archive handling due to integer overflow.
* 🎯 Impact: Malformed archives or extremely large split sets could trigger panics when incrementing part numbers (e.g., `archive_number + 1`).
* 🔧 Fix: Replaces unchecked `+ 1` increments with `checked_add(1)` and returns an error on overflow in both the library sequence validation and CLI split creation/collection loops.
* ✅ Verification: Verified with `cargo test` and manual inspection of the logic. Added explicit type annotations where necessary for compiler inference.

Critical security findings have been recorded in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [17140378748929434910](https://jules.google.com/task/17140378748929434910) started by @ChanTsune*