### PR TITLE
🛡️ Sentinel: Bound link target memory allocation during extraction

### DIFF
--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -47,6 +47,8 @@ use std::{
     time::Instant,
 };
 
+const MAX_LINK_TARGET_SIZE: u64 = 64 * 1024;
+
 #[derive(Parser, Clone, Debug)]
 #[command(
     group(
@@ -1432,7 +1434,14 @@ where
     match item.header().data_kind() {
         DataKind::SymbolicLink => {
             let reader = item.reader(ReadOptions::with_password(password))?;
-            let original = io::read_to_string(reader)?;
+            let mut limited_reader = reader.take(MAX_LINK_TARGET_SIZE + 1);
+            let original = io::read_to_string(&mut limited_reader)?;
+            if original.len() as u64 > MAX_LINK_TARGET_SIZE {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("symbolic link target exceeds limit of {MAX_LINK_TARGET_SIZE} bytes"),
+                ));
+            }
             let original = pathname_editor.edit_symlink(original.as_ref());
             if !allow_unsafe_links && is_unsafe_link(&original) {
                 log::warn!(
@@ -1448,7 +1457,14 @@ where
         }
         DataKind::HardLink => {
             let reader = item.reader(ReadOptions::with_password(password))?;
-            let original = io::read_to_string(reader)?;
+            let mut limited_reader = reader.take(MAX_LINK_TARGET_SIZE + 1);
+            let original = io::read_to_string(&mut limited_reader)?;
+            if original.len() as u64 > MAX_LINK_TARGET_SIZE {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("hard link target exceeds limit of {MAX_LINK_TARGET_SIZE} bytes"),
+                ));
+            }
             let Some((original, had_root)) = pathname_editor.edit_hardlink(original.as_ref())
             else {
                 log::warn!(

--- a/cli/tests/cli/extract.rs
+++ b/cli/tests/cli/extract.rs
@@ -1,4 +1,5 @@
 mod hardlink;
+mod link_limit;
 mod missing_file;
 #[cfg(not(target_family = "wasm"))]
 mod option_chroot;

--- a/cli/tests/cli/extract/link_limit.rs
+++ b/cli/tests/cli/extract/link_limit.rs
@@ -1,0 +1,92 @@
+use crate::utils::setup;
+use clap::Parser;
+use portable_network_archive::cli;
+use std::fs;
+
+#[test]
+fn extract_fails_on_oversized_symlink_target() {
+    setup();
+
+    let work_dir = "extract_fails_on_oversized_symlink_target";
+    fs::create_dir_all(format!("{}/out", work_dir)).unwrap();
+
+    let archive_path = format!("{}/archive.pna", work_dir);
+    let archive_file = fs::File::create(&archive_path).unwrap();
+    let mut archive = pna::Archive::write_header(archive_file).unwrap();
+
+    // Create a target larger than 64 KiB
+    let oversized_target = "a".repeat(64 * 1024 + 1);
+    let entry_name = pna::EntryName::from("large_symlink");
+    let entry_reference = pna::EntryReference::from(oversized_target.as_str());
+
+    let entry = pna::EntryBuilder::new_symlink(entry_name, entry_reference)
+        .unwrap()
+        .build()
+        .unwrap();
+
+    archive.add_entry(entry).unwrap();
+    archive.finalize().unwrap();
+
+    let result = cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        &archive_path,
+        "--out-dir",
+        &format!("{}/out", work_dir),
+    ])
+    .unwrap()
+    .execute();
+
+    assert!(
+        result.is_err(),
+        "Expected error for oversized symlink target, but got Ok"
+    );
+    let err = result.unwrap_err();
+    let err_msg = format!("{:?}", err);
+    assert!(err_msg.contains("symbolic link target exceeds limit"));
+}
+
+#[test]
+fn extract_fails_on_oversized_hardlink_target() {
+    setup();
+
+    let work_dir = "extract_fails_on_oversized_hardlink_target";
+    fs::create_dir_all(format!("{}/out", work_dir)).unwrap();
+
+    let archive_path = format!("{}/archive.pna", work_dir);
+    let archive_file = fs::File::create(&archive_path).unwrap();
+    let mut archive = pna::Archive::write_header(archive_file).unwrap();
+
+    // Create a target larger than 64 KiB
+    let oversized_target = "a".repeat(64 * 1024 + 1);
+    let entry_name = pna::EntryName::from("large_hardlink");
+    let entry_reference = pna::EntryReference::from(oversized_target.as_str());
+
+    let entry = pna::EntryBuilder::new_hard_link(entry_name, entry_reference)
+        .unwrap()
+        .build()
+        .unwrap();
+
+    archive.add_entry(entry).unwrap();
+    archive.finalize().unwrap();
+
+    let result = cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        &archive_path,
+        "--out-dir",
+        &format!("{}/out", work_dir),
+    ])
+    .unwrap()
+    .execute();
+
+    assert!(
+        result.is_err(),
+        "Expected error for oversized hardlink target, but got Ok"
+    );
+    let err = result.unwrap_err();
+    let err_msg = format!("{:?}", err);
+    assert!(err_msg.contains("hard link target exceeds limit"));
+}


### PR DESCRIPTION
I have implemented a security enhancement to protect the archiver against resource exhaustion (DoS) attacks during extraction.

### Vulnerability
A maliciously crafted archive could contain symbolic or hard link entries with extremely large target paths. When the archiver attempts to extract such entries, it reads the target path into memory without any size bounds (using `io::read_to_string`), potentially leading to an Out-of-Memory (OOM) crash or severe performance degradation.

### Fix
In `cli/src/command/extract.rs`, I have:
1.  Introduced a constant `MAX_LINK_TARGET_SIZE` set to 64 KiB. This is well above standard OS path limits but provides a robust safety ceiling.
2.  Modified `extract_link_entry` to wrap the entry reader with `take(MAX_LINK_TARGET_SIZE + 1)` before reading.
3.  Added a check to ensure the read string does not exceed `MAX_LINK_TARGET_SIZE`, returning a descriptive `io::Error` with `ErrorKind::InvalidData` if the limit is reached.

### Verification
- Added comprehensive integration tests in `cli/tests/cli/extract/link_limit.rs` that verify both symbolic and hard links with oversized targets are correctly rejected.
- Ran all package tests (`cargo test -p portable-network-archive` and `cargo test -p libpna`).
- Verified code quality with `cargo clippy` and `cargo fmt`.
- Recorded the critical security learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [12494871236687112898](https://jules.google.com/task/12494871236687112898) started by @ChanTsune*