### PR TITLE
:bug: Render unrepresentable mtimes with bsdtar placeholder in list

### DIFF
--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -12,14 +12,11 @@ use crate::{
     utils::{BsdGlobMatcher, VCS_FILES},
 };
 use base64::Engine;
-use chrono::{
-    DateTime as ChronoLocalDateTime, Local,
-    format::{DelayedFormat, StrftimeItems},
-};
 use clap::{
     ArgGroup, Parser, ValueEnum, ValueHint,
     builder::styling::{AnsiColor, Color as Colour, Style},
 };
+use jiff::{Timestamp, Zoned, tz::TimeZone};
 use pna::{
     Compression, DataKind, Encryption, ExtendedAttribute, NormalEntry, RawChunk, ReadEntry,
     ReadOptions, SolidHeader, prelude::*,
@@ -837,13 +834,8 @@ fn bsd_tar_list_entries_to(
     Ok(())
 }
 
-fn bsd_tar_time(now: SystemTime, time: SystemTime) -> DelayedFormat<StrftimeItems<'static>> {
-    let datetime = ChronoLocalDateTime::<Local>::from(time);
-    if within_six_months(now, time) {
-        datetime.format("%b %e %H:%M")
-    } else {
-        datetime.format("%b %e  %Y")
-    }
+fn bsd_tar_time(now: SystemTime, time: SystemTime) -> String {
+    datetime(TimeFormat::Auto(now), time)
 }
 
 struct SimpleListDisplay<'a> {
@@ -1064,18 +1056,56 @@ fn within_six_months(now: SystemTime, x: SystemTime) -> bool {
 }
 
 fn datetime(format: TimeFormat, time: SystemTime) -> String {
-    let datetime = ChronoLocalDateTime::<Local>::from(time);
+    let Some(zoned) = system_time_to_local_opt(time) else {
+        return UNREPRESENTABLE_TIME_PLACEHOLDER.to_owned();
+    };
     match format {
         TimeFormat::Auto(now) => {
             if within_six_months(now, time) {
-                datetime.format("%b %e %H:%M")
+                zoned.strftime("%b %e %H:%M").to_string()
             } else {
-                datetime.format("%b %e  %Y")
+                zoned.strftime("%b %e  %Y").to_string()
             }
         }
-        TimeFormat::Long => datetime.format("%b %e %H:%M:%S %Y"),
+        TimeFormat::Long => zoned.strftime("%b %e %H:%M:%S %Y").to_string(),
     }
-    .to_string()
+}
+
+/// Literal bsdtar `tar/util.c` emits when `localtime`/`strftime` cannot render
+/// an mtime; matched byte-for-byte so unrepresentable values never look like
+/// real dates.
+const UNREPRESENTABLE_TIME_PLACEHOLDER: &str = "-- -- ----";
+
+/// Returns `None` when `time` falls outside jiff's representable range
+/// (years -9999..=9999) or its seconds overflow `i64`.
+#[inline]
+fn system_time_to_local_opt(time: SystemTime) -> Option<Zoned> {
+    let (sec, nsec) = system_time_to_unix_timestamp(time)?;
+    unix_timestamp_to_local_opt(sec, nsec)
+}
+
+#[inline]
+fn system_time_to_unix_timestamp(time: SystemTime) -> Option<(i64, u32)> {
+    match time.duration_since(SystemTime::UNIX_EPOCH) {
+        Ok(d) => Some((i64::try_from(d.as_secs()).ok()?, d.subsec_nanos())),
+        Err(e) => {
+            let d = e.duration();
+            let secs = i64::try_from(d.as_secs()).ok()?;
+            let nsec = d.subsec_nanos();
+            if nsec == 0 {
+                Some((-secs, 0))
+            } else {
+                Some((-secs - 1, 1_000_000_000 - nsec))
+            }
+        }
+    }
+}
+
+#[inline]
+fn unix_timestamp_to_local_opt(sec: i64, nsec: u32) -> Option<Zoned> {
+    Timestamp::new(sec, nsec as i32)
+        .ok()
+        .map(|ts| ts.to_zoned(TimeZone::system()))
 }
 
 #[inline]
@@ -1530,5 +1560,69 @@ fn format_name<'a>(name: &'a str, kind: DataKind, options: &ListOptions) -> Cow<
         Cow::Owned(hide_control_chars(&name).to_string())
     } else {
         name
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unix_epoch_is_representable() {
+        assert!(system_time_to_local_opt(SystemTime::UNIX_EPOCH).is_some());
+        assert_eq!(
+            system_time_to_unix_timestamp(SystemTime::UNIX_EPOCH),
+            Some((0, 0))
+        );
+    }
+
+    #[test]
+    fn pre_epoch_subsecond_borrows_one_second() {
+        assert_eq!(
+            system_time_to_unix_timestamp(SystemTime::UNIX_EPOCH - Duration::from_millis(1)),
+            Some((-1, 999_000_000))
+        );
+    }
+
+    #[test]
+    fn pre_epoch_whole_second_keeps_zero_subsecond() {
+        assert_eq!(
+            system_time_to_unix_timestamp(SystemTime::UNIX_EPOCH - Duration::from_secs(1)),
+            Some((-1, 0))
+        );
+    }
+
+    #[test]
+    fn jiff_window_inclusive_boundaries_are_representable() {
+        assert!(unix_timestamp_to_local_opt(Timestamp::MIN.as_second(), 0).is_some());
+        assert!(unix_timestamp_to_local_opt(Timestamp::MAX.as_second(), 0).is_some());
+    }
+
+    #[test]
+    fn one_second_past_jiff_max_is_unrepresentable() {
+        assert!(unix_timestamp_to_local_opt(Timestamp::MAX.as_second() + 1, 0).is_none());
+    }
+
+    #[test]
+    fn i64_max_seconds_exceed_jiff_window() {
+        assert!(unix_timestamp_to_local_opt(i64::MAX, 0).is_none());
+    }
+
+    #[test]
+    fn i64_min_seconds_exceed_jiff_window() {
+        assert!(unix_timestamp_to_local_opt(i64::MIN, 0).is_none());
+    }
+
+    #[test]
+    fn system_time_past_jiff_max_renders_placeholder() {
+        let past_jiff_window =
+            SystemTime::UNIX_EPOCH + Duration::from_secs(Timestamp::MAX.as_second() as u64 + 1);
+        let now = SystemTime::UNIX_EPOCH;
+        assert_eq!(bsd_tar_time(now, past_jiff_window), "-- -- ----");
+        assert_eq!(
+            datetime(TimeFormat::Auto(now), past_jiff_window),
+            "-- -- ----"
+        );
+        assert_eq!(datetime(TimeFormat::Long, past_jiff_window), "-- -- ----");
     }
 }

--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -793,6 +793,7 @@ fn bsd_tar_list_entries_to(
     mut out: impl Write,
 ) -> io::Result<()> {
     let now = SystemTime::now();
+    let tz = TimeZone::system();
     let mut u_width = 6usize;
     let mut gs_width = 13usize;
     for row in entries {
@@ -801,7 +802,7 @@ fn bsd_tar_list_entries_to(
         let has_acl = !row.acl.is_empty();
         let perm = PermissionDisplay::bsdtar(&row.entry_type, permission, has_acl);
         let size = row.raw_size.unwrap_or(0);
-        let mtime = bsd_tar_time(now, row.modified.unwrap_or(now));
+        let mtime = bsd_tar_time(now, &tz, row.modified.unwrap_or(now));
         let (uname, gname) = match &row.permission {
             Some(p) => (
                 if options.numeric_owner || p.uname().is_empty() {
@@ -834,8 +835,9 @@ fn bsd_tar_list_entries_to(
     Ok(())
 }
 
-fn bsd_tar_time(now: SystemTime, time: SystemTime) -> String {
-    datetime(TimeFormat::Auto(now), time)
+#[inline]
+fn bsd_tar_time(now: SystemTime, tz: &TimeZone, time: SystemTime) -> String {
+    datetime(TimeFormat::Auto(now), tz, time)
 }
 
 struct SimpleListDisplay<'a> {
@@ -888,6 +890,7 @@ fn detail_list_entries_to(
 ) -> io::Result<()> {
     let underline = Color::new("\x1B[4m", "\x1B[0m");
     let reset = Color::new("\x1B[8m", "\x1B[0m");
+    let tz = TimeZone::system();
     let mut acl_rows = Vec::new();
     let mut xattr_rows = Vec::new();
     let mut builder = TableBuilder::new();
@@ -950,7 +953,7 @@ fn detail_list_entries_to(
                         TimeField::Modified => content.modified,
                         TimeField::Accessed => content.accessed,
                     }
-                    .map_or_else(|| "-".into(), |d| datetime(options.time_format, d)),
+                    .map_or_else(|| "-".into(), |d| datetime(options.time_format, &tz, d)),
                 ),
                 Some(detailed_format_name(content.entry_type, options)),
             ]
@@ -1055,33 +1058,25 @@ fn within_six_months(now: SystemTime, x: SystemTime) -> bool {
     six_months_ago <= x
 }
 
-fn datetime(format: TimeFormat, time: SystemTime) -> String {
-    let Some(zoned) = system_time_to_local_opt(time) else {
+fn datetime(format: TimeFormat, tz: &TimeZone, time: SystemTime) -> String {
+    let Some(zoned) = system_time_to_local_opt(tz, time) else {
         return UNREPRESENTABLE_TIME_PLACEHOLDER.to_owned();
     };
-    match format {
-        TimeFormat::Auto(now) => {
-            if within_six_months(now, time) {
-                zoned.strftime("%b %e %H:%M").to_string()
-            } else {
-                zoned.strftime("%b %e  %Y").to_string()
-            }
-        }
-        TimeFormat::Long => zoned.strftime("%b %e %H:%M:%S %Y").to_string(),
-    }
+    let fmt = match format {
+        TimeFormat::Auto(now) if within_six_months(now, time) => "%b %e %H:%M",
+        TimeFormat::Auto(_) => "%b %e  %Y",
+        TimeFormat::Long => "%b %e %H:%M:%S %Y",
+    };
+    zoned.strftime(fmt).to_string()
 }
 
-/// Literal bsdtar `tar/util.c` emits when `localtime`/`strftime` cannot render
-/// an mtime; matched byte-for-byte so unrepresentable values never look like
-/// real dates.
+/// Matches bsdtar's placeholder so unrepresentable values never look like real dates.
 const UNREPRESENTABLE_TIME_PLACEHOLDER: &str = "-- -- ----";
 
-/// Returns `None` when `time` falls outside jiff's representable range
-/// (years -9999..=9999) or its seconds overflow `i64`.
 #[inline]
-fn system_time_to_local_opt(time: SystemTime) -> Option<Zoned> {
+fn system_time_to_local_opt(tz: &TimeZone, time: SystemTime) -> Option<Zoned> {
     let (sec, nsec) = system_time_to_unix_timestamp(time)?;
-    unix_timestamp_to_local_opt(sec, nsec)
+    unix_timestamp_to_local_opt(tz, sec, nsec)
 }
 
 #[inline]
@@ -1091,21 +1086,20 @@ fn system_time_to_unix_timestamp(time: SystemTime) -> Option<(i64, u32)> {
         Err(e) => {
             let d = e.duration();
             let secs = i64::try_from(d.as_secs()).ok()?;
-            let nsec = d.subsec_nanos();
-            if nsec == 0 {
-                Some((-secs, 0))
-            } else {
-                Some((-secs - 1, 1_000_000_000 - nsec))
-            }
+            let (carry, nsec) = match d.subsec_nanos() {
+                0 => (0, 0),
+                n => (1, 1_000_000_000 - n),
+            };
+            Some((-secs - carry, nsec))
         }
     }
 }
 
 #[inline]
-fn unix_timestamp_to_local_opt(sec: i64, nsec: u32) -> Option<Zoned> {
+fn unix_timestamp_to_local_opt(tz: &TimeZone, sec: i64, nsec: u32) -> Option<Zoned> {
     Timestamp::new(sec, nsec as i32)
         .ok()
-        .map(|ts| ts.to_zoned(TimeZone::system()))
+        .map(|ts| ts.to_zoned(tz.clone()))
 }
 
 #[inline]
@@ -1307,6 +1301,7 @@ fn json_line_entries_to(
     let show_fflags = options.show_fflags;
     let show_acl = options.show_acl;
     let show_xattr = options.show_xattr;
+    let tz = TimeZone::system();
     let entries = entries
         .par_iter()
         .map(|it| {
@@ -1336,13 +1331,13 @@ fn json_line_entries_to(
                 compression: &it.compression,
                 created: it
                     .created
-                    .map_or_else(String::new, |d| datetime(TimeFormat::Long, d)),
+                    .map_or_else(String::new, |d| datetime(TimeFormat::Long, &tz, d)),
                 modified: it
                     .modified
-                    .map_or_else(String::new, |d| datetime(TimeFormat::Long, d)),
+                    .map_or_else(String::new, |d| datetime(TimeFormat::Long, &tz, d)),
                 accessed: it
                     .accessed
-                    .map_or_else(String::new, |d| datetime(TimeFormat::Long, d)),
+                    .map_or_else(String::new, |d| datetime(TimeFormat::Long, &tz, d)),
                 fflags: show_fflags.then_some(it.fflags.as_slice()),
                 acl: show_acl.then(|| {
                     it.acl
@@ -1415,6 +1410,7 @@ fn delimited_entries_to(
         .flatten(),
     )?;
 
+    let tz = TimeZone::system();
     let rows = entries
         .par_iter()
         .map(|row| {
@@ -1430,7 +1426,7 @@ fn delimited_entries_to(
                 TimeField::Modified => row.modified,
                 TimeField::Accessed => row.accessed,
             }
-            .map_or_else(String::new, |d| datetime(TimeFormat::Long, d));
+            .map_or_else(String::new, |d| datetime(TimeFormat::Long, &tz, d));
 
             [
                 Some(row.entry_type.name().to_string()),
@@ -1569,7 +1565,7 @@ mod tests {
 
     #[test]
     fn unix_epoch_is_representable() {
-        assert!(system_time_to_local_opt(SystemTime::UNIX_EPOCH).is_some());
+        assert!(system_time_to_local_opt(&TimeZone::UTC, SystemTime::UNIX_EPOCH).is_some());
         assert_eq!(
             system_time_to_unix_timestamp(SystemTime::UNIX_EPOCH),
             Some((0, 0))
@@ -1594,23 +1590,30 @@ mod tests {
 
     #[test]
     fn jiff_window_inclusive_boundaries_are_representable() {
-        assert!(unix_timestamp_to_local_opt(Timestamp::MIN.as_second(), 0).is_some());
-        assert!(unix_timestamp_to_local_opt(Timestamp::MAX.as_second(), 0).is_some());
+        assert!(
+            unix_timestamp_to_local_opt(&TimeZone::UTC, Timestamp::MIN.as_second(), 0).is_some()
+        );
+        assert!(
+            unix_timestamp_to_local_opt(&TimeZone::UTC, Timestamp::MAX.as_second(), 0).is_some()
+        );
     }
 
     #[test]
     fn one_second_past_jiff_max_is_unrepresentable() {
-        assert!(unix_timestamp_to_local_opt(Timestamp::MAX.as_second() + 1, 0).is_none());
+        assert!(
+            unix_timestamp_to_local_opt(&TimeZone::UTC, Timestamp::MAX.as_second() + 1, 0)
+                .is_none()
+        );
     }
 
     #[test]
     fn i64_max_seconds_exceed_jiff_window() {
-        assert!(unix_timestamp_to_local_opt(i64::MAX, 0).is_none());
+        assert!(unix_timestamp_to_local_opt(&TimeZone::UTC, i64::MAX, 0).is_none());
     }
 
     #[test]
     fn i64_min_seconds_exceed_jiff_window() {
-        assert!(unix_timestamp_to_local_opt(i64::MIN, 0).is_none());
+        assert!(unix_timestamp_to_local_opt(&TimeZone::UTC, i64::MIN, 0).is_none());
     }
 
     #[test]
@@ -1618,11 +1621,15 @@ mod tests {
         let past_jiff_window =
             SystemTime::UNIX_EPOCH + Duration::from_secs(Timestamp::MAX.as_second() as u64 + 1);
         let now = SystemTime::UNIX_EPOCH;
-        assert_eq!(bsd_tar_time(now, past_jiff_window), "-- -- ----");
+        let tz = TimeZone::UTC;
+        assert_eq!(bsd_tar_time(now, &tz, past_jiff_window), "-- -- ----");
         assert_eq!(
-            datetime(TimeFormat::Auto(now), past_jiff_window),
+            datetime(TimeFormat::Auto(now), &tz, past_jiff_window),
             "-- -- ----"
         );
-        assert_eq!(datetime(TimeFormat::Long, past_jiff_window), "-- -- ----");
+        assert_eq!(
+            datetime(TimeFormat::Long, &tz, past_jiff_window),
+            "-- -- ----"
+        );
     }
 }


### PR DESCRIPTION
`pna list -l` rendered every entry's mtime via an infallible `From<SystemTime>` whose body finishes with `timestamp_opt(...).unwrap()`, so any value outside the formatter's representable range aborted the process. Replace with a fallible two-step conversion (`system_time_to_unix_timestamp` + `unix_timestamp_to_local_opt`) and emit `-- -- ----` (libarchive's `tar/util.c` placeholder) when the value cannot be rendered, so a single extreme timestamp no longer kills the listing.

Migrate the list-display formatting from `chrono::DateTime<Local>` to `jiff::Zoned` at the same time — jiff is already a direct cli dependency and its `Timestamp::new(sec, nsec) -> Result<...>` is fallible by design, removing the panic-prone trait impl that necessitated the wrapper. The bsdtar-compat path keeps byte-for-byte output parity (same `%b %e %H:%M` / `%b %e  %Y` / long-format patterns; `UNREPRESENTABLE_TIME_PLACEHOLDER` mirrors libarchive's literal).

Tests drive the formatter-window check directly with `i64::MAX` / `i64::MIN` seconds so the placeholder branch is exercised regardless of how the host platform represents `SystemTime` (Windows FILETIME caps near year 60055, which sits inside chrono's representable window and made the previous `1u64 << 62` probe silently succeed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More reliable time display for the list command, with consistent timezone handling across table, JSON, CSV and archive outputs.
  * Better handling and clear placeholder rendering for dates outside representable ranges.

* **Tests**
  * Added comprehensive tests covering epoch boundaries, pre-epoch rounding, representability limits and overflow scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChanTsune/Portable-Network-Archive/pull/3045)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->