### PR TITLE
⚡ Bolt: optimize chunk writing with single-pass CRC calculation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+## 2025-05-14 - Optimized Chunk Writing with Single-Pass CRC Calculation
+
+**Learning:** Blanket optimization of `ChunkExt::write_chunk_in` to use a single-pass CRC calculation can cause a performance regression for `RawChunk` because `RawChunk` already has a cached/pre-calculated CRC. Re-calculating it during write is redundant.
+
+**Action:** Use a specialized single-pass utility (`write_chunk_single_pass_in`) only for ephemeral/tuple-based chunks (like `(ChunkType::FDAT, data)`) that don't have a pre-calculated CRC. This preserves the performance of `RawChunk` while optimizing hot paths for data and metadata chunks.

--- a/lib/benches/create_extract.rs
+++ b/lib/benches/create_extract.rs
@@ -317,8 +317,32 @@ fn bench_read_empty_archive(c: &mut Criterion) {
     });
 }
 
+fn bench_write_large_store_archive(c: &mut Criterion) {
+    let mut group = c.benchmark_group("large_archive");
+    group.sample_size(10);
+    let size = 10 * 1024 * 1024; // 10 MB
+    let buf = vec![24u8; size];
+    group.bench_function("write_large_store_archive", |b| {
+        b.iter(|| {
+            let mut vec = Vec::with_capacity(size + 1000);
+            let mut writer = Archive::write_header(&mut vec).unwrap();
+            writer
+                .add_entry({
+                    let mut builder = EntryBuilder::new_file("bench".into(), WriteOptions::store())
+                        .expect("failed to create entry builder");
+                    builder.write_all(&buf).expect("failed to write data");
+                    builder.build().expect("failed to build entry")
+                })
+                .expect("failed to add entry");
+            writer.finalize().expect("failed to finalize archive");
+        })
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
+    bench_write_large_store_archive,
     bench_write_store_archive,
     bench_read_store_archive,
     bench_read_store_archive_from_slice,

--- a/lib/src/chunk/write.rs
+++ b/lib/src/chunk/write.rs
@@ -1,6 +1,6 @@
 //! Chunk writing and serialization to byte streams.
 
-use crate::chunk::{Chunk, ChunkExt, ChunkType};
+use crate::chunk::{Chunk, ChunkExt, ChunkType, Crc32};
 use core::num::NonZeroU32;
 #[cfg(feature = "unstable-async")]
 use futures_io::AsyncWrite;
@@ -20,10 +20,67 @@ impl<W> ChunkWriter<W> {
 }
 
 impl<W: Write> ChunkWriter<W> {
+    #[allow(dead_code)]
     #[inline]
     pub(crate) fn write_chunk(&mut self, chunk: impl Chunk) -> io::Result<usize> {
         chunk.write_chunk_in(&mut self.w)
     }
+}
+
+pub(crate) struct CrcWriter<W> {
+    w: W,
+    crc: Crc32,
+}
+
+impl<W> CrcWriter<W> {
+    #[inline]
+    pub(crate) fn new(w: W) -> Self {
+        Self {
+            w,
+            crc: Crc32::new(),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn finalize(self) -> u32 {
+        self.crc.finalize()
+    }
+}
+
+impl<W: Write> Write for CrcWriter<W> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let n = self.w.write(buf)?;
+        self.crc.update(&buf[..n]);
+        Ok(n)
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.w.write_all(buf)?;
+        self.crc.update(buf);
+        Ok(())
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        self.w.flush()
+    }
+}
+
+pub(crate) fn write_chunk_single_pass_in<W: Write>(
+    ty: ChunkType,
+    data: &[u8],
+    writer: &mut W,
+) -> io::Result<usize> {
+    let length = data.len() as u32;
+    writer.write_all(&length.to_be_bytes())?;
+    let mut crc_writer = CrcWriter::new(&mut *writer);
+    crc_writer.write_all(ty.as_bytes())?;
+    crc_writer.write_all(data)?;
+    let crc = crc_writer.finalize();
+    writer.write_all(&crc.to_be_bytes())?;
+    Ok(crate::chunk::MIN_CHUNK_BYTES_SIZE + data.len())
 }
 
 #[cfg(feature = "unstable-async")]
@@ -77,7 +134,7 @@ impl<W: Write> Write for ChunkStreamWriter<W> {
             return Ok(0);
         }
         let chunk = &buf[..buf.len().min(self.max_chunk_size)];
-        self.w.write_chunk((self.ty, chunk))?;
+        write_chunk_single_pass_in(self.ty, chunk, &mut self.w.w)?;
         Ok(chunk.len())
     }
 

--- a/lib/src/chunk/write.rs
+++ b/lib/src/chunk/write.rs
@@ -1,6 +1,8 @@
 //! Chunk writing and serialization to byte streams.
 
-use crate::chunk::{Chunk, ChunkExt, ChunkType, Crc32};
+#[cfg(any(test, feature = "unstable-async"))]
+use crate::chunk::{Chunk, ChunkExt};
+use crate::chunk::{ChunkType, Crc32};
 use core::num::NonZeroU32;
 #[cfg(feature = "unstable-async")]
 use futures_io::AsyncWrite;
@@ -20,7 +22,7 @@ impl<W> ChunkWriter<W> {
 }
 
 impl<W: Write> ChunkWriter<W> {
-    #[allow(dead_code)]
+    #[cfg(test)]
     #[inline]
     pub(crate) fn write_chunk(&mut self, chunk: impl Chunk) -> io::Result<usize> {
         chunk.write_chunk_in(&mut self.w)

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -24,6 +24,7 @@ use crate::{
     Duration,
     chunk::{
         Chunk, ChunkExt, ChunkReader, ChunkType, MIN_CHUNK_BYTES_SIZE, RawChunk, chunk_data_split,
+        write_chunk_single_pass_in,
     },
     io::ChainReader,
     util::slice::skip_while,
@@ -324,10 +325,10 @@ where
             total += extra_chunk.write_chunk_in(writer)?;
         }
         if let Some(phsf) = &self.phsf {
-            total += (ChunkType::PHSF, phsf.as_bytes()).write_chunk_in(writer)?;
+            total += write_chunk_single_pass_in(ChunkType::PHSF, phsf.as_bytes(), writer)?;
         }
         for data in &self.data {
-            total += (ChunkType::SDAT, data).write_chunk_in(writer)?;
+            total += write_chunk_single_pass_in(ChunkType::SDAT, data.as_ref(), writer)?;
         }
         total += (ChunkType::SEND, []).write_chunk_in(writer)?;
         Ok(total)
@@ -739,10 +740,10 @@ where
         }
 
         if let Some(p) = &self.phsf {
-            total += (ChunkType::PHSF, p.as_bytes()).write_chunk_in(writer)?;
+            total += write_chunk_single_pass_in(ChunkType::PHSF, p.as_bytes(), writer)?;
         }
         for data_chunk in &self.data {
-            total += (ChunkType::FDAT, data_chunk).write_chunk_in(writer)?;
+            total += write_chunk_single_pass_in(ChunkType::FDAT, data_chunk.as_ref(), writer)?;
         }
         if let Some(c) = created {
             total += (ChunkType::cTIM, c.whole_seconds().to_be_bytes()).write_chunk_in(writer)?;


### PR DESCRIPTION
Optimized chunk writing in `libpna` by implementing a single-pass write and CRC calculation. Introduced `CrcWriter` and applied it to `ChunkStreamWriter` and `NormalEntry`/`SolidEntry` serialization paths for `FDAT` and `SDAT` chunks. This reduces the number of data passes from two to one, improving cache locality and performance for large archive writes.

---
*PR created automatically by Jules for task [12426435877400360254](https://jules.google.com/task/12426435877400360254) started by @ChanTsune*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized chunk writing with single-pass CRC calculation for faster archive serialization, particularly beneficial for large entries and store-only archives.

* **Tests**
  * Added comprehensive benchmark for large archive write operations to improve performance testing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->