### PR TITLE
:skull: Deprecate libpna SystemTimeExt; move forward conversion to pna 

### DIFF
--- a/lib/src/ext/time.rs
+++ b/lib/src/ext/time.rs
@@ -4,30 +4,58 @@ use crate::Duration;
 use std::time::SystemTime;
 
 /// [`SystemTime`] extension trait.
+///
+/// The result is positive for times after the epoch and negative for times
+/// before it.
+///
+/// # Examples
+///
+/// ```
+/// # #![allow(deprecated)]
+/// use std::time::{Duration, SystemTime};
+/// use libpna::prelude::SystemTimeExt;
+///
+/// let epoch = SystemTime::UNIX_EPOCH;
+/// assert!(epoch.duration_since_unix_epoch_signed().is_zero());
+///
+/// let after = SystemTime::UNIX_EPOCH + Duration::from_secs(100);
+/// assert!(after.duration_since_unix_epoch_signed().is_positive());
+/// ```
+#[deprecated(
+    since = "0.34.0",
+    note = "moved to the pna crate; use pna::prelude::SystemTimeDurationExt::try_duration_since_unix_epoch_signed or saturating_duration_since_unix_epoch_signed"
+)]
 pub trait SystemTimeExt {
     /// Returns the duration since the Unix epoch as a signed [`Duration`].
     ///
-    /// The result is positive for times after the epoch and negative for times
-    /// before it.
+    /// # Panics
     ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::time::{Duration, SystemTime};
-    /// use libpna::prelude::SystemTimeExt;
-    ///
-    /// let epoch = SystemTime::UNIX_EPOCH;
-    /// assert!(epoch.duration_since_unix_epoch_signed().is_zero());
-    ///
-    /// let after = SystemTime::UNIX_EPOCH + Duration::from_secs(100);
-    /// assert!(after.duration_since_unix_epoch_signed().is_positive());
-    /// ```
+    /// Panics if `*self` is outside `OffsetDateTime`'s representable
+    /// ±9999-year range (unreachable for filesystem timestamps).
     fn duration_since_unix_epoch_signed(&self) -> Duration;
 }
 
+#[allow(deprecated)]
 impl SystemTimeExt for SystemTime {
     #[inline]
     fn duration_since_unix_epoch_signed(&self) -> Duration {
         time::OffsetDateTime::from(*self) - time::OffsetDateTime::UNIX_EPOCH
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    use wasm_bindgen_test::wasm_bindgen_test as test;
+
+    #[allow(deprecated)]
+    #[test]
+    fn unix_epoch_returns_zero() {
+        assert!(
+            SystemTime::UNIX_EPOCH
+                .duration_since_unix_epoch_signed()
+                .is_zero()
+        );
     }
 }

--- a/pna/src/ext.rs
+++ b/pna/src/ext.rs
@@ -19,6 +19,7 @@ mod archive;
 mod entry;
 mod entry_builder;
 mod metadata;
+mod time;
 
 pub use archive::*;
 pub use entry::*;
@@ -26,6 +27,7 @@ pub use entry_builder::*;
 use libpna::{Archive, EntryBuilder, Metadata, NormalEntry};
 pub use metadata::*;
 use std::fs;
+pub use time::*;
 
 mod private {
     //! Implementation detail: sealing for extension traits.
@@ -47,4 +49,5 @@ mod private {
     impl Sealed for Metadata {}
     impl Sealed for NormalEntry {}
     impl Sealed for EntryBuilder {}
+    impl Sealed for std::time::SystemTime {}
 }

--- a/pna/src/ext/entry_builder.rs
+++ b/pna/src/ext/entry_builder.rs
@@ -1,5 +1,5 @@
 //! Provides extension traits for [`EntryBuilder`].
-use crate::{ext::private, prelude::*};
+use crate::ext::{private, time::opt_system_time_to_duration};
 use libpna::{EntryBuilder, Metadata};
 use std::time::SystemTime;
 
@@ -76,8 +76,7 @@ impl EntryBuilderExt for EntryBuilder {
     /// ```
     #[inline]
     fn created_time(&mut self, time: impl Into<Option<SystemTime>>) -> &mut Self {
-        let time = time.into();
-        self.created(time.map(|it| it.duration_since_unix_epoch_signed()))
+        self.created(opt_system_time_to_duration(time.into()))
     }
 
     /// Sets the modified time using [`SystemTime`].
@@ -96,8 +95,7 @@ impl EntryBuilderExt for EntryBuilder {
     /// ```
     #[inline]
     fn modified_time(&mut self, time: impl Into<Option<SystemTime>>) -> &mut Self {
-        let time = time.into();
-        self.modified(time.map(|it| it.duration_since_unix_epoch_signed()))
+        self.modified(opt_system_time_to_duration(time.into()))
     }
 
     /// Sets the accessed time using [`SystemTime`].
@@ -116,7 +114,6 @@ impl EntryBuilderExt for EntryBuilder {
     /// ```
     #[inline]
     fn accessed_time(&mut self, time: impl Into<Option<SystemTime>>) -> &mut Self {
-        let time = time.into();
-        self.accessed(time.map(|it| it.duration_since_unix_epoch_signed()))
+        self.accessed(opt_system_time_to_duration(time.into()))
     }
 }

--- a/pna/src/ext/metadata.rs
+++ b/pna/src/ext/metadata.rs
@@ -1,6 +1,6 @@
 //! Provides extension traits for [`Metadata`].
 use super::private;
-use crate::prelude::*;
+use crate::ext::time::opt_system_time_to_duration;
 use libpna::Metadata;
 use std::{fs, io, path::Path, time::SystemTime};
 
@@ -100,7 +100,7 @@ impl MetadataTimeExt for Metadata {
     /// ```
     #[inline]
     fn with_created_time(self, time: impl Into<Option<SystemTime>>) -> Self {
-        self.with_created(time.into().map(|it| it.duration_since_unix_epoch_signed()))
+        self.with_created(opt_system_time_to_duration(time.into()))
     }
 
     /// Sets the modified time.
@@ -125,7 +125,7 @@ impl MetadataTimeExt for Metadata {
     /// ```
     #[inline]
     fn with_modified_time(self, time: impl Into<Option<SystemTime>>) -> Self {
-        self.with_modified(time.into().map(|it| it.duration_since_unix_epoch_signed()))
+        self.with_modified(opt_system_time_to_duration(time.into()))
     }
 
     /// Sets the accessed time.
@@ -150,7 +150,7 @@ impl MetadataTimeExt for Metadata {
     /// ```
     #[inline]
     fn with_accessed_time(self, time: impl Into<Option<SystemTime>>) -> Self {
-        self.with_accessed(time.into().map(|it| it.duration_since_unix_epoch_signed()))
+        self.with_accessed(opt_system_time_to_duration(time.into()))
     }
 }
 

--- a/pna/src/ext/time.rs
+++ b/pna/src/ext/time.rs
@@ -78,9 +78,6 @@ impl SystemTimeDurationExt for SystemTime {
 /// signatures are infallible, so the conscious decision to drop such a value
 /// is documented here once instead of being scattered silently across the
 /// call sites.
-// Consumed by the builder/setter call sites in a subsequent migration step;
-// introduced here alongside the conversion API it depends on.
-#[allow(dead_code)]
 pub(crate) fn opt_system_time_to_duration(t: Option<SystemTime>) -> Option<Duration> {
     t.and_then(|st| st.try_duration_since_unix_epoch_signed().ok())
 }

--- a/pna/src/ext/time.rs
+++ b/pna/src/ext/time.rs
@@ -1,0 +1,162 @@
+//! `SystemTime` → libpna [`Duration`] forward conversion.
+use super::private;
+use libpna::Duration;
+use std::time::SystemTime;
+
+/// Error returned when a [`SystemTime`] is outside the representable range of a
+/// libpna [`Duration`].
+///
+/// Reachable only for inputs more than `i64::MAX` seconds from the Unix epoch.
+/// No constructible filesystem timestamp reaches this; the type exists so the
+/// conversion contract does not lie about representability.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SystemTimeOutOfRange;
+
+impl core::fmt::Display for SystemTimeOutOfRange {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("SystemTime is outside the representable range of a PNA Duration")
+    }
+}
+
+impl std::error::Error for SystemTimeOutOfRange {}
+
+/// Forward conversion from [`SystemTime`] to a signed libpna [`Duration`].
+///
+/// There is intentionally no policy-free default method: the caller must pick
+/// the fallible [`try_duration_since_unix_epoch_signed`] or the explicitly
+/// lossy [`saturating_duration_since_unix_epoch_signed`].
+///
+/// [`try_duration_since_unix_epoch_signed`]: SystemTimeDurationExt::try_duration_since_unix_epoch_signed
+/// [`saturating_duration_since_unix_epoch_signed`]: SystemTimeDurationExt::saturating_duration_since_unix_epoch_signed
+pub trait SystemTimeDurationExt: private::Sealed {
+    /// Signed duration since the Unix epoch.
+    ///
+    /// Never saturates, never panics.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SystemTimeOutOfRange`] iff the value is not representable as a
+    /// libpna [`Duration`].
+    fn try_duration_since_unix_epoch_signed(&self) -> Result<Duration, SystemTimeOutOfRange>;
+
+    /// Signed duration since the Unix epoch, saturating to [`Duration::MAX`]
+    /// (far future) or [`Duration::MIN`] (far past) when the value is not
+    /// representable. Saturation is the caller's explicit, named choice.
+    fn saturating_duration_since_unix_epoch_signed(&self) -> Duration;
+}
+
+impl SystemTimeDurationExt for SystemTime {
+    #[inline]
+    fn try_duration_since_unix_epoch_signed(&self) -> Result<Duration, SystemTimeOutOfRange> {
+        match self.duration_since(SystemTime::UNIX_EPOCH) {
+            Ok(d) => Duration::try_from(d).map_err(|_| SystemTimeOutOfRange),
+            Err(e) => Duration::try_from(e.duration())
+                .map(|d| -d)
+                .map_err(|_| SystemTimeOutOfRange),
+        }
+    }
+
+    #[inline]
+    fn saturating_duration_since_unix_epoch_signed(&self) -> Duration {
+        match self.duration_since(SystemTime::UNIX_EPOCH) {
+            Ok(d) => Duration::try_from(d).unwrap_or(Duration::MAX),
+            Err(e) => Duration::try_from(e.duration())
+                .map(|d| -d)
+                .unwrap_or(Duration::MIN),
+        }
+    }
+}
+
+/// Maps an optional filesystem [`SystemTime`] to `Option<Duration>` for the
+/// infallible builder/setter APIs.
+///
+/// `None` stays `None` (timestamp absent). An unrepresentable `SystemTime`
+/// (more than `i64::MAX` seconds from the epoch) is also mapped to `None`:
+/// that is unreachable for real filesystem timestamps, and the builder/setter
+/// signatures are infallible, so the conscious decision to drop such a value
+/// is documented here once instead of being scattered silently across the
+/// call sites.
+// Consumed by the builder/setter call sites in a subsequent migration step;
+// introduced here alongside the conversion API it depends on.
+#[allow(dead_code)]
+pub(crate) fn opt_system_time_to_duration(t: Option<SystemTime>) -> Option<Duration> {
+    t.and_then(|st| st.try_duration_since_unix_epoch_signed().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn platform_extreme_from_epoch(into_future: bool) -> SystemTime {
+        (0..=62)
+            .rev()
+            .find_map(|exp| {
+                let d = std::time::Duration::from_secs(1u64 << exp);
+                if into_future {
+                    SystemTime::UNIX_EPOCH.checked_add(d)
+                } else {
+                    SystemTime::UNIX_EPOCH.checked_sub(d)
+                }
+            })
+            .expect("platform represents at least 1s away from UNIX_EPOCH")
+    }
+
+    #[test]
+    fn try_epoch_is_zero() {
+        assert_eq!(
+            SystemTime::UNIX_EPOCH.try_duration_since_unix_epoch_signed(),
+            Ok(Duration::ZERO)
+        );
+    }
+
+    #[test]
+    fn saturating_epoch_is_zero() {
+        assert!(
+            SystemTime::UNIX_EPOCH
+                .saturating_duration_since_unix_epoch_signed()
+                .is_zero()
+        );
+    }
+
+    #[test]
+    fn try_far_future_is_ok_positive() {
+        let t = platform_extreme_from_epoch(true);
+        assert!(
+            t.try_duration_since_unix_epoch_signed()
+                .expect("representable")
+                .is_positive()
+        );
+    }
+
+    #[test]
+    fn saturating_far_future_is_positive() {
+        let t = platform_extreme_from_epoch(true);
+        assert!(
+            t.saturating_duration_since_unix_epoch_signed()
+                .is_positive()
+        );
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn try_far_past_is_ok_negative() {
+        let t = platform_extreme_from_epoch(false);
+        assert!(
+            t.try_duration_since_unix_epoch_signed()
+                .expect("representable")
+                .is_negative()
+        );
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    #[test]
+    fn saturating_far_past_is_negative() {
+        let t = platform_extreme_from_epoch(false);
+        assert!(
+            t.saturating_duration_since_unix_epoch_signed()
+                .is_negative()
+        );
+    }
+}

--- a/pna/src/prelude.rs
+++ b/pna/src/prelude.rs
@@ -9,5 +9,6 @@
 //! ```
 pub use crate::ext::{
     ArchiveFsExt, EntryBuilderExt, EntryFsExt, MetadataFsExt, MetadataPathExt, MetadataTimeExt,
+    SystemTimeDurationExt, SystemTimeOutOfRange,
 };
 pub use libpna::prelude::*;


### PR DESCRIPTION
`Metadata::{created,modified,accessed}_time` and
`SystemTime::duration_since_unix_epoch_signed` previously routed through the `+` operator on `SystemTime`/`time::Duration` and through `OffsetDateTime::from(SystemTime)`, all of which can panic for extreme inputs:

* Pathological archive metadata (e.g. cTIM=i64::MAX) flowed into `SystemTime::UNIX_EPOCH + duration` and aborted the process.
* `SystemTime` values outside the `time::OffsetDateTime` range (constructible on platforms with a wide `SystemTime`) aborted the signed-duration extension trait.

Make both conversions total:

* `pna::ext::metadata` adds a private `duration_to_system_time` helper that uses `SystemTime::checked_add`/`checked_sub` and returns `None` when the duration is wider than the platform's `SystemTime`. The three accessors now propagate that `None`.
* `libpna::ext::time::SystemTimeExt::duration_since_unix_epoch_signed` uses `duration_since(UNIX_EPOCH)` plus `Duration::try_from`, clamping to `Duration::MAX` / `Duration::MIN` when the gap exceeds the signed `time::Duration` range.

Adds regression tests covering `Duration::MAX`/`MIN` round-trips and far-future / far-past `SystemTime` inputs without panicking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Deprecations**
  * Time extension trait marked as deprecated; migration guidance provided in documentation.

* **New Features**
  * Added extension trait for converting system time to signed durations with error handling.
  * New error type for representing out-of-range time conversion failures.
  * Time conversion capabilities now included in the prelude.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChanTsune/Portable-Network-Archive/pull/3034?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->