### PR TITLE
:boom: Restore String-typed uname/gname on Permission

### DIFF
--- a/cli/src/command/append.rs
+++ b/cli/src/command/append.rs
@@ -14,11 +14,7 @@ use crate::{
             read_paths, read_paths_stdin, spawn_entry_results,
         },
     },
-    utils::{
-        PathPartExt, VCS_FILES,
-        cli_parsers::{parse_gname, parse_uname},
-        fs::HardlinkResolver,
-    },
+    utils::{PathPartExt, VCS_FILES, fs::HardlinkResolver},
 };
 use clap::{ArgGroup, Parser, ValueHint};
 use pna::{Archive, prelude::*};
@@ -144,20 +140,10 @@ pub(crate) struct AppendCommand {
         help = "Do not archive ACLs. This is the inverse option of --keep-acl"
     )]
     no_keep_acl: bool,
-    #[arg(
-        long,
-        value_name = "NAME",
-        value_parser = parse_uname,
-        help = "Set user name for archive entries"
-    )]
-    uname: Option<pna::UserName>,
-    #[arg(
-        long,
-        value_name = "NAME",
-        value_parser = parse_gname,
-        help = "Set group name for archive entries"
-    )]
-    gname: Option<pna::GroupName>,
+    #[arg(long, value_name = "NAME", help = "Set user name for archive entries")]
+    uname: Option<String>,
+    #[arg(long, value_name = "NAME", help = "Set group name for archive entries")]
+    gname: Option<String>,
     #[arg(
         long,
         value_name = "ID",

--- a/cli/src/command/bsdtar.rs
+++ b/cli/src/command/bsdtar.rs
@@ -24,10 +24,7 @@ use crate::{
         update::run_update_archive,
     },
     utils::{
-        self, BsdGlobMatcher, PathPartExt, VCS_FILES,
-        cli_parsers::{parse_gname, parse_uname},
-        env::NamedTempFile,
-        fs::HardlinkResolver,
+        self, BsdGlobMatcher, PathPartExt, VCS_FILES, env::NamedTempFile, fs::HardlinkResolver,
     },
 };
 use clap::{ArgGroup, Args, Parser, ValueHint};
@@ -419,17 +416,15 @@ pub(crate) struct BsdtarCommand {
     #[arg(
         long,
         value_name = "NAME",
-        value_parser = parse_uname,
         help = "On create, archiving user to the entries from given name. On extract, restore user from given name"
     )]
-    uname: Option<pna::UserName>,
+    uname: Option<String>,
     #[arg(
         long,
         value_name = "NAME",
-        value_parser = parse_gname,
         help = "On create, archiving group to the entries from given name. On extract, restore group from given name"
     )]
-    gname: Option<pna::GroupName>,
+    gname: Option<String>,
     #[arg(
         long,
         value_name = "ID",
@@ -750,8 +745,8 @@ struct CreationPermissionStrategyResolver {
     no_same_permissions: bool,
     no_same_owner: bool,
     numeric_owner: bool,
-    uname: Option<pna::UserName>,
-    gname: Option<pna::GroupName>,
+    uname: Option<String>,
+    gname: Option<String>,
     uid: Option<u32>,
     gid: Option<u32>,
 }
@@ -769,12 +764,12 @@ impl CreationPermissionStrategyResolver {
             OwnerStrategy::Preserve {
                 options: OwnerOptions {
                     uname: if self.numeric_owner {
-                        Some(pna::UserName::default())
+                        Some(String::new())
                     } else {
                         self.uname
                     },
                     gname: if self.numeric_owner {
-                        Some(pna::GroupName::default())
+                        Some(String::new())
                     } else {
                         self.gname
                     },
@@ -796,10 +791,10 @@ struct ExtractionPermissionStrategyResolver {
     no_same_permissions: bool,
     same_owner: bool,
     numeric_owner: bool,
-    uname: Option<pna::UserName>,
+    uname: Option<String>,
     umask: Umask,
     is_root: bool,
-    gname: Option<pna::GroupName>,
+    gname: Option<String>,
     uid: Option<u32>,
     gid: Option<u32>,
     keep_xattr: bool,
@@ -842,12 +837,12 @@ impl ExtractionPermissionStrategyResolver {
             OwnerStrategy::Preserve {
                 options: OwnerOptions {
                     uname: if self.numeric_owner {
-                        Some(pna::UserName::default())
+                        Some(String::new())
                     } else {
                         self.uname
                     },
                     gname: if self.numeric_owner {
-                        Some(pna::GroupName::default())
+                        Some(String::new())
                     } else {
                         self.gname
                     },
@@ -955,8 +950,8 @@ fn run_create_archive(args: BsdtarCommand) -> anyhow::Result<()> {
         args.options.as_ref(),
         password,
     );
-    let (uname, uid) = resolve_name_id::<pna::UserName>(args.owner, args.uname, args.uid)?;
-    let (gname, gid) = resolve_name_id::<pna::GroupName>(args.group, args.gname, args.gid)?;
+    let (uname, uid) = resolve_name_id(args.owner, args.uname, args.uid);
+    let (gname, gid) = resolve_name_id(args.group, args.gname, args.gid);
     let (mode_strategy, owner_strategy) = CreationPermissionStrategyResolver {
         no_same_permissions: args.no_same_permissions,
         no_same_owner: args.no_same_owner,
@@ -1064,8 +1059,8 @@ fn run_extract_archive(ctx: &GlobalContext, args: BsdtarCommand) -> anyhow::Resu
         missing_mtime: MissingTimePolicy::Include,
     }
     .resolve()?;
-    let (uname, uid) = resolve_name_id::<pna::UserName>(args.owner, args.uname, args.uid)?;
-    let (gname, gid) = resolve_name_id::<pna::GroupName>(args.group, args.gname, args.gid)?;
+    let (uname, uid) = resolve_name_id(args.owner, args.uname, args.uid);
+    let (gname, gid) = resolve_name_id(args.group, args.gname, args.gid);
     let (
         mode_strategy,
         owner_strategy,
@@ -1278,8 +1273,8 @@ fn run_append(args: BsdtarCommand) -> anyhow::Result<()> {
         args.options.as_ref(),
         password,
     );
-    let (uname, uid) = resolve_name_id::<pna::UserName>(args.owner, args.uname, args.uid)?;
-    let (gname, gid) = resolve_name_id::<pna::GroupName>(args.group, args.gname, args.gid)?;
+    let (uname, uid) = resolve_name_id(args.owner, args.uname, args.uid);
+    let (gname, gid) = resolve_name_id(args.group, args.gname, args.gid);
     let (mode_strategy, owner_strategy) = CreationPermissionStrategyResolver {
         no_same_permissions: args.no_same_permissions,
         no_same_owner: args.no_same_owner,
@@ -1418,20 +1413,14 @@ fn run_append(args: BsdtarCommand) -> anyhow::Result<()> {
     }
 }
 
-fn resolve_name_id<N>(
+fn resolve_name_id(
     spec: Option<NameIdPair>,
-    name: Option<N>,
+    name: Option<String>,
     id: Option<u32>,
-) -> Result<(Option<N>, Option<u32>), pna::LengthExceeded>
-where
-    N: TryFrom<String, Error = pna::LengthExceeded>,
-{
+) -> (Option<String>, Option<u32>) {
     match spec {
-        Some(spec) => {
-            let resolved = spec.name.map(N::try_from).transpose()?;
-            Ok((resolved, spec.id))
-        }
-        None => Ok((name, id)),
+        Some(spec) => (spec.name, spec.id),
+        None => (name, id),
     }
 }
 
@@ -1447,8 +1436,8 @@ fn run_update(args: BsdtarCommand) -> anyhow::Result<()> {
         args.options.as_ref(),
         password,
     );
-    let (uname, uid) = resolve_name_id::<pna::UserName>(args.owner, args.uname, args.uid)?;
-    let (gname, gid) = resolve_name_id::<pna::GroupName>(args.group, args.gname, args.gid)?;
+    let (uname, uid) = resolve_name_id(args.owner, args.uname, args.uid);
+    let (gname, gid) = resolve_name_id(args.group, args.gname, args.gid);
     let (mode_strategy, owner_strategy) = CreationPermissionStrategyResolver {
         no_same_permissions: args.no_same_permissions,
         no_same_owner: args.no_same_owner,

--- a/cli/src/command/chmod.rs
+++ b/cli/src/command/chmod.rs
@@ -100,15 +100,7 @@ fn transform_entry<T>(entry: NormalEntry<T>, mode: &Mode) -> NormalEntry<T> {
     let metadata = entry.metadata().clone();
     let permission = metadata.permission().map(|p| {
         let mode = mode.apply_to(p.permissions());
-        pna::Permission::new(
-            p.uid(),
-            pna::UserName::try_from(p.uname())
-                .expect("p's uname is already bounded by UserName invariant"),
-            p.gid(),
-            pna::GroupName::try_from(p.gname())
-                .expect("p's gname is already bounded by GroupName invariant"),
-            mode,
-        )
+        pna::Permission::new(p.uid(), p.uname().into(), p.gid(), p.gname().into(), mode)
     });
     entry.with_metadata(metadata.with_permission(permission))
 }

--- a/cli/src/command/chown.rs
+++ b/cli/src/command/chown.rs
@@ -73,7 +73,7 @@ fn archive_chown(args: ChownCommand) -> anyhow::Result<()> {
             |entry| {
                 let entry = entry?;
                 if globs.matches_any(entry.name()) {
-                    Ok(Some(transform_entry(entry, &owner)?))
+                    Ok(Some(transform_entry(entry, &owner)))
                 } else {
                     Ok(Some(entry))
                 }
@@ -87,7 +87,7 @@ fn archive_chown(args: ChownCommand) -> anyhow::Result<()> {
             |entry| {
                 let entry = entry?;
                 if globs.matches_any(entry.name()) {
-                    Ok(Some(transform_entry(entry, &owner)?))
+                    Ok(Some(transform_entry(entry, &owner)))
                 } else {
                     Ok(Some(entry))
                 }
@@ -105,48 +105,31 @@ fn archive_chown(args: ChownCommand) -> anyhow::Result<()> {
 }
 
 #[inline]
-fn transform_entry<T>(entry: NormalEntry<T>, owner: &Ownership) -> io::Result<NormalEntry<T>> {
+fn transform_entry<T>(entry: NormalEntry<T>, owner: &Ownership) -> NormalEntry<T> {
     let metadata = entry.metadata().clone();
-    let permission = metadata
-        .permission()
-        .map(|p| -> io::Result<pna::Permission> {
-            let user = owner.user.as_ref().map(|it| match it {
-                OwnerSpecifier::Name(uname) => (u64::MAX, uname.clone()),
-                OwnerSpecifier::ID(uid) => (*uid, String::new()),
-                OwnerSpecifier::System(user) => (
-                    user.uid().unwrap_or(u64::MAX),
-                    user.name().unwrap_or_default().to_string(),
-                ),
-            });
-            let (uid, uname) = user.unwrap_or_else(|| (p.uid(), p.uname().to_string()));
+    let permission = metadata.permission().map(|p| {
+        let user = owner.user.as_ref().map(|it| match it {
+            OwnerSpecifier::Name(uname) => (u64::MAX, uname.into()),
+            OwnerSpecifier::ID(uid) => (*uid, String::new()),
+            OwnerSpecifier::System(user) => (
+                user.uid().unwrap_or(u64::MAX),
+                user.name().unwrap_or_default().into(),
+            ),
+        });
+        let (uid, uname) = user.unwrap_or_else(|| (p.uid(), p.uname().into()));
 
-            let group = owner.group.as_ref().map(|it| match it {
-                OwnerSpecifier::Name(gname) => (u64::MAX, gname.clone()),
-                OwnerSpecifier::ID(gid) => (*gid, String::new()),
-                OwnerSpecifier::System(group) => (
-                    group.gid().unwrap_or(u64::MAX),
-                    group.name().unwrap_or_default().to_string(),
-                ),
-            });
-            let (gid, gname) = group.unwrap_or_else(|| (p.gid(), p.gname().to_string()));
-            // CLI-derived names are bounded by RawOwnership::FromStr; archive-derived
-            // names are bounded by the UserName / GroupName invariants on `p`. The
-            // remaining failure mode is an NSS lookup whose pw_name / gr_name exceeds
-            // the format's u8 length prefix, which we surface as `InvalidData`.
-            let uname = pna::UserName::try_from(uname)
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-            let gname = pna::GroupName::try_from(gname)
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-            Ok(pna::Permission::new(
-                uid,
-                uname,
-                gid,
-                gname,
-                p.permissions(),
-            ))
-        })
-        .transpose()?;
-    Ok(entry.with_metadata(metadata.with_permission(permission)))
+        let group = owner.group.as_ref().map(|it| match it {
+            OwnerSpecifier::Name(gname) => (u64::MAX, gname.into()),
+            OwnerSpecifier::ID(gid) => (*gid, String::new()),
+            OwnerSpecifier::System(group) => (
+                group.gid().unwrap_or(u64::MAX),
+                group.name().unwrap_or_default().into(),
+            ),
+        });
+        let (gid, gname) = group.unwrap_or_else(|| (p.gid(), p.gname().into()));
+        pna::Permission::new(uid, uname, gid, gname, p.permissions())
+    });
+    entry.with_metadata(metadata.with_permission(permission))
 }
 
 pub(crate) enum OwnerSpecifier<T> {
@@ -235,11 +218,6 @@ impl RawOwnership {
     }
 }
 
-/// Maximum byte length of a uname or gname stored in an archive entry.
-/// Matches the `u8` length prefix in the `fPRM` chunk; UserName / GroupName
-/// share this bound.
-const NAME_MAX_BYTES: usize = u8::MAX as usize;
-
 impl FromStr for RawOwnership {
     type Err = String;
 
@@ -247,32 +225,15 @@ impl FromStr for RawOwnership {
         if s.is_empty() || s == ":" {
             return Err("owner must not be empty".into());
         }
-        let (user, group, use_login_group): (Option<String>, Option<String>, bool) =
-            if let Some((user, group)) = s.split_once(':') {
-                (
-                    user.is_empty().not().then(|| user.to_string()),
-                    group.is_empty().not().then(|| group.to_string()),
-                    !user.is_empty() && group.is_empty(),
-                )
-            } else {
-                (Some(s.to_string()), None, false)
-            };
-        if let Some(name) = user.as_deref()
-            && name.len() > NAME_MAX_BYTES
-        {
-            return Err(format!(
-                "user name length {} exceeds {NAME_MAX_BYTES}",
-                name.len()
-            ));
-        }
-        if let Some(name) = group.as_deref()
-            && name.len() > NAME_MAX_BYTES
-        {
-            return Err(format!(
-                "group name length {} exceeds {NAME_MAX_BYTES}",
-                name.len()
-            ));
-        }
+        let (user, group, use_login_group) = if let Some((user, group)) = s.split_once(':') {
+            (
+                user.is_empty().not().then(|| user.into()),
+                group.is_empty().not().then(|| group.into()),
+                !user.is_empty() && group.is_empty(),
+            )
+        } else {
+            (Some(s.into()), None, false)
+        };
         Ok(Self {
             user,
             group,

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -315,8 +315,8 @@ pub(crate) struct PermissionStrategyResolver {
     pub(crate) keep_permission: bool,
     pub(crate) no_keep_permission: bool,
     pub(crate) same_owner: bool,
-    pub(crate) uname: Option<pna::UserName>,
-    pub(crate) gname: Option<pna::GroupName>,
+    pub(crate) uname: Option<String>,
+    pub(crate) gname: Option<String>,
     pub(crate) uid: Option<u32>,
     pub(crate) gid: Option<u32>,
     pub(crate) numeric_owner: bool,
@@ -340,12 +340,12 @@ impl PermissionStrategyResolver {
                 OwnerStrategy::Preserve {
                     options: OwnerOptions {
                         uname: if self.numeric_owner {
-                            Some(pna::UserName::default())
+                            Some(String::new())
                         } else {
                             self.uname
                         },
                         gname: if self.numeric_owner {
-                            Some(pna::GroupName::default())
+                            Some(String::new())
                         } else {
                             self.gname
                         },
@@ -1038,26 +1038,18 @@ pub(crate) fn apply_metadata(
         // Get owner info: use overrides from OwnerStrategy if Preserve, else use filesystem values
         let uid = options.uid.unwrap_or(meta.uid());
         let gid = options.gid.unwrap_or(meta.gid());
-        let uname: pna::UserName = match &options.uname {
-            None => {
-                let nss_name = User::from_uid(uid.into())?
-                    .name()
-                    .unwrap_or_default()
-                    .to_string();
-                pna::UserName::try_from(nss_name)
-                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
-            }
+        let uname = match &options.uname {
+            None => User::from_uid(uid.into())?
+                .name()
+                .unwrap_or_default()
+                .into(),
             Some(uname) => uname.clone(),
         };
-        let gname: pna::GroupName = match &options.gname {
-            None => {
-                let nss_name = Group::from_gid(gid.into())?
-                    .name()
-                    .unwrap_or_default()
-                    .to_string();
-                pna::GroupName::try_from(nss_name)
-                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
-            }
+        let gname = match &options.gname {
+            None => Group::from_gid(gid.into())?
+                .name()
+                .unwrap_or_default()
+                .into(),
             Some(gname) => gname.clone(),
         };
         entry.permission(pna::Permission::new(
@@ -1084,16 +1076,8 @@ pub(crate) fn apply_metadata(
         // Get owner info: use overrides from OwnerStrategy
         let uid = options.uid.map_or(u64::MAX, Into::into);
         let gid = options.gid.map_or(u64::MAX, Into::into);
-        let uname: pna::UserName = match options.uname.clone() {
-            Some(uname) => uname,
-            None => pna::UserName::try_from(user.name)
-                .expect("Windows AD/SAM contracts limit usernames well within 255 bytes"),
-        };
-        let gname: pna::GroupName = match options.gname.clone() {
-            Some(gname) => gname,
-            None => pna::GroupName::try_from(group.name)
-                .expect("Windows AD/SAM contracts limit group names well within 255 bytes"),
-        };
+        let uname = options.uname.clone().unwrap_or(user.name);
+        let gname = options.gname.clone().unwrap_or(group.name);
         entry.permission(pna::Permission::new(uid, uname, gid, gname, mode));
     }
     // On macOS, when mac_metadata_strategy is Always, AppleDouble packing via copyfile()
@@ -2100,19 +2084,11 @@ fn transform_normal_entry(
         if (uid.is_some() || gid.is_some() || uname.is_some() || gname.is_some())
             && let Some(perm) = metadata.permission()
         {
-            let resolved_uname: pna::UserName = uname.clone().unwrap_or_else(|| {
-                pna::UserName::try_from(perm.uname())
-                    .expect("perm's uname is already bounded by UserName invariant")
-            });
-            let resolved_gname: pna::GroupName = gname.clone().unwrap_or_else(|| {
-                pna::GroupName::try_from(perm.gname())
-                    .expect("perm's gname is already bounded by GroupName invariant")
-            });
             let new_perm = pna::Permission::new(
                 uid.map(u64::from).unwrap_or_else(|| perm.uid()),
-                resolved_uname,
+                uname.clone().unwrap_or_else(|| perm.uname().to_string()),
                 gid.map(u64::from).unwrap_or_else(|| perm.gid()),
-                resolved_gname,
+                gname.clone().unwrap_or_else(|| perm.gname().to_string()),
                 perm.permissions(),
             );
             metadata = metadata.with_permission(Some(new_perm));

--- a/cli/src/command/core/mtree.rs
+++ b/cli/src/command/core/mtree.rs
@@ -461,7 +461,7 @@ fn apply_mtree_metadata(
         let uid = resolve_id(nochange, options.uid, mtree_entry.uid(), fs_metadata.uid());
         let gid = resolve_id(nochange, options.gid, mtree_entry.gid(), fs_metadata.gid());
 
-        let uname: pna::UserName = resolve_name(
+        let uname = resolve_name(
             nochange,
             options.uname.as_ref(),
             mtree_entry.uname(),
@@ -470,8 +470,8 @@ fn apply_mtree_metadata(
                     .ok()
                     .and_then(|u| u.name().map(String::from))
             },
-        )?;
-        let gname: pna::GroupName = resolve_name(
+        );
+        let gname = resolve_name(
             nochange,
             options.gname.as_ref(),
             mtree_entry.gname(),
@@ -480,7 +480,7 @@ fn apply_mtree_metadata(
                     .ok()
                     .and_then(|g| g.name().map(String::from))
             },
-        )?;
+        );
 
         entry.permission(pna::Permission::new(
             uid.into(),
@@ -506,25 +506,22 @@ fn resolve_id(nochange: bool, override_id: Option<u32>, mtree_id: Option<u32>, f
 
 /// Resolves a name (uname or gname) with nochange, override, and mtree handling.
 #[cfg(unix)]
-fn resolve_name<N, F>(
+fn resolve_name<F>(
     nochange: bool,
-    override_name: Option<&N>,
+    override_name: Option<&String>,
     mtree_name: Option<&[u8]>,
     lookup_from_id: F,
-) -> io::Result<N>
+) -> String
 where
-    N: Clone + TryFrom<String, Error = pna::LengthExceeded>,
     F: FnOnce() -> Option<String>,
 {
     if let Some(name) = override_name {
-        return Ok(name.clone());
+        return name.clone();
     }
     if !nochange && let Some(name) = mtree_name {
-        let raw = String::from_utf8_lossy(name).into_owned();
-        return N::try_from(raw).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e));
+        return String::from_utf8_lossy(name).into_owned();
     }
-    let raw = lookup_from_id().unwrap_or_default();
-    N::try_from(raw).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+    lookup_from_id().unwrap_or_default()
 }
 
 /// Applies metadata from mtree entry only (no filesystem metadata available).
@@ -548,10 +545,8 @@ fn apply_mtree_metadata_without_fs(
             .map(|m| u32::from(m) as u16)
             .unwrap_or(0o755);
 
-        let uname: pna::UserName =
-            resolve_name(false, options.uname.as_ref(), mtree_entry.uname(), || None)?;
-        let gname: pna::GroupName =
-            resolve_name(false, options.gname.as_ref(), mtree_entry.gname(), || None)?;
+        let uname = resolve_name(false, options.uname.as_ref(), mtree_entry.uname(), || None);
+        let gname = resolve_name(false, options.gname.as_ref(), mtree_entry.gname(), || None);
 
         entry.permission(pna::Permission::new(
             uid.into(),

--- a/cli/src/command/core/permission.rs
+++ b/cli/src/command/core/permission.rs
@@ -3,8 +3,8 @@
 /// During extraction: Override values restored from archive (None = use archive)
 #[derive(Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub(crate) struct OwnerOptions {
-    pub(crate) uname: Option<pna::UserName>,
-    pub(crate) gname: Option<pna::GroupName>,
+    pub(crate) uname: Option<String>,
+    pub(crate) gname: Option<String>,
     pub(crate) uid: Option<u32>,
     pub(crate) gid: Option<u32>,
 }

--- a/cli/src/command/create.rs
+++ b/cli/src/command/create.rs
@@ -16,12 +16,7 @@ use crate::{
             read_paths, read_paths_stdin, spawn_entry_results, write_split_archive,
         },
     },
-    utils::{
-        self, VCS_FILES,
-        cli_parsers::{parse_gname, parse_uname},
-        fmt::DurationDisplay,
-        fs::HardlinkResolver,
-    },
+    utils::{self, VCS_FILES, fmt::DurationDisplay, fs::HardlinkResolver},
 };
 use anyhow::ensure;
 use bytesize::ByteSize;
@@ -169,20 +164,10 @@ pub(crate) struct CreateCommand {
         help = "Compress multiple files together for better compression ratio"
     )]
     solid: bool,
-    #[arg(
-        long,
-        value_name = "NAME",
-        value_parser = parse_uname,
-        help = "Set user name for archive entries"
-    )]
-    uname: Option<pna::UserName>,
-    #[arg(
-        long,
-        value_name = "NAME",
-        value_parser = parse_gname,
-        help = "Set group name for archive entries"
-    )]
-    gname: Option<pna::GroupName>,
+    #[arg(long, value_name = "NAME", help = "Set user name for archive entries")]
+    uname: Option<String>,
+    #[arg(long, value_name = "NAME", help = "Set group name for archive entries")]
+    gname: Option<String>,
     #[arg(
         long,
         value_name = "ID",

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -20,7 +20,6 @@ use crate::{
     },
     utils::{
         self, BsdGlobMatcher, PathWithCwd, VCS_FILES,
-        cli_parsers::{parse_gname, parse_uname},
         fmt::DurationDisplay,
         fs::{Group, User},
     },
@@ -184,20 +183,10 @@ pub(crate) struct ExtractCommand {
         help = "Do not restore ACLs. This is the inverse option of --keep-acl"
     )]
     no_keep_acl: bool,
-    #[arg(
-        long,
-        value_name = "NAME",
-        value_parser = parse_uname,
-        help = "Restore user from given name"
-    )]
-    uname: Option<pna::UserName>,
-    #[arg(
-        long,
-        value_name = "NAME",
-        value_parser = parse_gname,
-        help = "Restore group from given name"
-    )]
-    gname: Option<pna::GroupName>,
+    #[arg(long, value_name = "NAME", help = "Restore user from given name")]
+    uname: Option<String>,
+    #[arg(long, value_name = "NAME", help = "Restore group from given name")]
+    gname: Option<String>,
     #[arg(
         long,
         value_name = "ID",

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -18,12 +18,7 @@ use crate::{
             read_paths, read_paths_stdin,
         },
     },
-    utils::{
-        PathPartExt, VCS_FILES,
-        cli_parsers::{parse_gname, parse_uname},
-        env::NamedTempFile,
-        fs::HardlinkResolver,
-    },
+    utils::{PathPartExt, VCS_FILES, env::NamedTempFile, fs::HardlinkResolver},
 };
 use clap::{ArgGroup, Parser, ValueHint};
 use indexmap::IndexMap;
@@ -146,20 +141,10 @@ pub(crate) struct UpdateCommand {
         help = "Do not archive ACLs. This is the inverse option of --keep-acl"
     )]
     no_keep_acl: bool,
-    #[arg(
-        long,
-        value_name = "NAME",
-        value_parser = parse_uname,
-        help = "Set user name for archive entries"
-    )]
-    uname: Option<pna::UserName>,
-    #[arg(
-        long,
-        value_name = "NAME",
-        value_parser = parse_gname,
-        help = "Set group name for archive entries"
-    )]
-    gname: Option<pna::GroupName>,
+    #[arg(long, value_name = "NAME", help = "Set user name for archive entries")]
+    uname: Option<String>,
+    #[arg(long, value_name = "NAME", help = "Set group name for archive entries")]
+    gname: Option<String>,
     #[arg(
         long,
         value_name = "ID",

--- a/cli/src/utils/cli_parsers.rs
+++ b/cli/src/utils/cli_parsers.rs
@@ -1,16 +1,6 @@
-//! Clap value parsers that validate CLI strings against PNA's bounded
-//! identifier types so out-of-range input is rejected by the argument parser
-//! before reaching the rest of the program.
-
-#[inline]
-pub(crate) fn parse_uname(s: &str) -> Result<pna::UserName, pna::LengthExceeded> {
-    pna::UserName::try_from(s)
-}
-
-#[inline]
-pub(crate) fn parse_gname(s: &str) -> Result<pna::GroupName, pna::LengthExceeded> {
-    pna::GroupName::try_from(s)
-}
+//! Clap value parser that validates the CLI extended-attribute name against
+//! PNA's bounded `XattrName` type so an over-long name is rejected by the
+//! argument parser before reaching the rest of the program.
 
 #[inline]
 pub(crate) fn parse_xattr_name(s: &str) -> Result<pna::XattrName, pna::LengthExceeded> {

--- a/cli/tests/cli/list/trailing_slash.rs
+++ b/cli/tests/cli/list/trailing_slash.rs
@@ -1,8 +1,6 @@
 use crate::utils::setup;
 use assert_cmd::cargo::cargo_bin_cmd;
-use pna::{
-    Archive, Duration, EntryBuilder, EntryName, GroupName, Permission, UserName, WriteOptions,
-};
+use pna::{Archive, Duration, EntryBuilder, EntryName, Permission, WriteOptions};
 use std::{fs, io::Write, path::Path};
 
 fn create_archive_with_trailing_slash_dir(path: &str) {
@@ -16,9 +14,9 @@ fn create_archive_with_trailing_slash_dir(path: &str) {
     let mut dir_builder = EntryBuilder::new_dir(EntryName::from_utf8_preserve_root("dir/"));
     dir_builder.modified(mtime).permission(Permission::new(
         0,
-        UserName::try_from("root").unwrap(),
+        "root".into(),
         0,
-        GroupName::try_from("root").unwrap(),
+        "root".into(),
         0o755,
     ));
     archive.add_entry(dir_builder.build().unwrap()).unwrap();
@@ -30,9 +28,9 @@ fn create_archive_with_trailing_slash_dir(path: &str) {
     .unwrap();
     file_builder.modified(mtime).permission(Permission::new(
         0,
-        UserName::try_from("root").unwrap(),
+        "root".into(),
         0,
-        GroupName::try_from("root").unwrap(),
+        "root".into(),
         0o644,
     ));
     file_builder.write_all(b"hello").unwrap();

--- a/cli/tests/cli/utils/archive.rs
+++ b/cli/tests/cli/utils/archive.rs
@@ -36,9 +36,9 @@ pub fn create_archive_with_permissions(
             pna::EntryBuilder::new_file(entry_def.path.into(), pna::WriteOptions::store())?;
         builder.permission(pna::Permission::new(
             1000,
-            pna::UserName::try_from("user").unwrap(),
+            "user".into(),
             1000,
-            pna::GroupName::try_from("group").unwrap(),
+            "group".into(),
             entry_def.permission,
         ));
         builder.write_all(entry_def.content)?;
@@ -64,9 +64,9 @@ pub fn create_solid_archive_with_permissions(
             pna::EntryBuilder::new_file(entry_def.path.into(), pna::WriteOptions::store())?;
         builder.permission(pna::Permission::new(
             1000,
-            pna::UserName::try_from("user").unwrap(),
+            "user".into(),
             1000,
-            pna::GroupName::try_from("group").unwrap(),
+            "group".into(),
             entry_def.permission,
         ));
         builder.write_all(entry_def.content)?;
@@ -100,9 +100,9 @@ pub fn create_encrypted_archive_with_permissions(
             pna::EntryBuilder::new_file(entry_def.path.into(), write_options.clone())?;
         builder.permission(pna::Permission::new(
             1000,
-            pna::UserName::try_from("user").unwrap(),
+            "user".into(),
             1000,
-            pna::GroupName::try_from("group").unwrap(),
+            "group".into(),
             entry_def.permission,
         ));
         builder.write_all(entry_def.content)?;
@@ -211,9 +211,9 @@ pub fn create_archive_with_symlinks(
             pna::EntryBuilder::new_file(entry_def.path.into(), pna::WriteOptions::store())?;
         builder.permission(pna::Permission::new(
             1000,
-            pna::UserName::try_from("user").unwrap(),
+            "user".into(),
             1000,
-            pna::GroupName::try_from("group").unwrap(),
+            "group".into(),
             entry_def.permission,
         ));
         builder.write_all(entry_def.content)?;
@@ -228,9 +228,9 @@ pub fn create_archive_with_symlinks(
         if let Some(mode) = symlink_def.permission {
             builder.permission(pna::Permission::new(
                 1000,
-                pna::UserName::try_from("user").unwrap(),
+                "user".into(),
                 1000,
-                pna::GroupName::try_from("group").unwrap(),
+                "group".into(),
                 mode,
             ));
         }

--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -514,13 +514,7 @@ mod tests {
             builder.created(Duration::seconds(31));
             builder.modified(Duration::seconds(32));
             builder.accessed(Duration::seconds(33));
-            builder.permission(Permission::new(
-                1,
-                UserName::try_from("uname").unwrap(),
-                2,
-                GroupName::try_from("gname").unwrap(),
-                0o775,
-            ));
+            builder.permission(Permission::new(1, "uname".into(), 2, "gname".into(), 0o775));
             builder.write_all(b"entry data").unwrap();
             builder.build().unwrap()
         };

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -1,139 +1,7 @@
 //! Metadata and permission types for archive entries.
 
-use crate::{
-    Duration, UnknownValueError,
-    util::bounded::{LengthExceeded, str::BoundedString},
-};
-use std::{
-    io::{self, Read},
-    ops::Deref,
-};
-
-/// User name identifier for an archive entry.
-///
-/// Bounded to 255 bytes to fit the `u8` length prefix used in the `fPRM`
-/// chunk's serialized form.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
-#[repr(transparent)]
-pub struct UserName(BoundedString<255>);
-
-impl UserName {
-    /// Constructs a [`UserName`], rejecting inputs whose byte length exceeds
-    /// 255.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`LengthExceeded`] when the input's byte length is greater than
-    /// 255.
-    #[inline]
-    pub fn new(value: impl Into<Box<str>>) -> Result<Self, LengthExceeded> {
-        BoundedString::new(value).map(Self)
-    }
-
-    /// Returns the user name as a string slice.
-    #[inline]
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
-    }
-}
-
-impl Deref for UserName {
-    type Target = str;
-
-    #[inline]
-    fn deref(&self) -> &str {
-        self.0.as_str()
-    }
-}
-
-impl TryFrom<String> for UserName {
-    type Error = LengthExceeded;
-
-    #[inline]
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        Self::new(value)
-    }
-}
-
-impl TryFrom<&str> for UserName {
-    type Error = LengthExceeded;
-
-    #[inline]
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        Self::new(value)
-    }
-}
-
-impl From<UserName> for String {
-    #[inline]
-    fn from(value: UserName) -> Self {
-        value.0.into()
-    }
-}
-
-/// Group name identifier for an archive entry.
-///
-/// Bounded to 255 bytes to fit the `u8` length prefix used in the `fPRM`
-/// chunk's serialized form.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
-#[repr(transparent)]
-pub struct GroupName(BoundedString<255>);
-
-impl GroupName {
-    /// Constructs a [`GroupName`], rejecting inputs whose byte length exceeds
-    /// 255.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`LengthExceeded`] when the input's byte length is greater than
-    /// 255.
-    #[inline]
-    pub fn new(value: impl Into<Box<str>>) -> Result<Self, LengthExceeded> {
-        BoundedString::new(value).map(Self)
-    }
-
-    /// Returns the group name as a string slice.
-    #[inline]
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
-    }
-}
-
-impl Deref for GroupName {
-    type Target = str;
-
-    #[inline]
-    fn deref(&self) -> &str {
-        self.0.as_str()
-    }
-}
-
-impl TryFrom<String> for GroupName {
-    type Error = LengthExceeded;
-
-    #[inline]
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        Self::new(value)
-    }
-}
-
-impl TryFrom<&str> for GroupName {
-    type Error = LengthExceeded;
-
-    #[inline]
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        Self::new(value)
-    }
-}
-
-impl From<GroupName> for String {
-    #[inline]
-    fn from(value: GroupName) -> Self {
-        value.0.into()
-    }
-}
+use crate::{Duration, UnknownValueError};
+use std::io::{self, Read};
 
 /// Metadata information about an entry.
 /// # Examples
@@ -301,9 +169,9 @@ impl Default for Metadata {
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Permission {
     uid: u64,
-    uname: UserName,
+    uname: String,
     gid: u64,
-    gname: GroupName,
+    gname: String,
     permission: u16,
 }
 
@@ -311,30 +179,17 @@ impl Permission {
     /// Creates a new [`Permission`] with the given user, group, and permission bits.
     ///
     /// The `uid`/`gid` are numeric POSIX IDs, `uname`/`gname` are the
-    /// corresponding names (each bounded to 255 bytes by [`UserName`] and
-    /// [`GroupName`]), and `permission` holds the file mode bits (e.g. `0o755`).
+    /// corresponding names, and `permission` holds the file mode bits (e.g. `0o755`).
     ///
     /// # Examples
     ///
     /// ```
-    /// use libpna::{Permission, UserName, GroupName};
+    /// use libpna::Permission;
     ///
-    /// let perm = Permission::new(
-    ///     1000,
-    ///     UserName::try_from("user").unwrap(),
-    ///     100,
-    ///     GroupName::try_from("group").unwrap(),
-    ///     0o755,
-    /// );
+    /// let perm = Permission::new(1000, "user".into(), 100, "group".into(), 0o755);
     /// ```
     #[inline]
-    pub const fn new(
-        uid: u64,
-        uname: UserName,
-        gid: u64,
-        gname: GroupName,
-        permission: u16,
-    ) -> Self {
+    pub const fn new(uid: u64, uname: String, gid: u64, gname: String, permission: u16) -> Self {
         Self {
             uid,
             uname,
@@ -348,15 +203,9 @@ impl Permission {
     /// # Examples
     ///
     /// ```
-    /// use libpna::{Permission, UserName, GroupName};
+    /// use libpna::Permission;
     ///
-    /// let perm = Permission::new(
-    ///     1000,
-    ///     UserName::try_from("user1").unwrap(),
-    ///     100,
-    ///     GroupName::try_from("group1").unwrap(),
-    ///     0o644,
-    /// );
+    /// let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
     /// assert_eq!(perm.uid(), 1000);
     /// ```
     #[inline]
@@ -369,20 +218,14 @@ impl Permission {
     /// # Examples
     ///
     /// ```
-    /// use libpna::{Permission, UserName, GroupName};
+    /// use libpna::Permission;
     ///
-    /// let perm = Permission::new(
-    ///     1000,
-    ///     UserName::try_from("user1").unwrap(),
-    ///     100,
-    ///     GroupName::try_from("group1").unwrap(),
-    ///     0o644,
-    /// );
+    /// let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
     /// assert_eq!(perm.uname(), "user1");
     /// ```
     #[inline]
     pub fn uname(&self) -> &str {
-        self.uname.as_str()
+        &self.uname
     }
 
     /// Returns the group ID associated with this permission.
@@ -390,15 +233,9 @@ impl Permission {
     /// # Examples
     ///
     /// ```
-    /// use libpna::{Permission, UserName, GroupName};
+    /// use libpna::Permission;
     ///
-    /// let perm = Permission::new(
-    ///     1000,
-    ///     UserName::try_from("user1").unwrap(),
-    ///     100,
-    ///     GroupName::try_from("group1").unwrap(),
-    ///     0o644,
-    /// );
+    /// let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
     /// assert_eq!(perm.gid(), 100);
     /// ```
     #[inline]
@@ -411,20 +248,14 @@ impl Permission {
     /// # Examples
     ///
     /// ```
-    /// use libpna::{Permission, UserName, GroupName};
+    /// use libpna::Permission;
     ///
-    /// let perm = Permission::new(
-    ///     1000,
-    ///     UserName::try_from("user1").unwrap(),
-    ///     100,
-    ///     GroupName::try_from("group1").unwrap(),
-    ///     0o644,
-    /// );
+    /// let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
     /// assert_eq!(perm.gname(), "group1");
     /// ```
     #[inline]
     pub fn gname(&self) -> &str {
-        self.gname.as_str()
+        &self.gname
     }
 
     /// Returns the permission bits associated with this permission.
@@ -432,15 +263,9 @@ impl Permission {
     /// # Examples
     ///
     /// ```
-    /// use libpna::{Permission, UserName, GroupName};
+    /// use libpna::Permission;
     ///
-    /// let perm = Permission::new(
-    ///     1000,
-    ///     UserName::try_from("user1").unwrap(),
-    ///     100,
-    ///     GroupName::try_from("group1").unwrap(),
-    ///     0o644,
-    /// );
+    /// let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
     /// assert_eq!(perm.permissions(), 0o644);
     /// ```
     #[inline]
@@ -449,17 +274,13 @@ impl Permission {
     }
 
     pub(crate) fn to_bytes(&self) -> Vec<u8> {
-        let uname_bytes = self.uname.as_str().as_bytes();
-        let gname_bytes = self.gname.as_str().as_bytes();
-        let mut bytes = Vec::with_capacity(20 + uname_bytes.len() + gname_bytes.len());
+        let mut bytes = Vec::with_capacity(20 + self.uname.len() + self.gname.len());
         bytes.extend_from_slice(&self.uid.to_be_bytes());
-        // Type guarantees uname.len() <= 255 (UserName invariant).
-        bytes.extend_from_slice(&(uname_bytes.len() as u8).to_be_bytes());
-        bytes.extend_from_slice(uname_bytes);
+        bytes.extend_from_slice(&(self.uname.len() as u8).to_be_bytes());
+        bytes.extend_from_slice(self.uname.as_bytes());
         bytes.extend_from_slice(&self.gid.to_be_bytes());
-        // Type guarantees gname.len() <= 255 (GroupName invariant).
-        bytes.extend_from_slice(&(gname_bytes.len() as u8).to_be_bytes());
-        bytes.extend_from_slice(gname_bytes);
+        bytes.extend_from_slice(&(self.gname.len() as u8).to_be_bytes());
+        bytes.extend_from_slice(self.gname.as_bytes());
         bytes.extend_from_slice(&self.permission.to_be_bytes());
         bytes
     }
@@ -475,15 +296,12 @@ impl Permission {
             bytes.read_exact(&mut buf)?;
             buf[0] as usize
         };
-        let uname_string = String::from_utf8({
+        let uname = String::from_utf8({
             let mut buf = vec![0; uname_len];
             bytes.read_exact(&mut buf)?;
             buf
         })
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-        // u8 length read above already enforces UserName's 255-byte bound.
-        let uname = UserName::new(uname_string)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         let gid = u64::from_be_bytes({
             let mut buf = [0; 8];
             bytes.read_exact(&mut buf)?;
@@ -494,14 +312,12 @@ impl Permission {
             bytes.read_exact(&mut buf)?;
             buf[0] as usize
         };
-        let gname_string = String::from_utf8({
+        let gname = String::from_utf8({
             let mut buf = vec![0; gname_len];
             bytes.read_exact(&mut buf)?;
             buf
         })
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-        let gname = GroupName::new(gname_string)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         let permission = u16::from_be_bytes({
             let mut buf = [0; 2];
             bytes.read_exact(&mut buf)?;
@@ -590,13 +406,7 @@ mod tests {
 
     #[test]
     fn permission() {
-        let perm = Permission::new(
-            1000,
-            UserName::try_from("user1").unwrap(),
-            100,
-            GroupName::try_from("group1").unwrap(),
-            0o644,
-        );
+        let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
         assert_eq!(perm, Permission::try_from_bytes(&perm.to_bytes()).unwrap());
     }
 
@@ -659,37 +469,5 @@ mod tests {
             LinkTargetType::try_from_bytes(&[0x01, 0xFF, 0xFF]).unwrap(),
             Some(LinkTargetType::File),
         );
-    }
-
-    #[test]
-    fn user_name_at_boundary() {
-        let raw = "u".repeat(255);
-        let name = UserName::new(raw.clone()).unwrap();
-        assert_eq!(name.as_str(), raw);
-    }
-
-    #[test]
-    fn user_name_rejects_one_over() {
-        let raw = "u".repeat(256);
-        assert!(UserName::new(raw).is_err());
-    }
-
-    #[test]
-    fn group_name_at_boundary() {
-        let raw = "g".repeat(255);
-        let name = GroupName::new(raw.clone()).unwrap();
-        assert_eq!(name.as_str(), raw);
-    }
-
-    #[test]
-    fn group_name_rejects_one_over() {
-        let raw = "g".repeat(256);
-        assert!(GroupName::new(raw).is_err());
-    }
-
-    #[test]
-    fn user_and_group_name_default_is_empty() {
-        assert!(UserName::default().is_empty());
-        assert!(GroupName::default().is_empty());
     }
 }

--- a/lib/src/util/bounded.rs
+++ b/lib/src/util/bounded.rs
@@ -41,12 +41,12 @@ use std::{error, fmt};
 ///
 /// # Examples
 ///
-/// ```
-/// use libpna::{LengthExceeded, UserName};
+/// ```ignore
+/// use libpna::util::bounded::str::BoundedString;
 ///
-/// let err: LengthExceeded = UserName::try_from("a".repeat(256)).unwrap_err();
-/// assert_eq!(err.max(), 255);
-/// assert_eq!(err.actual(), 256);
+/// let err = BoundedString::<3>::new("hello").unwrap_err();
+/// assert_eq!(err.max(), 3);
+/// assert_eq!(err.actual(), 5);
 /// ```
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[non_exhaustive]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -373,15 +373,7 @@ fn build_permission(header: &tar::Header, path: &str) -> libpna::Permission {
             String::new()
         }
     };
-    libpna::Permission::new(
-        uid,
-        libpna::UserName::try_from(uname)
-            .expect("ustar header username field is bounded to 32 bytes by tar format spec"),
-        gid,
-        libpna::GroupName::try_from(gname)
-            .expect("ustar header groupname field is bounded to 32 bytes by tar format spec"),
-        mode,
-    )
+    libpna::Permission::new(uid, uname, gid, gname, mode)
 }
 
 fn zip2pna(args: Zip2pnaArgs) -> Result<(), Box<dyn std::error::Error>> {
@@ -489,12 +481,6 @@ fn build_zip_permission<R: Read + io::Seek>(
 ) -> Option<libpna::Permission> {
     entry.unix_mode().map(|mode| {
         let mode_bits = (mode & 0o7777) as u16;
-        libpna::Permission::new(
-            0,
-            libpna::UserName::default(),
-            0,
-            libpna::GroupName::default(),
-            mode_bits,
-        )
+        libpna::Permission::new(0, String::new(), 0, String::new(), mode_bits)
     })
 }


### PR DESCRIPTION
Permission::new and the uname()/gname() accessors take and return plain String/&str again, and fPRM serialization/deserialization is String-based. The byte-length-bounded ExtendedAttribute/xattr validation and the util::bounded module are unaffected and remain in place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated user and group name handling throughout the archive management system to accept raw string values instead of validated typed inputs. User and group name options (`--uname`, `--gname`) are now processed as plain strings, with simplified internal permission metadata storage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChanTsune/Portable-Network-Archive/pull/3064?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->