### PR TITLE
🛡️ Sentinel: [HIGH] Harden metadata serialization against length truncation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-10 - Prevent metadata injection via length truncation
+**Vulnerability:** Integer truncation in `Permission::to_bytes` and `ExtendedAttribute::to_bytes` allowed names longer than 255 bytes (for `uname`/`gname`) or 4GB (for xattrs) to be stored with a truncated length-prefix. This could lead to parser desynchronization where the remainder of a long name is misinterpreted as subsequent metadata fields (like UID, GID, or mode).
+**Learning:** Using `as u8` or `as u32` on untrusted or unchecked lengths in serialization logic can create "parser confusion" vulnerabilities similar to those found in classic binary format parsers.
+**Prevention:** Always use `try_from` when casting lengths to fixed-size width fields in binary formats. Serialization methods for metadata should return `io::Result` to allow propagating overflow errors back to the caller.

--- a/lib/src/archive/write.rs
+++ b/lib/src/archive/write.rs
@@ -566,7 +566,7 @@ where
         }
     }
     if let Some(p) = metadata.permission {
-        (ChunkType::fPRM, p.to_bytes()).write_chunk_in(inner)?;
+        (ChunkType::fPRM, p.to_bytes()?).write_chunk_in(inner)?;
     }
     let context = get_writer_context(option)?;
     if let Some(WriteCipher { context: c, .. }) = &context.cipher {

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -38,6 +38,7 @@ mod private {
     use super::*;
     pub trait SealedEntryExt {
         fn into_chunks(self) -> Vec<RawChunk>;
+        fn try_into_chunks(self) -> io::Result<Vec<RawChunk>>;
         fn write_in<W: Write>(&self, writer: &mut W) -> io::Result<usize>;
     }
 }
@@ -68,6 +69,11 @@ where
     #[inline]
     fn into_chunks(self) -> Vec<RawChunk> {
         self.0.into_iter().map(Into::into).collect()
+    }
+
+    #[inline]
+    fn try_into_chunks(self) -> io::Result<Vec<RawChunk>> {
+        Ok(self.into_chunks())
     }
 
     #[inline]
@@ -153,6 +159,14 @@ where
         match self {
             Self::Normal(r) => r.into_chunks(),
             Self::Solid(s) => s.into_chunks(),
+        }
+    }
+
+    #[inline]
+    fn try_into_chunks(self) -> io::Result<Vec<RawChunk>> {
+        match self {
+            Self::Normal(r) => r.try_into_chunks(),
+            Self::Solid(s) => s.try_into_chunks(),
         }
     }
 
@@ -339,7 +353,12 @@ where
     T: AsRef<[u8]>,
     RawChunk<T>: Chunk + Into<RawChunk>,
 {
+    #[inline]
     fn into_chunks(self) -> Vec<RawChunk> {
+        self.try_into_chunks().unwrap()
+    }
+
+    fn try_into_chunks(self) -> io::Result<Vec<RawChunk>> {
         let mut chunks = vec![];
         chunks.push(RawChunk::from_data(ChunkType::SHED, self.header.to_bytes()));
         chunks.extend(self.extra.into_iter().map(Into::into));
@@ -351,7 +370,7 @@ where
             chunks.push(RawChunk::from((ChunkType::SDAT, data)).into());
         }
         chunks.push(RawChunk::from_data(ChunkType::SEND, Vec::new()));
-        chunks
+        Ok(chunks)
     }
 
     #[inline]
@@ -766,13 +785,13 @@ where
             }
         }
         if let Some(p) = permission {
-            total += (ChunkType::fPRM, p.to_bytes()).write_chunk_in(writer)?;
+            total += (ChunkType::fPRM, p.to_bytes()?).write_chunk_in(writer)?;
         }
         if let Some(ltp) = link_target_type {
             total += (ChunkType::fLTP, ltp.to_bytes()).write_chunk_in(writer)?;
         }
         for xattr in &self.xattrs {
-            total += (ChunkType::xATR, xattr.to_bytes()).write_chunk_in(writer)?;
+            total += (ChunkType::xATR, xattr.to_bytes()?).write_chunk_in(writer)?;
         }
         total += (ChunkType::FEND, []).write_chunk_in(writer)?;
         Ok(total)
@@ -784,7 +803,12 @@ where
     T: AsRef<[u8]>,
     RawChunk<T>: Chunk + Into<RawChunk>,
 {
+    #[inline]
     fn into_chunks(self) -> Vec<RawChunk> {
+        self.try_into_chunks().unwrap()
+    }
+
+    fn try_into_chunks(self) -> io::Result<Vec<RawChunk>> {
         let Metadata {
             raw_file_size,
             compressed_size: _,
@@ -847,16 +871,16 @@ where
             }
         }
         if let Some(p) = permission {
-            vec.push(RawChunk::from_data(ChunkType::fPRM, p.to_bytes()));
+            vec.push(RawChunk::from_data(ChunkType::fPRM, p.to_bytes()?));
         }
         if let Some(ltp) = link_target_type {
             vec.push(RawChunk::from_data(ChunkType::fLTP, ltp.to_bytes()));
         }
         for xattr in self.xattrs {
-            vec.push(RawChunk::from_data(ChunkType::xATR, xattr.to_bytes()));
+            vec.push(RawChunk::from_data(ChunkType::xATR, xattr.to_bytes()?));
         }
         vec.push(RawChunk::from_data(ChunkType::FEND, Vec::new()));
-        vec
+        Ok(vec)
     }
 
     #[inline]

--- a/lib/src/entry/attr.rs
+++ b/lib/src/entry/attr.rs
@@ -74,14 +74,22 @@ impl ExtendedAttribute {
         Ok(Self { name, value })
     }
 
-    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+    pub(crate) fn to_bytes(&self) -> io::Result<Vec<u8>> {
         let mut vec =
             Vec::with_capacity(self.name.len() + self.value.len() + mem::size_of::<u32>() * 2);
-        vec.extend_from_slice(&(self.name.len() as u32).to_be_bytes());
+        vec.extend_from_slice(
+            &u32::try_from(self.name.len())
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
+                .to_be_bytes(),
+        );
         vec.extend_from_slice(self.name.as_bytes());
-        vec.extend_from_slice(&(self.value.len() as u32).to_be_bytes());
+        vec.extend_from_slice(
+            &u32::try_from(self.value.len())
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
+                .to_be_bytes(),
+        );
         vec.extend_from_slice(&self.value);
-        vec
+        Ok(vec)
     }
 }
 
@@ -96,7 +104,7 @@ mod tests {
         let xattr = ExtendedAttribute::new("name".into(), "value".into());
         assert_eq!(
             xattr,
-            ExtendedAttribute::try_from_bytes(&xattr.to_bytes()).unwrap()
+            ExtendedAttribute::try_from_bytes(&xattr.to_bytes().unwrap()).unwrap()
         );
     }
 }

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -273,16 +273,24 @@ impl Permission {
         self.permission
     }
 
-    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+    pub(crate) fn to_bytes(&self) -> io::Result<Vec<u8>> {
         let mut bytes = Vec::with_capacity(20 + self.uname.len() + self.gname.len());
         bytes.extend_from_slice(&self.uid.to_be_bytes());
-        bytes.extend_from_slice(&(self.uname.len() as u8).to_be_bytes());
+        bytes.extend_from_slice(
+            &u8::try_from(self.uname.len())
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
+                .to_be_bytes(),
+        );
         bytes.extend_from_slice(self.uname.as_bytes());
         bytes.extend_from_slice(&self.gid.to_be_bytes());
-        bytes.extend_from_slice(&(self.gname.len() as u8).to_be_bytes());
+        bytes.extend_from_slice(
+            &u8::try_from(self.gname.len())
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
+                .to_be_bytes(),
+        );
         bytes.extend_from_slice(self.gname.as_bytes());
         bytes.extend_from_slice(&self.permission.to_be_bytes());
-        bytes
+        Ok(bytes)
     }
 
     pub(crate) fn try_from_bytes(mut bytes: &[u8]) -> io::Result<Self> {
@@ -407,7 +415,18 @@ mod tests {
     #[test]
     fn permission() {
         let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
-        assert_eq!(perm, Permission::try_from_bytes(&perm.to_bytes()).unwrap());
+        assert_eq!(
+            perm,
+            Permission::try_from_bytes(&perm.to_bytes().unwrap()).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_permission_long_name_truncation() {
+        let long_name = "a".repeat(256);
+        let perm = Permission::new(1000, long_name.clone(), 100, "group".into(), 0o755);
+        let result = perm.to_bytes();
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Integer truncation in `Permission::to_bytes` and `ExtendedAttribute::to_bytes`.
🎯 Impact: User or group names longer than 255 bytes were stored with a truncated 1-byte length prefix. During extraction, the parser would read only the truncated number of bytes and misinterpret the remainder of the name as subsequent metadata fields (UID, GID, mode), causing parser desynchronization and potential metadata injection.
🔧 Fix: Replaced unchecked casts (`as u8`, `as u32`) with `try_from` and updated the serialization pipeline to propagate `io::Result`. Refactored the internal `SealedEntryExt` trait to support fallible chunk generation.
✅ Verification: Added a unit test `test_permission_long_name_truncation` in `lib/src/entry/meta.rs` that confirms the overflow is now caught and returns an error instead of producing malformed output. Verified all workspace tests pass.

---
*PR created automatically by Jules for task [11424086848038454304](https://jules.google.com/task/11424086848038454304) started by @ChanTsune*