### PR TITLE
:construction_worker: Double RISC-V release build timeout to 180 minutes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
   # Build and packages all the platform-specific things
   build-local-artifacts:
     name: build-local-artifacts (${{ join(matrix.targets, ', ') }})
-    timeout-minutes: 90
+    timeout-minutes: ${{ contains(matrix.targets, 'riscv64gc-unknown-linux-gnu') && 180 || 90 }}
     # Let the initial task tell us to not run (currently very blunt)
     needs:
       - plan


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build job timing so longer-running release builds can complete successfully, reducing the chance of timeouts during packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->