### PR TITLE
Lib/owner facet chunks

### DIFF
--- a/lib/src/chunk/types.rs
+++ b/lib/src/chunk/types.rs
@@ -146,6 +146,27 @@ impl ChunkType {
     /// Link target type.
     #[allow(non_upper_case_globals)]
     pub const fLTP: ChunkType = ChunkType(*b"fLTP");
+    /// Owner user id.
+    #[allow(non_upper_case_globals)]
+    pub const fUId: ChunkType = ChunkType(*b"fUId");
+    /// Owner group id.
+    #[allow(non_upper_case_globals)]
+    pub const fGId: ChunkType = ChunkType(*b"fGId");
+    /// Owner user name.
+    #[allow(non_upper_case_globals)]
+    pub const fONm: ChunkType = ChunkType(*b"fONm");
+    /// Owner group name.
+    #[allow(non_upper_case_globals)]
+    pub const fGNm: ChunkType = ChunkType(*b"fGNm");
+    /// Owner user SID.
+    #[allow(non_upper_case_globals)]
+    pub const fOSi: ChunkType = ChunkType(*b"fOSi");
+    /// Owner group SID.
+    #[allow(non_upper_case_globals)]
+    pub const fGSi: ChunkType = ChunkType(*b"fGSi");
+    /// POSIX permission mode.
+    #[allow(non_upper_case_globals)]
+    pub const fMOd: ChunkType = ChunkType(*b"fMOd");
 
     /// Returns the length of the chunk type code.
     ///

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -647,6 +647,8 @@ where
         let mut atime_ns = None;
         let mut permission = None;
         let mut link_target_type = None;
+        let mut owner_uid = None;
+        let mut owner_gid = None;
         for chunk in chunks {
             match chunk.ty {
                 ChunkType::FEND => break,
@@ -668,6 +670,8 @@ where
                 ChunkType::mTNS => mtime_ns = Some(nanos(chunk.data())?),
                 ChunkType::aTNS => atime_ns = Some(nanos(chunk.data())?),
                 ChunkType::fPRM => permission = Some(Permission::try_from_bytes(chunk.data())?),
+                ChunkType::fUId => owner_uid = Some(OwnerUid::try_from_bytes(chunk.data())?),
+                ChunkType::fGId => owner_gid = Some(OwnerGid::try_from_bytes(chunk.data())?),
                 ChunkType::xATR => xattrs.push(ExtendedAttribute::try_from_bytes(chunk.data())?),
                 ChunkType::fLTP => link_target_type = LinkTargetType::try_from_bytes(chunk.data())?,
                 _ => {
@@ -700,8 +704,8 @@ where
                 accessed: atime,
                 permission,
                 link_target_type,
-                owner_uid: None,
-                owner_gid: None,
+                owner_uid,
+                owner_gid,
                 owner_user_name: None,
                 owner_group_name: None,
                 owner_user_sid: None,
@@ -731,8 +735,8 @@ where
             accessed,
             permission,
             link_target_type,
-            owner_uid: _owner_uid,
-            owner_gid: _owner_gid,
+            owner_uid,
+            owner_gid,
             owner_user_name: _owner_user_name,
             owner_group_name: _owner_group_name,
             owner_user_sid: _owner_user_sid,
@@ -782,6 +786,12 @@ where
         if let Some(p) = permission {
             total += (ChunkType::fPRM, p.to_bytes()).write_chunk_in(writer)?;
         }
+        if let Some(v) = owner_uid {
+            total += (ChunkType::fUId, v.to_bytes()).write_chunk_in(writer)?;
+        }
+        if let Some(v) = owner_gid {
+            total += (ChunkType::fGId, v.to_bytes()).write_chunk_in(writer)?;
+        }
         if let Some(ltp) = link_target_type {
             total += (ChunkType::fLTP, ltp.to_bytes()).write_chunk_in(writer)?;
         }
@@ -807,8 +817,8 @@ where
             accessed,
             permission,
             link_target_type,
-            owner_uid: _owner_uid,
-            owner_gid: _owner_gid,
+            owner_uid,
+            owner_gid,
             owner_user_name: _owner_user_name,
             owner_group_name: _owner_group_name,
             owner_user_sid: _owner_user_sid,
@@ -869,6 +879,12 @@ where
         }
         if let Some(p) = permission {
             vec.push(RawChunk::from_data(ChunkType::fPRM, p.to_bytes()));
+        }
+        if let Some(v) = owner_uid {
+            vec.push(RawChunk::from_data(ChunkType::fUId, v.to_bytes().to_vec()));
+        }
+        if let Some(v) = owner_gid {
+            vec.push(RawChunk::from_data(ChunkType::fGId, v.to_bytes().to_vec()));
         }
         if let Some(ltp) = link_target_type {
             vec.push(RawChunk::from_data(ChunkType::fLTP, ltp.to_bytes()));

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -700,6 +700,13 @@ where
                 accessed: atime,
                 permission,
                 link_target_type,
+                owner_uid: None,
+                owner_gid: None,
+                owner_user_name: None,
+                owner_group_name: None,
+                owner_user_sid: None,
+                owner_group_sid: None,
+                permission_mode: None,
             },
             data,
             xattrs,
@@ -724,6 +731,13 @@ where
             accessed,
             permission,
             link_target_type,
+            owner_uid: _owner_uid,
+            owner_gid: _owner_gid,
+            owner_user_name: _owner_user_name,
+            owner_group_name: _owner_group_name,
+            owner_user_sid: _owner_user_sid,
+            owner_group_sid: _owner_group_sid,
+            permission_mode: _permission_mode,
         } = &self.metadata;
 
         total += (ChunkType::FHED, self.header.to_bytes()).write_chunk_in(writer)?;
@@ -793,6 +807,13 @@ where
             accessed,
             permission,
             link_target_type,
+            owner_uid: _owner_uid,
+            owner_gid: _owner_gid,
+            owner_user_name: _owner_user_name,
+            owner_group_name: _owner_group_name,
+            owner_user_sid: _owner_user_sid,
+            owner_group_sid: _owner_group_sid,
+            permission_mode: _permission_mode,
         } = self.metadata;
         let mut vec = Vec::new();
         vec.push(RawChunk::from_data(ChunkType::FHED, self.header.to_bytes()));

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -651,6 +651,8 @@ where
         let mut owner_gid = None;
         let mut owner_user_name = None;
         let mut owner_group_name = None;
+        let mut owner_user_sid = None;
+        let mut owner_group_sid = None;
         for chunk in chunks {
             match chunk.ty {
                 ChunkType::FEND => break,
@@ -679,6 +681,12 @@ where
                 }
                 ChunkType::fGNm => {
                     owner_group_name = Some(OwnerGroupName::try_from_bytes(chunk.data())?)
+                }
+                ChunkType::fOSi => {
+                    owner_user_sid = Some(OwnerUserSid::try_from_bytes(chunk.data())?)
+                }
+                ChunkType::fGSi => {
+                    owner_group_sid = Some(OwnerGroupSid::try_from_bytes(chunk.data())?)
                 }
                 ChunkType::xATR => xattrs.push(ExtendedAttribute::try_from_bytes(chunk.data())?),
                 ChunkType::fLTP => link_target_type = LinkTargetType::try_from_bytes(chunk.data())?,
@@ -716,8 +724,8 @@ where
                 owner_gid,
                 owner_user_name,
                 owner_group_name,
-                owner_user_sid: None,
-                owner_group_sid: None,
+                owner_user_sid,
+                owner_group_sid,
                 permission_mode: None,
             },
             data,
@@ -747,8 +755,8 @@ where
             owner_gid,
             owner_user_name,
             owner_group_name,
-            owner_user_sid: _owner_user_sid,
-            owner_group_sid: _owner_group_sid,
+            owner_user_sid,
+            owner_group_sid,
             permission_mode: _permission_mode,
         } = &self.metadata;
 
@@ -806,6 +814,12 @@ where
         if let Some(v) = owner_group_name {
             total += (ChunkType::fGNm, v.to_bytes()).write_chunk_in(writer)?;
         }
+        if let Some(v) = owner_user_sid {
+            total += (ChunkType::fOSi, v.to_bytes()).write_chunk_in(writer)?;
+        }
+        if let Some(v) = owner_group_sid {
+            total += (ChunkType::fGSi, v.to_bytes()).write_chunk_in(writer)?;
+        }
         if let Some(ltp) = link_target_type {
             total += (ChunkType::fLTP, ltp.to_bytes()).write_chunk_in(writer)?;
         }
@@ -835,8 +849,8 @@ where
             owner_gid,
             owner_user_name,
             owner_group_name,
-            owner_user_sid: _owner_user_sid,
-            owner_group_sid: _owner_group_sid,
+            owner_user_sid,
+            owner_group_sid,
             permission_mode: _permission_mode,
         } = self.metadata;
         let mut vec = Vec::new();
@@ -905,6 +919,12 @@ where
         }
         if let Some(v) = owner_group_name {
             vec.push(RawChunk::from_data(ChunkType::fGNm, v.to_bytes()));
+        }
+        if let Some(v) = owner_user_sid {
+            vec.push(RawChunk::from_data(ChunkType::fOSi, v.to_bytes()));
+        }
+        if let Some(v) = owner_group_sid {
+            vec.push(RawChunk::from_data(ChunkType::fGSi, v.to_bytes()));
         }
         if let Some(ltp) = link_target_type {
             vec.push(RawChunk::from_data(ChunkType::fLTP, ltp.to_bytes()));

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -881,10 +881,10 @@ where
             vec.push(RawChunk::from_data(ChunkType::fPRM, p.to_bytes()));
         }
         if let Some(v) = owner_uid {
-            vec.push(RawChunk::from_data(ChunkType::fUId, v.to_bytes().to_vec()));
+            vec.push(RawChunk::from_data(ChunkType::fUId, v.to_bytes()));
         }
         if let Some(v) = owner_gid {
-            vec.push(RawChunk::from_data(ChunkType::fGId, v.to_bytes().to_vec()));
+            vec.push(RawChunk::from_data(ChunkType::fGId, v.to_bytes()));
         }
         if let Some(ltp) = link_target_type {
             vec.push(RawChunk::from_data(ChunkType::fLTP, ltp.to_bytes()));

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -649,6 +649,8 @@ where
         let mut link_target_type = None;
         let mut owner_uid = None;
         let mut owner_gid = None;
+        let mut owner_user_name = None;
+        let mut owner_group_name = None;
         for chunk in chunks {
             match chunk.ty {
                 ChunkType::FEND => break,
@@ -672,6 +674,12 @@ where
                 ChunkType::fPRM => permission = Some(Permission::try_from_bytes(chunk.data())?),
                 ChunkType::fUId => owner_uid = Some(OwnerUid::try_from_bytes(chunk.data())?),
                 ChunkType::fGId => owner_gid = Some(OwnerGid::try_from_bytes(chunk.data())?),
+                ChunkType::fONm => {
+                    owner_user_name = Some(OwnerUserName::try_from_bytes(chunk.data())?)
+                }
+                ChunkType::fGNm => {
+                    owner_group_name = Some(OwnerGroupName::try_from_bytes(chunk.data())?)
+                }
                 ChunkType::xATR => xattrs.push(ExtendedAttribute::try_from_bytes(chunk.data())?),
                 ChunkType::fLTP => link_target_type = LinkTargetType::try_from_bytes(chunk.data())?,
                 _ => {
@@ -706,8 +714,8 @@ where
                 link_target_type,
                 owner_uid,
                 owner_gid,
-                owner_user_name: None,
-                owner_group_name: None,
+                owner_user_name,
+                owner_group_name,
                 owner_user_sid: None,
                 owner_group_sid: None,
                 permission_mode: None,
@@ -737,8 +745,8 @@ where
             link_target_type,
             owner_uid,
             owner_gid,
-            owner_user_name: _owner_user_name,
-            owner_group_name: _owner_group_name,
+            owner_user_name,
+            owner_group_name,
             owner_user_sid: _owner_user_sid,
             owner_group_sid: _owner_group_sid,
             permission_mode: _permission_mode,
@@ -792,6 +800,12 @@ where
         if let Some(v) = owner_gid {
             total += (ChunkType::fGId, v.to_bytes()).write_chunk_in(writer)?;
         }
+        if let Some(v) = owner_user_name {
+            total += (ChunkType::fONm, v.to_bytes()).write_chunk_in(writer)?;
+        }
+        if let Some(v) = owner_group_name {
+            total += (ChunkType::fGNm, v.to_bytes()).write_chunk_in(writer)?;
+        }
         if let Some(ltp) = link_target_type {
             total += (ChunkType::fLTP, ltp.to_bytes()).write_chunk_in(writer)?;
         }
@@ -819,8 +833,8 @@ where
             link_target_type,
             owner_uid,
             owner_gid,
-            owner_user_name: _owner_user_name,
-            owner_group_name: _owner_group_name,
+            owner_user_name,
+            owner_group_name,
             owner_user_sid: _owner_user_sid,
             owner_group_sid: _owner_group_sid,
             permission_mode: _permission_mode,
@@ -885,6 +899,12 @@ where
         }
         if let Some(v) = owner_gid {
             vec.push(RawChunk::from_data(ChunkType::fGId, v.to_bytes()));
+        }
+        if let Some(v) = owner_user_name {
+            vec.push(RawChunk::from_data(ChunkType::fONm, v.to_bytes()));
+        }
+        if let Some(v) = owner_group_name {
+            vec.push(RawChunk::from_data(ChunkType::fGNm, v.to_bytes()));
         }
         if let Some(ltp) = link_target_type {
             vec.push(RawChunk::from_data(ChunkType::fLTP, ltp.to_bytes()));

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -653,6 +653,7 @@ where
         let mut owner_group_name = None;
         let mut owner_user_sid = None;
         let mut owner_group_sid = None;
+        let mut permission_mode = None;
         for chunk in chunks {
             match chunk.ty {
                 ChunkType::FEND => break,
@@ -687,6 +688,9 @@ where
                 }
                 ChunkType::fGSi => {
                     owner_group_sid = Some(OwnerGroupSid::try_from_bytes(chunk.data())?)
+                }
+                ChunkType::fMOd => {
+                    permission_mode = Some(PermissionMode::try_from_bytes(chunk.data())?)
                 }
                 ChunkType::xATR => xattrs.push(ExtendedAttribute::try_from_bytes(chunk.data())?),
                 ChunkType::fLTP => link_target_type = LinkTargetType::try_from_bytes(chunk.data())?,
@@ -726,7 +730,7 @@ where
                 owner_group_name,
                 owner_user_sid,
                 owner_group_sid,
-                permission_mode: None,
+                permission_mode,
             },
             data,
             xattrs,
@@ -757,7 +761,7 @@ where
             owner_group_name,
             owner_user_sid,
             owner_group_sid,
-            permission_mode: _permission_mode,
+            permission_mode,
         } = &self.metadata;
 
         total += (ChunkType::FHED, self.header.to_bytes()).write_chunk_in(writer)?;
@@ -820,6 +824,9 @@ where
         if let Some(v) = owner_group_sid {
             total += (ChunkType::fGSi, v.to_bytes()).write_chunk_in(writer)?;
         }
+        if let Some(v) = permission_mode {
+            total += (ChunkType::fMOd, v.to_bytes()).write_chunk_in(writer)?;
+        }
         if let Some(ltp) = link_target_type {
             total += (ChunkType::fLTP, ltp.to_bytes()).write_chunk_in(writer)?;
         }
@@ -851,7 +858,7 @@ where
             owner_group_name,
             owner_user_sid,
             owner_group_sid,
-            permission_mode: _permission_mode,
+            permission_mode,
         } = self.metadata;
         let mut vec = Vec::new();
         vec.push(RawChunk::from_data(ChunkType::FHED, self.header.to_bytes()));
@@ -925,6 +932,9 @@ where
         }
         if let Some(v) = owner_group_sid {
             vec.push(RawChunk::from_data(ChunkType::fGSi, v.to_bytes()));
+        }
+        if let Some(v) = permission_mode {
+            vec.push(RawChunk::from_data(ChunkType::fMOd, v.to_bytes()));
         }
         if let Some(ltp) = link_target_type {
             vec.push(RawChunk::from_data(ChunkType::fLTP, ltp.to_bytes()));

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -8,8 +8,9 @@ use crate::{
     compress::CompressionWriter,
     entry::{
         DataKind, Entry, EntryHeader, EntryName, EntryReference, ExtendedAttribute, LinkTargetType,
-        Metadata, NormalEntry, Permission, SolidEntry, SolidHeader, WriteCipher, WriteOption,
-        WriteOptions, get_writer, get_writer_context, private::SealedEntryExt,
+        Metadata, NormalEntry, OwnerGid, OwnerGroupName, OwnerGroupSid, OwnerUid, OwnerUserName,
+        OwnerUserSid, Permission, PermissionMode, SolidEntry, SolidHeader, WriteCipher,
+        WriteOption, WriteOptions, get_writer, get_writer_context, private::SealedEntryExt,
     },
     io::{FlattenWriter, TryIntoInner},
 };
@@ -148,6 +149,13 @@ pub struct EntryBuilder {
     last_modified: Option<Duration>,
     accessed: Option<Duration>,
     permission: Option<Permission>,
+    owner_uid: Option<OwnerUid>,
+    owner_gid: Option<OwnerGid>,
+    owner_user_name: Option<OwnerUserName>,
+    owner_group_name: Option<OwnerGroupName>,
+    owner_user_sid: Option<OwnerUserSid>,
+    owner_group_sid: Option<OwnerGroupSid>,
+    permission_mode: Option<PermissionMode>,
     link_target_type: Option<LinkTargetType>,
     store_file_size: bool,
     file_size: u128,
@@ -166,6 +174,13 @@ impl EntryBuilder {
             last_modified: None,
             accessed: None,
             permission: None,
+            owner_uid: None,
+            owner_gid: None,
+            owner_user_name: None,
+            owner_group_name: None,
+            owner_user_sid: None,
+            owner_group_sid: None,
+            permission_mode: None,
             link_target_type: None,
             store_file_size: true,
             file_size: 0,
@@ -297,6 +312,49 @@ impl EntryBuilder {
         self
     }
 
+    /// Sets the owner user id facet (`fUId`).
+    #[inline]
+    pub fn owner_uid(&mut self, value: impl Into<Option<OwnerUid>>) -> &mut Self {
+        self.owner_uid = value.into();
+        self
+    }
+    /// Sets the owner group id facet (`fGId`).
+    #[inline]
+    pub fn owner_gid(&mut self, value: impl Into<Option<OwnerGid>>) -> &mut Self {
+        self.owner_gid = value.into();
+        self
+    }
+    /// Sets the owner user name facet (`fONm`).
+    #[inline]
+    pub fn owner_user_name(&mut self, value: impl Into<Option<OwnerUserName>>) -> &mut Self {
+        self.owner_user_name = value.into();
+        self
+    }
+    /// Sets the owner group name facet (`fGNm`).
+    #[inline]
+    pub fn owner_group_name(&mut self, value: impl Into<Option<OwnerGroupName>>) -> &mut Self {
+        self.owner_group_name = value.into();
+        self
+    }
+    /// Sets the owner user SID facet (`fOSi`).
+    #[inline]
+    pub fn owner_user_sid(&mut self, value: impl Into<Option<OwnerUserSid>>) -> &mut Self {
+        self.owner_user_sid = value.into();
+        self
+    }
+    /// Sets the owner group SID facet (`fGSi`).
+    #[inline]
+    pub fn owner_group_sid(&mut self, value: impl Into<Option<OwnerGroupSid>>) -> &mut Self {
+        self.owner_group_sid = value.into();
+        self
+    }
+    /// Sets the POSIX permission mode facet (`fMOd`).
+    #[inline]
+    pub fn permission_mode(&mut self, value: impl Into<Option<PermissionMode>>) -> &mut Self {
+        self.permission_mode = value.into();
+        self
+    }
+
     /// Sets the link target type for link entries.
     ///
     /// Combined with [`DataKind`](crate::DataKind), this determines the link type:
@@ -392,6 +450,13 @@ impl EntryBuilder {
             accessed: self.accessed,
             permission: self.permission,
             link_target_type: self.link_target_type,
+            owner_uid: self.owner_uid,
+            owner_gid: self.owner_gid,
+            owner_user_name: self.owner_user_name,
+            owner_group_name: self.owner_group_name,
+            owner_user_sid: self.owner_user_sid,
+            owner_group_sid: self.owner_group_sid,
+            permission_mode: self.permission_mode,
         };
         Ok(NormalEntry {
             header: self.header,

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -971,6 +971,55 @@ mod tests {
     }
 
     #[test]
+    fn owner_sid_facets_round_trip_via_entry() {
+        use crate::entry::{OwnerGroupSid, OwnerUserSid};
+        use crate::{Archive, EntryBuilder, WriteOptions};
+        let mut buf = Vec::new();
+        {
+            let mut archive = Archive::write_header(&mut buf).unwrap();
+            let mut b = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
+            b.owner_user_sid(OwnerUserSid::new("S-1-5-21-1-2-3-1001").unwrap());
+            b.owner_group_sid(OwnerGroupSid::new("S-1-5-32-544").unwrap());
+            let entry = b.build().unwrap();
+            archive.add_entry(entry).unwrap();
+            archive.finalize().unwrap();
+        }
+        let mut archive = Archive::read_header(&buf[..]).unwrap();
+        let entry = archive.entries().skip_solid().next().unwrap().unwrap();
+        let m = entry.metadata();
+        assert_eq!(
+            m.owner_user_sid().map(|v| v.as_str()),
+            Some("S-1-5-21-1-2-3-1001")
+        );
+        assert_eq!(
+            m.owner_group_sid().map(|v| v.as_str()),
+            Some("S-1-5-32-544")
+        );
+    }
+
+    #[test]
+    fn fosi_length_prefixed_round_trip_and_empty() {
+        use crate::entry::{OwnerGroupSid, OwnerUserSid};
+        use crate::{Archive, EntryBuilder, WriteOptions};
+        let mut buf = Vec::new();
+        {
+            let mut a = Archive::write_header(&mut buf).unwrap();
+            let mut b = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
+            b.owner_user_sid(OwnerUserSid::new("S-1-5-21-1-2-3-1001").unwrap());
+            b.owner_group_sid(OwnerGroupSid::new("").unwrap()); // empty -> [0] -> Some("")
+            a.add_entry(b.build().unwrap()).unwrap();
+            a.finalize().unwrap();
+        }
+        let mut a = Archive::read_header(&buf[..]).unwrap();
+        let e = a.entries().skip_solid().next().unwrap().unwrap();
+        assert_eq!(
+            e.metadata().owner_user_sid().map(|v| v.as_str()),
+            Some("S-1-5-21-1-2-3-1001")
+        );
+        assert_eq!(e.metadata().owner_group_sid().map(|v| v.as_str()), Some(""));
+    }
+
+    #[test]
     fn link_target_type_roundtrip_unknown() {
         let ltp = LinkTargetType::Unknown;
         assert_eq!(

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -929,6 +929,27 @@ mod tests {
     }
 
     #[test]
+    fn owner_id_facets_round_trip_via_entry() {
+        use crate::entry::{OwnerGid, OwnerUid};
+        use crate::{Archive, EntryBuilder, WriteOptions};
+        let mut buf = Vec::new();
+        {
+            let mut archive = Archive::write_header(&mut buf).unwrap();
+            let mut b = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
+            b.owner_uid(OwnerUid::from(1000));
+            b.owner_gid(OwnerGid::from(2000));
+            let entry = b.build().unwrap();
+            archive.add_entry(entry).unwrap();
+            archive.finalize().unwrap();
+        }
+        let mut archive = Archive::read_header(&buf[..]).unwrap();
+        let entry = archive.entries().skip_solid().next().unwrap().unwrap();
+        let m = entry.metadata();
+        assert_eq!(m.owner_uid().map(|v| v.get()), Some(1000));
+        assert_eq!(m.owner_gid().map(|v| v.get()), Some(2000));
+    }
+
+    #[test]
     fn link_target_type_roundtrip_unknown() {
         let ltp = LinkTargetType::Unknown;
         assert_eq!(

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -1093,4 +1093,79 @@ mod tests {
             Some(LinkTargetType::File),
         );
     }
+
+    #[test]
+    fn all_owner_facets_and_fprm_coexist_round_trip() {
+        use crate::entry::{
+            OwnerGid, OwnerGroupName, OwnerGroupSid, OwnerUid, OwnerUserName, OwnerUserSid,
+            PermissionMode,
+        };
+        use crate::{Archive, EntryBuilder, WriteOptions};
+        let mut buf = Vec::new();
+        {
+            let mut archive = Archive::write_header(&mut buf).unwrap();
+            let mut b = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
+            // Legacy fPRM (Permission uses plain String uname/gname on this branch).
+            b.permission(Permission::new(
+                7,
+                "legacy".to_string(),
+                8,
+                "grp".to_string(),
+                0o600,
+            ));
+            // All 7 new owner facets.
+            b.owner_uid(OwnerUid::from(1));
+            b.owner_gid(OwnerGid::from(2));
+            b.owner_user_name(OwnerUserName::new("u").unwrap());
+            b.owner_group_name(OwnerGroupName::new("g").unwrap());
+            b.owner_user_sid(OwnerUserSid::new("S-1-1").unwrap());
+            b.owner_group_sid(OwnerGroupSid::new("S-1-2").unwrap());
+            b.permission_mode(PermissionMode::from(0o644));
+            let entry = b.build().unwrap();
+            archive.add_entry(entry).unwrap();
+            archive.finalize().unwrap();
+        }
+        let mut archive = Archive::read_header(&buf[..]).unwrap();
+        let entry = archive.entries().skip_solid().next().unwrap().unwrap();
+        let m = entry.metadata();
+        // All 7 new facets survived.
+        assert_eq!(m.owner_uid().map(|v| v.get()), Some(1));
+        assert_eq!(m.owner_gid().map(|v| v.get()), Some(2));
+        assert_eq!(m.owner_user_name().map(|v| v.as_str()), Some("u"));
+        assert_eq!(m.owner_group_name().map(|v| v.as_str()), Some("g"));
+        assert_eq!(m.owner_user_sid().map(|v| v.as_str()), Some("S-1-1"));
+        assert_eq!(m.owner_group_sid().map(|v| v.as_str()), Some("S-1-2"));
+        assert_eq!(m.permission_mode().map(|v| v.get()), Some(0o644));
+        // Legacy fPRM still round-trips intact, independently of the new owner facets.
+        let p = m
+            .permission()
+            .expect("fPRM permission must still be present");
+        assert_eq!(p.uid(), 7);
+        assert_eq!(p.uname(), "legacy");
+        assert_eq!(p.gid(), 8);
+        assert_eq!(p.gname(), "grp");
+        assert_eq!(p.permissions(), 0o600);
+    }
+
+    #[test]
+    fn fonm_trailing_bytes_after_length_are_ignored() {
+        use crate::{Archive, ChunkType, EntryBuilder, RawChunk, WriteOptions};
+        let mut buf = Vec::new();
+        {
+            let mut a = Archive::write_header(&mut buf).unwrap();
+            let mut b = EntryBuilder::new_file("g".into(), WriteOptions::store()).unwrap();
+            b.add_extra_chunk(RawChunk::from_data(
+                ChunkType::fONm,
+                vec![3, b'a', b'b', b'c', 0xFF],
+            ));
+            a.add_entry(b.build().unwrap()).unwrap();
+            a.finalize().unwrap();
+        }
+        let mut a = Archive::read_header(&buf[..]).unwrap();
+        let e = a.entries().skip_solid().next().unwrap().unwrap();
+        assert_eq!(
+            e.metadata().owner_user_name().map(|v| v.as_str()),
+            Some("abc")
+        );
+    }
 }

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -437,7 +437,6 @@ const OWNER_STR_MAX: usize = u8::MAX as usize;
 #[repr(transparent)]
 pub struct OwnerUserName(BoundedString<OWNER_STR_MAX>);
 
-#[allow(dead_code)]
 impl OwnerUserName {
     /// Constructs an [`OwnerUserName`].
     ///
@@ -505,7 +504,6 @@ impl From<OwnerUserName> for String {
 #[repr(transparent)]
 pub struct OwnerGroupName(BoundedString<OWNER_STR_MAX>);
 
-#[allow(dead_code)]
 impl OwnerGroupName {
     /// Constructs an [`OwnerGroupName`].
     ///
@@ -573,7 +571,6 @@ impl From<OwnerGroupName> for String {
 #[repr(transparent)]
 pub struct OwnerUserSid(BoundedString<OWNER_STR_MAX>);
 
-#[allow(dead_code)]
 impl OwnerUserSid {
     /// Constructs an [`OwnerUserSid`].
     ///
@@ -641,7 +638,6 @@ impl From<OwnerUserSid> for String {
 #[repr(transparent)]
 pub struct OwnerGroupSid(BoundedString<OWNER_STR_MAX>);
 
-#[allow(dead_code)]
 impl OwnerGroupSid {
     /// Constructs an [`OwnerGroupSid`].
     ///
@@ -709,7 +705,6 @@ impl From<OwnerGroupSid> for String {
 #[repr(transparent)]
 pub struct OwnerUid(u64);
 
-#[allow(dead_code)]
 impl OwnerUid {
     /// Returns the raw user id.
     #[inline]
@@ -739,7 +734,6 @@ impl From<u64> for OwnerUid {
 #[repr(transparent)]
 pub struct OwnerGid(u64);
 
-#[allow(dead_code)]
 impl OwnerGid {
     /// Returns the raw group id.
     #[inline]
@@ -770,7 +764,6 @@ impl From<u64> for OwnerGid {
 #[repr(transparent)]
 pub struct PermissionMode(u16);
 
-#[allow(dead_code)]
 impl PermissionMode {
     /// Returns the permission bits (`0o7777`-masked).
     #[inline]
@@ -1017,6 +1010,27 @@ mod tests {
             Some("S-1-5-21-1-2-3-1001")
         );
         assert_eq!(e.metadata().owner_group_sid().map(|v| v.as_str()), Some(""));
+    }
+
+    #[test]
+    fn permission_mode_facet_round_trip_via_entry() {
+        use crate::entry::PermissionMode;
+        use crate::{Archive, EntryBuilder, WriteOptions};
+        let mut buf = Vec::new();
+        {
+            let mut archive = Archive::write_header(&mut buf).unwrap();
+            let mut b = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
+            b.permission_mode(PermissionMode::from(0o750));
+            let entry = b.build().unwrap();
+            archive.add_entry(entry).unwrap();
+            archive.finalize().unwrap();
+        }
+        let mut archive = Archive::read_header(&buf[..]).unwrap();
+        let entry = archive.entries().skip_solid().next().unwrap().unwrap();
+        assert_eq!(
+            entry.metadata().permission_mode().map(|v| v.get()),
+            Some(0o750)
+        );
     }
 
     #[test]

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -1,7 +1,10 @@
 //! Metadata and permission types for archive entries.
 
+use crate::util::bounded::{LengthExceeded, str::BoundedString};
 use crate::{Duration, UnknownValueError};
 use std::io::{self, Read};
+use std::ops::Deref;
+use std::str;
 
 /// Metadata information about an entry.
 /// # Examples
@@ -27,6 +30,13 @@ pub struct Metadata {
     pub(crate) accessed: Option<Duration>,
     pub(crate) permission: Option<Permission>,
     pub(crate) link_target_type: Option<LinkTargetType>,
+    pub(crate) owner_uid: Option<OwnerUid>,
+    pub(crate) owner_gid: Option<OwnerGid>,
+    pub(crate) owner_user_name: Option<OwnerUserName>,
+    pub(crate) owner_group_name: Option<OwnerGroupName>,
+    pub(crate) owner_user_sid: Option<OwnerUserSid>,
+    pub(crate) owner_group_sid: Option<OwnerGroupSid>,
+    pub(crate) permission_mode: Option<PermissionMode>,
 }
 
 impl Metadata {
@@ -41,6 +51,13 @@ impl Metadata {
             accessed: None,
             permission: None,
             link_target_type: None,
+            owner_uid: None,
+            owner_gid: None,
+            owner_user_name: None,
+            owner_group_name: None,
+            owner_user_sid: None,
+            owner_group_sid: None,
+            permission_mode: None,
         }
     }
 
@@ -108,6 +125,49 @@ impl Metadata {
         self
     }
 
+    /// Sets the owner user id facet (`fUId`).
+    #[inline]
+    pub fn with_owner_uid(mut self, value: Option<OwnerUid>) -> Self {
+        self.owner_uid = value;
+        self
+    }
+    /// Sets the owner group id facet (`fGId`).
+    #[inline]
+    pub fn with_owner_gid(mut self, value: Option<OwnerGid>) -> Self {
+        self.owner_gid = value;
+        self
+    }
+    /// Sets the owner user name facet (`fONm`).
+    #[inline]
+    pub fn with_owner_user_name(mut self, value: Option<OwnerUserName>) -> Self {
+        self.owner_user_name = value;
+        self
+    }
+    /// Sets the owner group name facet (`fGNm`).
+    #[inline]
+    pub fn with_owner_group_name(mut self, value: Option<OwnerGroupName>) -> Self {
+        self.owner_group_name = value;
+        self
+    }
+    /// Sets the owner user SID facet (`fOSi`).
+    #[inline]
+    pub fn with_owner_user_sid(mut self, value: Option<OwnerUserSid>) -> Self {
+        self.owner_user_sid = value;
+        self
+    }
+    /// Sets the owner group SID facet (`fGSi`).
+    #[inline]
+    pub fn with_owner_group_sid(mut self, value: Option<OwnerGroupSid>) -> Self {
+        self.owner_group_sid = value;
+        self
+    }
+    /// Sets the POSIX permission mode facet (`fMOd`).
+    #[inline]
+    pub fn with_permission_mode(mut self, value: Option<PermissionMode>) -> Self {
+        self.permission_mode = value;
+        self
+    }
+
     /// Sets the link target type of the entry.
     /// Only meaningful for symbolic link and hard link entries.
     #[inline]
@@ -145,6 +205,41 @@ impl Metadata {
     #[inline]
     pub const fn permission(&self) -> Option<&Permission> {
         self.permission.as_ref()
+    }
+    /// Returns the owner user id facet (`fUId`), if recorded.
+    #[inline]
+    pub const fn owner_uid(&self) -> Option<OwnerUid> {
+        self.owner_uid
+    }
+    /// Returns the owner group id facet (`fGId`), if recorded.
+    #[inline]
+    pub const fn owner_gid(&self) -> Option<OwnerGid> {
+        self.owner_gid
+    }
+    /// Returns the owner user name facet (`fONm`), if recorded.
+    #[inline]
+    pub fn owner_user_name(&self) -> Option<&OwnerUserName> {
+        self.owner_user_name.as_ref()
+    }
+    /// Returns the owner group name facet (`fGNm`), if recorded.
+    #[inline]
+    pub fn owner_group_name(&self) -> Option<&OwnerGroupName> {
+        self.owner_group_name.as_ref()
+    }
+    /// Returns the owner user SID facet (`fOSi`), if recorded.
+    #[inline]
+    pub fn owner_user_sid(&self) -> Option<&OwnerUserSid> {
+        self.owner_user_sid.as_ref()
+    }
+    /// Returns the owner group SID facet (`fGSi`), if recorded.
+    #[inline]
+    pub fn owner_group_sid(&self) -> Option<&OwnerGroupSid> {
+        self.owner_group_sid.as_ref()
+    }
+    /// Returns the POSIX permission mode facet (`fMOd`), if recorded.
+    #[inline]
+    pub const fn permission_mode(&self) -> Option<PermissionMode> {
+        self.permission_mode
     }
 
     /// Returns the link target type for this entry, if present.
@@ -333,6 +428,373 @@ impl Permission {
     }
 }
 
+/// Maximum owner-facet string byte length (the `fONm`/`fGNm`/`fOSi`/`fGSi`
+/// chunk Body uses a 1-byte length prefix).
+const OWNER_STR_MAX: usize = u8::MAX as usize;
+
+/// Owner user name (`fONm`).
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[repr(transparent)]
+pub struct OwnerUserName(BoundedString<OWNER_STR_MAX>);
+
+#[allow(dead_code)]
+impl OwnerUserName {
+    /// Constructs an [`OwnerUserName`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LengthExceeded`] when the byte length exceeds 255.
+    #[inline]
+    pub fn new(value: impl Into<Box<str>>) -> Result<Self, LengthExceeded> {
+        BoundedString::new(value).map(Self)
+    }
+    /// Returns the name as a string slice.
+    #[inline]
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        let b = self.0.as_str().as_bytes();
+        let mut v = Vec::with_capacity(1 + b.len());
+        // Type guarantees b.len() <= 255 (BoundedString<255> invariant).
+        v.push(b.len() as u8);
+        v.extend_from_slice(b);
+        v
+    }
+    pub(crate) fn try_from_bytes(bytes: &[u8]) -> io::Result<Self> {
+        let (&len, rest) = bytes.split_first().ok_or(io::ErrorKind::UnexpectedEof)?;
+        let s = rest
+            .get(..len as usize)
+            .ok_or(io::ErrorKind::UnexpectedEof)?;
+        let s = str::from_utf8(s).map_err(|_| io::ErrorKind::InvalidData)?;
+        Self::new(s.to_owned()).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+    }
+}
+
+impl Deref for OwnerUserName {
+    type Target = str;
+    #[inline]
+    fn deref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+impl TryFrom<String> for OwnerUserName {
+    type Error = LengthExceeded;
+    #[inline]
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+impl TryFrom<&str> for OwnerUserName {
+    type Error = LengthExceeded;
+    #[inline]
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+impl From<OwnerUserName> for String {
+    #[inline]
+    fn from(value: OwnerUserName) -> Self {
+        value.0.into()
+    }
+}
+
+/// Owner group name (`fGNm`).
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[repr(transparent)]
+pub struct OwnerGroupName(BoundedString<OWNER_STR_MAX>);
+
+#[allow(dead_code)]
+impl OwnerGroupName {
+    /// Constructs an [`OwnerGroupName`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LengthExceeded`] when the byte length exceeds 255.
+    #[inline]
+    pub fn new(value: impl Into<Box<str>>) -> Result<Self, LengthExceeded> {
+        BoundedString::new(value).map(Self)
+    }
+    /// Returns the name as a string slice.
+    #[inline]
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        let b = self.0.as_str().as_bytes();
+        let mut v = Vec::with_capacity(1 + b.len());
+        // Type guarantees b.len() <= 255 (BoundedString<255> invariant).
+        v.push(b.len() as u8);
+        v.extend_from_slice(b);
+        v
+    }
+    pub(crate) fn try_from_bytes(bytes: &[u8]) -> io::Result<Self> {
+        let (&len, rest) = bytes.split_first().ok_or(io::ErrorKind::UnexpectedEof)?;
+        let s = rest
+            .get(..len as usize)
+            .ok_or(io::ErrorKind::UnexpectedEof)?;
+        let s = str::from_utf8(s).map_err(|_| io::ErrorKind::InvalidData)?;
+        Self::new(s.to_owned()).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+    }
+}
+
+impl Deref for OwnerGroupName {
+    type Target = str;
+    #[inline]
+    fn deref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+impl TryFrom<String> for OwnerGroupName {
+    type Error = LengthExceeded;
+    #[inline]
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+impl TryFrom<&str> for OwnerGroupName {
+    type Error = LengthExceeded;
+    #[inline]
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+impl From<OwnerGroupName> for String {
+    #[inline]
+    fn from(value: OwnerGroupName) -> Self {
+        value.0.into()
+    }
+}
+
+/// Owner user SID (`fOSi`).
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[repr(transparent)]
+pub struct OwnerUserSid(BoundedString<OWNER_STR_MAX>);
+
+#[allow(dead_code)]
+impl OwnerUserSid {
+    /// Constructs an [`OwnerUserSid`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LengthExceeded`] when the byte length exceeds 255.
+    #[inline]
+    pub fn new(value: impl Into<Box<str>>) -> Result<Self, LengthExceeded> {
+        BoundedString::new(value).map(Self)
+    }
+    /// Returns the name as a string slice.
+    #[inline]
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        let b = self.0.as_str().as_bytes();
+        let mut v = Vec::with_capacity(1 + b.len());
+        // Type guarantees b.len() <= 255 (BoundedString<255> invariant).
+        v.push(b.len() as u8);
+        v.extend_from_slice(b);
+        v
+    }
+    pub(crate) fn try_from_bytes(bytes: &[u8]) -> io::Result<Self> {
+        let (&len, rest) = bytes.split_first().ok_or(io::ErrorKind::UnexpectedEof)?;
+        let s = rest
+            .get(..len as usize)
+            .ok_or(io::ErrorKind::UnexpectedEof)?;
+        let s = str::from_utf8(s).map_err(|_| io::ErrorKind::InvalidData)?;
+        Self::new(s.to_owned()).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+    }
+}
+
+impl Deref for OwnerUserSid {
+    type Target = str;
+    #[inline]
+    fn deref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+impl TryFrom<String> for OwnerUserSid {
+    type Error = LengthExceeded;
+    #[inline]
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+impl TryFrom<&str> for OwnerUserSid {
+    type Error = LengthExceeded;
+    #[inline]
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+impl From<OwnerUserSid> for String {
+    #[inline]
+    fn from(value: OwnerUserSid) -> Self {
+        value.0.into()
+    }
+}
+
+/// Owner group SID (`fGSi`).
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[repr(transparent)]
+pub struct OwnerGroupSid(BoundedString<OWNER_STR_MAX>);
+
+#[allow(dead_code)]
+impl OwnerGroupSid {
+    /// Constructs an [`OwnerGroupSid`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LengthExceeded`] when the byte length exceeds 255.
+    #[inline]
+    pub fn new(value: impl Into<Box<str>>) -> Result<Self, LengthExceeded> {
+        BoundedString::new(value).map(Self)
+    }
+    /// Returns the name as a string slice.
+    #[inline]
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        let b = self.0.as_str().as_bytes();
+        let mut v = Vec::with_capacity(1 + b.len());
+        // Type guarantees b.len() <= 255 (BoundedString<255> invariant).
+        v.push(b.len() as u8);
+        v.extend_from_slice(b);
+        v
+    }
+    pub(crate) fn try_from_bytes(bytes: &[u8]) -> io::Result<Self> {
+        let (&len, rest) = bytes.split_first().ok_or(io::ErrorKind::UnexpectedEof)?;
+        let s = rest
+            .get(..len as usize)
+            .ok_or(io::ErrorKind::UnexpectedEof)?;
+        let s = str::from_utf8(s).map_err(|_| io::ErrorKind::InvalidData)?;
+        Self::new(s.to_owned()).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+    }
+}
+
+impl Deref for OwnerGroupSid {
+    type Target = str;
+    #[inline]
+    fn deref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+impl TryFrom<String> for OwnerGroupSid {
+    type Error = LengthExceeded;
+    #[inline]
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+impl TryFrom<&str> for OwnerGroupSid {
+    type Error = LengthExceeded;
+    #[inline]
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+impl From<OwnerGroupSid> for String {
+    #[inline]
+    fn from(value: OwnerGroupSid) -> Self {
+        value.0.into()
+    }
+}
+
+/// Owner user id (`fUId`).
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[repr(transparent)]
+pub struct OwnerUid(u64);
+
+#[allow(dead_code)]
+impl OwnerUid {
+    /// Returns the raw user id.
+    #[inline]
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+    pub(crate) fn to_bytes(self) -> [u8; 8] {
+        self.0.to_be_bytes()
+    }
+    pub(crate) fn try_from_bytes(bytes: &[u8]) -> io::Result<Self> {
+        let a: [u8; 8] = bytes
+            .try_into()
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "fUId must be 8 bytes"))?;
+        Ok(Self(u64::from_be_bytes(a)))
+    }
+}
+impl From<u64> for OwnerUid {
+    #[inline]
+    fn from(v: u64) -> Self {
+        Self(v)
+    }
+}
+
+/// Owner group id (`fGId`).
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[repr(transparent)]
+pub struct OwnerGid(u64);
+
+#[allow(dead_code)]
+impl OwnerGid {
+    /// Returns the raw group id.
+    #[inline]
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+    pub(crate) fn to_bytes(self) -> [u8; 8] {
+        self.0.to_be_bytes()
+    }
+    pub(crate) fn try_from_bytes(bytes: &[u8]) -> io::Result<Self> {
+        let a: [u8; 8] = bytes
+            .try_into()
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "fGId must be 8 bytes"))?;
+        Ok(Self(u64::from_be_bytes(a)))
+    }
+}
+impl From<u64> for OwnerGid {
+    #[inline]
+    fn from(v: u64) -> Self {
+        Self(v)
+    }
+}
+
+/// POSIX permission mode (`fMOd`). Reserved bits outside `0o7777`
+/// (the rwx + setuid/setgid/sticky bits) are masked to 0 on construction.
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
+#[repr(transparent)]
+pub struct PermissionMode(u16);
+
+#[allow(dead_code)]
+impl PermissionMode {
+    /// Returns the permission bits (`0o7777`-masked).
+    #[inline]
+    #[must_use]
+    pub const fn get(self) -> u16 {
+        self.0
+    }
+    pub(crate) fn to_bytes(self) -> [u8; 2] {
+        self.0.to_be_bytes()
+    }
+    pub(crate) fn try_from_bytes(bytes: &[u8]) -> io::Result<Self> {
+        let a: [u8; 2] = bytes
+            .try_into()
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "fMOd must be 2 bytes"))?;
+        Ok(Self::from(u16::from_be_bytes(a)))
+    }
+}
+impl From<u16> for PermissionMode {
+    #[inline]
+    fn from(v: u16) -> Self {
+        Self(v & 0o7777)
+    }
+}
+
 /// Link target type for link entries.
 ///
 /// Stored in the `fLTP` ancillary chunk. Indicates whether the link target
@@ -408,6 +870,62 @@ mod tests {
     fn permission() {
         let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
         assert_eq!(perm, Permission::try_from_bytes(&perm.to_bytes()).unwrap());
+    }
+
+    #[test]
+    fn owner_string_newtype_bound_and_codec() {
+        use crate::entry::OwnerUserName;
+        assert!(OwnerUserName::new("").is_ok());
+        assert!(OwnerUserName::new("alice").is_ok());
+        assert!(OwnerUserName::new("a".repeat(255)).is_ok());
+        assert!(OwnerUserName::new("a".repeat(256)).is_err());
+        let n = OwnerUserName::new("alice").unwrap();
+        assert_eq!(n.to_bytes(), vec![5, b'a', b'l', b'i', b'c', b'e']);
+        assert_eq!(OwnerUserName::try_from_bytes(&n.to_bytes()).unwrap(), n);
+        assert_eq!(OwnerUserName::try_from_bytes(&[0]).unwrap().as_str(), "");
+        assert_eq!(
+            OwnerUserName::try_from_bytes(&[3, b'a', b'b', b'c', 0xFF])
+                .unwrap()
+                .as_str(),
+            "abc"
+        );
+        assert!(OwnerUserName::try_from_bytes(&[]).is_err());
+        assert!(OwnerUserName::try_from_bytes(&[5, b'a']).is_err());
+        assert!(OwnerUserName::try_from_bytes(&[1, 0xFF]).is_err());
+    }
+
+    #[test]
+    fn owner_uid_and_permission_mode_codec() {
+        use crate::entry::{OwnerUid, PermissionMode};
+        let u = OwnerUid::from(1000u64);
+        assert_eq!(u.get(), 1000);
+        assert_eq!(u.to_bytes(), 1000u64.to_be_bytes());
+        assert_eq!(OwnerUid::try_from_bytes(&u.to_bytes()).unwrap(), u);
+        assert!(OwnerUid::try_from_bytes(&[0, 0, 0]).is_err());
+        assert_eq!(PermissionMode::from(0o7777u16).get(), 0o7777);
+        assert_eq!(PermissionMode::from(0o170755u16).get(), 0o0755);
+        let m = PermissionMode::from(0o644u16);
+        assert_eq!(m.to_bytes(), 0o644u16.to_be_bytes());
+        assert_eq!(PermissionMode::try_from_bytes(&m.to_bytes()).unwrap(), m);
+        assert_eq!(
+            PermissionMode::try_from_bytes(&0o170644u16.to_be_bytes())
+                .unwrap()
+                .get(),
+            0o0644
+        );
+        assert!(PermissionMode::try_from_bytes(&[0]).is_err());
+    }
+
+    #[test]
+    fn metadata_owner_facets_default_none() {
+        let m = Metadata::new();
+        assert_eq!(m.owner_uid(), None);
+        assert_eq!(m.owner_gid(), None);
+        assert_eq!(m.owner_user_name(), None);
+        assert_eq!(m.owner_group_name(), None);
+        assert_eq!(m.owner_user_sid(), None);
+        assert_eq!(m.owner_group_sid(), None);
+        assert_eq!(m.permission_mode(), None);
     }
 
     #[test]

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -950,6 +950,27 @@ mod tests {
     }
 
     #[test]
+    fn owner_name_facets_round_trip_via_entry() {
+        use crate::entry::{OwnerGroupName, OwnerUserName};
+        use crate::{Archive, EntryBuilder, WriteOptions};
+        let mut buf = Vec::new();
+        {
+            let mut archive = Archive::write_header(&mut buf).unwrap();
+            let mut b = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
+            b.owner_user_name(OwnerUserName::new("alice").unwrap());
+            b.owner_group_name(OwnerGroupName::new("").unwrap());
+            let entry = b.build().unwrap();
+            archive.add_entry(entry).unwrap();
+            archive.finalize().unwrap();
+        }
+        let mut archive = Archive::read_header(&buf[..]).unwrap();
+        let entry = archive.entries().skip_solid().next().unwrap().unwrap();
+        let m = entry.metadata();
+        assert_eq!(m.owner_user_name().map(|v| v.as_str()), Some("alice"));
+        assert_eq!(m.owner_group_name().map(|v| v.as_str()), Some("")); // recorded empty name, NOT absent
+    }
+
+    #[test]
     fn link_target_type_roundtrip_unknown() {
         let ltp = LinkTargetType::Unknown;
         assert_eq!(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Archives now support storing and preserving complete ownership and group metadata, including user/group identifiers, names, and security information.
  * Added permission mode tracking for entries.
  * New builder API methods enable setting ownership and permission properties when creating entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChanTsune/Portable-Network-Archive/pull/3067?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->