### PR TITLE
🛡️ Sentinel: [HIGH] Limit link target size during extraction

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-24 - Oversized Link Target DoS
+**Vulnerability:** Memory exhaustion (DoS) during archive extraction. Symbolic and hard link targets were read into memory using `io::read_to_string` without size limits. A malicious archive entry could specify a multi-gigabyte target path, causing an OOM crash.
+**Learning:** Metadata-like fields (link targets, names, attributes) are often assumed to be "small" and read entirely into memory. Archives are untrusted and can violate these assumptions.
+**Prevention:** Always use `io::Read::take` to bound memory allocations when reading untrusted variable-length fields from an archive, even for fields that "should" be small like file paths.

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -47,6 +47,9 @@ use std::{
     time::Instant,
 };
 
+/// Maximum byte size for a symbolic or hard link target path to prevent memory exhaustion.
+const MAX_LINK_TARGET_SIZE: u64 = 64 * 1024;
+
 #[derive(Parser, Clone, Debug)]
 #[command(
     group(
@@ -1432,7 +1435,14 @@ where
     match item.header().data_kind() {
         DataKind::SymbolicLink => {
             let reader = item.reader(ReadOptions::with_password(password))?;
-            let original = io::read_to_string(reader)?;
+            let mut limited_reader = reader.take(MAX_LINK_TARGET_SIZE + 1);
+            let original = io::read_to_string(&mut limited_reader)?;
+            if original.len() as u64 > MAX_LINK_TARGET_SIZE {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("symbolic link target exceeds {} bytes", MAX_LINK_TARGET_SIZE),
+                ));
+            }
             let original = pathname_editor.edit_symlink(original.as_ref());
             if !allow_unsafe_links && is_unsafe_link(&original) {
                 log::warn!(
@@ -1448,7 +1458,14 @@ where
         }
         DataKind::HardLink => {
             let reader = item.reader(ReadOptions::with_password(password))?;
-            let original = io::read_to_string(reader)?;
+            let mut limited_reader = reader.take(MAX_LINK_TARGET_SIZE + 1);
+            let original = io::read_to_string(&mut limited_reader)?;
+            if original.len() as u64 > MAX_LINK_TARGET_SIZE {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("hard link target exceeds {} bytes", MAX_LINK_TARGET_SIZE),
+                ));
+            }
             let Some((original, had_root)) = pathname_editor.edit_hardlink(original.as_ref())
             else {
                 log::warn!(


### PR DESCRIPTION
- 🚨 Severity: HIGH
- 💡 Vulnerability: Memory exhaustion (DoS) during archive extraction.
- 🎯 Impact: A malicious archive with oversized link targets could cause an Out-Of-Memory (OOM) crash of the archiver.
- 🔧 Fix: Introduced `MAX_LINK_TARGET_SIZE` (64 KiB) and used `reader.take()` to bound memory allocation when reading link targets.
- ✅ Verification: Ran `cargo test` for extraction commands; all tests passed. Verified logic handles the limit correctly via manual inspection and code review.

---
*PR created automatically by Jules for task [5876807857394793726](https://jules.google.com/task/5876807857394793726) started by @ChanTsune*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a security vulnerability where malicious archives could cause memory exhaustion during link target extraction by imposing size limits.

* **Documentation**
  * Added security documentation regarding Oversized Link Target DoS prevention measures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChanTsune/Portable-Network-Archive/pull/3058)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->