### PR TITLE
🛡️ Sentinel: Harden link target extraction against memory exhaustion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-12 - Bound Link Target Size
+**Vulnerability:** Denial of Service (DoS) via memory exhaustion when reading excessively large symbolic or hard link targets into memory.
+**Learning:** Link targets are stored in the archive and need to be decompressed and read into memory for processing (extraction, listing, or comparison). Without a size limit, a malicious archive could contain a "link target" that is gigabytes in size, causing the archiver to run out of memory.
+**Prevention:** Enforce a reasonable maximum size (`MAX_LINK_TARGET_SIZE`) using `std::io::Read::take` when reading link targets or any other metadata that is not naturally bounded by the format or operating system limits.

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -153,6 +153,10 @@ pub(crate) const SPLIT_ARCHIVE_OVERHEAD_BYTES: usize =
 /// Minimum bytes required for a split archive part (overhead + one minimal chunk).
 pub(crate) const MIN_SPLIT_PART_BYTES: usize = SPLIT_ARCHIVE_OVERHEAD_BYTES + MIN_CHUNK_BYTES_SIZE;
 
+/// Maximum size of a link target in bytes.
+/// Prevents memory exhaustion when reading link targets from untrusted archives.
+pub(crate) const MAX_LINK_TARGET_SIZE: usize = 64 * 1024;
+
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub(crate) enum XattrStrategy {
     Never,

--- a/cli/src/command/diff.rs
+++ b/cli/src/command/diff.rs
@@ -2,7 +2,7 @@ use crate::{
     cli::{FileArgs, PasswordArgs},
     command::{
         Command, ask_password,
-        core::{SplitArchiveReader, collect_split_archives},
+        core::{MAX_LINK_TARGET_SIZE, SplitArchiveReader, collect_split_archives},
     },
     utils::{BsdGlobMatcher, io::streams_equal},
 };
@@ -308,7 +308,16 @@ fn compare_entry<T: AsRef<[u8]>>(
             let link = fs::read_link(path)?;
             let mut reader = entry.reader(ReadOptions::with_password(password))?;
             let mut link_str = String::new();
-            reader.read_to_string(&mut link_str)?;
+            reader
+                .by_ref()
+                .take(MAX_LINK_TARGET_SIZE as u64 + 1)
+                .read_to_string(&mut link_str)?;
+            if link_str.len() > MAX_LINK_TARGET_SIZE {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "link target too long",
+                ));
+            }
             if link.as_path() != Path::new(&link_str) {
                 println!("{}", DiffKind::SymlinkDiffers.display(path_str));
             }
@@ -319,7 +328,16 @@ fn compare_entry<T: AsRef<[u8]>>(
         DataKind::HardLink if meta.is_file() => {
             let mut reader = entry.reader(ReadOptions::with_password(password))?;
             let mut target = String::new();
-            reader.read_to_string(&mut target)?;
+            reader
+                .by_ref()
+                .take(MAX_LINK_TARGET_SIZE as u64 + 1)
+                .read_to_string(&mut target)?;
+            if target.len() > MAX_LINK_TARGET_SIZE {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "link target too long",
+                ));
+            }
 
             match is_same_file(path, &target) {
                 Ok(true) => (),

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -1649,6 +1649,8 @@ where
     ) && item.mac_metadata().is_some();
     #[cfg(not(target_os = "macos"))]
     let skip_xattr_acl = false;
+    #[cfg(not(target_os = "macos"))]
+    let _ = skip_xattr_acl;
 
     #[cfg(unix)]
     if !skip_xattr_acl && matches!(keep_options.xattr_strategy, XattrStrategy::Always) {

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -8,11 +8,11 @@ use crate::{
     command::{
         Command, ask_password,
         core::{
-            AclStrategy, FflagsStrategy, KeepOptions, MacMetadataStrategy, ModeStrategy,
-            OwnerOptions, OwnerStrategy, PathFilter, PathTransformers, PathnameEditor,
-            PermissionStrategyResolver, ProcessAction, SafeWriter, TimeFilterResolver, TimeFilters,
-            TimestampStrategy, TimestampStrategyResolver, Umask, XattrStrategy, apply_chroot,
-            collect_split_archives,
+            AclStrategy, FflagsStrategy, KeepOptions, MAX_LINK_TARGET_SIZE, MacMetadataStrategy,
+            ModeStrategy, OwnerOptions, OwnerStrategy, PathFilter, PathTransformers,
+            PathnameEditor, PermissionStrategyResolver, ProcessAction, SafeWriter,
+            TimeFilterResolver, TimeFilters, TimestampStrategy, TimestampStrategyResolver, Umask,
+            XattrStrategy, apply_chroot, collect_split_archives,
             path_lock::OrderedPathLocks,
             re::{bsd::SubstitutionRule, gnu::TransformRule},
             read_paths, run_process_archive, run_process_archive_stoppable,
@@ -1423,8 +1423,18 @@ where
 
     match item.header().data_kind() {
         DataKind::SymbolicLink => {
-            let reader = item.reader(ReadOptions::with_password(password))?;
-            let original = io::read_to_string(reader)?;
+            let mut reader = item.reader(ReadOptions::with_password(password))?;
+            let mut original = String::new();
+            reader
+                .by_ref()
+                .take(MAX_LINK_TARGET_SIZE as u64 + 1)
+                .read_to_string(&mut original)?;
+            if original.len() > MAX_LINK_TARGET_SIZE {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "link target too long",
+                ));
+            }
             let original = pathname_editor.edit_symlink(original.as_ref());
             if !allow_unsafe_links && is_unsafe_link(&original) {
                 log::warn!(
@@ -1439,8 +1449,18 @@ where
             symlink_with_type(&original, &path, link_target_type)?;
         }
         DataKind::HardLink => {
-            let reader = item.reader(ReadOptions::with_password(password))?;
-            let original = io::read_to_string(reader)?;
+            let mut reader = item.reader(ReadOptions::with_password(password))?;
+            let mut original = String::new();
+            reader
+                .by_ref()
+                .take(MAX_LINK_TARGET_SIZE as u64 + 1)
+                .read_to_string(&mut original)?;
+            if original.len() > MAX_LINK_TARGET_SIZE {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "link target too long",
+                ));
+            }
             let Some((original, had_root)) = pathname_editor.edit_hardlink(original.as_ref())
             else {
                 log::warn!(

--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -4,8 +4,9 @@ use crate::{
     command::{
         Command, ask_password,
         core::{
-            PathFilter, ProcessAction, SplitArchiveReader, TimeFilterResolver, TimeFilters,
-            collect_split_archives, read_paths, run_read_entries, run_read_entries_stoppable,
+            MAX_LINK_TARGET_SIZE, PathFilter, ProcessAction, SplitArchiveReader,
+            TimeFilterResolver, TimeFilters, collect_split_archives, read_paths, run_read_entries,
+            run_read_entries_stoppable,
         },
     },
     ext::*,
@@ -429,10 +430,22 @@ impl TableRow {
                     entry.name().to_string(),
                     // Only read link target if needed (requires decompression)
                     if collect.link_target {
-                        entry
-                            .reader(ReadOptions::with_password(password))
-                            .and_then(io::read_to_string)
-                            .unwrap_or_else(|_| "-".into())
+                        (|| {
+                            let mut reader = entry.reader(ReadOptions::with_password(password))?;
+                            let mut s = String::new();
+                            reader
+                                .by_ref()
+                                .take(MAX_LINK_TARGET_SIZE as u64 + 1)
+                                .read_to_string(&mut s)?;
+                            if s.len() > MAX_LINK_TARGET_SIZE {
+                                return Err(io::Error::new(
+                                    io::ErrorKind::InvalidData,
+                                    "link target too long",
+                                ));
+                            }
+                            Ok(s)
+                        })()
+                        .unwrap_or_else(|_| "-".into())
                     } else {
                         String::new()
                     },
@@ -441,10 +454,22 @@ impl TableRow {
                     entry.name().to_string(),
                     // Only read link target if needed (requires decompression)
                     if collect.link_target {
-                        entry
-                            .reader(ReadOptions::with_password(password))
-                            .and_then(io::read_to_string)
-                            .unwrap_or_else(|_| "-".into())
+                        (|| {
+                            let mut reader = entry.reader(ReadOptions::with_password(password))?;
+                            let mut s = String::new();
+                            reader
+                                .by_ref()
+                                .take(MAX_LINK_TARGET_SIZE as u64 + 1)
+                                .read_to_string(&mut s)?;
+                            if s.len() > MAX_LINK_TARGET_SIZE {
+                                return Err(io::Error::new(
+                                    io::ErrorKind::InvalidData,
+                                    "link target too long",
+                                ));
+                            }
+                            Ok(s)
+                        })()
+                        .unwrap_or_else(|_| "-".into())
                     } else {
                         String::new()
                     },

--- a/cli/tests/cli/extract.rs
+++ b/cli/tests/cli/extract.rs
@@ -1,4 +1,5 @@
 mod hardlink;
+mod link_limit;
 mod missing_file;
 #[cfg(not(target_family = "wasm"))]
 mod option_chroot;

--- a/cli/tests/cli/extract.rs
+++ b/cli/tests/cli/extract.rs
@@ -1,4 +1,5 @@
 mod hardlink;
+#[cfg(not(target_family = "wasm"))]
 mod link_limit;
 mod missing_file;
 #[cfg(not(target_family = "wasm"))]

--- a/cli/tests/cli/extract/link_limit.rs
+++ b/cli/tests/cli/extract/link_limit.rs
@@ -1,0 +1,80 @@
+use crate::utils::setup;
+use assert_cmd::cargo::cargo_bin_cmd;
+use std::fs;
+
+#[test]
+fn extract_fails_on_huge_symlink_target() {
+    setup();
+
+    let base_dir = "extract_fails_on_huge_symlink_target";
+    fs::create_dir_all(format!("{base_dir}/out")).unwrap();
+
+    let archive_path = format!("{base_dir}/archive.pna");
+    let archive_file = fs::File::create(&archive_path).unwrap();
+    let mut archive = pna::Archive::write_header(archive_file).unwrap();
+
+    // MAX_LINK_TARGET_SIZE is 64 KiB (65536 bytes).
+    // We create a target that is slightly larger.
+    let huge_target = "a".repeat(65536 + 1);
+    let entry_name = pna::EntryName::from("huge_link");
+    let entry_reference = pna::EntryReference::from_utf8_preserve_root(&huge_target);
+
+    let entry = pna::EntryBuilder::new_symlink(entry_name, entry_reference)
+        .unwrap()
+        .build()
+        .unwrap();
+    archive.add_entry(entry).unwrap();
+    archive.finalize().unwrap();
+
+    let mut cmd = cargo_bin_cmd!("pna");
+    cmd.arg("x")
+        .arg(&archive_path)
+        .arg("--out-dir")
+        .arg(format!("{base_dir}/out"))
+        .arg("--overwrite");
+
+    let output = cmd.output().unwrap();
+
+    // It should fail because the link target is too long.
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("link target too long"));
+}
+
+#[test]
+fn extract_fails_on_huge_hardlink_target() {
+    setup();
+
+    let base_dir = "extract_fails_on_huge_hardlink_target";
+    fs::create_dir_all(format!("{base_dir}/out")).unwrap();
+
+    let archive_path = format!("{base_dir}/archive.pna");
+    let archive_file = fs::File::create(&archive_path).unwrap();
+    let mut archive = pna::Archive::write_header(archive_file).unwrap();
+
+    // Create a hard link with a huge target name.
+    let huge_target = "a".repeat(65536 + 1);
+    let entry_name = pna::EntryName::from("huge_hardlink");
+    let entry_reference = pna::EntryReference::from_utf8_preserve_root(&huge_target);
+
+    let entry = pna::EntryBuilder::new_hard_link(entry_name, entry_reference)
+        .unwrap()
+        .build()
+        .unwrap();
+    archive.add_entry(entry).unwrap();
+    archive.finalize().unwrap();
+
+    let mut cmd = cargo_bin_cmd!("pna");
+    cmd.arg("x")
+        .arg(&archive_path)
+        .arg("--out-dir")
+        .arg(format!("{base_dir}/out"))
+        .arg("--overwrite");
+
+    let output = cmd.output().unwrap();
+
+    // It should fail because the link target is too long.
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("link target too long"));
+}


### PR DESCRIPTION
### 🛡️ Sentinel: [HIGH] Harden link target extraction against memory exhaustion

- 🚨 **Severity:** HIGH
- 💡 **Vulnerability:** Potential Denial of Service (DoS) via memory exhaustion when reading excessively large symbolic or hard link targets from a malformed archive.
- 🎯 **Impact:** An attacker could craft an archive with a link target payload (stored in the archive and decompressed on the fly) that is much larger than available memory, causing the archiver to crash or become unresponsive during extraction, listing, or comparison.
- 🔧 **Fix:** Introduced a `MAX_LINK_TARGET_SIZE` constant set to 64 KiB (a generous limit considering standard OS path limits like 4096 bytes). Modified the `extract`, `list`, and `diff` commands to use `reader.take(MAX_LINK_TARGET_SIZE + 1)` when reading link targets and verify that the actual length does not exceed the limit.
- ✅ **Verification:** Added new integration tests in `cli/tests/cli/extract/link_limit.rs` that verify the archiver correctly rejects archives with link targets exceeding the 64 KiB limit. All tests passed.

```bash
cargo test -p portable-network-archive --test cli link_limit
```

---
*PR created automatically by Jules for task [6585411856353083135](https://jules.google.com/task/6585411856353083135) started by @ChanTsune*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Archive extraction and listing operations now enforce a 64 KiB limit on link target sizes; operations exceeding this limit will fail with an error message.

## Tests
* Added tests to verify enforcement of link target size limits during extraction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChanTsune/Portable-Network-Archive/pull/3069?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->