### PR TITLE
:bug: Match bsdtar's CRLF list output on Windows in compat mode

### DIFF
--- a/cli/src/command/bsdtar.rs
+++ b/cli/src/command/bsdtar.rs
@@ -20,7 +20,7 @@ use crate::{
         },
         create::{CreationContext, create_archive_file},
         extract::{OutputOption, OverwriteStrategy, run_extract_archive_reader},
-        list::{Format, ListOptions, TimeField, TimeFormat},
+        list::{Format, LineEnding, ListOptions, TimeField, TimeFormat},
         update::run_update_archive,
     },
     utils::{
@@ -1214,6 +1214,11 @@ fn run_list_archive(args: BsdtarCommand) -> anyhow::Result<()> {
         out_to_stderr: args.to_stdout,
         color: ColorChoice::Auto,
         time_filters,
+        line_ending: if cfg!(target_os = "windows") {
+            LineEnding::Crlf
+        } else {
+            LineEnding::Lf
+        },
     };
     let files_globs = BsdGlobMatcher::new(args.files.iter().map(|it| it.as_str()))
         .with_no_recursive(args.no_recursive);

--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -532,6 +532,7 @@ fn list_archive(ctx: &crate::cli::GlobalContext, args: ListCommand) -> anyhow::R
         out_to_stderr: false,
         color: ctx.color(),
         time_filters,
+        line_ending: LineEnding::default(),
     };
     let archive = args.file.archive();
     let files = args.file.files();
@@ -586,6 +587,23 @@ fn list_archive(ctx: &crate::cli::GlobalContext, args: ListCommand) -> anyhow::R
     print_entries(entries, files_globs, filter, options)
 }
 
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum LineEnding {
+    #[default]
+    Lf,
+    Crlf,
+}
+
+impl LineEnding {
+    #[inline]
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            LineEnding::Lf => "\n",
+            LineEnding::Crlf => "\r\n",
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) enum TimeFormat {
     Auto(SystemTime),
@@ -630,6 +648,7 @@ pub(crate) struct ListOptions {
     pub(crate) out_to_stderr: bool,
     pub(crate) color: ColorChoice,
     pub(crate) time_filters: TimeFilters,
+    pub(crate) line_ending: LineEnding,
 }
 
 pub(crate) fn run_list_archive<'a>(
@@ -827,9 +846,10 @@ fn bsd_tar_list_entries_to(
 
         // permission nlink uname gname size mtime name link
         // ex: -rw-r--r--  0 1000   1000        0 Jan  1  1980 f
-        writeln!(
+        write!(
             out,
-            "{perm} {nlink} {uname:<u_width$} {gname}{size_str:>size_width$} {mtime} {name}"
+            "{perm} {nlink} {uname:<u_width$} {gname}{size_str:>size_width$} {mtime} {name}{}",
+            options.line_ending.as_str()
         )?;
     }
     Ok(())
@@ -866,7 +886,7 @@ impl<'a> Display for SimpleListDisplay<'a> {
                 EntryType::SymbolicLink(_, _) if self.options.classify => f.write_char('@')?,
                 _ => (),
             };
-            f.write_char('\n')
+            f.write_str(self.options.line_ending.as_str())
         })
     }
 }
@@ -1631,5 +1651,20 @@ mod tests {
             datetime(TimeFormat::Long, &tz, past_jiff_window),
             "-- -- ----"
         );
+    }
+
+    #[test]
+    fn line_ending_lf_as_str() {
+        assert_eq!(LineEnding::Lf.as_str(), "\n");
+    }
+
+    #[test]
+    fn line_ending_crlf_as_str() {
+        assert_eq!(LineEnding::Crlf.as_str(), "\r\n");
+    }
+
+    #[test]
+    fn line_ending_default_is_lf() {
+        assert_eq!(LineEnding::default(), LineEnding::Lf);
     }
 }

--- a/cli/tests/cli/stdio.rs
+++ b/cli/tests/cli/stdio.rs
@@ -1,5 +1,6 @@
 mod archive_inclusion;
 mod files_from;
+mod list_line_ending;
 mod missing_file;
 #[cfg(unix)]
 mod mtree;

--- a/cli/tests/cli/stdio/list_line_ending.rs
+++ b/cli/tests/cli/stdio/list_line_ending.rs
@@ -1,0 +1,110 @@
+#![cfg(not(target_family = "wasm"))]
+
+use crate::utils::setup;
+use assert_cmd::cargo::cargo_bin_cmd;
+use pna::{Archive, EntryBuilder, WriteOptions};
+use std::io::Write;
+
+fn build_two_entry_archive() -> Vec<u8> {
+    let mut archive = Archive::write_header(Vec::new()).unwrap();
+
+    let mut a = EntryBuilder::new_file("a.txt".into(), WriteOptions::store()).unwrap();
+    a.write_all(b"alpha").unwrap();
+    archive.add_entry(a.build().unwrap()).unwrap();
+
+    let mut b = EntryBuilder::new_file("b.txt".into(), WriteOptions::store()).unwrap();
+    b.write_all(b"beta").unwrap();
+    archive.add_entry(b.build().unwrap()).unwrap();
+
+    archive.finalize().unwrap()
+}
+
+#[cfg(target_os = "windows")]
+const EXPECTED_LINE_ENDING: &[u8] = b"\r\n";
+
+#[cfg(not(target_os = "windows"))]
+const EXPECTED_LINE_ENDING: &[u8] = b"\n";
+
+/// Precondition: An archive with multiple entries is piped through stdin.
+/// Action: Run bsdtar-compat list (simple format) reading from stdin.
+/// Expectation: Every record ends with the platform's expected line
+///   separator (CRLF on Windows, LF elsewhere) so the output matches
+///   the byte stream that the reference bsdtar implementation produces.
+#[test]
+fn stdio_list_simple_uses_platform_line_ending() {
+    setup();
+    let archive_data = build_two_entry_archive();
+
+    let output = cargo_bin_cmd!("pna")
+        .write_stdin(archive_data)
+        .args(["compat", "bsdtar", "--unstable", "-tf", "-"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let separator_count = output
+        .windows(EXPECTED_LINE_ENDING.len())
+        .filter(|w| *w == EXPECTED_LINE_ENDING)
+        .count();
+    assert_eq!(
+        separator_count, 2,
+        "expected two records terminated by the platform line ending in {output:?}"
+    );
+    assert!(
+        output.ends_with(EXPECTED_LINE_ENDING),
+        "expected list output to end with the platform line ending: {output:?}"
+    );
+
+    #[cfg(target_os = "windows")]
+    {
+        // On Windows the bare LF byte must only appear as the second
+        // byte of a CRLF pair so downstream tools see exact bsdtar
+        // semantics rather than mixed terminators.
+        let bare_lf_count = output.iter().filter(|b| **b == b'\n').count();
+        assert_eq!(bare_lf_count, separator_count);
+        let cr_count = output.iter().filter(|b| **b == b'\r').count();
+        assert_eq!(cr_count, separator_count);
+    }
+}
+
+/// Precondition: An archive with multiple entries is piped through stdin.
+/// Action: Run bsdtar-compat list in verbose mode (long format).
+/// Expectation: Each formatted record ends with the platform's
+///   expected line separator.
+#[test]
+fn stdio_list_verbose_uses_platform_line_ending() {
+    setup();
+    let archive_data = build_two_entry_archive();
+
+    let output = cargo_bin_cmd!("pna")
+        .write_stdin(archive_data)
+        .args(["compat", "bsdtar", "--unstable", "-tvf", "-"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let separator_count = output
+        .windows(EXPECTED_LINE_ENDING.len())
+        .filter(|w| *w == EXPECTED_LINE_ENDING)
+        .count();
+    assert_eq!(
+        separator_count, 2,
+        "expected two verbose records terminated by the platform line ending in {output:?}"
+    );
+    assert!(
+        output.ends_with(EXPECTED_LINE_ENDING),
+        "expected verbose list output to end with the platform line ending: {output:?}"
+    );
+
+    #[cfg(target_os = "windows")]
+    {
+        let bare_lf_count = output.iter().filter(|b| **b == b'\n').count();
+        assert_eq!(bare_lf_count, separator_count);
+        let cr_count = output.iter().filter(|b| **b == b'\r').count();
+        assert_eq!(cr_count, separator_count);
+    }
+}

--- a/cli/tests/cli/stdio/option_fast_read.rs
+++ b/cli/tests/cli/stdio/option_fast_read.rs
@@ -1,4 +1,4 @@
-use crate::utils::setup;
+use crate::utils::{list_lines, setup};
 use assert_cmd::cargo::cargo_bin_cmd;
 use pna::{Archive, EntryBuilder, WriteOptions};
 use std::{
@@ -43,7 +43,7 @@ fn stdio_list_with_fast_read() {
         .args(["experimental", "stdio", "--list", "-q", "a.txt", "b.txt"])
         .assert()
         .success()
-        .stdout("a.txt\na.txt\nb.txt\n");
+        .stdout(list_lines(&["a.txt", "a.txt", "b.txt"]));
 }
 
 /// Precondition: Archive contains duplicate entries.
@@ -59,7 +59,7 @@ fn stdio_list_with_fast_read_without_operands() {
         .args(["experimental", "stdio", "--list", "--fast-read"])
         .assert()
         .success()
-        .stdout("a.txt\na.txt\nb.txt\nb.txt\n");
+        .stdout(list_lines(&["a.txt", "a.txt", "b.txt", "b.txt"]));
 }
 
 /// Precondition: Archive contains duplicate entries for multiple operands.

--- a/cli/tests/cli/stdio/option_ignore_zeros.rs
+++ b/cli/tests/cli/stdio/option_ignore_zeros.rs
@@ -1,4 +1,4 @@
-use crate::utils::setup;
+use crate::utils::{list_lines, setup};
 use assert_cmd::cargo::cargo_bin_cmd;
 use pna::{Archive, EntryBuilder, ReadOptions, WriteOptions};
 use predicates::prelude::*;
@@ -116,7 +116,7 @@ fn stdio_list_ignore_zeros_controls_concatenated_archive_handling() {
         .args(["experimental", "stdio", "--list"])
         .assert()
         .success()
-        .stdout("a.txt\n")
+        .stdout(list_lines(&["a.txt"]))
         .stderr(predicate::str::contains(STDIO_DEPRECATION_WARNING));
 
     let mut cmd = cargo_bin_cmd!("pna");
@@ -130,7 +130,7 @@ fn stdio_list_ignore_zeros_controls_concatenated_archive_handling() {
         ])
         .assert()
         .success()
-        .stdout("a.txt\nb.txt\n")
+        .stdout(list_lines(&["a.txt", "b.txt"]))
         .stderr(predicate::str::contains(STDIO_DEPRECATION_WARNING));
 }
 
@@ -152,7 +152,7 @@ fn stdio_list_ignore_zeros_with_fast_read_continues_into_next_archive() {
         ])
         .assert()
         .success()
-        .stdout("b.txt\n")
+        .stdout(list_lines(&["b.txt"]))
         .stderr(predicate::str::contains(STDIO_DEPRECATION_WARNING));
 }
 
@@ -665,7 +665,7 @@ fn stdio_append_ignore_zeros_handles_concatenated_archive_before_split_archive()
     ])
     .assert()
     .success()
-    .stdout("a.txt\nsplit.txt\nc.txt\n")
+    .stdout(list_lines(&["a.txt", "split.txt", "c.txt"]))
     .stderr(predicate::str::contains(STDIO_DEPRECATION_WARNING));
 }
 

--- a/cli/tests/cli/stdio/option_no_recursive.rs
+++ b/cli/tests/cli/stdio/option_no_recursive.rs
@@ -1,4 +1,4 @@
-use crate::utils::{EmbedExt, TestResources, setup};
+use crate::utils::{EmbedExt, TestResources, list_lines, setup};
 use assert_cmd::cargo::cargo_bin_cmd;
 use std::fs;
 
@@ -21,12 +21,12 @@ fn stdio_list_recursive_by_default() {
         // Without -n, matches directory and all children
         // Directory entries have trailing slash in this archive
         .success()
-        .stdout(concat!(
-            "raw/images/\n",
-            "raw/images/icon.svg\n",
-            "raw/images/icon.png\n",
-            "raw/images/icon.bmp\n",
-        ));
+        .stdout(list_lines(&[
+            "raw/images/",
+            "raw/images/icon.svg",
+            "raw/images/icon.png",
+            "raw/images/icon.bmp",
+        ]));
 }
 
 /// Precondition: An archive contains entries under 'raw/images/' directory.
@@ -47,7 +47,7 @@ fn stdio_list_no_recursive_matches_exact_only() {
         // With -n, only matches the exact entry, not children
         // Directory entries have trailing slash in this archive
         .success()
-        .stdout("raw/images/\n");
+        .stdout(list_lines(&["raw/images/"]));
 }
 
 /// Precondition: An archive contains entries under 'raw/images/' directory.
@@ -73,7 +73,7 @@ fn stdio_list_no_recursive_long_form() {
         .assert()
         // Directory entries have trailing slash in this archive
         .success()
-        .stdout("raw/images/\n");
+        .stdout(list_lines(&["raw/images/"]));
 }
 
 /// Precondition: An archive contains multiple file entries.
@@ -92,7 +92,7 @@ fn stdio_list_no_recursive_exact_file_path() {
         .args(["experimental", "stdio", "--list", "-n", "raw/text.txt"])
         .assert()
         .success()
-        .stdout("raw/text.txt\n");
+        .stdout(list_lines(&["raw/text.txt"]));
 }
 
 /// Precondition: An archive contains entries like 'raw/images/icon.png'.
@@ -112,7 +112,7 @@ fn stdio_list_no_recursive_glob_still_works() {
         .assert()
         // Glob patterns work regardless of -n
         .success()
-        .stdout("raw/images/icon.png\n");
+        .stdout(list_lines(&["raw/images/icon.png"]));
 }
 
 /// Precondition: An archive contains entries.
@@ -140,7 +140,7 @@ fn stdio_list_no_recursive_multiple_patterns() {
         // Only exact directory entries, no children
         // Directory entries have trailing slash in stdio output
         .success()
-        .stdout(concat!("raw/images/\n", "raw/pna/\n",));
+        .stdout(list_lines(&["raw/images/", "raw/pna/"]));
 }
 
 /// Precondition: An archive contains entries but no exact match for pattern.

--- a/cli/tests/cli/utils.rs
+++ b/cli/tests/cli/utils.rs
@@ -73,6 +73,33 @@ pub fn setup() {
     std::env::set_current_dir(env!("CARGO_TARGET_TMPDIR")).expect("Failed to set current dir");
 }
 
+/// Record separator that the bsdtar-compat list output is expected to emit on
+/// the host platform. Reference bsdtar relies on the C runtime's text-mode
+/// translation, so Windows list output ends each record with CRLF while every
+/// other platform keeps a bare LF.
+pub fn list_record_separator() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "\r\n"
+    } else {
+        "\n"
+    }
+}
+
+/// Build the expected stdout payload for a list command by joining each record
+/// with the platform's record separator and terminating the final record with
+/// the same separator.
+pub fn list_lines(records: &[&str]) -> String {
+    let separator = list_record_separator();
+    let mut out = String::with_capacity(
+        records.iter().map(|r| r.len()).sum::<usize>() + separator.len() * records.len(),
+    );
+    for record in records {
+        out.push_str(record);
+        out.push_str(separator);
+    }
+    out
+}
+
 pub fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
     fs::create_dir_all(&dst)?;
     for entry in fs::read_dir(src)? {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed list command output to use platform-appropriate line endings (CRLF on Windows, LF on other platforms).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChanTsune/Portable-Network-Archive/pull/3062?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->