### PR TITLE
:construction_worker: Cap libFuzzer per-input runtime to 25s

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -71,7 +71,7 @@ jobs:
         env:
           FUZZ_TARGET: ${{ matrix.fuzz_target }}
         run: |
-          cargo fuzz run --release "$FUZZ_TARGET" -- -max_total_time=300
+          cargo fuzz run --release "$FUZZ_TARGET" -- -max_total_time=300 -timeout=25
       - name: Upload crash artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
`cargo fuzz run` was invoked without `-timeout`, leaving libFuzzer's default per-input timeout of 1200s in effect. When a single input hangs the harness for more than the runner's job hard limit, the runner kills the entire job before libFuzzer can mark the input as a Slow Unit, so the offending bytes never make it into `fuzz/artifacts/<target>/timeout-*` for follow-up analysis.

Set `-timeout=25` so any single iteration that exceeds 25s is aborted by libFuzzer itself. The harness then resumes with the next input, the `-max_total_time=300` budget actually completes, and the problematic input is uploaded via the existing `Upload crash artifacts` step.

25s matches the historical "slow unit" threshold used by Google's OSS-Fuzz tooling and is roughly 150x the observed normal per-input runtime (~167ms, dominated by KDF * 2 in the encrypt/decrypt round trip), so the cap will not false-positive on legitimate inputs while still firing well below the runner's hard limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated fuzzing testing configuration with additional timing constraints for improved test coverage management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->