### PR TITLE
Group github/codeql-action updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
       vmactions:
         patterns:
           - "vmactions/*"
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

Group all `github/codeql-action/*` actions (`init`, `analyze`, `upload-sarif`) into a single Dependabot update.

Splitting them into separate PRs bumps one action ahead of the others, and CodeQL requires `init` and `analyze` to run at the same version, so those PRs fail with `Loaded a configuration file for version 'X', but running version 'Y'`. Grouping keeps the versions in lockstep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to group CodeQL-related GitHub Actions pull requests together for easier review and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->