### PR TITLE
:sparkles: Add Reserved/Private variants to Compression, Encryption, CipherMode, DataKind enums

### DIFF
--- a/cli/src/command/chmod.rs
+++ b/cli/src/command/chmod.rs
@@ -137,6 +137,7 @@ const fn default_permission_mode(kind: DataKind) -> u16 {
     match kind {
         DataKind::Directory => 0o755,
         DataKind::File | DataKind::SymbolicLink | DataKind::HardLink => 0o644,
+        DataKind::Reserved(_) | DataKind::Private(_) => 0,
     }
 }
 

--- a/cli/src/command/diff.rs
+++ b/cli/src/command/diff.rs
@@ -341,6 +341,9 @@ fn compare_entry<T: AsRef<[u8]>>(
         DataKind::HardLink => {
             println!("{}", DiffKind::TypeMismatch.display(path_str));
         }
+        _ => {
+            println!("{}", DiffKind::TypeMismatch.display(path_str));
+        }
     }
     Ok(())
 }

--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -288,6 +288,7 @@ enum EntryType {
     Directory(String),
     SymbolicLink(String, String),
     HardLink(String, String),
+    Unknown(String, DataKind),
 }
 
 impl EntryType {
@@ -297,7 +298,8 @@ impl EntryType {
             EntryType::File(name)
             | EntryType::Directory(name)
             | EntryType::SymbolicLink(name, _)
-            | EntryType::HardLink(name, _) => name,
+            | EntryType::HardLink(name, _)
+            | EntryType::Unknown(name, _) => name,
         }
     }
 
@@ -322,6 +324,7 @@ impl Display for EntryTypeBsdLongStyleDisplay<'_> {
             EntryType::HardLink(name, link_to) => {
                 write!(f, "{name} link to {link_to}")
             }
+            EntryType::Unknown(name, _) => Display::fmt(&name, f),
         }
     }
 }
@@ -451,6 +454,7 @@ impl TableRow {
                 ),
                 DataKind::Directory => EntryType::Directory(entry.name().to_string()),
                 DataKind::File => EntryType::File(entry.name().to_string()),
+                kind => EntryType::Unknown(entry.name().to_string(), kind),
             },
             // Only collect xattrs if needed
             xattrs: if collect.xattrs {
@@ -1081,7 +1085,7 @@ fn detailed_format_name(entry: EntryType, options: &ListOptions) -> String {
         EntryType::SymbolicLink(name, link_to) if options.classify => {
             format!("{name}@ -> {link_to}")
         }
-        EntryType::File(path) | EntryType::Directory(path) => path,
+        EntryType::File(path) | EntryType::Directory(path) | EntryType::Unknown(path, _) => path,
         EntryType::SymbolicLink(path, link_to) | EntryType::HardLink(path, link_to) => {
             format!("{path} -> {link_to}")
         }
@@ -1200,6 +1204,7 @@ fn kind_paint(kind: &EntryType) -> impl Display + 'static {
         EntryType::File(_) | EntryType::HardLink(_, _) => STYLE_HYPHEN.paint('.'),
         EntryType::Directory(_) => STYLE_DIR.paint('d'),
         EntryType::SymbolicLink(_, _) => STYLE_LINK.paint('l'),
+        EntryType::Unknown(_, _) => STYLE_HYPHEN.paint('?'),
     }
 }
 
@@ -1239,6 +1244,7 @@ const fn kind_char(kind: &EntryType) -> char {
         EntryType::File(_) | EntryType::HardLink(_, _) => '-',
         EntryType::Directory(_) => 'd',
         EntryType::SymbolicLink(_, _) => 'l',
+        EntryType::Unknown(_, _) => '?',
     }
 }
 
@@ -1272,6 +1278,7 @@ impl PermissionDisplay {
                 EntryType::HardLink(_, _) => 'h',
                 EntryType::Directory(_) => 'd',
                 EntryType::SymbolicLink(_, _) => 'l',
+                EntryType::Unknown(_, _) => '?',
             },
             permission,
             indicator: if has_acl { '+' } else { ' ' },
@@ -1526,6 +1533,7 @@ fn tree_entries_to(
         EntryType::Directory(name) => (name.as_str(), DataKind::Directory),
         EntryType::SymbolicLink(name, _) => (name.as_str(), DataKind::SymbolicLink),
         EntryType::HardLink(name, _) => (name.as_str(), DataKind::HardLink),
+        EntryType::Unknown(name, kind) => (name.as_str(), *kind),
     });
     let map = build_tree_map(entries);
     let tree = build_term_tree(&map, Cow::Borrowed(""), None, DataKind::Directory, options);
@@ -1645,6 +1653,26 @@ mod tests {
         assert!(
             unix_timestamp_to_local_opt(&TimeZone::UTC, Timestamp::MAX.as_second() + 1, 0)
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn unknown_entry_type_does_not_render_as_file() {
+        let entry_type = EntryType::Unknown("private-entry".into(), DataKind::Private(128));
+
+        assert_eq!(entry_type.name(), "private-entry");
+        assert_eq!(
+            entry_type.bsd_long_style_display().to_string(),
+            "private-entry"
+        );
+        assert_eq!(kind_char(&entry_type), '?');
+        assert_eq!(
+            PermissionDisplay::new(&entry_type, 0o644, false, false).to_string(),
+            "?rw-r--r-- "
+        );
+        assert_eq!(
+            PermissionDisplay::bsdtar(&entry_type, 0o644, false).to_string(),
+            "?rw-r--r-- "
         );
     }
 

--- a/lib/src/entry/header.rs
+++ b/lib/src/entry/header.rs
@@ -122,10 +122,10 @@ impl EntryHeader {
         let mut data = Vec::with_capacity(6 + name.len());
         data.push(self.major);
         data.push(self.minor);
-        data.push(self.data_kind as u8);
-        data.push(self.compression as u8);
-        data.push(self.encryption as u8);
-        data.push(self.cipher_mode as u8);
+        data.push(self.data_kind.to_byte());
+        data.push(self.compression.to_byte());
+        data.push(self.encryption.to_byte());
+        data.push(self.cipher_mode.to_byte());
         data.extend_from_slice(name);
         data
     }
@@ -272,9 +272,9 @@ impl SolidHeader {
         [
             self.major,
             self.minor,
-            self.compression as u8,
-            self.encryption as u8,
-            self.cipher_mode as u8,
+            self.compression.to_byte(),
+            self.encryption.to_byte(),
+            self.cipher_mode.to_byte(),
         ]
     }
 

--- a/lib/src/entry/options.rs
+++ b/lib/src/entry/options.rs
@@ -132,16 +132,45 @@ mod private {
 
 /// Compression method.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[repr(u8)]
 pub enum Compression {
     /// Do not apply any compression.
-    No = 0,
+    No,
     /// Zlib format.
-    Deflate = 1,
+    Deflate,
     /// ZStandard format.
-    ZStandard = 2,
+    ZStandard,
     /// Xz format.
-    XZ = 4,
+    XZ,
+    /// Value reserved for future PNA specification (raw value < 128).
+    Reserved(u8),
+    /// Application-specific private value (raw value >= 128).
+    Private(u8),
+}
+
+impl Compression {
+    /// Serialize this compression method to its u8 representation.
+    #[inline]
+    pub const fn to_byte(self) -> u8 {
+        match self {
+            Self::No => 0,
+            Self::Deflate => 1,
+            Self::ZStandard => 2,
+            Self::XZ => 4,
+            Self::Reserved(v) | Self::Private(v) => v,
+        }
+    }
+
+    /// Returns `true` if this is a reserved value.
+    #[inline]
+    pub const fn is_reserved(self) -> bool {
+        matches!(self, Self::Reserved(_))
+    }
+
+    /// Returns `true` if this is a private value.
+    #[inline]
+    pub const fn is_private(self) -> bool {
+        matches!(self, Self::Private(_))
+    }
 }
 
 impl TryFrom<u8> for Compression {
@@ -154,7 +183,8 @@ impl TryFrom<u8> for Compression {
             1 => Ok(Self::Deflate),
             2 => Ok(Self::ZStandard),
             4 => Ok(Self::XZ),
-            value => Err(UnknownValueError(value)),
+            v if v < 128 => Ok(Self::Reserved(v)),
+            v => Ok(Self::Private(v)),
         }
     }
 }
@@ -291,14 +321,42 @@ impl<T: AsRef<[u8]>> From<T> for Password {
 
 /// Encryption algorithm.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[repr(u8)]
 pub enum Encryption {
     /// Do not apply any encryption.
-    No = 0,
+    No,
     /// Aes algorithm.
-    Aes = 1,
+    Aes,
     /// Camellia algorithm.
-    Camellia = 2,
+    Camellia,
+    /// Value reserved for future PNA specification (raw value < 128).
+    Reserved(u8),
+    /// Application-specific private value (raw value >= 128).
+    Private(u8),
+}
+
+impl Encryption {
+    /// Serialize this encryption method to its u8 representation.
+    #[inline]
+    pub const fn to_byte(self) -> u8 {
+        match self {
+            Self::No => 0,
+            Self::Aes => 1,
+            Self::Camellia => 2,
+            Self::Reserved(v) | Self::Private(v) => v,
+        }
+    }
+
+    /// Returns `true` if this is a reserved value.
+    #[inline]
+    pub const fn is_reserved(self) -> bool {
+        matches!(self, Self::Reserved(_))
+    }
+
+    /// Returns `true` if this is a private value.
+    #[inline]
+    pub const fn is_private(self) -> bool {
+        matches!(self, Self::Private(_))
+    }
 }
 
 impl TryFrom<u8> for Encryption {
@@ -310,19 +368,47 @@ impl TryFrom<u8> for Encryption {
             0 => Ok(Self::No),
             1 => Ok(Self::Aes),
             2 => Ok(Self::Camellia),
-            value => Err(UnknownValueError(value)),
+            v if v < 128 => Ok(Self::Reserved(v)),
+            v => Ok(Self::Private(v)),
         }
     }
 }
 
 /// Cipher mode of encryption algorithm.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[repr(u8)]
 pub enum CipherMode {
     /// Cipher Block Chaining mode.
-    CBC = 0,
+    CBC,
     /// Counter mode.
-    CTR = 1,
+    CTR,
+    /// Value reserved for future PNA specification (raw value < 128).
+    Reserved(u8),
+    /// Application-specific private value (raw value >= 128).
+    Private(u8),
+}
+
+impl CipherMode {
+    /// Serialize this cipher mode to its u8 representation.
+    #[inline]
+    pub const fn to_byte(self) -> u8 {
+        match self {
+            Self::CBC => 0,
+            Self::CTR => 1,
+            Self::Reserved(v) | Self::Private(v) => v,
+        }
+    }
+
+    /// Returns `true` if this is a reserved value.
+    #[inline]
+    pub const fn is_reserved(self) -> bool {
+        matches!(self, Self::Reserved(_))
+    }
+
+    /// Returns `true` if this is a private value.
+    #[inline]
+    pub const fn is_private(self) -> bool {
+        matches!(self, Self::Private(_))
+    }
 }
 
 impl TryFrom<u8> for CipherMode {
@@ -333,7 +419,8 @@ impl TryFrom<u8> for CipherMode {
         match value {
             0 => Ok(Self::CBC),
             1 => Ok(Self::CTR),
-            value => Err(UnknownValueError(value)),
+            v if v < 128 => Ok(Self::Reserved(v)),
+            v => Ok(Self::Private(v)),
         }
     }
 }
@@ -472,17 +559,46 @@ impl HashAlgorithm {
 /// Each variant determines how the entry's data should be interpreted
 /// and how the entry should be extracted to the filesystem.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[repr(u8)]
 pub enum DataKind {
     /// Regular file. Entry data contains the file contents.
-    File = 0,
+    File,
     /// Directory. Entry has no data content.
-    Directory = 1,
+    Directory,
     /// Symbolic link. Entry data contains the UTF-8 encoded link target path.
-    SymbolicLink = 2,
+    SymbolicLink,
     /// Hard link. Entry data contains the UTF-8 encoded path of the target entry
     /// within the same archive.
-    HardLink = 3,
+    HardLink,
+    /// Value reserved for future PNA specification (raw value < 128).
+    Reserved(u8),
+    /// Application-specific private value (raw value >= 128).
+    Private(u8),
+}
+
+impl DataKind {
+    /// Serialize this data kind to its u8 representation.
+    #[inline]
+    pub const fn to_byte(self) -> u8 {
+        match self {
+            Self::File => 0,
+            Self::Directory => 1,
+            Self::SymbolicLink => 2,
+            Self::HardLink => 3,
+            Self::Reserved(v) | Self::Private(v) => v,
+        }
+    }
+
+    /// Returns `true` if this is a reserved value.
+    #[inline]
+    pub const fn is_reserved(self) -> bool {
+        matches!(self, Self::Reserved(_))
+    }
+
+    /// Returns `true` if this is a private value.
+    #[inline]
+    pub const fn is_private(self) -> bool {
+        matches!(self, Self::Private(_))
+    }
 }
 
 impl TryFrom<u8> for DataKind {
@@ -495,7 +611,8 @@ impl TryFrom<u8> for DataKind {
             1 => Ok(Self::Directory),
             2 => Ok(Self::SymbolicLink),
             3 => Ok(Self::HardLink),
-            value => Err(UnknownValueError(value)),
+            v if v < 128 => Ok(Self::Reserved(v)),
+            v => Ok(Self::Private(v)),
         }
     }
 }
@@ -778,7 +895,10 @@ impl WriteOptionsBuilder {
                 match self.encryption {
                     Encryption::Aes => CipherAlgorithm::Aes,
                     Encryption::Camellia => CipherAlgorithm::Camellia,
-                    Encryption::No => unreachable!(),
+                    other => panic!(
+                        "unsupported encryption method for writing: byte={}",
+                        other.to_byte()
+                    ),
                 },
                 self.cipher_mode,
             ))
@@ -791,6 +911,10 @@ impl WriteOptionsBuilder {
                 Compression::Deflate => Compress::Deflate(self.compression_level.into()),
                 Compression::ZStandard => Compress::ZStandard(self.compression_level.into()),
                 Compression::XZ => Compress::XZ(self.compression_level.into()),
+                other => panic!(
+                    "unsupported compression method for writing: byte={}",
+                    other.to_byte()
+                ),
             },
             cipher,
         }

--- a/lib/src/entry/read.rs
+++ b/lib/src/entry/read.rs
@@ -58,6 +58,12 @@ pub(crate) fn decrypt_reader<R: Read>(
                 }
             }
         }
+        _ => {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!("unsupported encryption method: {encryption:?}"),
+            ));
+        }
     })
 }
 
@@ -76,6 +82,12 @@ pub(crate) fn decompress_reader<R: Read>(
         }
         Compression::ZStandard => DecompressReader::ZStd(zstd::Decoder::with_buffer(reader)?),
         Compression::XZ => DecompressReader::Xz(liblzma::bufread::XzDecoder::new(reader)),
+        _ => {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!("unsupported compression method: {compression:?}"),
+            ));
+        }
     })
 }
 

--- a/lib/src/entry/write.rs
+++ b/lib/src/entry/write.rs
@@ -161,6 +161,12 @@ fn encryption_writer<W: Write>(
                     ..
                 },
         }) => CipherWriter::CtrCamellia(Ctr128BEWriter::new(writer, key.as_bytes(), iv)?),
+        Some(WriteCipher { context, .. }) => {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!("unsupported cipher mode for writing: {:?}", context.mode),
+            ));
+        }
     })
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for unsupported compression, encryption, and cipher-mode combinations (explicit "unsupported" errors).
  * Fixed handling so unknown/unsupported entry kinds are not treated as regular files in listings and tree output.

* **Improvements**
  * Unknown entry kinds render with a "?"-style marker in names, long formats, and permission strings.
  * Default permissions for reserved/private entry kinds now fall back to 0.
  * Better support for reserved/private archive format values for forward compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChanTsune/Portable-Network-Archive/pull/3061?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->