### PR TITLE
:lock: Pin container image references to digests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - container: redoxos/redoxer
+          # no versioned tag is published upstream; pinned to the current `latest` digest
+          - container: redoxos/redoxer:latest@sha256:d628a0193067798e7ea5ce2c47e89585080217390232e1fb6e4562a19235a10b
             target: x86_64-unknown-redox
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/webassembly.yml
+++ b/.github/workflows/webassembly.yml
@@ -43,15 +43,15 @@ jobs:
           - wasm32-wasip2
         include:
           - target: wasm32-unknown-emscripten
-            container: emscripten/emsdk:latest
+            container: emscripten/emsdk:6.0.2@sha256:644883f58ca15c38c8be59b3a727ba0eff347729bc31d50a3348a6c9ed92bc07
             runner: ubuntu-latest
           - target: wasm32-unknown-unknown
             runner: ubuntu-24.04-arm
           - target: wasm32-wasip1
-            container: ghcr.io/portable-network-archive/wasi-sdk-gh-actions:wasi-sdk-27
+            container: ghcr.io/portable-network-archive/wasi-sdk-gh-actions:wasi-sdk-27@sha256:c683f8ea612f05ca7e5113696f0bb20b6ad28188074532dfdc3c64977ed5fbaf
             runner: ubuntu-24.04-arm
           - target: wasm32-wasip2
-            container: ghcr.io/portable-network-archive/wasi-sdk-gh-actions:wasi-sdk-27
+            container: ghcr.io/portable-network-archive/wasi-sdk-gh-actions:wasi-sdk-27@sha256:c683f8ea612f05ca7e5113696f0bb20b6ad28188074532dfdc3c64977ed5fbaf
             runner: ubuntu-24.04-arm
 
     runs-on: ${{ matrix.runner }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -27,6 +27,10 @@ rules:
   template-injection:
     ignore:
       - release.yml
+  # container image is picked dynamically by `dist` from its own pinned config
+  unpinned-images:
+    ignore:
+      - release.yml
   # daily interval is intentional for this project
   dependabot-cooldown:
     disable: true


### PR DESCRIPTION
## Summary
- Pin the `redoxos/redoxer`, `emscripten/emsdk`, and `wasi-sdk-gh-actions` container images used in `test.yml`/`webassembly.yml` to their current sha256 digests, fixing zizmor's `unpinned-images` findings.
- `release.yml`'s container is picked dynamically by `dist` itself, so that finding is suppressed via `zizmor.yml` instead of hand-editing the generated workflow.

## Notes
- Dependabot's `github-actions` ecosystem does not track `container:` image references, so these digests will need manual bumps going forward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned several CI container images to specific digests for more reliable and reproducible workflow runs.
  * Updated WebAssembly and Redox-related build jobs to use fixed image versions instead of floating tags.
  * Added a targeted exception for an image-pinning check in one release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->