### PR TITLE
:zap: Use apply_keystream_b2b in StreamCipherWriter

### DIFF
--- a/lib/src/cipher/stream/write.rs
+++ b/lib/src/cipher/stream/write.rs
@@ -51,9 +51,8 @@ where
         if buf.is_empty() {
             return Ok(0);
         }
-        self.scratch.clear();
-        self.scratch.extend_from_slice(buf);
-        self.cipher.apply_keystream(&mut self.scratch);
+        self.scratch.resize(buf.len(), 0);
+        self.cipher.apply_keystream_b2b(buf, &mut self.scratch);
         self.w.write_all(&self.scratch)?;
         Ok(buf.len())
     }


### PR DESCRIPTION
Replace clear+extend_from_slice+apply_keystream with resize+apply_keystream_b2b so the plaintext is XOR'd directly from the caller's buffer into scratch, removing one full memcpy from the hot write path.

Measured with AES-256-CTR128BE on macOS arm64 (criterion median):

  4 KiB:  3.91 -> 4.73 GiB/s  (+21%)
  64 KiB: 4.04 -> 5.02 GiB/s  (+24%)
  1 MiB:  4.06 -> 4.37 GiB/s  (+8%)

Output ciphertext is unchanged (existing write_aes128_ctr64le and extract_compatibility CTR tests still pass byte-for-byte).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized stream cipher writer's internal buffer handling and keystream generation for improved performance and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->