### PR TITLE
:boom: Remove experimental delete subcommand

### DIFF
--- a/cli/src/cli/old_style.rs
+++ b/cli/src/cli/old_style.rs
@@ -573,7 +573,7 @@ mod tests {
 
     #[test]
     fn non_stdio_experimental_subcommand_passthrough() {
-        let args = s(&["pna", "experimental", "delete", "cvf"]);
+        let args = s(&["pna", "experimental", "chown", "cvf"]);
         assert_eq!(expand_bsdtar_old_style_args(args.clone()), args);
     }
 
@@ -962,7 +962,7 @@ mod tests {
 
     #[test]
     fn w_option_non_stdio_experimental_subcommand_passthrough() {
-        let args = s(&["pna", "experimental", "delete", "-W", "help"]);
+        let args = s(&["pna", "experimental", "chown", "-W", "help"]);
         assert_eq!(expand_bsdtar_w_option(args.clone()), args);
     }
 

--- a/cli/src/command/experimental.rs
+++ b/cli/src/command/experimental.rs
@@ -24,17 +24,6 @@ impl Command for ExperimentalCommand {
                 );
                 cmd.execute(ctx)
             }
-            ExperimentalCommands::Delete(cmd) => {
-                log::warn!(
-                    "`{0} experimental delete` subcommand was stabilized, use `{0} delete` instead. this command will be removed in the future.",
-                    std::env::current_exe()
-                        .ok()
-                        .and_then(|it| it.file_name().map(|n| n.to_os_string()))
-                        .unwrap_or_default()
-                        .to_string_lossy()
-                );
-                cmd.execute(ctx)
-            }
             ExperimentalCommands::Update(cmd) => cmd.execute(ctx),
             ExperimentalCommands::Chown(cmd) => cmd.execute(ctx),
             ExperimentalCommands::Chmod(cmd) => cmd.execute(ctx),
@@ -74,10 +63,6 @@ pub(crate) enum ExperimentalCommands {
         about = "bsdtar-like CLI semantics for PNA archives (stabilized, use `pna compat bsdtar` instead)"
     )]
     Stdio(command::bsdtar::BsdtarCommand),
-    #[command(
-        about = "Delete entry from archive (stabilized, use `pna delete` command instead. this command will be removed in the future)"
-    )]
-    Delete(command::delete::DeleteCommand),
     #[command(about = "Update entries in archive")]
     Update(command::update::UpdateCommand),
     #[command(about = "Change owner")]

--- a/cli/tests/cli/delete/delete_all_entries.rs
+++ b/cli/tests/cli/delete/delete_all_entries.rs
@@ -26,7 +26,6 @@ fn delete_all_entries() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "delete",
         "-f",
         "delete_all_entries/delete_all_entries.pna",

--- a/cli/tests/cli/delete/directory_entry.rs
+++ b/cli/tests/cli/delete/directory_entry.rs
@@ -56,7 +56,6 @@ fn delete_directory_entry() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "delete",
         "-f",
         &format!("{base}/archive.pna"),
@@ -129,7 +128,6 @@ fn delete_directory_and_contents() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "delete",
         "-f",
         &format!("{base}/archive.pna"),

--- a/cli/tests/cli/delete/missing_file.rs
+++ b/cli/tests/cli/delete/missing_file.rs
@@ -25,7 +25,6 @@ fn delete_fail_with_missing_file() {
     let result = cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "delete",
         "-f",
         "delete_missing/archive.pna",

--- a/cli/tests/cli/delete/multipart.rs
+++ b/cli/tests/cli/delete/multipart.rs
@@ -47,7 +47,6 @@ fn delete_from_multipart_archive() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "delete",
         "-f",
         "delete_multipart/split/archive.part1.pna",

--- a/cli/tests/cli/delete/option_exclude.rs
+++ b/cli/tests/cli/delete/option_exclude.rs
@@ -27,7 +27,6 @@ fn delete_with_exclude() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "delete",
         "-f",
         "delete_output_exclude/delete_output_exclude.pna",

--- a/cli/tests/cli/delete/option_exclude_from.rs
+++ b/cli/tests/cli/delete/option_exclude_from.rs
@@ -32,7 +32,6 @@ fn delete_with_exclude_from() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "delete",
         "-f",
         "delete_exclude_from/exclude_from.pna",

--- a/cli/tests/cli/delete/option_exclude_vcs.rs
+++ b/cli/tests/cli/delete/option_exclude_vcs.rs
@@ -49,7 +49,6 @@ fn delete_with_exclude_vcs() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "delete",
         "-f",
         "delete_with_exclude_vcs/delete_with_exclude_vcs.pna",
@@ -135,7 +134,6 @@ fn delete_without_exclude_vcs() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "delete",
         "-f",
         "delete_without_exclude_vcs/delete_without_exclude_vcs.pna",

--- a/cli/tests/cli/delete/option_files_from.rs
+++ b/cli/tests/cli/delete/option_files_from.rs
@@ -36,7 +36,6 @@ fn delete_with_files_from() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "delete",
         "-f",
         "delete_files_from/delete_files_from.pna",

--- a/cli/tests/cli/delete/option_files_from_stdin.rs
+++ b/cli/tests/cli/delete/option_files_from_stdin.rs
@@ -33,7 +33,6 @@ fn delete_with_files_from_stdin() {
     cmd.write_stdin(list);
     cmd.args([
         "--quiet",
-        "experimental",
         "delete",
         "-f",
         "delete_files_from_stdin/delete_files_from_stdin.pna",

--- a/cli/tests/cli/delete/option_include.rs
+++ b/cli/tests/cli/delete/option_include.rs
@@ -28,7 +28,6 @@ fn delete_with_include() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "delete",
         "-f",
         "delete_with_include/include.pna",

--- a/cli/tests/cli/delete/option_keep_solid.rs
+++ b/cli/tests/cli/delete/option_keep_solid.rs
@@ -31,7 +31,6 @@ fn delete_with_keep_solid() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "delete",
         "-f",
         "delete_with_keep_solid/delete_with_keep_solid.pna",

--- a/cli/tests/cli/delete/option_null.rs
+++ b/cli/tests/cli/delete/option_null.rs
@@ -37,7 +37,6 @@ fn delete_with_files_from_null() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "delete",
         "-f",
         "delete_files_from_null/delete_files_from_null.pna",
@@ -125,7 +124,6 @@ fn delete_with_files_from_null_rejects_newline_separator() {
     let result = cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "delete",
         "-f",
         "delete_null_newline/delete_null_newline.pna",

--- a/cli/tests/cli/delete/option_output.rs
+++ b/cli/tests/cli/delete/option_output.rs
@@ -29,7 +29,6 @@ fn delete_output() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "delete",
         "-f",
         "delete_output/delete_output.pna",

--- a/cli/tests/cli/delete/option_password.rs
+++ b/cli/tests/cli/delete/option_password.rs
@@ -16,7 +16,6 @@ fn delete_with_password() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "delete",
         "-f",
         "delete_password/zstd_aes_ctr.pna",

--- a/cli/tests/cli/delete/option_password_file.rs
+++ b/cli/tests/cli/delete/option_password_file.rs
@@ -20,7 +20,6 @@ fn delete_with_password_file() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "delete",
         "-f",
         "delete_password_file/zstd_aes_ctr.pna",

--- a/cli/tests/cli/delete/option_unsolid.rs
+++ b/cli/tests/cli/delete/option_unsolid.rs
@@ -31,7 +31,6 @@ fn delete_with_unsolid() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "delete",
         "--unsolid",
         "-f",

--- a/cli/tests/cli/delete/overwrite_original.rs
+++ b/cli/tests/cli/delete/overwrite_original.rs
@@ -29,7 +29,6 @@ fn delete_overwrite() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "delete",
         "-f",
         "delete_overwrite/delete_overwrite.pna",

--- a/cli/tests/cli/delete/symlink_entry.rs
+++ b/cli/tests/cli/delete/symlink_entry.rs
@@ -54,7 +54,6 @@ fn delete_symlink_entry() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "delete",
         "-f",
         "delete_symlink_entry/archive.pna",
@@ -117,7 +116,6 @@ fn delete_symlink_target_keeps_symlink() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "delete",
         "-f",
         "delete_symlink_target/archive.pna",
@@ -187,7 +185,6 @@ fn delete_directory_symlink_entry() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "delete",
         "-f",
         "delete_dir_symlink/archive.pna",


### PR DESCRIPTION
## Summary
- Remove the `pna experimental delete` subcommand; `pna delete` has been stable since v0.30.0.

Closes #2989

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The delete command is now available directly from the main CLI path, without requiring the experimental prefix.
  * Updated delete-related behavior to match the new command layout across common archive workflows.

* **Tests**
  * Refreshed CLI tests to use the direct delete command in scenarios covering exclusions, files lists, passwords, solid archives, multipart archives, symlinks, directories, and missing files.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->