### PR TITLE
Fix extraction into verbatim out-dir paths on Windows

### DIFF
--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -1912,7 +1912,16 @@ fn ensure_directory_components(
                 current.pop();
                 continue;
             }
-            Component::RootDir | Component::Prefix(_) | Component::Normal(_) => {
+            // A prefix or root names the volume/share root, which cannot be a
+            // symlink and must not be probed: `symlink_metadata` on a bare
+            // verbatim disk prefix (`\\?\C:`, no trailing separator) addresses
+            // the volume device rather than the drive's root directory and
+            // fails with `ERROR_INVALID_FUNCTION`.
+            Component::RootDir | Component::Prefix(_) => {
+                current.push(component.as_os_str());
+                continue;
+            }
+            Component::Normal(_) => {
                 current.push(component.as_os_str());
             }
         }

--- a/cli/tests/cli/extract.rs
+++ b/cli/tests/cli/extract.rs
@@ -18,3 +18,5 @@ mod sanitize_parent_components;
 #[cfg(windows)]
 mod symlink_link_target_type;
 mod symlink_metadata;
+#[cfg(windows)]
+mod verbatim_out_dir;

--- a/cli/tests/cli/extract/verbatim_out_dir.rs
+++ b/cli/tests/cli/extract/verbatim_out_dir.rs
@@ -1,0 +1,50 @@
+use crate::utils::setup;
+use clap::Parser;
+use portable_network_archive::cli;
+use std::fs;
+
+/// Precondition: an archive containing a regular file entry inside a
+/// directory, and an existing output directory addressed by its
+/// canonicalized (verbatim `\\?\`-prefixed) path.
+/// Action: extract the archive with `--out-dir` set to the verbatim path.
+/// Expectation: extraction succeeds and the file is restored with its
+/// contents under the output directory.
+#[test]
+fn extract_with_verbatim_out_dir() {
+    setup();
+    let base = "extract_with_verbatim_out_dir";
+    let _ = fs::remove_dir_all(base);
+    fs::create_dir_all(format!("{base}/in/dir")).unwrap();
+    fs::write(format!("{base}/in/dir/file.txt"), b"payload").unwrap();
+    let archive = format!("{base}/{base}.pna");
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        &archive,
+        "--overwrite",
+        &format!("{base}/in/"),
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    fs::create_dir_all(format!("{base}/out")).unwrap();
+    let out_dir = fs::canonicalize(format!("{base}/out")).unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        "-f",
+        &archive,
+        "--out-dir",
+        out_dir.to_str().unwrap(),
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let restored = out_dir.join(base).join("in/dir/file.txt");
+    assert_eq!(fs::read(&restored).unwrap(), b"payload");
+}


### PR DESCRIPTION
## Summary
On Windows, `pna x --out-dir <path>` fails with `Incorrect function. (os error 1)` when the output directory is given in verbatim form (`\\?\C:\...`, e.g. the result of `std::fs::canonicalize`). The secure component walk in `ensure_directory_components` probes each accumulated component with `symlink_metadata`, and the bare verbatim disk prefix (`\\?\C:` without a trailing separator) addresses the volume device rather than the drive's root directory, which fails with `ERROR_INVALID_FUNCTION`. Prefix and root components now skip the probe — they name the volume/share root, which cannot be a symlink.

## Verification
Mechanism confirmed on windows-latest: `fs::symlink_metadata(r"\\?\C:")` returns os error 1 while `r"\\?\C:\"` succeeds; the added regression test fails before the fix and passes with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extraction behavior on Windows so volume roots and verbatim path prefixes are handled correctly.
  * Fixed `--out-dir` extraction for canonicalized Windows-style paths, including `\\?\`-prefixed locations.

* **Tests**
  * Added Windows-specific integration coverage for extracting archives into verbatim output directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->