### PR TITLE
🛡️ Sentinel: Fix metadata length parsing confusion

### DIFF
--- a/cli/src/command/append.rs
+++ b/cli/src/command/append.rs
@@ -14,7 +14,11 @@ use crate::{
             read_paths, read_paths_stdin, spawn_entry_results,
         },
     },
-    utils::{PathPartExt, VCS_FILES, fs::HardlinkResolver},
+    utils::{
+        PathPartExt, VCS_FILES,
+        cli_parsers::{parse_gname, parse_uname},
+        fs::HardlinkResolver,
+    },
 };
 use clap::{ArgGroup, Parser, ValueHint};
 use pna::{Archive, prelude::*};
@@ -140,10 +144,20 @@ pub(crate) struct AppendCommand {
         help = "Do not archive ACLs. This is the inverse option of --keep-acl"
     )]
     no_keep_acl: bool,
-    #[arg(long, value_name = "NAME", help = "Set user name for archive entries")]
-    uname: Option<String>,
-    #[arg(long, value_name = "NAME", help = "Set group name for archive entries")]
-    gname: Option<String>,
+    #[arg(
+        long,
+        value_name = "NAME",
+        value_parser = parse_uname,
+        help = "Set user name for archive entries"
+    )]
+    uname: Option<pna::UserName>,
+    #[arg(
+        long,
+        value_name = "NAME",
+        value_parser = parse_gname,
+        help = "Set group name for archive entries"
+    )]
+    gname: Option<pna::GroupName>,
     #[arg(
         long,
         value_name = "ID",

--- a/cli/src/command/bsdtar.rs
+++ b/cli/src/command/bsdtar.rs
@@ -24,7 +24,10 @@ use crate::{
         update::run_update_archive,
     },
     utils::{
-        self, BsdGlobMatcher, PathPartExt, VCS_FILES, env::NamedTempFile, fs::HardlinkResolver,
+        self, BsdGlobMatcher, PathPartExt, VCS_FILES,
+        cli_parsers::{parse_gname, parse_uname},
+        env::NamedTempFile,
+        fs::HardlinkResolver,
     },
 };
 use clap::{ArgGroup, Args, Parser, ValueHint};
@@ -416,15 +419,17 @@ pub(crate) struct BsdtarCommand {
     #[arg(
         long,
         value_name = "NAME",
+        value_parser = parse_uname,
         help = "On create, archiving user to the entries from given name. On extract, restore user from given name"
     )]
-    uname: Option<String>,
+    uname: Option<pna::UserName>,
     #[arg(
         long,
         value_name = "NAME",
+        value_parser = parse_gname,
         help = "On create, archiving group to the entries from given name. On extract, restore group from given name"
     )]
-    gname: Option<String>,
+    gname: Option<pna::GroupName>,
     #[arg(
         long,
         value_name = "ID",
@@ -745,8 +750,8 @@ struct CreationPermissionStrategyResolver {
     no_same_permissions: bool,
     no_same_owner: bool,
     numeric_owner: bool,
-    uname: Option<String>,
-    gname: Option<String>,
+    uname: Option<pna::UserName>,
+    gname: Option<pna::GroupName>,
     uid: Option<u32>,
     gid: Option<u32>,
 }
@@ -764,12 +769,12 @@ impl CreationPermissionStrategyResolver {
             OwnerStrategy::Preserve {
                 options: OwnerOptions {
                     uname: if self.numeric_owner {
-                        Some(String::new())
+                        Some(pna::UserName::default())
                     } else {
                         self.uname
                     },
                     gname: if self.numeric_owner {
-                        Some(String::new())
+                        Some(pna::GroupName::default())
                     } else {
                         self.gname
                     },
@@ -791,10 +796,10 @@ struct ExtractionPermissionStrategyResolver {
     no_same_permissions: bool,
     same_owner: bool,
     numeric_owner: bool,
-    uname: Option<String>,
+    uname: Option<pna::UserName>,
     umask: Umask,
     is_root: bool,
-    gname: Option<String>,
+    gname: Option<pna::GroupName>,
     uid: Option<u32>,
     gid: Option<u32>,
     keep_xattr: bool,
@@ -837,12 +842,12 @@ impl ExtractionPermissionStrategyResolver {
             OwnerStrategy::Preserve {
                 options: OwnerOptions {
                     uname: if self.numeric_owner {
-                        Some(String::new())
+                        Some(pna::UserName::default())
                     } else {
                         self.uname
                     },
                     gname: if self.numeric_owner {
-                        Some(String::new())
+                        Some(pna::GroupName::default())
                     } else {
                         self.gname
                     },
@@ -950,8 +955,8 @@ fn run_create_archive(args: BsdtarCommand) -> anyhow::Result<()> {
         args.options.as_ref(),
         password,
     );
-    let (uname, uid) = resolve_name_id(args.owner, args.uname, args.uid);
-    let (gname, gid) = resolve_name_id(args.group, args.gname, args.gid);
+    let (uname, uid) = resolve_name_id::<pna::UserName>(args.owner, args.uname, args.uid)?;
+    let (gname, gid) = resolve_name_id::<pna::GroupName>(args.group, args.gname, args.gid)?;
     let (mode_strategy, owner_strategy) = CreationPermissionStrategyResolver {
         no_same_permissions: args.no_same_permissions,
         no_same_owner: args.no_same_owner,
@@ -1059,8 +1064,8 @@ fn run_extract_archive(ctx: &GlobalContext, args: BsdtarCommand) -> anyhow::Resu
         missing_mtime: MissingTimePolicy::Include,
     }
     .resolve()?;
-    let (uname, uid) = resolve_name_id(args.owner, args.uname, args.uid);
-    let (gname, gid) = resolve_name_id(args.group, args.gname, args.gid);
+    let (uname, uid) = resolve_name_id::<pna::UserName>(args.owner, args.uname, args.uid)?;
+    let (gname, gid) = resolve_name_id::<pna::GroupName>(args.group, args.gname, args.gid)?;
     let (
         mode_strategy,
         owner_strategy,
@@ -1268,8 +1273,8 @@ fn run_append(args: BsdtarCommand) -> anyhow::Result<()> {
         args.options.as_ref(),
         password,
     );
-    let (uname, uid) = resolve_name_id(args.owner, args.uname, args.uid);
-    let (gname, gid) = resolve_name_id(args.group, args.gname, args.gid);
+    let (uname, uid) = resolve_name_id::<pna::UserName>(args.owner, args.uname, args.uid)?;
+    let (gname, gid) = resolve_name_id::<pna::GroupName>(args.group, args.gname, args.gid)?;
     let (mode_strategy, owner_strategy) = CreationPermissionStrategyResolver {
         no_same_permissions: args.no_same_permissions,
         no_same_owner: args.no_same_owner,
@@ -1408,14 +1413,20 @@ fn run_append(args: BsdtarCommand) -> anyhow::Result<()> {
     }
 }
 
-fn resolve_name_id(
+fn resolve_name_id<N>(
     spec: Option<NameIdPair>,
-    name: Option<String>,
+    name: Option<N>,
     id: Option<u32>,
-) -> (Option<String>, Option<u32>) {
+) -> Result<(Option<N>, Option<u32>), pna::LengthExceeded>
+where
+    N: TryFrom<String, Error = pna::LengthExceeded>,
+{
     match spec {
-        Some(spec) => (spec.name, spec.id),
-        None => (name, id),
+        Some(spec) => {
+            let resolved = spec.name.map(N::try_from).transpose()?;
+            Ok((resolved, spec.id))
+        }
+        None => Ok((name, id)),
     }
 }
 
@@ -1431,8 +1442,8 @@ fn run_update(args: BsdtarCommand) -> anyhow::Result<()> {
         args.options.as_ref(),
         password,
     );
-    let (uname, uid) = resolve_name_id(args.owner, args.uname, args.uid);
-    let (gname, gid) = resolve_name_id(args.group, args.gname, args.gid);
+    let (uname, uid) = resolve_name_id::<pna::UserName>(args.owner, args.uname, args.uid)?;
+    let (gname, gid) = resolve_name_id::<pna::GroupName>(args.group, args.gname, args.gid)?;
     let (mode_strategy, owner_strategy) = CreationPermissionStrategyResolver {
         no_same_permissions: args.no_same_permissions,
         no_same_owner: args.no_same_owner,

--- a/cli/src/command/chmod.rs
+++ b/cli/src/command/chmod.rs
@@ -100,7 +100,15 @@ fn transform_entry<T>(entry: NormalEntry<T>, mode: &Mode) -> NormalEntry<T> {
     let metadata = entry.metadata().clone();
     let permission = metadata.permission().map(|p| {
         let mode = mode.apply_to(p.permissions());
-        pna::Permission::new(p.uid(), p.uname().into(), p.gid(), p.gname().into(), mode)
+        pna::Permission::new(
+            p.uid(),
+            pna::UserName::try_from(p.uname())
+                .expect("source Permission's uname is already bounded"),
+            p.gid(),
+            pna::GroupName::try_from(p.gname())
+                .expect("source Permission's gname is already bounded"),
+            mode,
+        )
     });
     entry.with_metadata(metadata.with_permission(permission))
 }

--- a/cli/src/command/chmod.rs
+++ b/cli/src/command/chmod.rs
@@ -103,10 +103,10 @@ fn transform_entry<T>(entry: NormalEntry<T>, mode: &Mode) -> NormalEntry<T> {
         pna::Permission::new(
             p.uid(),
             pna::UserName::try_from(p.uname())
-                .expect("source Permission's uname is already bounded"),
+                .expect("p's uname is already bounded by UserName invariant"),
             p.gid(),
             pna::GroupName::try_from(p.gname())
-                .expect("source Permission's gname is already bounded"),
+                .expect("p's gname is already bounded by GroupName invariant"),
             mode,
         )
     });

--- a/cli/src/command/chown.rs
+++ b/cli/src/command/chown.rs
@@ -73,7 +73,7 @@ fn archive_chown(args: ChownCommand) -> anyhow::Result<()> {
             |entry| {
                 let entry = entry?;
                 if globs.matches_any(entry.name()) {
-                    Ok(Some(transform_entry(entry, &owner)))
+                    Ok(Some(transform_entry(entry, &owner)?))
                 } else {
                     Ok(Some(entry))
                 }
@@ -87,7 +87,7 @@ fn archive_chown(args: ChownCommand) -> anyhow::Result<()> {
             |entry| {
                 let entry = entry?;
                 if globs.matches_any(entry.name()) {
-                    Ok(Some(transform_entry(entry, &owner)))
+                    Ok(Some(transform_entry(entry, &owner)?))
                 } else {
                     Ok(Some(entry))
                 }
@@ -105,39 +105,48 @@ fn archive_chown(args: ChownCommand) -> anyhow::Result<()> {
 }
 
 #[inline]
-fn transform_entry<T>(entry: NormalEntry<T>, owner: &Ownership) -> NormalEntry<T> {
+fn transform_entry<T>(entry: NormalEntry<T>, owner: &Ownership) -> io::Result<NormalEntry<T>> {
     let metadata = entry.metadata().clone();
-    let permission = metadata.permission().map(|p| {
-        let user = owner.user.as_ref().map(|it| match it {
-            OwnerSpecifier::Name(uname) => (u64::MAX, uname.into()),
-            OwnerSpecifier::ID(uid) => (*uid, String::new()),
-            OwnerSpecifier::System(user) => (
-                user.uid().unwrap_or(u64::MAX),
-                user.name().unwrap_or_default().into(),
-            ),
-        });
-        let (uid, uname) = user.unwrap_or_else(|| (p.uid(), p.uname().into()));
+    let permission = metadata
+        .permission()
+        .map(|p| -> io::Result<pna::Permission> {
+            let user = owner.user.as_ref().map(|it| match it {
+                OwnerSpecifier::Name(uname) => (u64::MAX, uname.clone()),
+                OwnerSpecifier::ID(uid) => (*uid, String::new()),
+                OwnerSpecifier::System(user) => (
+                    user.uid().unwrap_or(u64::MAX),
+                    user.name().unwrap_or_default().to_string(),
+                ),
+            });
+            let (uid, uname) = user.unwrap_or_else(|| (p.uid(), p.uname().to_string()));
 
-        let group = owner.group.as_ref().map(|it| match it {
-            OwnerSpecifier::Name(gname) => (u64::MAX, gname.into()),
-            OwnerSpecifier::ID(gid) => (*gid, String::new()),
-            OwnerSpecifier::System(group) => (
-                group.gid().unwrap_or(u64::MAX),
-                group.name().unwrap_or_default().into(),
-            ),
-        });
-        let (gid, gname) = group.unwrap_or_else(|| (p.gid(), p.gname().into()));
-        let uname: String = uname;
-        let gname: String = gname;
-        pna::Permission::new(
-            uid,
-            pna::UserName::try_from(uname).expect("uname must fit within 255 bytes"),
-            gid,
-            pna::GroupName::try_from(gname).expect("gname must fit within 255 bytes"),
-            p.permissions(),
-        )
-    });
-    entry.with_metadata(metadata.with_permission(permission))
+            let group = owner.group.as_ref().map(|it| match it {
+                OwnerSpecifier::Name(gname) => (u64::MAX, gname.clone()),
+                OwnerSpecifier::ID(gid) => (*gid, String::new()),
+                OwnerSpecifier::System(group) => (
+                    group.gid().unwrap_or(u64::MAX),
+                    group.name().unwrap_or_default().to_string(),
+                ),
+            });
+            let (gid, gname) = group.unwrap_or_else(|| (p.gid(), p.gname().to_string()));
+            // CLI-derived names are bounded by RawOwnership::FromStr; archive-derived
+            // names are bounded by the UserName / GroupName invariants on `p`. The
+            // remaining failure mode is an NSS lookup whose pw_name / gr_name exceeds
+            // the format's u8 length prefix, which we surface as `InvalidData`.
+            let uname = pna::UserName::try_from(uname)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            let gname = pna::GroupName::try_from(gname)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            Ok(pna::Permission::new(
+                uid,
+                uname,
+                gid,
+                gname,
+                p.permissions(),
+            ))
+        })
+        .transpose()?;
+    Ok(entry.with_metadata(metadata.with_permission(permission)))
 }
 
 pub(crate) enum OwnerSpecifier<T> {
@@ -226,6 +235,11 @@ impl RawOwnership {
     }
 }
 
+/// Maximum byte length of a uname or gname stored in an archive entry.
+/// Matches the `u8` length prefix in the `fPRM` chunk; UserName / GroupName
+/// share this bound.
+const NAME_MAX_BYTES: usize = u8::MAX as usize;
+
 impl FromStr for RawOwnership {
     type Err = String;
 
@@ -233,15 +247,32 @@ impl FromStr for RawOwnership {
         if s.is_empty() || s == ":" {
             return Err("owner must not be empty".into());
         }
-        let (user, group, use_login_group) = if let Some((user, group)) = s.split_once(':') {
-            (
-                user.is_empty().not().then(|| user.into()),
-                group.is_empty().not().then(|| group.into()),
-                !user.is_empty() && group.is_empty(),
-            )
-        } else {
-            (Some(s.into()), None, false)
-        };
+        let (user, group, use_login_group): (Option<String>, Option<String>, bool) =
+            if let Some((user, group)) = s.split_once(':') {
+                (
+                    user.is_empty().not().then(|| user.to_string()),
+                    group.is_empty().not().then(|| group.to_string()),
+                    !user.is_empty() && group.is_empty(),
+                )
+            } else {
+                (Some(s.to_string()), None, false)
+            };
+        if let Some(name) = user.as_deref()
+            && name.len() > NAME_MAX_BYTES
+        {
+            return Err(format!(
+                "user name length {} exceeds {NAME_MAX_BYTES}",
+                name.len()
+            ));
+        }
+        if let Some(name) = group.as_deref()
+            && name.len() > NAME_MAX_BYTES
+        {
+            return Err(format!(
+                "group name length {} exceeds {NAME_MAX_BYTES}",
+                name.len()
+            ));
+        }
         Ok(Self {
             user,
             group,

--- a/cli/src/command/chown.rs
+++ b/cli/src/command/chown.rs
@@ -127,7 +127,15 @@ fn transform_entry<T>(entry: NormalEntry<T>, owner: &Ownership) -> NormalEntry<T
             ),
         });
         let (gid, gname) = group.unwrap_or_else(|| (p.gid(), p.gname().into()));
-        pna::Permission::new(uid, uname, gid, gname, p.permissions())
+        let uname: String = uname;
+        let gname: String = gname;
+        pna::Permission::new(
+            uid,
+            pna::UserName::try_from(uname).expect("uname must fit within 255 bytes"),
+            gid,
+            pna::GroupName::try_from(gname).expect("gname must fit within 255 bytes"),
+            p.permissions(),
+        )
     });
     entry.with_metadata(metadata.with_permission(permission))
 }

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -315,8 +315,8 @@ pub(crate) struct PermissionStrategyResolver {
     pub(crate) keep_permission: bool,
     pub(crate) no_keep_permission: bool,
     pub(crate) same_owner: bool,
-    pub(crate) uname: Option<String>,
-    pub(crate) gname: Option<String>,
+    pub(crate) uname: Option<pna::UserName>,
+    pub(crate) gname: Option<pna::GroupName>,
     pub(crate) uid: Option<u32>,
     pub(crate) gid: Option<u32>,
     pub(crate) numeric_owner: bool,
@@ -340,12 +340,12 @@ impl PermissionStrategyResolver {
                 OwnerStrategy::Preserve {
                     options: OwnerOptions {
                         uname: if self.numeric_owner {
-                            Some(String::new())
+                            Some(pna::UserName::default())
                         } else {
                             self.uname
                         },
                         gname: if self.numeric_owner {
-                            Some(String::new())
+                            Some(pna::GroupName::default())
                         } else {
                             self.gname
                         },
@@ -996,25 +996,33 @@ pub(crate) fn apply_metadata(
         // Get owner info: use overrides from OwnerStrategy if Preserve, else use filesystem values
         let uid = options.uid.unwrap_or(meta.uid());
         let gid = options.gid.unwrap_or(meta.gid());
-        let uname = match &options.uname {
-            None => User::from_uid(uid.into())?
-                .name()
-                .unwrap_or_default()
-                .into(),
+        let uname: pna::UserName = match &options.uname {
+            None => {
+                let nss_name = User::from_uid(uid.into())?
+                    .name()
+                    .unwrap_or_default()
+                    .to_string();
+                pna::UserName::try_from(nss_name)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
+            }
             Some(uname) => uname.clone(),
         };
-        let gname = match &options.gname {
-            None => Group::from_gid(gid.into())?
-                .name()
-                .unwrap_or_default()
-                .into(),
+        let gname: pna::GroupName = match &options.gname {
+            None => {
+                let nss_name = Group::from_gid(gid.into())?
+                    .name()
+                    .unwrap_or_default()
+                    .to_string();
+                pna::GroupName::try_from(nss_name)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
+            }
             Some(gname) => gname.clone(),
         };
         entry.permission(pna::Permission::new(
             uid.into(),
-            pna::UserName::try_from(uname).expect("uname must fit within 255 bytes"),
+            uname,
             gid.into(),
-            pna::GroupName::try_from(gname).expect("gname must fit within 255 bytes"),
+            gname,
             mode,
         ));
     }
@@ -1034,15 +1042,17 @@ pub(crate) fn apply_metadata(
         // Get owner info: use overrides from OwnerStrategy
         let uid = options.uid.map_or(u64::MAX, Into::into);
         let gid = options.gid.map_or(u64::MAX, Into::into);
-        let uname = options.uname.clone().unwrap_or(user.name);
-        let gname = options.gname.clone().unwrap_or(group.name);
-        entry.permission(pna::Permission::new(
-            uid,
-            pna::UserName::try_from(uname).expect("uname must fit within 255 bytes"),
-            gid,
-            pna::GroupName::try_from(gname).expect("gname must fit within 255 bytes"),
-            mode,
-        ));
+        let uname: pna::UserName = match options.uname.clone() {
+            Some(uname) => uname,
+            None => pna::UserName::try_from(user.name)
+                .expect("Windows AD/SAM contracts limit usernames well within 255 bytes"),
+        };
+        let gname: pna::GroupName = match options.gname.clone() {
+            Some(gname) => gname,
+            None => pna::GroupName::try_from(group.name)
+                .expect("Windows AD/SAM contracts limit group names well within 255 bytes"),
+        };
+        entry.permission(pna::Permission::new(uid, uname, gid, gname, mode));
     }
     // On macOS, when mac_metadata_strategy is Always, AppleDouble packing via copyfile()
     // already includes xattrs and ACLs. Skip separate handling to avoid duplication.
@@ -2048,13 +2058,19 @@ fn transform_normal_entry(
         if (uid.is_some() || gid.is_some() || uname.is_some() || gname.is_some())
             && let Some(perm) = metadata.permission()
         {
-            let resolved_uname = uname.clone().unwrap_or_else(|| perm.uname().to_string());
-            let resolved_gname = gname.clone().unwrap_or_else(|| perm.gname().to_string());
+            let resolved_uname: pna::UserName = uname.clone().unwrap_or_else(|| {
+                pna::UserName::try_from(perm.uname())
+                    .expect("perm's uname is already bounded by UserName invariant")
+            });
+            let resolved_gname: pna::GroupName = gname.clone().unwrap_or_else(|| {
+                pna::GroupName::try_from(perm.gname())
+                    .expect("perm's gname is already bounded by GroupName invariant")
+            });
             let new_perm = pna::Permission::new(
                 uid.map(u64::from).unwrap_or_else(|| perm.uid()),
-                pna::UserName::try_from(resolved_uname).expect("uname must fit within 255 bytes"),
+                resolved_uname,
                 gid.map(u64::from).unwrap_or_else(|| perm.gid()),
-                pna::GroupName::try_from(resolved_gname).expect("gname must fit within 255 bytes"),
+                resolved_gname,
                 perm.permissions(),
             );
             metadata = metadata.with_permission(Some(new_perm));

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -1012,9 +1012,9 @@ pub(crate) fn apply_metadata(
         };
         entry.permission(pna::Permission::new(
             uid.into(),
-            uname,
+            pna::UserName::try_from(uname).expect("uname must fit within 255 bytes"),
             gid.into(),
-            gname,
+            pna::GroupName::try_from(gname).expect("gname must fit within 255 bytes"),
             mode,
         ));
     }
@@ -1036,7 +1036,13 @@ pub(crate) fn apply_metadata(
         let gid = options.gid.map_or(u64::MAX, Into::into);
         let uname = options.uname.clone().unwrap_or(user.name);
         let gname = options.gname.clone().unwrap_or(group.name);
-        entry.permission(pna::Permission::new(uid, uname, gid, gname, mode));
+        entry.permission(pna::Permission::new(
+            uid,
+            pna::UserName::try_from(uname).expect("uname must fit within 255 bytes"),
+            gid,
+            pna::GroupName::try_from(gname).expect("gname must fit within 255 bytes"),
+            mode,
+        ));
     }
     // On macOS, when mac_metadata_strategy is Always, AppleDouble packing via copyfile()
     // already includes xattrs and ACLs. Skip separate handling to avoid duplication.
@@ -2042,11 +2048,13 @@ fn transform_normal_entry(
         if (uid.is_some() || gid.is_some() || uname.is_some() || gname.is_some())
             && let Some(perm) = metadata.permission()
         {
+            let resolved_uname = uname.clone().unwrap_or_else(|| perm.uname().to_string());
+            let resolved_gname = gname.clone().unwrap_or_else(|| perm.gname().to_string());
             let new_perm = pna::Permission::new(
                 uid.map(u64::from).unwrap_or_else(|| perm.uid()),
-                uname.clone().unwrap_or_else(|| perm.uname().to_string()),
+                pna::UserName::try_from(resolved_uname).expect("uname must fit within 255 bytes"),
                 gid.map(u64::from).unwrap_or_else(|| perm.gid()),
-                gname.clone().unwrap_or_else(|| perm.gname().to_string()),
+                pna::GroupName::try_from(resolved_gname).expect("gname must fit within 255 bytes"),
                 perm.permissions(),
             );
             metadata = metadata.with_permission(Some(new_perm));

--- a/cli/src/command/core/mtree.rs
+++ b/cli/src/command/core/mtree.rs
@@ -461,7 +461,7 @@ fn apply_mtree_metadata(
         let uid = resolve_id(nochange, options.uid, mtree_entry.uid(), fs_metadata.uid());
         let gid = resolve_id(nochange, options.gid, mtree_entry.gid(), fs_metadata.gid());
 
-        let uname = resolve_name(
+        let uname: pna::UserName = resolve_name(
             nochange,
             options.uname.as_ref(),
             mtree_entry.uname(),
@@ -470,8 +470,8 @@ fn apply_mtree_metadata(
                     .ok()
                     .and_then(|u| u.name().map(String::from))
             },
-        );
-        let gname = resolve_name(
+        )?;
+        let gname: pna::GroupName = resolve_name(
             nochange,
             options.gname.as_ref(),
             mtree_entry.gname(),
@@ -480,13 +480,13 @@ fn apply_mtree_metadata(
                     .ok()
                     .and_then(|g| g.name().map(String::from))
             },
-        );
+        )?;
 
         entry.permission(pna::Permission::new(
             uid.into(),
-            pna::UserName::try_from(uname).expect("uname must fit within 255 bytes"),
+            uname,
             gid.into(),
-            pna::GroupName::try_from(gname).expect("gname must fit within 255 bytes"),
+            gname,
             mode,
         ));
     }
@@ -506,22 +506,25 @@ fn resolve_id(nochange: bool, override_id: Option<u32>, mtree_id: Option<u32>, f
 
 /// Resolves a name (uname or gname) with nochange, override, and mtree handling.
 #[cfg(unix)]
-fn resolve_name<F>(
+fn resolve_name<N, F>(
     nochange: bool,
-    override_name: Option<&String>,
+    override_name: Option<&N>,
     mtree_name: Option<&[u8]>,
     lookup_from_id: F,
-) -> String
+) -> io::Result<N>
 where
+    N: Clone + TryFrom<String, Error = pna::LengthExceeded>,
     F: FnOnce() -> Option<String>,
 {
     if let Some(name) = override_name {
-        return name.clone();
+        return Ok(name.clone());
     }
     if !nochange && let Some(name) = mtree_name {
-        return String::from_utf8_lossy(name).into_owned();
+        let raw = String::from_utf8_lossy(name).into_owned();
+        return N::try_from(raw).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e));
     }
-    lookup_from_id().unwrap_or_default()
+    let raw = lookup_from_id().unwrap_or_default();
+    N::try_from(raw).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
 }
 
 /// Applies metadata from mtree entry only (no filesystem metadata available).
@@ -545,14 +548,16 @@ fn apply_mtree_metadata_without_fs(
             .map(|m| u32::from(m) as u16)
             .unwrap_or(0o755);
 
-        let uname = resolve_name(false, options.uname.as_ref(), mtree_entry.uname(), || None);
-        let gname = resolve_name(false, options.gname.as_ref(), mtree_entry.gname(), || None);
+        let uname: pna::UserName =
+            resolve_name(false, options.uname.as_ref(), mtree_entry.uname(), || None)?;
+        let gname: pna::GroupName =
+            resolve_name(false, options.gname.as_ref(), mtree_entry.gname(), || None)?;
 
         entry.permission(pna::Permission::new(
             uid.into(),
-            pna::UserName::try_from(uname).expect("uname must fit within 255 bytes"),
+            uname,
             gid.into(),
-            pna::GroupName::try_from(gname).expect("gname must fit within 255 bytes"),
+            gname,
             mode,
         ));
     }

--- a/cli/src/command/core/mtree.rs
+++ b/cli/src/command/core/mtree.rs
@@ -484,9 +484,9 @@ fn apply_mtree_metadata(
 
         entry.permission(pna::Permission::new(
             uid.into(),
-            uname,
+            pna::UserName::try_from(uname).expect("uname must fit within 255 bytes"),
             gid.into(),
-            gname,
+            pna::GroupName::try_from(gname).expect("gname must fit within 255 bytes"),
             mode,
         ));
     }
@@ -550,9 +550,9 @@ fn apply_mtree_metadata_without_fs(
 
         entry.permission(pna::Permission::new(
             uid.into(),
-            uname,
+            pna::UserName::try_from(uname).expect("uname must fit within 255 bytes"),
             gid.into(),
-            gname,
+            pna::GroupName::try_from(gname).expect("gname must fit within 255 bytes"),
             mode,
         ));
     }

--- a/cli/src/command/core/permission.rs
+++ b/cli/src/command/core/permission.rs
@@ -3,8 +3,8 @@
 /// During extraction: Override values restored from archive (None = use archive)
 #[derive(Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub(crate) struct OwnerOptions {
-    pub(crate) uname: Option<String>,
-    pub(crate) gname: Option<String>,
+    pub(crate) uname: Option<pna::UserName>,
+    pub(crate) gname: Option<pna::GroupName>,
     pub(crate) uid: Option<u32>,
     pub(crate) gid: Option<u32>,
 }

--- a/cli/src/command/create.rs
+++ b/cli/src/command/create.rs
@@ -16,7 +16,12 @@ use crate::{
             read_paths, read_paths_stdin, spawn_entry_results, write_split_archive,
         },
     },
-    utils::{self, VCS_FILES, fmt::DurationDisplay, fs::HardlinkResolver},
+    utils::{
+        self, VCS_FILES,
+        cli_parsers::{parse_gname, parse_uname},
+        fmt::DurationDisplay,
+        fs::HardlinkResolver,
+    },
 };
 use anyhow::ensure;
 use bytesize::ByteSize;
@@ -164,10 +169,20 @@ pub(crate) struct CreateCommand {
         help = "Compress multiple files together for better compression ratio"
     )]
     solid: bool,
-    #[arg(long, value_name = "NAME", help = "Set user name for archive entries")]
-    uname: Option<String>,
-    #[arg(long, value_name = "NAME", help = "Set group name for archive entries")]
-    gname: Option<String>,
+    #[arg(
+        long,
+        value_name = "NAME",
+        value_parser = parse_uname,
+        help = "Set user name for archive entries"
+    )]
+    uname: Option<pna::UserName>,
+    #[arg(
+        long,
+        value_name = "NAME",
+        value_parser = parse_gname,
+        help = "Set group name for archive entries"
+    )]
+    gname: Option<pna::GroupName>,
     #[arg(
         long,
         value_name = "ID",

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -20,6 +20,7 @@ use crate::{
     },
     utils::{
         self, BsdGlobMatcher, PathWithCwd, VCS_FILES,
+        cli_parsers::{parse_gname, parse_uname},
         fmt::DurationDisplay,
         fs::{Group, User},
     },
@@ -183,10 +184,20 @@ pub(crate) struct ExtractCommand {
         help = "Do not restore ACLs. This is the inverse option of --keep-acl"
     )]
     no_keep_acl: bool,
-    #[arg(long, value_name = "NAME", help = "Restore user from given name")]
-    uname: Option<String>,
-    #[arg(long, value_name = "NAME", help = "Restore group from given name")]
-    gname: Option<String>,
+    #[arg(
+        long,
+        value_name = "NAME",
+        value_parser = parse_uname,
+        help = "Restore user from given name"
+    )]
+    uname: Option<pna::UserName>,
+    #[arg(
+        long,
+        value_name = "NAME",
+        value_parser = parse_gname,
+        help = "Restore group from given name"
+    )]
+    gname: Option<pna::GroupName>,
     #[arg(
         long,
         value_name = "ID",

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -18,7 +18,12 @@ use crate::{
             read_paths, read_paths_stdin,
         },
     },
-    utils::{PathPartExt, VCS_FILES, env::NamedTempFile, fs::HardlinkResolver},
+    utils::{
+        PathPartExt, VCS_FILES,
+        cli_parsers::{parse_gname, parse_uname},
+        env::NamedTempFile,
+        fs::HardlinkResolver,
+    },
 };
 use clap::{ArgGroup, Parser, ValueHint};
 use indexmap::IndexMap;
@@ -141,10 +146,20 @@ pub(crate) struct UpdateCommand {
         help = "Do not archive ACLs. This is the inverse option of --keep-acl"
     )]
     no_keep_acl: bool,
-    #[arg(long, value_name = "NAME", help = "Set user name for archive entries")]
-    uname: Option<String>,
-    #[arg(long, value_name = "NAME", help = "Set group name for archive entries")]
-    gname: Option<String>,
+    #[arg(
+        long,
+        value_name = "NAME",
+        value_parser = parse_uname,
+        help = "Set user name for archive entries"
+    )]
+    uname: Option<pna::UserName>,
+    #[arg(
+        long,
+        value_name = "NAME",
+        value_parser = parse_gname,
+        help = "Set group name for archive entries"
+    )]
+    gname: Option<pna::GroupName>,
     #[arg(
         long,
         value_name = "ID",

--- a/cli/src/command/xattr.rs
+++ b/cli/src/command/xattr.rs
@@ -10,7 +10,7 @@ use crate::{
             collect_split_archives,
         },
     },
-    utils::{GlobPatterns, PathPartExt, env::NamedTempFile},
+    utils::{GlobPatterns, PathPartExt, cli_parsers::parse_xattr_name, env::NamedTempFile},
 };
 use base64::Engine;
 use bstr::{ByteSlice, io::BufReadExt};
@@ -89,8 +89,13 @@ impl Command for GetXattrCommand {
 pub(crate) struct SetXattrCommand {
     #[command(flatten)]
     file: FileArgsCompat,
-    #[arg(short, long, help = "Name of extended attribute")]
-    name: Option<String>,
+    #[arg(
+        short,
+        long,
+        value_parser = parse_xattr_name,
+        help = "Name of extended attribute"
+    )]
+    name: Option<pna::XattrName>,
     #[arg(short, long, help = "Value of extended attribute")]
     value: Option<Value>,
     #[arg(
@@ -262,14 +267,14 @@ fn archive_set_xattr(args: SetXattrCommand) -> anyhow::Result<()> {
             temp_file.as_file_mut(),
             password.as_deref(),
             #[hooq::skip_all]
-            |entry| Ok(Some(set_strategy.transform_entry(entry?))),
+            |entry| Ok(Some(set_strategy.transform_entry(entry?)?)),
             TransformStrategyUnSolid,
         ),
         SolidEntriesTransformStrategy::KeepSolid => source.transform_entries(
             temp_file.as_file_mut(),
             password.as_deref(),
             #[hooq::skip_all]
-            |entry| Ok(Some(set_strategy.transform_entry(entry?))),
+            |entry| Ok(Some(set_strategy.transform_entry(entry?)?)),
             TransformStrategyKeepSolid,
         ),
     }?;
@@ -288,7 +293,7 @@ enum SetAttrStrategy<'s> {
     Restore(HashMap<String, Vec<(String, Value)>>),
     Apply {
         globs: GlobPatterns<'s>,
-        name: Option<String>,
+        name: Option<pna::XattrName>,
         value: Value,
         remove: Option<String>,
     },
@@ -296,7 +301,7 @@ enum SetAttrStrategy<'s> {
 
 impl SetAttrStrategy<'_> {
     #[inline]
-    fn transform_entry<T>(&mut self, entry: NormalEntry<T>) -> NormalEntry<T> {
+    fn transform_entry<T>(&mut self, entry: NormalEntry<T>) -> io::Result<NormalEntry<T>> {
         match self {
             SetAttrStrategy::Restore(restore) => {
                 if let Some(attrs) = restore.get(entry.name().as_str()) {
@@ -308,18 +313,20 @@ impl SetAttrStrategy<'_> {
                         .collect::<IndexMap<_, _>>();
                     let xattrs = xattrs
                         .into_iter()
-                        .map(|(key, value)| {
-                            pna::ExtendedAttribute::new(
-                                pna::XattrName::try_from(key)
-                                    .expect("xattr name must fit within u32::MAX bytes"),
-                                pna::XattrValue::try_from(value)
-                                    .expect("xattr value must fit within u32::MAX bytes"),
-                            )
+                        .map(|(key, value)| -> io::Result<pna::ExtendedAttribute> {
+                            // dump-file-derived names/values may exceed the
+                            // u32 length prefix; existing entry xattrs are
+                            // already bounded by their newtype invariants.
+                            let name = pna::XattrName::try_from(key)
+                                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                            let value = pna::XattrValue::try_from(value)
+                                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                            Ok(pna::ExtendedAttribute::new(name, value))
                         })
-                        .collect::<Vec<_>>();
-                    entry.with_xattrs(xattrs)
+                        .collect::<io::Result<Vec<_>>>()?;
+                    Ok(entry.with_xattrs(xattrs))
                 } else {
-                    entry
+                    Ok(entry)
                 }
             }
             SetAttrStrategy::Apply {
@@ -329,9 +336,9 @@ impl SetAttrStrategy<'_> {
                 remove,
             } => {
                 if globs.matches_any(entry.name()) {
-                    transform_entry(entry, name.as_deref(), value.as_bytes(), remove.as_deref())
+                    transform_entry(entry, name.as_ref(), value.as_bytes(), remove.as_deref())
                 } else {
-                    entry
+                    Ok(entry)
                 }
             }
         }
@@ -366,39 +373,44 @@ fn parse_dump(reader: impl io::BufRead) -> io::Result<HashMap<String, Vec<(Strin
 #[inline]
 fn transform_entry<T>(
     entry: NormalEntry<T>,
-    name: Option<&str>,
+    name: Option<&pna::XattrName>,
     value: &[u8],
     remove: Option<&str>,
-) -> NormalEntry<T> {
-    let xattrs = transform_xattr(entry.xattrs(), name, value, remove);
-    entry.with_xattrs(xattrs)
+) -> io::Result<NormalEntry<T>> {
+    let xattrs = transform_xattr(entry.xattrs(), name, value, remove)?;
+    Ok(entry.with_xattrs(xattrs))
 }
 
 #[inline]
 fn transform_xattr(
     xattrs: &[pna::ExtendedAttribute],
-    name: Option<&str>,
+    name: Option<&pna::XattrName>,
     value: &[u8],
     remove: Option<&str>,
-) -> Vec<pna::ExtendedAttribute> {
+) -> io::Result<Vec<pna::ExtendedAttribute>> {
     let mut xattrs = xattrs
         .iter()
         .map(|it| (it.name(), it.value()))
         .collect::<IndexMap<_, _>>();
     if let Some(name) = name {
-        xattrs.insert(name, value);
+        xattrs.insert(name.as_str(), value);
     }
     if let Some(name) = remove {
         xattrs.shift_remove_entry(name);
     }
     xattrs
         .into_iter()
-        .map(|(key, value)| {
-            pna::ExtendedAttribute::new(
-                pna::XattrName::try_from(key).expect("xattr name must fit within u32::MAX bytes"),
-                pna::XattrValue::try_from(value)
-                    .expect("xattr value must fit within u32::MAX bytes"),
-            )
+        .map(|(key, value)| -> io::Result<pna::ExtendedAttribute> {
+            // CLI-supplied --name was validated by clap value_parser; existing
+            // entry xattrs are already bounded by their newtype invariants. The
+            // CLI-supplied --value's argv-bounded size cannot reach u32::MAX,
+            // so this conversion is provably safe here, but propagating any
+            // future bound violation as InvalidData costs nothing.
+            let name = pna::XattrName::try_from(key)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            let value = pna::XattrValue::try_from(value)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            Ok(pna::ExtendedAttribute::new(name, value))
         })
         .collect()
 }
@@ -652,7 +664,8 @@ mod tests {
 
     #[test]
     fn set_xattr() {
-        let xattrs = transform_xattr(&[], Some("key"), b"value", None);
+        let key = pna::XattrName::try_from("key").unwrap();
+        let xattrs = transform_xattr(&[], Some(&key), b"value", None).unwrap();
 
         assert_eq!(
             xattrs,
@@ -665,15 +678,17 @@ mod tests {
 
     #[test]
     fn overwrite_xattr() {
+        let key = pna::XattrName::try_from("key").unwrap();
         let xattrs = transform_xattr(
             &[pna::ExtendedAttribute::new(
                 pna::XattrName::try_from("key").unwrap(),
                 pna::XattrValue::try_from(b"origin".as_slice()).unwrap(),
             )],
-            Some("key"),
+            Some(&key),
             b"value",
             None,
-        );
+        )
+        .unwrap();
 
         assert_eq!(
             xattrs,
@@ -694,7 +709,8 @@ mod tests {
             None,
             b"value",
             Some("key"),
-        );
+        )
+        .unwrap();
 
         assert_eq!(xattrs, vec![]);
     }

--- a/cli/src/command/xattr.rs
+++ b/cli/src/command/xattr.rs
@@ -308,7 +308,14 @@ impl SetAttrStrategy<'_> {
                         .collect::<IndexMap<_, _>>();
                     let xattrs = xattrs
                         .into_iter()
-                        .map(|(key, value)| pna::ExtendedAttribute::new(key.into(), value.into()))
+                        .map(|(key, value)| {
+                            pna::ExtendedAttribute::new(
+                                pna::XattrName::try_from(key)
+                                    .expect("xattr name must fit within u32::MAX bytes"),
+                                pna::XattrValue::try_from(value)
+                                    .expect("xattr value must fit within u32::MAX bytes"),
+                            )
+                        })
                         .collect::<Vec<_>>();
                     entry.with_xattrs(xattrs)
                 } else {
@@ -386,7 +393,13 @@ fn transform_xattr(
     }
     xattrs
         .into_iter()
-        .map(|(key, value)| pna::ExtendedAttribute::new(key.into(), value.into()))
+        .map(|(key, value)| {
+            pna::ExtendedAttribute::new(
+                pna::XattrName::try_from(key).expect("xattr name must fit within u32::MAX bytes"),
+                pna::XattrValue::try_from(value)
+                    .expect("xattr value must fit within u32::MAX bytes"),
+            )
+        })
         .collect()
 }
 
@@ -643,14 +656,20 @@ mod tests {
 
         assert_eq!(
             xattrs,
-            vec![pna::ExtendedAttribute::new("key".into(), b"value".into()),]
+            vec![pna::ExtendedAttribute::new(
+                pna::XattrName::try_from("key").unwrap(),
+                pna::XattrValue::try_from(b"value".as_slice()).unwrap(),
+            ),]
         );
     }
 
     #[test]
     fn overwrite_xattr() {
         let xattrs = transform_xattr(
-            &[pna::ExtendedAttribute::new("key".into(), b"origin".into())],
+            &[pna::ExtendedAttribute::new(
+                pna::XattrName::try_from("key").unwrap(),
+                pna::XattrValue::try_from(b"origin".as_slice()).unwrap(),
+            )],
             Some("key"),
             b"value",
             None,
@@ -658,14 +677,20 @@ mod tests {
 
         assert_eq!(
             xattrs,
-            vec![pna::ExtendedAttribute::new("key".into(), b"value".into()),]
+            vec![pna::ExtendedAttribute::new(
+                pna::XattrName::try_from("key").unwrap(),
+                pna::XattrValue::try_from(b"value".as_slice()).unwrap(),
+            ),]
         );
     }
 
     #[test]
     fn remove_xattr() {
         let xattrs = transform_xattr(
-            &[pna::ExtendedAttribute::new("key".into(), b"origin".into())],
+            &[pna::ExtendedAttribute::new(
+                pna::XattrName::try_from("key").unwrap(),
+                pna::XattrValue::try_from(b"origin".as_slice()).unwrap(),
+            )],
             None,
             b"value",
             Some("key"),

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "acl")]
 pub(crate) mod acl;
+pub(crate) mod cli_parsers;
 pub(crate) mod env;
 pub(crate) mod fmt;
 pub(crate) mod fs;

--- a/cli/src/utils/cli_parsers.rs
+++ b/cli/src/utils/cli_parsers.rs
@@ -1,0 +1,18 @@
+//! Clap value parsers that validate CLI strings against PNA's bounded
+//! identifier types so out-of-range input is rejected by the argument parser
+//! before reaching the rest of the program.
+
+#[inline]
+pub(crate) fn parse_uname(s: &str) -> Result<pna::UserName, pna::LengthExceeded> {
+    pna::UserName::try_from(s)
+}
+
+#[inline]
+pub(crate) fn parse_gname(s: &str) -> Result<pna::GroupName, pna::LengthExceeded> {
+    pna::GroupName::try_from(s)
+}
+
+#[inline]
+pub(crate) fn parse_xattr_name(s: &str) -> Result<pna::XattrName, pna::LengthExceeded> {
+    pna::XattrName::try_from(s)
+}

--- a/cli/src/utils/os/unix/fs/xattrs.rs
+++ b/cli/src/utils/os/unix/fs/xattrs.rs
@@ -40,9 +40,9 @@ pub(crate) fn get_xattrs<P: AsRef<Path>>(path: P) -> io::Result<Vec<ExtendedAttr
             let value = xattr::get(path, &name)?.unwrap_or_default();
             xattrs.push(ExtendedAttribute::new(
                 pna::XattrName::try_from(name_cow.into_owned())
-                    .expect("xattr name must fit within u32::MAX bytes"),
+                    .expect("OS xattr name ABI bounds names to <= 255 bytes"),
                 pna::XattrValue::try_from(value)
-                    .expect("xattr value must fit within u32::MAX bytes"),
+                    .expect("OS xattr value ABI bounds values to << u32::MAX bytes"),
             ))
         }
         Ok(xattrs)

--- a/cli/src/utils/os/unix/fs/xattrs.rs
+++ b/cli/src/utils/os/unix/fs/xattrs.rs
@@ -38,7 +38,12 @@ pub(crate) fn get_xattrs<P: AsRef<Path>>(path: P) -> io::Result<Vec<ExtendedAttr
                 continue;
             }
             let value = xattr::get(path, &name)?.unwrap_or_default();
-            xattrs.push(ExtendedAttribute::new(name_cow.into_owned(), value))
+            xattrs.push(ExtendedAttribute::new(
+                pna::XattrName::try_from(name_cow.into_owned())
+                    .expect("xattr name must fit within u32::MAX bytes"),
+                pna::XattrValue::try_from(value)
+                    .expect("xattr value must fit within u32::MAX bytes"),
+            ))
         }
         Ok(xattrs)
     }

--- a/cli/tests/cli/list/trailing_slash.rs
+++ b/cli/tests/cli/list/trailing_slash.rs
@@ -1,6 +1,8 @@
 use crate::utils::setup;
 use assert_cmd::cargo::cargo_bin_cmd;
-use pna::{Archive, Duration, EntryBuilder, EntryName, Permission, WriteOptions};
+use pna::{
+    Archive, Duration, EntryBuilder, EntryName, GroupName, Permission, UserName, WriteOptions,
+};
 use std::{fs, io::Write, path::Path};
 
 fn create_archive_with_trailing_slash_dir(path: &str) {
@@ -14,9 +16,9 @@ fn create_archive_with_trailing_slash_dir(path: &str) {
     let mut dir_builder = EntryBuilder::new_dir(EntryName::from_utf8_preserve_root("dir/"));
     dir_builder.modified(mtime).permission(Permission::new(
         0,
-        "root".into(),
+        UserName::try_from("root").unwrap(),
         0,
-        "root".into(),
+        GroupName::try_from("root").unwrap(),
         0o755,
     ));
     archive.add_entry(dir_builder.build().unwrap()).unwrap();
@@ -28,9 +30,9 @@ fn create_archive_with_trailing_slash_dir(path: &str) {
     .unwrap();
     file_builder.modified(mtime).permission(Permission::new(
         0,
-        "root".into(),
+        UserName::try_from("root").unwrap(),
         0,
-        "root".into(),
+        GroupName::try_from("root").unwrap(),
         0o644,
     ));
     file_builder.write_all(b"hello").unwrap();

--- a/cli/tests/cli/utils/archive.rs
+++ b/cli/tests/cli/utils/archive.rs
@@ -12,6 +12,16 @@ pub struct FileEntryDef<'a> {
     pub permission: u16,
 }
 
+/// Constructs an [`pna::ExtendedAttribute`] from raw name/value, panicking on
+/// length-bound violations. Test-only helper; production code must propagate
+/// the [`pna::LengthExceeded`] error instead.
+pub fn xattr(name: &str, value: &[u8]) -> pna::ExtendedAttribute {
+    pna::ExtendedAttribute::new(
+        pna::XattrName::try_from(name).expect("xattr name fits within u32::MAX bytes"),
+        pna::XattrValue::try_from(value).expect("xattr value fits within u32::MAX bytes"),
+    )
+}
+
 /// Creates an archive with file entries having specific permissions.
 /// This bypasses filesystem permission requirements by constructing entries programmatically.
 pub fn create_archive_with_permissions(
@@ -26,9 +36,9 @@ pub fn create_archive_with_permissions(
             pna::EntryBuilder::new_file(entry_def.path.into(), pna::WriteOptions::store())?;
         builder.permission(pna::Permission::new(
             1000,
-            "user".into(),
+            pna::UserName::try_from("user").unwrap(),
             1000,
-            "group".into(),
+            pna::GroupName::try_from("group").unwrap(),
             entry_def.permission,
         ));
         builder.write_all(entry_def.content)?;
@@ -54,9 +64,9 @@ pub fn create_solid_archive_with_permissions(
             pna::EntryBuilder::new_file(entry_def.path.into(), pna::WriteOptions::store())?;
         builder.permission(pna::Permission::new(
             1000,
-            "user".into(),
+            pna::UserName::try_from("user").unwrap(),
             1000,
-            "group".into(),
+            pna::GroupName::try_from("group").unwrap(),
             entry_def.permission,
         ));
         builder.write_all(entry_def.content)?;
@@ -90,9 +100,9 @@ pub fn create_encrypted_archive_with_permissions(
             pna::EntryBuilder::new_file(entry_def.path.into(), write_options.clone())?;
         builder.permission(pna::Permission::new(
             1000,
-            "user".into(),
+            pna::UserName::try_from("user").unwrap(),
             1000,
-            "group".into(),
+            pna::GroupName::try_from("group").unwrap(),
             entry_def.permission,
         ));
         builder.write_all(entry_def.content)?;
@@ -201,9 +211,9 @@ pub fn create_archive_with_symlinks(
             pna::EntryBuilder::new_file(entry_def.path.into(), pna::WriteOptions::store())?;
         builder.permission(pna::Permission::new(
             1000,
-            "user".into(),
+            pna::UserName::try_from("user").unwrap(),
             1000,
-            "group".into(),
+            pna::GroupName::try_from("group").unwrap(),
             entry_def.permission,
         ));
         builder.write_all(entry_def.content)?;
@@ -218,9 +228,9 @@ pub fn create_archive_with_symlinks(
         if let Some(mode) = symlink_def.permission {
             builder.permission(pna::Permission::new(
                 1000,
-                "user".into(),
+                pna::UserName::try_from("user").unwrap(),
                 1000,
-                "group".into(),
+                pna::GroupName::try_from("group").unwrap(),
                 mode,
             ));
         }

--- a/cli/tests/cli/xattr/get/option_match_encoding.rs
+++ b/cli/tests/cli/xattr/get/option_match_encoding.rs
@@ -1,4 +1,8 @@
-use crate::utils::{EmbedExt, TestResources, archive::for_each_entry, setup};
+use crate::utils::{
+    EmbedExt, TestResources,
+    archive::{for_each_entry, xattr},
+    setup,
+};
 use assert_cmd::cargo::cargo_bin_cmd;
 use clap::Parser;
 use portable_network_archive::cli;
@@ -61,22 +65,10 @@ fn xattr_get_name_match_encoding() {
     for_each_entry("xattr_get_opts/archive.pna", |entry| {
         match entry.header().path().as_str() {
             "xattr_get_opts/in/raw/empty.txt" => {
-                assert_eq!(
-                    entry.xattrs(),
-                    &[pna::ExtendedAttribute::new(
-                        "user.name".into(),
-                        b"pna".to_vec()
-                    )]
-                );
+                assert_eq!(entry.xattrs(), &[xattr("user.name", b"pna")]);
             }
             "xattr_get_opts/in/raw/text.txt" => {
-                assert_eq!(
-                    entry.xattrs(),
-                    &[pna::ExtendedAttribute::new(
-                        "user.value".into(),
-                        b"data".to_vec()
-                    )]
-                );
+                assert_eq!(entry.xattrs(), &[xattr("user.value", b"data")]);
             }
             _ => {
                 assert!(entry.xattrs().is_empty());

--- a/cli/tests/cli/xattr/set/basic.rs
+++ b/cli/tests/cli/xattr/set/basic.rs
@@ -30,10 +30,7 @@ fn archive_xattr_set() {
         if entry.name() == "raw/empty.txt" {
             assert_eq!(
                 entry.xattrs(),
-                &[pna::ExtendedAttribute::new(
-                    "user.name".into(),
-                    b"pna developers!".into()
-                )]
+                &[archive::xattr("user.name", b"pna developers!")]
             );
         } else {
             // Non-target entries should remain unaffected (no xattrs)
@@ -94,14 +91,8 @@ fn xattr_long_key_value() {
             assert_eq!(
                 entry.xattrs(),
                 &[
-                    pna::ExtendedAttribute::new(
-                        long_name.as_str().into(),
-                        long_value.as_bytes().into()
-                    ),
-                    pna::ExtendedAttribute::new(
-                        "user.special".into(),
-                        "\0\n\r\x7f\u{1F600}".into()
-                    ),
+                    archive::xattr(long_name.as_str(), long_value.as_bytes()),
+                    archive::xattr("user.special", "\0\n\r\x7f\u{1F600}".as_bytes()),
                 ]
             );
         } else {
@@ -143,10 +134,7 @@ fn xattr_empty_key() {
 
     archive::for_each_entry("xattr_empty_key/zstd.pna", |entry| {
         if entry.name() == "raw/empty.txt" {
-            assert_eq!(
-                entry.xattrs(),
-                &[pna::ExtendedAttribute::new("".into(), b"value".into())]
-            );
+            assert_eq!(entry.xattrs(), &[archive::xattr("", b"value")]);
         } else {
             // Non-target entries should remain unaffected (no xattrs)
             assert!(
@@ -186,10 +174,7 @@ fn xattr_empty_value() {
 
     archive::for_each_entry("xattr_empty_value/zstd.pna", |entry| {
         if entry.name() == "raw/empty.txt" {
-            assert_eq!(
-                entry.xattrs(),
-                &[pna::ExtendedAttribute::new("user.empty".into(), b"".into())]
-            );
+            assert_eq!(entry.xattrs(), &[archive::xattr("user.empty", b"")]);
         } else {
             // Non-target entries should remain unaffected (no xattrs)
             assert!(
@@ -233,10 +218,7 @@ fn xattr_set_preserved_in_archive() {
             found = true;
             assert_eq!(
                 entry.xattrs(),
-                &[pna::ExtendedAttribute::new(
-                    "user.roundtrip".into(),
-                    b"preserved_value".into()
-                )]
+                &[archive::xattr("user.roundtrip", b"preserved_value")]
             );
         }
     })
@@ -317,10 +299,7 @@ fn xattr_round_trip_preservation() {
             found = true;
             assert_eq!(
                 entry.xattrs(),
-                &[pna::ExtendedAttribute::new(
-                    "user.roundtrip".into(),
-                    b"preserved_value".into()
-                )],
+                &[archive::xattr("user.roundtrip", b"preserved_value")],
             );
         }
     })

--- a/cli/tests/cli/xattr/set/option_base64.rs
+++ b/cli/tests/cli/xattr/set/option_base64.rs
@@ -32,10 +32,7 @@ fn xattr_set_base64() {
         if entry.name() == "raw/empty.txt" {
             assert_eq!(
                 entry.xattrs(),
-                &[pna::ExtendedAttribute::new(
-                    "user.base64".into(),
-                    b"Hello World".to_vec()
-                )]
+                &[archive::xattr("user.base64", b"Hello World")]
             );
         } else {
             // Non-target entries should remain unaffected (no xattrs)

--- a/cli/tests/cli/xattr/set/option_hex.rs
+++ b/cli/tests/cli/xattr/set/option_hex.rs
@@ -32,10 +32,7 @@ fn xattr_set_hex() {
         if entry.name() == "raw/empty.txt" {
             assert_eq!(
                 entry.xattrs(),
-                &[pna::ExtendedAttribute::new(
-                    "user.hex".into(),
-                    b"Hello World".to_vec()
-                )]
+                &[archive::xattr("user.hex", b"Hello World")]
             );
         } else {
             // Non-target entries should remain unaffected (no xattrs)

--- a/cli/tests/cli/xattr/set/option_remove.rs
+++ b/cli/tests/cli/xattr/set/option_remove.rs
@@ -1,4 +1,8 @@
-use crate::utils::{EmbedExt, TestResources, archive::for_each_entry, setup};
+use crate::utils::{
+    EmbedExt, TestResources,
+    archive::{for_each_entry, xattr},
+    setup,
+};
 use clap::Parser;
 use portable_network_archive::cli;
 
@@ -38,13 +42,7 @@ fn archive_xattr_remove() {
 
     for_each_entry("xattr_remove/xattr_remove.pna", |entry| {
         if entry.name() == "xattr_remove/in/raw/empty.txt" {
-            assert_eq!(
-                entry.xattrs(),
-                &[pna::ExtendedAttribute::new(
-                    "user.name".into(),
-                    b"pna developers!".into()
-                )],
-            );
+            assert_eq!(entry.xattrs(), &[xattr("user.name", b"pna developers!")],);
         } else {
             // Non-target entries should have no xattrs
             assert!(

--- a/cli/tests/cli/xattr/set/overwrite.rs
+++ b/cli/tests/cli/xattr/set/overwrite.rs
@@ -43,13 +43,7 @@ fn xattr_overwrite() {
 
     archive::for_each_entry("xattr_overwrite/zstd.pna", |entry| {
         if entry.name() == "raw/empty.txt" {
-            assert_eq!(
-                entry.xattrs(),
-                &[pna::ExtendedAttribute::new(
-                    "user.name".into(),
-                    b"second".into()
-                )]
-            );
+            assert_eq!(entry.xattrs(), &[archive::xattr("user.name", b"second")]);
         } else {
             // Non-target entries should remain unaffected (no xattrs)
             assert!(

--- a/cli/tests/cli/xattr/set/set_and_remove.rs
+++ b/cli/tests/cli/xattr/set/set_and_remove.rs
@@ -59,10 +59,7 @@ fn xattr_multiple_set_and_remove() {
 
     archive::for_each_entry("xattr_multi/zstd.pna", |entry| {
         if entry.name() == "raw/empty.txt" {
-            assert_eq!(
-                entry.xattrs(),
-                &[pna::ExtendedAttribute::new("user.b".into(), b"B".into())]
-            );
+            assert_eq!(entry.xattrs(), &[archive::xattr("user.b", b"B")]);
         } else {
             // Non-target entries should remain unaffected (no xattrs)
             assert!(

--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -514,7 +514,13 @@ mod tests {
             builder.created(Duration::seconds(31));
             builder.modified(Duration::seconds(32));
             builder.accessed(Duration::seconds(33));
-            builder.permission(Permission::new(1, "uname".into(), 2, "gname".into(), 0o775));
+            builder.permission(Permission::new(
+                1,
+                UserName::try_from("uname").unwrap(),
+                2,
+                GroupName::try_from("gname").unwrap(),
+                0o775,
+            ));
             builder.write_all(b"entry data").unwrap();
             builder.build().unwrap()
         };

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -954,11 +954,14 @@ impl<T> NormalEntry<T> {
     /// # Examples
     /// ```rust
     /// # use std::io;
-    /// use libpna::{EntryBuilder, ExtendedAttribute};
+    /// use libpna::{EntryBuilder, ExtendedAttribute, XattrName, XattrValue};
     ///
     /// # fn main() -> io::Result<()> {
     /// let mut entry = EntryBuilder::new_dir("dir_entry".into()).build()?;
-    /// entry.with_xattrs(&[ExtendedAttribute::new("key".into(), b"value".into())]);
+    /// entry.with_xattrs(&[ExtendedAttribute::new(
+    ///     XattrName::try_from("key").unwrap(),
+    ///     XattrValue::try_from(b"value".as_slice()).unwrap(),
+    /// )]);
     /// # Ok(())
     /// # }
     /// ```

--- a/lib/src/entry/attr.rs
+++ b/lib/src/entry/attr.rs
@@ -1,12 +1,141 @@
 //! Extended attribute types for PNA archive entries.
 
-use std::{io, mem, str};
+use crate::util::bounded::{LengthExceeded, bytes::BoundedBytes, str::BoundedString};
+use std::{io, mem, ops::Deref, str};
+
+const XATTR_LENGTH_LIMIT: usize = u32::MAX as usize;
+
+/// Extended-attribute name identifier.
+///
+/// Bounded by the `u32` length prefix used in the `xATR` chunk's serialized
+/// form.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[repr(transparent)]
+pub struct XattrName(BoundedString<XATTR_LENGTH_LIMIT>);
+
+impl XattrName {
+    /// Constructs an [`XattrName`], rejecting inputs whose byte length exceeds
+    /// `u32::MAX`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LengthExceeded`] when the input's byte length is greater than
+    /// `u32::MAX`.
+    #[inline]
+    pub fn new(value: impl Into<Box<str>>) -> Result<Self, LengthExceeded> {
+        BoundedString::new(value).map(Self)
+    }
+
+    /// Returns the name as a string slice.
+    #[inline]
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl Deref for XattrName {
+    type Target = str;
+
+    #[inline]
+    fn deref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl TryFrom<String> for XattrName {
+    type Error = LengthExceeded;
+
+    #[inline]
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<&str> for XattrName {
+    type Error = LengthExceeded;
+
+    #[inline]
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<XattrName> for String {
+    #[inline]
+    fn from(value: XattrName) -> Self {
+        value.0.into()
+    }
+}
+
+/// Extended-attribute value (arbitrary bytes).
+///
+/// Bounded by the `u32` length prefix used in the `xATR` chunk's serialized
+/// form.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[repr(transparent)]
+pub struct XattrValue(BoundedBytes<XATTR_LENGTH_LIMIT>);
+
+impl XattrValue {
+    /// Constructs an [`XattrValue`], rejecting inputs whose byte length exceeds
+    /// `u32::MAX`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LengthExceeded`] when the input's byte length is greater than
+    /// `u32::MAX`.
+    #[inline]
+    pub fn new(value: impl Into<Box<[u8]>>) -> Result<Self, LengthExceeded> {
+        BoundedBytes::new(value).map(Self)
+    }
+
+    /// Returns the value as a byte slice.
+    #[inline]
+    #[must_use]
+    pub fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+}
+
+impl Deref for XattrValue {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+}
+
+impl TryFrom<Vec<u8>> for XattrValue {
+    type Error = LengthExceeded;
+
+    #[inline]
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<&[u8]> for XattrValue {
+    type Error = LengthExceeded;
+
+    #[inline]
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<XattrValue> for Vec<u8> {
+    #[inline]
+    fn from(value: XattrValue) -> Self {
+        value.0.into()
+    }
+}
 
 /// Represents a single extended attribute of a file entry.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct ExtendedAttribute {
-    name: String,
-    value: Vec<u8>,
+    name: XattrName,
+    value: XattrValue,
 }
 
 impl ExtendedAttribute {
@@ -15,12 +144,15 @@ impl ExtendedAttribute {
     /// # Examples
     ///
     /// ```rust
-    /// use libpna::ExtendedAttribute;
+    /// use libpna::{ExtendedAttribute, XattrName, XattrValue};
     ///
-    /// let xattr = ExtendedAttribute::new("name".into(), b"value".into());
+    /// let xattr = ExtendedAttribute::new(
+    ///     XattrName::try_from("name").unwrap(),
+    ///     XattrValue::try_from(b"value".as_slice()).unwrap(),
+    /// );
     /// ```
     #[inline]
-    pub const fn new(name: String, value: Vec<u8>) -> Self {
+    pub const fn new(name: XattrName, value: XattrValue) -> Self {
         Self { name, value }
     }
 
@@ -29,14 +161,17 @@ impl ExtendedAttribute {
     /// # Examples
     ///
     /// ```rust
-    /// use libpna::ExtendedAttribute;
+    /// use libpna::{ExtendedAttribute, XattrName, XattrValue};
     ///
-    /// let xattr = ExtendedAttribute::new("name".into(), b"value".into());
+    /// let xattr = ExtendedAttribute::new(
+    ///     XattrName::try_from("name").unwrap(),
+    ///     XattrValue::try_from(b"value".as_slice()).unwrap(),
+    /// );
     /// assert_eq!("name", xattr.name());
     /// ```
     #[inline]
     pub fn name(&self) -> &str {
-        &self.name
+        self.name.as_str()
     }
 
     /// Returns the value of the extended attribute as a byte slice.
@@ -44,14 +179,17 @@ impl ExtendedAttribute {
     /// # Examples
     ///
     /// ```rust
-    /// use libpna::ExtendedAttribute;
+    /// use libpna::{ExtendedAttribute, XattrName, XattrValue};
     ///
-    /// let xattr = ExtendedAttribute::new("name".into(), b"value".into());
+    /// let xattr = ExtendedAttribute::new(
+    ///     XattrName::try_from("name").unwrap(),
+    ///     XattrValue::try_from(b"value".as_slice()).unwrap(),
+    /// );
     /// assert_eq!(b"value", xattr.value());
     /// ```
     #[inline]
     pub fn value(&self) -> &[u8] {
-        &self.value
+        self.value.as_slice()
     }
 
     pub(crate) fn try_from_bytes(value: &[u8]) -> io::Result<Self> {
@@ -63,24 +201,30 @@ impl ExtendedAttribute {
             .split_at_checked(len)
             .ok_or(io::ErrorKind::UnexpectedEof)?;
         let name = str::from_utf8(name).map_err(|_| io::ErrorKind::InvalidData)?;
+        let name = XattrName::new(name.to_owned())
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
 
         let (len, value) = value
             .split_first_chunk::<{ mem::size_of::<u32>() }>()
             .ok_or(io::ErrorKind::UnexpectedEof)?;
         let len = u32::from_be_bytes(*len) as usize;
         let value = value.get(..len).ok_or(io::ErrorKind::UnexpectedEof)?;
-        let value = value.to_vec();
-        let name = name.to_owned();
+        let value = XattrValue::new(value.to_vec())
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         Ok(Self { name, value })
     }
 
     pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        let name_bytes = self.name.as_str().as_bytes();
+        let value_bytes = self.value.as_slice();
         let mut vec =
-            Vec::with_capacity(self.name.len() + self.value.len() + mem::size_of::<u32>() * 2);
-        vec.extend_from_slice(&(self.name.len() as u32).to_be_bytes());
-        vec.extend_from_slice(self.name.as_bytes());
-        vec.extend_from_slice(&(self.value.len() as u32).to_be_bytes());
-        vec.extend_from_slice(&self.value);
+            Vec::with_capacity(name_bytes.len() + value_bytes.len() + mem::size_of::<u32>() * 2);
+        // Type guarantees name.len() <= u32::MAX (XattrName invariant).
+        vec.extend_from_slice(&(name_bytes.len() as u32).to_be_bytes());
+        vec.extend_from_slice(name_bytes);
+        // Type guarantees value.len() <= u32::MAX (XattrValue invariant).
+        vec.extend_from_slice(&(value_bytes.len() as u32).to_be_bytes());
+        vec.extend_from_slice(value_bytes);
         vec
     }
 }
@@ -93,10 +237,31 @@ mod tests {
 
     #[test]
     fn xattr() {
-        let xattr = ExtendedAttribute::new("name".into(), "value".into());
+        let xattr = ExtendedAttribute::new(
+            XattrName::try_from("name").unwrap(),
+            XattrValue::try_from(b"value".as_slice()).unwrap(),
+        );
         assert_eq!(
             xattr,
             ExtendedAttribute::try_from_bytes(&xattr.to_bytes()).unwrap()
         );
+    }
+
+    #[test]
+    fn xattr_name_roundtrip() {
+        let name = XattrName::new("user.foo").unwrap();
+        assert_eq!(name.as_str(), "user.foo");
+        assert_eq!(String::from(name), "user.foo");
+    }
+
+    #[test]
+    fn xattr_value_accepts_arbitrary_bytes() {
+        let value = XattrValue::new(vec![0xFF, 0x00, 0x80]).unwrap();
+        assert_eq!(value.as_slice(), &[0xFF, 0x00, 0x80]);
+    }
+
+    #[test]
+    fn xattr_value_default_is_empty() {
+        assert!(XattrValue::default().is_empty());
     }
 }

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -97,12 +97,15 @@ use std::{
 ///
 /// ```
 /// # use std::io::{self, Write};
-/// use libpna::{EntryBuilder, WriteOptions, ExtendedAttribute};
+/// use libpna::{EntryBuilder, WriteOptions, ExtendedAttribute, XattrName, XattrValue};
 ///
 /// # fn main() -> io::Result<()> {
 /// let mut builder = EntryBuilder::new_file("data.txt".into(), WriteOptions::store())?;
 /// builder.write_all(b"file content")?;
-/// builder.add_xattr(ExtendedAttribute::new("user.comment".into(), b"important".to_vec()));
+/// builder.add_xattr(ExtendedAttribute::new(
+///     XattrName::try_from("user.comment").unwrap(),
+///     XattrValue::try_from(b"important".as_slice()).unwrap(),
+/// ));
 /// let entry = builder.build()?;
 /// # Ok(())
 /// # }

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -1,7 +1,139 @@
 //! Metadata and permission types for archive entries.
 
-use crate::{Duration, UnknownValueError};
-use std::io::{self, Read};
+use crate::{
+    Duration, UnknownValueError,
+    util::bounded::{LengthExceeded, str::BoundedString},
+};
+use std::{
+    io::{self, Read},
+    ops::Deref,
+};
+
+/// User name identifier for an archive entry.
+///
+/// Bounded to 255 bytes to fit the `u8` length prefix used in the `fPRM`
+/// chunk's serialized form.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[repr(transparent)]
+pub struct UserName(BoundedString<255>);
+
+impl UserName {
+    /// Constructs a [`UserName`], rejecting inputs whose byte length exceeds
+    /// 255.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LengthExceeded`] when the input's byte length is greater than
+    /// 255.
+    #[inline]
+    pub fn new(value: impl Into<Box<str>>) -> Result<Self, LengthExceeded> {
+        BoundedString::new(value).map(Self)
+    }
+
+    /// Returns the user name as a string slice.
+    #[inline]
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl Deref for UserName {
+    type Target = str;
+
+    #[inline]
+    fn deref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl TryFrom<String> for UserName {
+    type Error = LengthExceeded;
+
+    #[inline]
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<&str> for UserName {
+    type Error = LengthExceeded;
+
+    #[inline]
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<UserName> for String {
+    #[inline]
+    fn from(value: UserName) -> Self {
+        value.0.into()
+    }
+}
+
+/// Group name identifier for an archive entry.
+///
+/// Bounded to 255 bytes to fit the `u8` length prefix used in the `fPRM`
+/// chunk's serialized form.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[repr(transparent)]
+pub struct GroupName(BoundedString<255>);
+
+impl GroupName {
+    /// Constructs a [`GroupName`], rejecting inputs whose byte length exceeds
+    /// 255.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LengthExceeded`] when the input's byte length is greater than
+    /// 255.
+    #[inline]
+    pub fn new(value: impl Into<Box<str>>) -> Result<Self, LengthExceeded> {
+        BoundedString::new(value).map(Self)
+    }
+
+    /// Returns the group name as a string slice.
+    #[inline]
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl Deref for GroupName {
+    type Target = str;
+
+    #[inline]
+    fn deref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl TryFrom<String> for GroupName {
+    type Error = LengthExceeded;
+
+    #[inline]
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<&str> for GroupName {
+    type Error = LengthExceeded;
+
+    #[inline]
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<GroupName> for String {
+    #[inline]
+    fn from(value: GroupName) -> Self {
+        value.0.into()
+    }
+}
 
 /// Metadata information about an entry.
 /// # Examples
@@ -169,9 +301,9 @@ impl Default for Metadata {
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Permission {
     uid: u64,
-    uname: String,
+    uname: UserName,
     gid: u64,
-    gname: String,
+    gname: GroupName,
     permission: u16,
 }
 
@@ -179,17 +311,30 @@ impl Permission {
     /// Creates a new [`Permission`] with the given user, group, and permission bits.
     ///
     /// The `uid`/`gid` are numeric POSIX IDs, `uname`/`gname` are the
-    /// corresponding names, and `permission` holds the file mode bits (e.g. `0o755`).
+    /// corresponding names (each bounded to 255 bytes by [`UserName`] and
+    /// [`GroupName`]), and `permission` holds the file mode bits (e.g. `0o755`).
     ///
     /// # Examples
     ///
     /// ```
-    /// use libpna::Permission;
+    /// use libpna::{Permission, UserName, GroupName};
     ///
-    /// let perm = Permission::new(1000, "user".into(), 100, "group".into(), 0o755);
+    /// let perm = Permission::new(
+    ///     1000,
+    ///     UserName::try_from("user").unwrap(),
+    ///     100,
+    ///     GroupName::try_from("group").unwrap(),
+    ///     0o755,
+    /// );
     /// ```
     #[inline]
-    pub const fn new(uid: u64, uname: String, gid: u64, gname: String, permission: u16) -> Self {
+    pub const fn new(
+        uid: u64,
+        uname: UserName,
+        gid: u64,
+        gname: GroupName,
+        permission: u16,
+    ) -> Self {
         Self {
             uid,
             uname,
@@ -203,9 +348,15 @@ impl Permission {
     /// # Examples
     ///
     /// ```
-    /// use libpna::Permission;
+    /// use libpna::{Permission, UserName, GroupName};
     ///
-    /// let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
+    /// let perm = Permission::new(
+    ///     1000,
+    ///     UserName::try_from("user1").unwrap(),
+    ///     100,
+    ///     GroupName::try_from("group1").unwrap(),
+    ///     0o644,
+    /// );
     /// assert_eq!(perm.uid(), 1000);
     /// ```
     #[inline]
@@ -218,14 +369,20 @@ impl Permission {
     /// # Examples
     ///
     /// ```
-    /// use libpna::Permission;
+    /// use libpna::{Permission, UserName, GroupName};
     ///
-    /// let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
+    /// let perm = Permission::new(
+    ///     1000,
+    ///     UserName::try_from("user1").unwrap(),
+    ///     100,
+    ///     GroupName::try_from("group1").unwrap(),
+    ///     0o644,
+    /// );
     /// assert_eq!(perm.uname(), "user1");
     /// ```
     #[inline]
     pub fn uname(&self) -> &str {
-        &self.uname
+        self.uname.as_str()
     }
 
     /// Returns the group ID associated with this permission.
@@ -233,9 +390,15 @@ impl Permission {
     /// # Examples
     ///
     /// ```
-    /// use libpna::Permission;
+    /// use libpna::{Permission, UserName, GroupName};
     ///
-    /// let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
+    /// let perm = Permission::new(
+    ///     1000,
+    ///     UserName::try_from("user1").unwrap(),
+    ///     100,
+    ///     GroupName::try_from("group1").unwrap(),
+    ///     0o644,
+    /// );
     /// assert_eq!(perm.gid(), 100);
     /// ```
     #[inline]
@@ -248,14 +411,20 @@ impl Permission {
     /// # Examples
     ///
     /// ```
-    /// use libpna::Permission;
+    /// use libpna::{Permission, UserName, GroupName};
     ///
-    /// let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
+    /// let perm = Permission::new(
+    ///     1000,
+    ///     UserName::try_from("user1").unwrap(),
+    ///     100,
+    ///     GroupName::try_from("group1").unwrap(),
+    ///     0o644,
+    /// );
     /// assert_eq!(perm.gname(), "group1");
     /// ```
     #[inline]
     pub fn gname(&self) -> &str {
-        &self.gname
+        self.gname.as_str()
     }
 
     /// Returns the permission bits associated with this permission.
@@ -263,9 +432,15 @@ impl Permission {
     /// # Examples
     ///
     /// ```
-    /// use libpna::Permission;
+    /// use libpna::{Permission, UserName, GroupName};
     ///
-    /// let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
+    /// let perm = Permission::new(
+    ///     1000,
+    ///     UserName::try_from("user1").unwrap(),
+    ///     100,
+    ///     GroupName::try_from("group1").unwrap(),
+    ///     0o644,
+    /// );
     /// assert_eq!(perm.permissions(), 0o644);
     /// ```
     #[inline]
@@ -274,13 +449,17 @@ impl Permission {
     }
 
     pub(crate) fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(20 + self.uname.len() + self.gname.len());
+        let uname_bytes = self.uname.as_str().as_bytes();
+        let gname_bytes = self.gname.as_str().as_bytes();
+        let mut bytes = Vec::with_capacity(20 + uname_bytes.len() + gname_bytes.len());
         bytes.extend_from_slice(&self.uid.to_be_bytes());
-        bytes.extend_from_slice(&(self.uname.len() as u8).to_be_bytes());
-        bytes.extend_from_slice(self.uname.as_bytes());
+        // Type guarantees uname.len() <= 255 (UserName invariant).
+        bytes.extend_from_slice(&(uname_bytes.len() as u8).to_be_bytes());
+        bytes.extend_from_slice(uname_bytes);
         bytes.extend_from_slice(&self.gid.to_be_bytes());
-        bytes.extend_from_slice(&(self.gname.len() as u8).to_be_bytes());
-        bytes.extend_from_slice(self.gname.as_bytes());
+        // Type guarantees gname.len() <= 255 (GroupName invariant).
+        bytes.extend_from_slice(&(gname_bytes.len() as u8).to_be_bytes());
+        bytes.extend_from_slice(gname_bytes);
         bytes.extend_from_slice(&self.permission.to_be_bytes());
         bytes
     }
@@ -296,12 +475,15 @@ impl Permission {
             bytes.read_exact(&mut buf)?;
             buf[0] as usize
         };
-        let uname = String::from_utf8({
+        let uname_string = String::from_utf8({
             let mut buf = vec![0; uname_len];
             bytes.read_exact(&mut buf)?;
             buf
         })
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        // u8 length read above already enforces UserName's 255-byte bound.
+        let uname = UserName::new(uname_string)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         let gid = u64::from_be_bytes({
             let mut buf = [0; 8];
             bytes.read_exact(&mut buf)?;
@@ -312,12 +494,14 @@ impl Permission {
             bytes.read_exact(&mut buf)?;
             buf[0] as usize
         };
-        let gname = String::from_utf8({
+        let gname_string = String::from_utf8({
             let mut buf = vec![0; gname_len];
             bytes.read_exact(&mut buf)?;
             buf
         })
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let gname = GroupName::new(gname_string)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         let permission = u16::from_be_bytes({
             let mut buf = [0; 2];
             bytes.read_exact(&mut buf)?;
@@ -406,7 +590,13 @@ mod tests {
 
     #[test]
     fn permission() {
-        let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
+        let perm = Permission::new(
+            1000,
+            UserName::try_from("user1").unwrap(),
+            100,
+            GroupName::try_from("group1").unwrap(),
+            0o644,
+        );
         assert_eq!(perm, Permission::try_from_bytes(&perm.to_bytes()).unwrap());
     }
 
@@ -469,5 +659,37 @@ mod tests {
             LinkTargetType::try_from_bytes(&[0x01, 0xFF, 0xFF]).unwrap(),
             Some(LinkTargetType::File),
         );
+    }
+
+    #[test]
+    fn user_name_at_boundary() {
+        let raw = "u".repeat(255);
+        let name = UserName::new(raw.clone()).unwrap();
+        assert_eq!(name.as_str(), raw);
+    }
+
+    #[test]
+    fn user_name_rejects_one_over() {
+        let raw = "u".repeat(256);
+        assert!(UserName::new(raw).is_err());
+    }
+
+    #[test]
+    fn group_name_at_boundary() {
+        let raw = "g".repeat(255);
+        let name = GroupName::new(raw.clone()).unwrap();
+        assert_eq!(name.as_str(), raw);
+    }
+
+    #[test]
+    fn group_name_rejects_one_over() {
+        let raw = "g".repeat(256);
+        assert!(GroupName::new(raw).is_err());
+    }
+
+    #[test]
+    fn user_and_group_name_default_is_empty() {
+        assert!(UserName::default().is_empty());
+        assert!(GroupName::default().is_empty());
     }
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -150,6 +150,7 @@ pub use chunk::*;
 pub use entry::*;
 pub use error::UnknownValueError;
 pub use time::Duration;
+pub use util::bounded::LengthExceeded;
 
 #[cfg(test)]
 mod tests {

--- a/lib/src/util.rs
+++ b/lib/src/util.rs
@@ -1,6 +1,7 @@
 //! Internal utility helpers shared across modules.
 //!
 //! The contents of this module are crate-internal.
+pub(crate) mod bounded;
 pub(crate) mod str;
 pub(crate) mod utf8path;
 

--- a/lib/src/util/bounded.rs
+++ b/lib/src/util/bounded.rs
@@ -33,17 +33,20 @@ pub mod str;
 
 use std::{error, fmt};
 
-/// Error returned when a value exceeds the byte-length bound of a
-/// [`str::BoundedString`] or [`bytes::BoundedBytes`].
+/// Error returned when a value exceeds the byte-length bound of a bounded
+/// owned string or byte slice.
+///
+/// Inspect the bound and the actual length via [`max`](Self::max) and
+/// [`actual`](Self::actual).
 ///
 /// # Examples
 ///
-/// ```ignore
-/// use libpna::util::bounded::str::BoundedString;
+/// ```
+/// use libpna::{LengthExceeded, UserName};
 ///
-/// let err = BoundedString::<3>::new("hello").unwrap_err();
-/// assert_eq!(err.max(), 3);
-/// assert_eq!(err.actual(), 5);
+/// let err: LengthExceeded = UserName::try_from("a".repeat(256)).unwrap_err();
+/// assert_eq!(err.max(), 255);
+/// assert_eq!(err.actual(), 256);
 /// ```
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[non_exhaustive]
@@ -73,6 +76,7 @@ impl LengthExceeded {
 }
 
 impl fmt::Display for LengthExceeded {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "length {} exceeds bound {}", self.actual, self.max)
     }

--- a/lib/src/util/bounded.rs
+++ b/lib/src/util/bounded.rs
@@ -1,0 +1,92 @@
+//! Byte-length-bounded owned UTF-8 strings and byte slices.
+//!
+//! Binary formats and wire protocols routinely encode variable-length fields
+//! with a fixed-width length prefix (commonly `u8`, `u16`, or `u32`). Casting
+//! a `usize` length into a narrower integer at serialization time silently
+//! truncates oversized inputs and corrupts the framing of subsequent fields.
+//!
+//! [`str::BoundedString`] and [`bytes::BoundedBytes`] move that
+//! constraint from the serializer into the type system: the maximum byte
+//! length is a const generic parameter, the bound is checked once at
+//! construction, and serialization can downcast the length infallibly
+//! thereafter.
+//!
+//! # Examples
+//!
+//! ```ignore
+//! use libpna::util::bounded::{str::BoundedString, bytes::BoundedBytes};
+//!
+//! // A field whose on-the-wire length prefix is a `u8` accepts at most 255 bytes.
+//! let name: BoundedString<255> = "root".try_into().unwrap();
+//! assert_eq!(name.len(), 4);
+//!
+//! let too_long: Result<BoundedString<255>, _> = "a".repeat(256).try_into();
+//! assert!(too_long.is_err());
+//!
+//! // Arbitrary bytes (non-UTF-8 permitted).
+//! let payload: BoundedBytes<8> = vec![0xFF, 0x00, 0x42].try_into().unwrap();
+//! assert_eq!(payload.len(), 3);
+//! ```
+
+pub mod bytes;
+pub mod str;
+
+use std::{error, fmt};
+
+/// Error returned when a value exceeds the byte-length bound of a
+/// [`str::BoundedString`] or [`bytes::BoundedBytes`].
+///
+/// # Examples
+///
+/// ```ignore
+/// use libpna::util::bounded::str::BoundedString;
+///
+/// let err = BoundedString::<3>::new("hello").unwrap_err();
+/// assert_eq!(err.max(), 3);
+/// assert_eq!(err.actual(), 5);
+/// ```
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct LengthExceeded {
+    max: usize,
+    actual: usize,
+}
+
+impl LengthExceeded {
+    pub(crate) const fn new(max: usize, actual: usize) -> Self {
+        Self { max, actual }
+    }
+
+    /// Returns the maximum byte length permitted by the bounding type.
+    #[inline]
+    #[must_use]
+    pub const fn max(&self) -> usize {
+        self.max
+    }
+
+    /// Returns the actual byte length of the rejected input.
+    #[inline]
+    #[must_use]
+    pub const fn actual(&self) -> usize {
+        self.actual
+    }
+}
+
+impl fmt::Display for LengthExceeded {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "length {} exceeds bound {}", self.actual, self.max)
+    }
+}
+
+impl error::Error for LengthExceeded {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_formats_actual_then_bound() {
+        let err = LengthExceeded::new(255, 256);
+        assert_eq!(format!("{err}"), "length 256 exceeds bound 255");
+    }
+}

--- a/lib/src/util/bounded/bytes.rs
+++ b/lib/src/util/bounded/bytes.rs
@@ -1,0 +1,271 @@
+//! Byte slice with a byte-length upper bound enforced at construction.
+
+use crate::util::bounded::LengthExceeded;
+use std::{borrow::Borrow, ops::Deref};
+
+/// Owned byte slice whose length is guaranteed not to exceed `MAX`.
+///
+/// Suitable for arbitrary (non-UTF-8) byte fields whose maximum length is
+/// constrained by a fixed-width on-the-wire length prefix.
+///
+/// # Examples
+///
+/// ```ignore
+/// use libpna::util::bounded::bytes::BoundedBytes;
+///
+/// let payload: BoundedBytes<4> = vec![0xFF, 0x00, 0x42].try_into().unwrap();
+/// assert_eq!(payload.as_slice(), &[0xFF, 0x00, 0x42]);
+///
+/// let err: Result<BoundedBytes<2>, _> = vec![0u8; 3].try_into();
+/// assert!(err.is_err());
+/// ```
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[repr(transparent)]
+pub struct BoundedBytes<const MAX: usize>(Box<[u8]>);
+
+impl<const MAX: usize> BoundedBytes<MAX> {
+    /// Constructs from any value convertible to [`Box<[u8]>`], rejecting inputs
+    /// whose byte length exceeds `MAX`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LengthExceeded`] when the input's byte length is greater than
+    /// `MAX`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use libpna::util::bounded::bytes::BoundedBytes;
+    ///
+    /// let ok = BoundedBytes::<3>::new(vec![1u8, 2, 3]).unwrap();
+    /// assert_eq!(ok.as_slice(), &[1, 2, 3]);
+    ///
+    /// let err = BoundedBytes::<2>::new(vec![1u8, 2, 3]).unwrap_err();
+    /// assert_eq!(err.max(), 2);
+    /// assert_eq!(err.actual(), 3);
+    /// ```
+    pub fn new(value: impl Into<Box<[u8]>>) -> Result<Self, LengthExceeded> {
+        let inner: Box<[u8]> = value.into();
+        if inner.len() > MAX {
+            Err(LengthExceeded::new(MAX, inner.len()))
+        } else {
+            Ok(Self(inner))
+        }
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl<const MAX: usize> AsRef<[u8]> for BoundedBytes<MAX> {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl<const MAX: usize> Borrow<[u8]> for BoundedBytes<MAX> {
+    #[inline]
+    fn borrow(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl<const MAX: usize> Deref for BoundedBytes<MAX> {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl<const MAX: usize> TryFrom<Vec<u8>> for BoundedBytes<MAX> {
+    type Error = LengthExceeded;
+
+    #[inline]
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl<const MAX: usize> TryFrom<&[u8]> for BoundedBytes<MAX> {
+    type Error = LengthExceeded;
+
+    #[inline]
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl<const MAX: usize> TryFrom<Box<[u8]>> for BoundedBytes<MAX> {
+    type Error = LengthExceeded;
+
+    #[inline]
+    fn try_from(value: Box<[u8]>) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl<const MAX: usize> From<BoundedBytes<MAX>> for Box<[u8]> {
+    #[inline]
+    fn from(value: BoundedBytes<MAX>) -> Self {
+        value.0
+    }
+}
+
+impl<const MAX: usize> From<BoundedBytes<MAX>> for Vec<u8> {
+    #[inline]
+    fn from(value: BoundedBytes<MAX>) -> Self {
+        value.0.into_vec()
+    }
+}
+
+impl<const MAX: usize> PartialEq<[u8]> for BoundedBytes<MAX> {
+    #[inline]
+    fn eq(&self, other: &[u8]) -> bool {
+        self.as_slice() == other
+    }
+}
+
+impl<const MAX: usize> PartialEq<BoundedBytes<MAX>> for [u8] {
+    #[inline]
+    fn eq(&self, other: &BoundedBytes<MAX>) -> bool {
+        self == other.as_slice()
+    }
+}
+
+impl<const MAX: usize> PartialEq<&[u8]> for BoundedBytes<MAX> {
+    #[inline]
+    fn eq(&self, other: &&[u8]) -> bool {
+        self.as_slice() == *other
+    }
+}
+
+impl<const MAX: usize> PartialEq<BoundedBytes<MAX>> for &[u8] {
+    #[inline]
+    fn eq(&self, other: &BoundedBytes<MAX>) -> bool {
+        *self == other.as_slice()
+    }
+}
+
+impl<const MAX: usize> PartialEq<Vec<u8>> for BoundedBytes<MAX> {
+    #[inline]
+    fn eq(&self, other: &Vec<u8>) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+impl<const MAX: usize> PartialEq<BoundedBytes<MAX>> for Vec<u8> {
+    #[inline]
+    fn eq(&self, other: &BoundedBytes<MAX>) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_empty() {
+        let b = BoundedBytes::<255>::new(Vec::<u8>::new()).unwrap();
+        assert!(b.is_empty());
+    }
+
+    #[test]
+    fn accepts_at_boundary() {
+        let raw = vec![0u8; 255];
+        let b = BoundedBytes::<255>::new(raw.clone()).unwrap();
+        assert_eq!(b.len(), 255);
+        assert_eq!(b.as_slice(), raw.as_slice());
+    }
+
+    #[test]
+    fn rejects_one_over() {
+        let raw = vec![0u8; 256];
+        let err = BoundedBytes::<255>::new(raw).unwrap_err();
+        assert_eq!(err.max(), 255);
+        assert_eq!(err.actual(), 256);
+    }
+
+    #[test]
+    fn try_from_vec_and_slice() {
+        let from_vec: BoundedBytes<5> = vec![1, 2, 3].try_into().unwrap();
+        let from_slice: BoundedBytes<5> = (&[1u8, 2, 3][..]).try_into().unwrap();
+        assert_eq!(from_vec, from_slice);
+    }
+
+    #[test]
+    fn try_from_vec_too_long() {
+        let result: Result<BoundedBytes<3>, _> = vec![0u8; 4].try_into();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn try_from_box_slice() {
+        let boxed: Box<[u8]> = vec![1u8, 2, 3].into();
+        let b: BoundedBytes<5> = boxed.try_into().unwrap();
+        assert_eq!(b.as_slice(), &[1u8, 2, 3]);
+
+        let oversize: Box<[u8]> = vec![0u8; 4].into();
+        let err: Result<BoundedBytes<3>, _> = oversize.try_into();
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn deref_to_slice() {
+        let b = BoundedBytes::<10>::new(vec![1u8, 2, 3]).unwrap();
+        assert_eq!(b.first(), Some(&1));
+        assert_eq!(&b[1..], &[2u8, 3]);
+    }
+
+    #[test]
+    fn zero_max_only_accepts_empty() {
+        BoundedBytes::<0>::new(Vec::<u8>::new()).unwrap();
+        assert!(BoundedBytes::<0>::new(vec![0u8]).is_err());
+    }
+
+    #[test]
+    fn supports_arbitrary_non_utf8_bytes() {
+        // 0xFF is invalid UTF-8 — the bytes type must accept it.
+        let b = BoundedBytes::<4>::new(vec![0xFF, 0xFE, 0x00, 0x80]).unwrap();
+        assert_eq!(b.as_slice(), &[0xFF, 0xFE, 0x00, 0x80]);
+    }
+
+    #[test]
+    fn default_is_empty() {
+        let b = BoundedBytes::<255>::default();
+        assert!(b.is_empty());
+        let zero = BoundedBytes::<0>::default();
+        assert!(zero.is_empty());
+    }
+
+    #[test]
+    fn from_into_inner_types() {
+        let b = BoundedBytes::<10>::new(vec![1u8, 2, 3]).unwrap();
+        let boxed: Box<[u8]> = b.clone().into();
+        assert_eq!(&*boxed, &[1u8, 2, 3]);
+        let owned: Vec<u8> = b.into();
+        assert_eq!(owned, vec![1u8, 2, 3]);
+    }
+
+    #[test]
+    fn partial_eq_with_slice_and_vec() {
+        let b = BoundedBytes::<10>::new(vec![1u8, 2, 3]).unwrap();
+        // [u8] (lhs and rhs)
+        assert_eq!(b, *([1u8, 2, 3].as_slice()));
+        assert_eq!(*([1u8, 2, 3].as_slice()), b);
+        // &[u8] (lhs and rhs)
+        assert_eq!(b, &[1u8, 2, 3][..]);
+        assert_eq!(&[1u8, 2, 3][..], b);
+        // Vec<u8> (lhs and rhs)
+        assert_eq!(b, vec![1u8, 2, 3]);
+        assert_eq!(vec![1u8, 2, 3], b);
+        // negative
+        assert_ne!(b, &[9u8, 9][..]);
+    }
+}

--- a/lib/src/util/bounded/str.rs
+++ b/lib/src/util/bounded/str.rs
@@ -1,0 +1,285 @@
+//! UTF-8 string with a byte-length upper bound enforced at construction.
+
+use crate::util::bounded::LengthExceeded;
+use std::{borrow::Borrow, fmt, ops::Deref};
+
+/// UTF-8 string whose byte length is guaranteed not to exceed `MAX`.
+///
+/// Construction is fallible (`new` / `TryFrom`); once constructed the bound is
+/// a type-level invariant, so callers serializing into a fixed-width length
+/// prefix (e.g. `u8`, `u32`) can downcast the length infallibly.
+///
+/// # Examples
+///
+/// ```ignore
+/// use libpna::util::bounded::str::BoundedString;
+///
+/// let s: BoundedString<8> = "🦀rust".try_into().unwrap();
+/// assert_eq!(s.len(), 8); // 4-byte 🦀 + "rust"
+///
+/// let err: Result<BoundedString<8>, _> = "rust🦀rust".try_into();
+/// assert!(err.is_err());
+/// ```
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[repr(transparent)]
+pub struct BoundedString<const MAX: usize>(Box<str>);
+
+impl<const MAX: usize> BoundedString<MAX> {
+    /// Constructs from any value convertible to [`Box<str>`], rejecting inputs
+    /// whose byte length exceeds `MAX`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LengthExceeded`] when the input's byte length is greater than
+    /// `MAX`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use libpna::util::bounded::str::BoundedString;
+    ///
+    /// let ok = BoundedString::<5>::new("hello").unwrap();
+    /// assert_eq!(ok.as_str(), "hello");
+    ///
+    /// let err = BoundedString::<3>::new("hello").unwrap_err();
+    /// assert_eq!(err.max(), 3);
+    /// assert_eq!(err.actual(), 5);
+    /// ```
+    pub fn new(value: impl Into<Box<str>>) -> Result<Self, LengthExceeded> {
+        let inner: Box<str> = value.into();
+        if inner.len() > MAX {
+            Err(LengthExceeded::new(MAX, inner.len()))
+        } else {
+            Ok(Self(inner))
+        }
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<const MAX: usize> AsRef<str> for BoundedString<MAX> {
+    #[inline]
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<const MAX: usize> Borrow<str> for BoundedString<MAX> {
+    #[inline]
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<const MAX: usize> Deref for BoundedString<MAX> {
+    type Target = str;
+
+    #[inline]
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<const MAX: usize> TryFrom<String> for BoundedString<MAX> {
+    type Error = LengthExceeded;
+
+    #[inline]
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl<const MAX: usize> TryFrom<&str> for BoundedString<MAX> {
+    type Error = LengthExceeded;
+
+    #[inline]
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl<const MAX: usize> TryFrom<Box<str>> for BoundedString<MAX> {
+    type Error = LengthExceeded;
+
+    #[inline]
+    fn try_from(value: Box<str>) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl<const MAX: usize> From<BoundedString<MAX>> for Box<str> {
+    #[inline]
+    fn from(value: BoundedString<MAX>) -> Self {
+        value.0
+    }
+}
+
+impl<const MAX: usize> From<BoundedString<MAX>> for String {
+    #[inline]
+    fn from(value: BoundedString<MAX>) -> Self {
+        value.0.into_string()
+    }
+}
+
+impl<const MAX: usize> fmt::Display for BoundedString<MAX> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl<const MAX: usize> PartialEq<str> for BoundedString<MAX> {
+    #[inline]
+    fn eq(&self, other: &str) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl<const MAX: usize> PartialEq<BoundedString<MAX>> for str {
+    #[inline]
+    fn eq(&self, other: &BoundedString<MAX>) -> bool {
+        self == other.as_str()
+    }
+}
+
+impl<const MAX: usize> PartialEq<&str> for BoundedString<MAX> {
+    #[inline]
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
+impl<const MAX: usize> PartialEq<BoundedString<MAX>> for &str {
+    #[inline]
+    fn eq(&self, other: &BoundedString<MAX>) -> bool {
+        *self == other.as_str()
+    }
+}
+
+impl<const MAX: usize> PartialEq<String> for BoundedString<MAX> {
+    #[inline]
+    fn eq(&self, other: &String) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl<const MAX: usize> PartialEq<BoundedString<MAX>> for String {
+    #[inline]
+    fn eq(&self, other: &BoundedString<MAX>) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_empty() {
+        let s = BoundedString::<255>::new("").unwrap();
+        assert_eq!(s.as_str(), "");
+    }
+
+    #[test]
+    fn accepts_at_boundary() {
+        let raw = "a".repeat(255);
+        let s = BoundedString::<255>::new(raw.clone()).unwrap();
+        assert_eq!(s.as_str(), raw);
+        assert_eq!(s.len(), 255);
+    }
+
+    #[test]
+    fn rejects_one_over() {
+        let raw = "a".repeat(256);
+        let err = BoundedString::<255>::new(raw).unwrap_err();
+        assert_eq!(err.max(), 255);
+        assert_eq!(err.actual(), 256);
+    }
+
+    #[test]
+    fn measures_bytes_not_chars() {
+        // U+1F600 (😀) is 4 bytes in UTF-8.
+        let raw = "😀".repeat(2); // 8 bytes, 2 chars
+        let ok = BoundedString::<8>::new(raw.clone()).unwrap();
+        assert_eq!(ok.len(), 8);
+        let err = BoundedString::<7>::new(raw).unwrap_err();
+        assert_eq!(err.max(), 7);
+        assert_eq!(err.actual(), 8);
+    }
+
+    #[test]
+    fn try_from_string_and_str() {
+        let from_string: BoundedString<5> = String::from("hello").try_into().unwrap();
+        let from_str: BoundedString<5> = "hello".try_into().unwrap();
+        assert_eq!(from_string, from_str);
+    }
+
+    #[test]
+    fn try_from_string_too_long() {
+        let result: Result<BoundedString<3>, _> = String::from("hello").try_into();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn try_from_box_str() {
+        let boxed: Box<str> = "hello".into();
+        let s: BoundedString<5> = boxed.try_into().unwrap();
+        assert_eq!(s.as_str(), "hello");
+
+        let oversize: Box<str> = "hello".into();
+        let err: Result<BoundedString<3>, _> = oversize.try_into();
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn deref_to_str() {
+        let s = BoundedString::<10>::new("hello").unwrap();
+        // Methods from str work via Deref.
+        assert!(s.starts_with("he"));
+        assert_eq!(&s[..2], "he");
+    }
+
+    #[test]
+    fn zero_max_only_accepts_empty() {
+        BoundedString::<0>::new("").unwrap();
+        assert!(BoundedString::<0>::new("a").is_err());
+    }
+
+    #[test]
+    fn default_is_empty() {
+        let s = BoundedString::<255>::default();
+        assert!(s.is_empty());
+        // Default works at MAX = 0 too (empty is always within bound).
+        let zero = BoundedString::<0>::default();
+        assert!(zero.is_empty());
+    }
+
+    #[test]
+    fn from_into_inner_types() {
+        let s = BoundedString::<10>::new("hello").unwrap();
+        let boxed: Box<str> = s.clone().into();
+        assert_eq!(&*boxed, "hello");
+        let owned: String = s.into();
+        assert_eq!(owned, "hello");
+    }
+
+    #[test]
+    fn partial_eq_with_str_and_string() {
+        let s = BoundedString::<10>::new("hello").unwrap();
+        // str (lhs and rhs)
+        assert_eq!(s, *"hello");
+        assert_eq!(*"hello", s);
+        // &str (lhs and rhs)
+        assert_eq!(s, "hello");
+        assert_eq!("hello", s);
+        // String (lhs and rhs)
+        assert_eq!(s, String::from("hello"));
+        assert_eq!(String::from("hello"), s);
+        // negative
+        assert_ne!(s, "world");
+        assert_ne!("world", s);
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -373,7 +373,13 @@ fn build_permission(header: &tar::Header, path: &str) -> libpna::Permission {
             String::new()
         }
     };
-    libpna::Permission::new(uid, uname, gid, gname, mode)
+    libpna::Permission::new(
+        uid,
+        libpna::UserName::try_from(uname).expect("uname must fit within 255 bytes"),
+        gid,
+        libpna::GroupName::try_from(gname).expect("gname must fit within 255 bytes"),
+        mode,
+    )
 }
 
 fn zip2pna(args: Zip2pnaArgs) -> Result<(), Box<dyn std::error::Error>> {
@@ -481,6 +487,12 @@ fn build_zip_permission<R: Read + io::Seek>(
 ) -> Option<libpna::Permission> {
     entry.unix_mode().map(|mode| {
         let mode_bits = (mode & 0o7777) as u16;
-        libpna::Permission::new(0, String::new(), 0, String::new(), mode_bits)
+        libpna::Permission::new(
+            0,
+            libpna::UserName::default(),
+            0,
+            libpna::GroupName::default(),
+            mode_bits,
+        )
     })
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -375,9 +375,11 @@ fn build_permission(header: &tar::Header, path: &str) -> libpna::Permission {
     };
     libpna::Permission::new(
         uid,
-        libpna::UserName::try_from(uname).expect("uname must fit within 255 bytes"),
+        libpna::UserName::try_from(uname)
+            .expect("ustar header username field is bounded to 32 bytes by tar format spec"),
         gid,
-        libpna::GroupName::try_from(gname).expect("gname must fit within 255 bytes"),
+        libpna::GroupName::try_from(gname)
+            .expect("ustar header groupname field is bounded to 32 bytes by tar format spec"),
         mode,
     )
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Metadata length parsing confusion via silent truncation.
🎯 Impact: Attacker-controlled long names could cause subsequent metadata fields (UID, GID) to be misaligned, enabling metadata injection.
🔧 Fix: Enforced format constraints at the serialization boundary using `u8::try_from` and `u32::try_from`, propagating errors up the stack.
✅ Verification: Added regression tests in `lib/src/entry/meta.rs` and `lib/src/entry/attr.rs`. Verified all tests and lints pass.

---
*PR created automatically by Jules for task [10749376436631233274](https://jules.google.com/task/10749376436631233274) started by @ChanTsune*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enforced byte-length limits for extended attribute names/values and for usernames/groupnames (validation on construction).
  * Archive/CLI operations now use the validated name/value types when creating or applying metadata and xattrs.

* **Documentation**
  * Updated examples to show validated construction of extended attributes and permissions.

* **Tests**
  * Updated and added tests to cover bounded-string/bytes behavior and roundtrip/edge cases for names, groups, and xattrs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->