### PR TITLE
:sparkles: Add experimental verify command

### DIFF
--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -20,6 +20,7 @@ pub mod sort;
 pub mod split;
 pub(crate) mod strip;
 pub mod update;
+pub(crate) mod verify;
 pub mod xattr;
 
 use crate::cli::{CipherAlgorithmArgs, Cli, Commands, GlobalContext, PasswordArgs};

--- a/cli/src/command/experimental.rs
+++ b/cli/src/command/experimental.rs
@@ -63,6 +63,7 @@ impl Command for ExperimentalCommand {
                 cmd.execute(ctx)
             }
             ExperimentalCommands::Diff(cmd) => cmd.execute(ctx),
+            ExperimentalCommands::Verify(cmd) => cmd.execute(ctx),
         }
     }
 }
@@ -97,4 +98,6 @@ pub(crate) enum ExperimentalCommands {
     Sort(command::sort::SortCommand),
     #[command(about = "Compare archive entries with filesystem")]
     Diff(command::diff::DiffCommand),
+    #[command(about = "Verify archive integrity")]
+    Verify(command::verify::VerifyCommand),
 }

--- a/cli/src/command/verify.rs
+++ b/cli/src/command/verify.rs
@@ -1,0 +1,194 @@
+use crate::{
+    cli::{GlobalContext, PasswordArgs},
+    command::{
+        Command, ask_password,
+        core::{collect_split_archives, run_read_entries},
+    },
+};
+use clap::{Parser, ValueHint};
+use pna::{Encryption, NormalEntry, ReadEntry, ReadOptions, SolidEntry};
+use std::{io, path::PathBuf};
+
+#[derive(Parser, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[command(
+    after_long_help = "Note: for encrypted entries, a wrong password is indistinguishable from corruption."
+)]
+pub(crate) struct VerifyCommand {
+    #[arg(short = 'f', long = "file", help = "Archive file path", value_hint = ValueHint::FilePath)]
+    archive: PathBuf,
+    #[arg(
+        long,
+        help = "Verify chunk structure and CRC32 only, without decoding entry data",
+        long_help = "Verify chunk structure and CRC32 only, without decoding entry data. Solid blocks are still decoded because enumerating their entries requires decompression and decryption, so stream corruption inside a solid block is detected even with --fast. Encrypted normal entries are counted as ok because nothing is decoded, so the skipped category does not apply."
+    )]
+    fast: bool,
+    #[command(flatten)]
+    password: PasswordArgs,
+}
+
+impl Command for VerifyCommand {
+    #[inline]
+    fn execute(self, _: &GlobalContext) -> anyhow::Result<()> {
+        verify_archive(self)
+    }
+}
+
+#[derive(Default)]
+struct VerifyReport {
+    ok: usize,
+    failed: usize,
+    skipped: usize,
+    encrypted_failure: bool,
+}
+
+impl VerifyReport {
+    fn total(&self) -> usize {
+        self.ok + self.failed + self.skipped
+    }
+}
+
+fn verify_archive(args: VerifyCommand) -> anyhow::Result<()> {
+    let fast = args.fast;
+    let password = ask_password(args.password)?;
+    let password = password.as_deref();
+    let archives = collect_split_archives(&args.archive)?;
+    let mut report = VerifyReport::default();
+    let mut solid_blocks = 0usize;
+    let mut resyncing = false;
+    let result = run_read_entries(
+        archives,
+        |entry| {
+            match entry {
+                Err(err) if err.kind() == io::ErrorKind::InvalidData => {
+                    // A broken chunk aborts the current entry's assembly, and
+                    // the remainder of that entry surfaces as one or more
+                    // InvalidData errors before the iterator resyncs on the
+                    // next entry header. Count the corrupted entry once;
+                    // adjacent corrupted entries with no healthy entry in
+                    // between collapse into a single failure (accepted
+                    // approximation).
+                    if !resyncing {
+                        println!("<corrupted entry>: FAILED ({err})");
+                        report.failed += 1;
+                        resyncing = true;
+                    }
+                    Ok(())
+                }
+                Err(err) => Err(err),
+                Ok(read_entry) => {
+                    resyncing = false;
+                    match read_entry {
+                        ReadEntry::Solid(solid) => {
+                            solid_blocks += 1;
+                            if solid.encryption() != Encryption::No && password.is_none() {
+                                println!("<solid block #{solid_blocks}>: skipped (encrypted)");
+                                report.skipped += 1;
+                                return Ok(());
+                            }
+                            if let Err(err) = verify_solid(&solid, password, fast, &mut report) {
+                                println!("<solid block #{solid_blocks}>: FAILED ({err})");
+                                report.failed += 1;
+                                report.encrypted_failure |= solid.encryption() != Encryption::No;
+                            }
+                        }
+                        ReadEntry::Normal(entry) => {
+                            verify_entry(&entry, password, fast, &mut report)
+                        }
+                    }
+                    Ok(())
+                }
+            }
+        },
+        false,
+    );
+    print_summary(&report);
+    if let Err(err) = result {
+        return Err(
+            anyhow::Error::new(err).context("archive structure is broken; verification aborted")
+        );
+    }
+    if report.failed > 0 {
+        anyhow::bail!(
+            "verification failed: {} of {} entries are corrupted",
+            report.failed,
+            report.total()
+        );
+    }
+    Ok(())
+}
+
+fn verify_solid(
+    solid: &SolidEntry,
+    password: Option<&[u8]>,
+    fast: bool,
+    report: &mut VerifyReport,
+) -> io::Result<()> {
+    for entry in solid.entries(password)? {
+        verify_entry(&entry?, password, fast, report);
+    }
+    Ok(())
+}
+
+fn verify_entry(
+    entry: &NormalEntry,
+    password: Option<&[u8]>,
+    fast: bool,
+    report: &mut VerifyReport,
+) {
+    if fast {
+        // Entry assembly already validated chunk CRC32 and structure.
+        report.ok += 1;
+        return;
+    }
+    let encrypted = entry.header().encryption() != Encryption::No;
+    if encrypted && password.is_none() {
+        // Decoding is impossible without the password.
+        report.skipped += 1;
+        return;
+    }
+    match read_through(entry, password) {
+        Ok(size) => {
+            if let Some(hint) = entry.metadata().raw_file_size()
+                && hint != u128::from(size)
+            {
+                log::warn!(
+                    "{}: size hint (fSIZ) mismatch: recorded {hint}, actual {size}",
+                    entry.name()
+                );
+            }
+            log::debug!("{}: ok", entry.name());
+            report.ok += 1;
+        }
+        Err(err) => {
+            println!("{}: FAILED ({err})", entry.name());
+            report.failed += 1;
+            report.encrypted_failure |= encrypted;
+        }
+    }
+}
+
+fn read_through(entry: &NormalEntry, password: Option<&[u8]>) -> io::Result<u64> {
+    let mut reader = entry.reader(ReadOptions::with_password(password))?;
+    io::copy(&mut reader, &mut io::sink())
+}
+
+fn print_summary(report: &VerifyReport) {
+    if report.skipped > 0 {
+        println!(
+            "{} entries skipped (encrypted; no password provided)",
+            report.skipped
+        );
+    }
+    println!(
+        "total: {}, ok: {}, failed: {}, skipped (encrypted): {}",
+        report.total(),
+        report.ok,
+        report.failed,
+        report.skipped
+    );
+    if report.encrypted_failure {
+        println!(
+            "note: a wrong password is indistinguishable from corruption for encrypted entries"
+        );
+    }
+}

--- a/cli/tests/cli/main.rs
+++ b/cli/tests/cli/main.rs
@@ -35,6 +35,8 @@ mod stdio;
 mod strip;
 mod update;
 pub mod utils;
+#[cfg(not(target_family = "wasm"))]
+mod verify;
 mod xattr;
 
 use clap::CommandFactory;

--- a/cli/tests/cli/utils/archive.rs
+++ b/cli/tests/cli/utils/archive.rs
@@ -250,3 +250,39 @@ pub fn get_archive_entry_names(path: impl AsRef<Path>) -> Vec<String> {
     .unwrap();
     names
 }
+
+/// Flips one byte in the data field of the first chunk of `target` type.
+/// With `recompute_crc: false` the stored CRC no longer matches (CRC-level
+/// corruption); with `true` the CRC is updated so the corruption is only
+/// detectable by decoding the data stream.
+/// Returns whether a matching non-empty chunk was found and corrupted.
+pub fn corrupt_first_chunk(
+    path: impl AsRef<Path>,
+    target: [u8; 4],
+    recompute_crc: bool,
+) -> io::Result<bool> {
+    let mut bytes = std::fs::read(&path)?;
+    let mut pos = 8; // skip PNA signature
+    while pos + 12 <= bytes.len() {
+        let len = u32::from_be_bytes(bytes[pos..pos + 4].try_into().unwrap()) as usize;
+        let ty: [u8; 4] = bytes[pos + 4..pos + 8].try_into().unwrap();
+        if ty == target && len > 0 {
+            let data_start = pos + 8;
+            bytes[data_start] ^= 0xFF;
+            if recompute_crc {
+                // SAFETY: `ty` was read from a valid archive, so it is a valid chunk type.
+                let chunk_type = unsafe { pna::ChunkType::from_unchecked(ty) };
+                let chunk = pna::RawChunk::from_data(
+                    chunk_type,
+                    bytes[data_start..data_start + len].to_vec(),
+                );
+                let crc_pos = data_start + len;
+                bytes[crc_pos..crc_pos + 4].copy_from_slice(&chunk.crc().to_be_bytes());
+            }
+            std::fs::write(&path, bytes)?;
+            return Ok(true);
+        }
+        pos += 12 + len; // always advances at least 12 bytes per iteration
+    }
+    Ok(false)
+}

--- a/cli/tests/cli/verify.rs
+++ b/cli/tests/cli/verify.rs
@@ -1,0 +1,488 @@
+use crate::utils::{EmbedExt, TestResources, archive::corrupt_first_chunk, setup};
+use assert_cmd::cargo::cargo_bin_cmd;
+use clap::Parser;
+use portable_network_archive::cli;
+use predicates::boolean::PredicateBooleanExt;
+use predicates::str::contains;
+
+/// Precondition: A healthy archive with plain entries exists.
+/// Action: Run verify against the archive.
+/// Expectation: Exit success and the summary reports zero failures.
+#[test]
+fn verify_without_corruption() {
+    setup();
+    TestResources::extract_in("raw/", "verify_ok/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "verify_ok/verify_ok.pna",
+        "--overwrite",
+        "verify_ok/in/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args(["experimental", "verify", "-f", "verify_ok/verify_ok.pna"])
+        .assert()
+        .success()
+        .stdout(contains("failed: 0"));
+}
+
+/// Precondition: An archive whose first data chunk's bytes were altered
+/// without updating the stored CRC.
+/// Action: Run verify against the archive.
+/// Expectation: Exit failure, the corrupted entry is reported as FAILED,
+/// and verification continues over the remaining entries.
+#[test]
+fn verify_with_crc_mismatch() {
+    setup();
+    TestResources::extract_in("raw/", "verify_crc/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "verify_crc/verify_crc.pna",
+        "--overwrite",
+        "verify_crc/in/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    assert!(corrupt_first_chunk("verify_crc/verify_crc.pna", *b"FDAT", false).unwrap());
+
+    cargo_bin_cmd!("pna")
+        .args(["experimental", "verify", "-f", "verify_crc/verify_crc.pna"])
+        .assert()
+        .failure()
+        .stdout(
+            contains("FAILED")
+                .and(contains("failed: 1,"))
+                .and(contains("ok: 0,").not()),
+        );
+}
+
+/// Precondition: A deflate archive whose compressed data was altered and the
+/// chunk CRC recomputed, so corruption is only detectable by decoding.
+/// Action: Run verify in default (deep) mode.
+/// Expectation: Exit failure with the entry reported as FAILED.
+#[test]
+fn verify_with_stream_corruption() {
+    setup();
+    TestResources::extract_in("raw/", "verify_stream/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "verify_stream/verify_stream.pna",
+        "--deflate",
+        "--overwrite",
+        "verify_stream/in/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    assert!(corrupt_first_chunk("verify_stream/verify_stream.pna", *b"FDAT", true).unwrap());
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "verify",
+            "-f",
+            "verify_stream/verify_stream.pna",
+        ])
+        .assert()
+        .failure()
+        .stdout(contains("FAILED"));
+}
+
+/// Precondition: Same corruption as the deep-mode test (valid CRC, broken
+/// compressed stream).
+/// Action: Run verify with --fast.
+/// Expectation: Exit success — fast mode's detection limit is fixed by design.
+#[test]
+fn verify_with_fast_on_stream_corruption() {
+    setup();
+    TestResources::extract_in("raw/", "verify_fast/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "verify_fast/verify_fast.pna",
+        "--deflate",
+        "--overwrite",
+        "verify_fast/in/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    assert!(corrupt_first_chunk("verify_fast/verify_fast.pna", *b"FDAT", true).unwrap());
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "verify",
+            "-f",
+            "verify_fast/verify_fast.pna",
+            "--fast",
+        ])
+        .assert()
+        .success()
+        .stdout(contains("failed: 0"));
+}
+
+/// Precondition: An encrypted archive exists and no password is supplied.
+/// Action: Run verify without a password.
+/// Expectation: Exit success; encrypted entries are counted as skipped.
+#[test]
+fn verify_without_password_on_encrypted_archive() {
+    setup();
+    TestResources::extract_in("raw/", "verify_enc_skip/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "verify_enc_skip/verify_enc_skip.pna",
+        "--overwrite",
+        "verify_enc_skip/in/",
+        "--password",
+        "password",
+        "--aes",
+        "ctr",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "verify",
+            "-f",
+            "verify_enc_skip/verify_enc_skip.pna",
+        ])
+        .assert()
+        .success()
+        .stdout(
+            contains("entries skipped (encrypted; no password provided)")
+                .and(contains("failed: 0"))
+                .and(contains("skipped (encrypted): 0").not()),
+        );
+}
+
+/// Precondition: An encrypted archive exists and the correct password is supplied.
+/// Action: Run verify with the correct password.
+/// Expectation: Exit success with all entries verified (nothing skipped).
+#[test]
+fn verify_with_password_on_encrypted_archive() {
+    setup();
+    TestResources::extract_in("raw/", "verify_enc_ok/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "verify_enc_ok/verify_enc_ok.pna",
+        "--overwrite",
+        "verify_enc_ok/in/",
+        "--password",
+        "password",
+        "--aes",
+        "ctr",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "verify",
+            "-f",
+            "verify_enc_ok/verify_enc_ok.pna",
+            "--password",
+            "password",
+        ])
+        .assert()
+        .success()
+        .stdout(contains("failed: 0").and(contains("skipped (encrypted): 0")));
+}
+
+/// Precondition: An encrypted archive exists and a wrong password is supplied.
+/// Action: Run verify with the wrong password.
+/// Expectation: Exit failure with entries reported as FAILED and a note that
+/// a wrong password is indistinguishable from corruption.
+#[test]
+fn verify_with_wrong_password_on_encrypted_archive() {
+    setup();
+    TestResources::extract_in("raw/", "verify_enc_wrong/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "verify_enc_wrong/verify_enc_wrong.pna",
+        "--overwrite",
+        "verify_enc_wrong/in/",
+        "--password",
+        "password",
+        "--aes",
+        "ctr",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "verify",
+            "-f",
+            "verify_enc_wrong/verify_enc_wrong.pna",
+            "--password",
+            "wrong-password",
+        ])
+        .assert()
+        .failure()
+        .stdout(contains("FAILED").and(contains(
+            "note: a wrong password is indistinguishable from corruption",
+        )));
+}
+
+/// Precondition: A plain solid archive exists.
+/// Action: Run verify against the archive.
+/// Expectation: Exit success; entries inside the solid block are verified
+/// individually.
+#[test]
+fn verify_with_solid_archive() {
+    setup();
+    TestResources::extract_in("raw/", "verify_solid/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "verify_solid/verify_solid.pna",
+        "--overwrite",
+        "--solid",
+        "verify_solid/in/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "verify",
+            "-f",
+            "verify_solid/verify_solid.pna",
+        ])
+        .assert()
+        .success()
+        .stdout(contains(
+            "total: 17, ok: 17, failed: 0, skipped (encrypted): 0",
+        ));
+}
+
+/// Precondition: A plain solid archive whose first solid-data chunk was altered
+/// and the chunk CRC recomputed, so corruption is only detectable by decoding.
+/// Action: Run verify with --fast.
+/// Expectation: Exit failure with the solid block reported as FAILED — fast mode
+/// still decodes solid blocks because enumerating their entries requires it.
+#[test]
+fn verify_with_fast_on_corrupted_solid_archive() {
+    setup();
+    TestResources::extract_in("raw/", "verify_fast_solid/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "verify_fast_solid/verify_fast_solid.pna",
+        "--overwrite",
+        "--solid",
+        "verify_fast_solid/in/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    assert!(
+        corrupt_first_chunk("verify_fast_solid/verify_fast_solid.pna", *b"SDAT", true).unwrap()
+    );
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "verify",
+            "-f",
+            "verify_fast_solid/verify_fast_solid.pna",
+            "--fast",
+        ])
+        .assert()
+        .failure()
+        .stdout(contains("FAILED"));
+}
+
+/// Precondition: An encrypted solid archive exists and no password is supplied.
+/// Action: Run verify without a password.
+/// Expectation: Exit success; the whole solid block is reported as one
+/// skipped unit because its entries cannot be enumerated without decryption.
+#[test]
+fn verify_without_password_on_encrypted_solid_archive() {
+    setup();
+    TestResources::extract_in("raw/", "verify_solid_enc/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "verify_solid_enc/verify_solid_enc.pna",
+        "--overwrite",
+        "--solid",
+        "verify_solid_enc/in/",
+        "--password",
+        "password",
+        "--aes",
+        "ctr",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "verify",
+            "-f",
+            "verify_solid_enc/verify_solid_enc.pna",
+        ])
+        .assert()
+        .success()
+        .stdout(
+            contains("<solid block #1>: skipped (encrypted)")
+                .and(contains("skipped (encrypted): 1")),
+        );
+}
+
+/// Precondition: A multipart archive exists.
+/// Action: Run verify against the first part.
+/// Expectation: Exit success; all parts are traversed and verified.
+#[test]
+fn verify_with_multipart_archive() {
+    setup();
+    TestResources::extract_in("raw/", "verify_multi/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "verify_multi/verify_multi.pna",
+        "--overwrite",
+        "verify_multi/in/",
+        "--unstable",
+        "--split",
+        "1000",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "verify",
+            "-f",
+            "verify_multi/verify_multi.part1.pna",
+        ])
+        .assert()
+        .success()
+        .stdout(contains(
+            "total: 17, ok: 17, failed: 0, skipped (encrypted): 0",
+        ));
+}
+
+/// Precondition: An archive whose fSIZ size-hint chunk was altered (CRC
+/// recomputed) so the recorded size no longer matches the actual data size.
+/// Action: Run verify against the archive.
+/// Expectation: Exit success (fSIZ is a non-authoritative hint) with a
+/// warning about the mismatch.
+#[test]
+fn verify_with_size_hint_mismatch() {
+    setup();
+    TestResources::extract_in("raw/", "verify_fsiz/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "verify_fsiz/verify_fsiz.pna",
+        "--overwrite",
+        "--store",
+        "verify_fsiz/in/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    assert!(corrupt_first_chunk("verify_fsiz/verify_fsiz.pna", *b"fSIZ", true).unwrap());
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "verify",
+            "-f",
+            "verify_fsiz/verify_fsiz.pna",
+        ])
+        .assert()
+        .success()
+        .stderr(contains("size hint (fSIZ) mismatch"));
+}
+
+/// Precondition: An archive truncated in the middle of the chunk stream.
+/// Action: Run verify against the archive.
+/// Expectation: Exit failure as a fatal structural error, with the partial
+/// summary still printed.
+#[test]
+fn verify_with_truncated_archive() {
+    setup();
+    TestResources::extract_in("raw/", "verify_trunc/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "verify_trunc/verify_trunc.pna",
+        "--overwrite",
+        "verify_trunc/in/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    let len = std::fs::metadata("verify_trunc/verify_trunc.pna")
+        .unwrap()
+        .len();
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .open("verify_trunc/verify_trunc.pna")
+        .unwrap();
+    file.set_len(len / 2).unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "verify",
+            "-f",
+            "verify_trunc/verify_trunc.pna",
+        ])
+        .assert()
+        .failure()
+        .stdout(contains("total: "))
+        .stderr(contains("archive structure is broken"));
+}


### PR DESCRIPTION
## Summary
Add `pna experimental verify`, a subcommand that verifies archive integrity. By default it decodes every entry end-to-end (decompressing, and decrypting when a password is supplied); `--fast` checks chunk structure and CRC32 only.

## Notes
- Corrupted entries are reported individually and verification continues; the command exits 1 with a summary (`total/ok/failed/skipped`). Structural damage (truncation, missing split part) aborts after printing a partial summary.
- Encrypted entries and solid blocks without a password are counted as skipped and do not fail the run. A wrong password is indistinguishable from corruption (PHSF stores no verifier), noted in the output and `--help`.
- `--fast` still decodes solid blocks because enumerating their entries requires it; `fSIZ` mismatches are warnings only (non-authoritative hint).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an archive verification command to check structure and data integrity.
  * Support includes a faster verification mode and optional password handling for encrypted content.

* **Bug Fixes**
  * Verification now reports corrupted, skipped, and failed entries more clearly.
  * Improved handling of partial, split, solid, and encrypted archives, including corruption and password-related cases.

* **Tests**
  * Added end-to-end coverage for successful verification, corruption detection, encrypted archives, multipart archives, and truncated files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->