### PR TITLE
Unify missing-time options into a single --missing-time option

### DIFF
--- a/cli/src/command/core/time_filter.rs
+++ b/cli/src/command/core/time_filter.rs
@@ -48,6 +48,11 @@ mod range {
             }
         }
 
+        /// Returns `true` when neither side constrains the range.
+        pub(crate) fn is_unbounded(&self) -> bool {
+            matches!((self.start, self.end), (Bound::Unbounded, Bound::Unbounded))
+        }
+
         pub(crate) fn contains(&self, time: SystemTime) -> bool {
             let start_ok = match self.start {
                 Bound::Unbounded => true,
@@ -160,6 +165,13 @@ mod range {
         }
 
         #[test]
+        fn is_unbounded_only_when_both_sides_unbounded() {
+            assert!(TimeRange::new_strict(None, None).is_unbounded());
+            assert!(!TimeRange::new_strict(Some(t2()), None).is_unbounded());
+            assert!(!TimeRange::new_strict(None, Some(t2())).is_unbounded());
+        }
+
+        #[test]
         fn contains_inverted_range_rejects_all() {
             // start > end: empty-range semantics
             let r = TimeRange::from_bounds(Bound::Excluded(t3()), Bound::Excluded(t1()));
@@ -209,6 +221,11 @@ impl TimeFilter {
 
     /// Determines whether a given timestamp passes this filter's constraints.
     fn matches(&self, time: Option<SystemTime>) -> bool {
+        // The missing-time policy only applies when there is an actual bound
+        // to compare against; an unbounded range accepts every entry.
+        if self.range.is_unbounded() {
+            return true;
+        }
         let time = match time {
             Some(t) => t,
             None => match &self.missing_policy {
@@ -678,6 +695,21 @@ mod tests {
                 ),
             };
             assert!(filters.matches(None, Some(now())));
+        }
+
+        #[test]
+        fn exclude_policy_ignored_when_range_unbounded() {
+            let filters = TimeFilters {
+                ctime: TimeFilter::new(
+                    TimeRange::new_strict(None, None),
+                    MissingTimePolicy::Exclude,
+                ),
+                mtime: TimeFilter::new(
+                    TimeRange::new_strict(None, None),
+                    MissingTimePolicy::Exclude,
+                ),
+            };
+            assert!(filters.matches(None, None));
         }
 
         #[test]

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -65,8 +65,7 @@ use std::{
     group(ArgGroup::new("ctime-newer-than-source").args(["newer_ctime", "newer_ctime_than"])),
     group(ArgGroup::new("mtime-older-than-source").args(["older_mtime", "older_mtime_than"])),
     group(ArgGroup::new("mtime-newer-than-source").args(["newer_mtime", "newer_mtime_than"])),
-    group(ArgGroup::new("ctime-filter").args(["older_ctime", "older_ctime_than", "newer_ctime", "newer_ctime_than"]).multiple(true)),
-    group(ArgGroup::new("mtime-filter").args(["older_mtime", "older_mtime_than", "newer_mtime", "newer_mtime_than"]).multiple(true)),
+    group(ArgGroup::new("time-filter").args(["older_ctime", "older_ctime_than", "newer_ctime", "newer_ctime_than", "older_mtime", "older_mtime_than", "newer_mtime", "newer_mtime_than"]).multiple(true)),
     group(
         ArgGroup::new("overwrite-flag")
             .args(["overwrite", "no_overwrite", "keep_newer_files", "keep_old_files"])
@@ -271,22 +270,11 @@ pub(crate) struct ExtractCommand {
     older_mtime_than: Option<PathBuf>,
     #[arg(
         long,
-        visible_alias = "arc-missing-ctime",
-        alias = "missing-ctime",
-        requires_all = ["unstable", "ctime-filter"],
+        requires_all = ["unstable", "time-filter"],
         help_heading = "Unstable Options",
-        help = "Behavior for archive entries without ctime when time filtering (unstable). Values: include, exclude, now, epoch, or a datetime. [default: include]"
+        help = "Behavior for entries missing a timestamp needed by the time filters (unstable). Values: include, exclude, now, epoch, or a datetime. [default: include]"
     )]
-    archive_missing_ctime: Option<MissingTimePolicy>,
-    #[arg(
-        long,
-        visible_alias = "arc-missing-mtime",
-        alias = "missing-mtime",
-        requires_all = ["unstable", "mtime-filter"],
-        help_heading = "Unstable Options",
-        help = "Behavior for archive entries without mtime when time filtering (unstable). Values: include, exclude, now, epoch, or a datetime. [default: include]"
-    )]
-    archive_missing_mtime: Option<MissingTimePolicy>,
+    missing_time: Option<MissingTimePolicy>,
     #[arg(
         long,
         value_name = "PATTERN",
@@ -443,12 +431,8 @@ fn extract_archive(args: ExtractCommand) -> anyhow::Result<()> {
         older_mtime_than: args.older_mtime_than.as_deref(),
         newer_mtime: args.newer_mtime.map(|it| it.to_system_time()),
         older_mtime: args.older_mtime.map(|it| it.to_system_time()),
-        missing_ctime: args
-            .archive_missing_ctime
-            .unwrap_or(MissingTimePolicy::Include),
-        missing_mtime: args
-            .archive_missing_mtime
-            .unwrap_or(MissingTimePolicy::Include),
+        missing_ctime: args.missing_time.unwrap_or(MissingTimePolicy::Include),
+        missing_mtime: args.missing_time.unwrap_or(MissingTimePolicy::Include),
     }
     .resolve()?;
     let overwrite_strategy = OverwriteStrategy::from_flags(

--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -49,8 +49,7 @@ use tabled::{
     group(ArgGroup::new("ctime-newer-than-source").args(["newer_ctime", "newer_ctime_than"])),
     group(ArgGroup::new("mtime-older-than-source").args(["older_mtime", "older_mtime_than"])),
     group(ArgGroup::new("mtime-newer-than-source").args(["newer_mtime", "newer_mtime_than"])),
-    group(ArgGroup::new("ctime-filter").args(["older_ctime", "older_ctime_than", "newer_ctime", "newer_ctime_than"]).multiple(true)),
-    group(ArgGroup::new("mtime-filter").args(["older_mtime", "older_mtime_than", "newer_mtime", "newer_mtime_than"]).multiple(true)),
+    group(ArgGroup::new("time-filter").args(["older_ctime", "older_ctime_than", "newer_ctime", "newer_ctime_than", "older_mtime", "older_mtime_than", "newer_mtime", "newer_mtime_than"]).multiple(true)),
 )]
 pub(crate) struct ListCommand {
     #[arg(short, long, help = "Display extended file metadata as a table")]
@@ -162,22 +161,11 @@ pub(crate) struct ListCommand {
     older_mtime_than: Option<PathBuf>,
     #[arg(
         long,
-        visible_alias = "arc-missing-ctime",
-        alias = "missing-ctime",
-        requires_all = ["unstable", "ctime-filter"],
+        requires_all = ["unstable", "time-filter"],
         help_heading = "Unstable Options",
-        help = "Behavior for archive entries without ctime when time filtering (unstable). Values: include, exclude, now, epoch, or a datetime. [default: include]"
+        help = "Behavior for entries missing a timestamp needed by the time filters (unstable). Values: include, exclude, now, epoch, or a datetime. [default: include]"
     )]
-    archive_missing_ctime: Option<MissingTimePolicy>,
-    #[arg(
-        long,
-        visible_alias = "arc-missing-mtime",
-        alias = "missing-mtime",
-        requires_all = ["unstable", "mtime-filter"],
-        help_heading = "Unstable Options",
-        help = "Behavior for archive entries without mtime when time filtering (unstable). Values: include, exclude, now, epoch, or a datetime. [default: include]"
-    )]
-    archive_missing_mtime: Option<MissingTimePolicy>,
+    missing_time: Option<MissingTimePolicy>,
     #[arg(
         short = 'q',
         help = "Force printing of non-graphic characters in file names as the character '?'"
@@ -505,12 +493,8 @@ fn list_archive(ctx: &crate::cli::GlobalContext, args: ListCommand) -> anyhow::R
         older_mtime_than: args.older_mtime_than.as_deref(),
         newer_mtime: args.newer_mtime.map(|it| it.to_system_time()),
         older_mtime: args.older_mtime.map(|it| it.to_system_time()),
-        missing_ctime: args
-            .archive_missing_ctime
-            .unwrap_or(MissingTimePolicy::Include),
-        missing_mtime: args
-            .archive_missing_mtime
-            .unwrap_or(MissingTimePolicy::Include),
+        missing_ctime: args.missing_time.unwrap_or(MissingTimePolicy::Include),
+        missing_mtime: args.missing_time.unwrap_or(MissingTimePolicy::Include),
     }
     .resolve()?;
 

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -272,20 +272,11 @@ pub(crate) struct UpdateCommand {
     older_mtime_than: Option<PathBuf>,
     #[arg(
         long,
-        visible_alias = "arc-missing-ctime",
         requires = "unstable",
         help_heading = "Unstable Options",
-        help = "Behavior for archive entries without ctime during update staleness judgment (unstable). Values: include, exclude, now, epoch, or a datetime. [default: include]"
+        help = "Behavior when a timestamp needed for time filtering or update staleness judgment is missing (unstable). Values: include, exclude, now, epoch, or a datetime. [default: include]"
     )]
-    archive_missing_ctime: Option<MissingTimePolicy>,
-    #[arg(
-        long,
-        visible_alias = "arc-missing-mtime",
-        requires = "unstable",
-        help_heading = "Unstable Options",
-        help = "Behavior for archive entries without mtime during update staleness judgment (unstable). Values: include, exclude, now, epoch, or a datetime. [default: include]"
-    )]
-    archive_missing_mtime: Option<MissingTimePolicy>,
+    missing_time: Option<MissingTimePolicy>,
     #[arg(
         long,
         value_name = "FILE",
@@ -444,6 +435,7 @@ fn update_archive(args: UpdateCommand) -> anyhow::Result<()> {
         fflags_strategy: FflagsStrategy::Never,
         mac_metadata_strategy: MacMetadataStrategy::Never,
     };
+    let missing_time = args.missing_time.unwrap_or(MissingTimePolicy::Include);
     let time_filters = TimeFilterResolver {
         newer_ctime_than: args.newer_ctime_than.as_deref(),
         older_ctime_than: args.older_ctime_than.as_deref(),
@@ -453,13 +445,10 @@ fn update_archive(args: UpdateCommand) -> anyhow::Result<()> {
         older_mtime_than: args.older_mtime_than.as_deref(),
         newer_mtime: args.newer_mtime.map(|it| it.to_system_time()),
         older_mtime: args.older_mtime.map(|it| it.to_system_time()),
-        missing_ctime: MissingTimePolicy::Include,
-        missing_mtime: MissingTimePolicy::Include,
+        missing_ctime: missing_time,
+        missing_mtime: missing_time,
     }
     .resolve()?;
-    let archive_missing_mtime = args
-        .archive_missing_mtime
-        .unwrap_or(MissingTimePolicy::Include);
     let create_options = CreateOptions {
         option,
         keep_options,
@@ -521,7 +510,7 @@ fn update_archive(args: UpdateCommand) -> anyhow::Result<()> {
             &create_options,
             target_items,
             sync,
-            archive_missing_mtime,
+            missing_time,
             &mut out_archive,
             TransformStrategyUnSolid,
             false,
@@ -533,7 +522,7 @@ fn update_archive(args: UpdateCommand) -> anyhow::Result<()> {
             &create_options,
             target_items,
             sync,
-            archive_missing_mtime,
+            missing_time,
             &mut out_archive,
             TransformStrategyKeepSolid,
             false,
@@ -555,7 +544,7 @@ pub(crate) fn run_update_archive<Strategy, W>(
     create_options: &CreateOptions,
     target_items: Vec<CollectedEntry>,
     sync: bool,
-    archive_missing_mtime: MissingTimePolicy,
+    missing_time: MissingTimePolicy,
     out_archive: &mut Archive<W>,
     _strategy: Strategy,
     verbose: bool,
@@ -581,12 +570,9 @@ where
                     if let Some((idx, item)) =
                         target_files_mapping.shift_remove(entry.header().path())
                     {
-                        let need_update = is_newer_than_archive(
-                            archive_missing_mtime,
-                            &item.metadata,
-                            entry.metadata(),
-                        )
-                        .unwrap_or(true);
+                        let need_update =
+                            is_newer_than_archive(missing_time, &item.metadata, entry.metadata())
+                                .unwrap_or(true);
                         if need_update {
                             let tx = tx.clone();
                             let create_options = create_options.clone();
@@ -648,12 +634,12 @@ where
 
 #[inline]
 fn is_newer_than_archive(
-    archive_missing_mtime: MissingTimePolicy,
+    missing_time: MissingTimePolicy,
     fs_meta: &fs::Metadata,
     metadata: &Metadata,
 ) -> Option<bool> {
     let fs_mtime = fs_meta.modified().ok()?;
-    let archive_mtime = match (metadata.saturating_modified_time(), archive_missing_mtime) {
+    let archive_mtime = match (metadata.saturating_modified_time(), missing_time) {
         (Some(t), _) => t,
         (None, MissingTimePolicy::Include) => return Some(true),
         (None, MissingTimePolicy::Exclude) => return Some(false),

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -571,8 +571,7 @@ where
                         target_files_mapping.shift_remove(entry.header().path())
                     {
                         let need_update =
-                            is_newer_than_archive(missing_time, &item.metadata, entry.metadata())
-                                .unwrap_or(true);
+                            is_newer_than_archive(missing_time, &item.metadata, entry.metadata());
                         if need_update {
                             let tx = tx.clone();
                             let create_options = create_options.clone();
@@ -632,18 +631,26 @@ where
     Ok(())
 }
 
+// The missing-time policy applies to whichever side lacks an mtime: the
+// filesystem side (unreadable metadata) as well as the archive side (no mTIM
+// chunk). With `Assume(t)` and both sides missing, `t < t` never updates.
 #[inline]
 fn is_newer_than_archive(
     missing_time: MissingTimePolicy,
     fs_meta: &fs::Metadata,
     metadata: &Metadata,
-) -> Option<bool> {
-    let fs_mtime = fs_meta.modified().ok()?;
+) -> bool {
+    let fs_mtime = match (fs_meta.modified(), missing_time) {
+        (Ok(t), _) => t,
+        (Err(_), MissingTimePolicy::Include) => return true,
+        (Err(_), MissingTimePolicy::Exclude) => return false,
+        (Err(_), MissingTimePolicy::Assume(t)) => t,
+    };
     let archive_mtime = match (metadata.saturating_modified_time(), missing_time) {
         (Some(t), _) => t,
-        (None, MissingTimePolicy::Include) => return Some(true),
-        (None, MissingTimePolicy::Exclude) => return Some(false),
+        (None, MissingTimePolicy::Include) => return true,
+        (None, MissingTimePolicy::Exclude) => return false,
         (None, MissingTimePolicy::Assume(t)) => t,
     };
-    Some(archive_mtime < fs_mtime)
+    archive_mtime < fs_mtime
 }

--- a/cli/tests/cli/extract.rs
+++ b/cli/tests/cli/extract.rs
@@ -7,6 +7,7 @@ mod option_keep_newer_files;
 mod option_keep_old_files;
 mod option_keep_permission;
 mod option_keep_timestamp;
+mod option_missing_time;
 mod option_mtime;
 mod option_password_from_file;
 mod option_safe_writes;

--- a/cli/tests/cli/extract/option_missing_time.rs
+++ b/cli/tests/cli/extract/option_missing_time.rs
@@ -1,0 +1,89 @@
+use crate::utils::setup;
+use clap::Parser;
+use portable_network_archive::cli;
+use std::{fs, path::Path};
+
+fn create_archive(dir: &str) {
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+    fs::write(format!("{dir}/file.txt"), "content").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        &format!("{dir}/archive.pna"),
+        "--overwrite",
+        &format!("{dir}/file.txt"),
+        "--no-keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+}
+
+/// Precondition: Archive entry has no mtime (mTIM chunk omitted).
+/// Action: Run `pna extract` with a newer-mtime filter and `--missing-time exclude`.
+/// Expectation: The mtime-missing entry is not extracted.
+#[test]
+fn extract_missing_time_exclude_skips_entry() {
+    setup();
+    create_archive("extract_missing_time_exclude");
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        "-f",
+        "extract_missing_time_exclude/archive.pna",
+        "--overwrite",
+        "--out-dir",
+        "extract_missing_time_exclude/out/",
+        "--unstable",
+        "--newer-mtime",
+        "@1000000000",
+        "--missing-time",
+        "exclude",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    assert!(
+        !Path::new("extract_missing_time_exclude/out/extract_missing_time_exclude/file.txt")
+            .exists(),
+        "exclude policy should skip mtime-missing entries"
+    );
+}
+
+/// Precondition: Archive entry has no mtime.
+/// Action: Run `pna extract` with a newer-mtime filter and no `--missing-time`.
+/// Expectation: Default `include` policy extracts the mtime-missing entry.
+#[test]
+fn extract_missing_time_default_extracts_entry() {
+    setup();
+    create_archive("extract_missing_time_default");
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        "-f",
+        "extract_missing_time_default/archive.pna",
+        "--overwrite",
+        "--out-dir",
+        "extract_missing_time_default/out/",
+        "--unstable",
+        "--newer-mtime",
+        "@1000000000",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    assert!(
+        Path::new("extract_missing_time_default/out/extract_missing_time_default/file.txt")
+            .exists(),
+        "default include policy should extract mtime-missing entries"
+    );
+}

--- a/cli/tests/cli/list.rs
+++ b/cli/tests/cli/list.rs
@@ -16,6 +16,8 @@ mod option_format_tree;
 #[cfg(not(target_family = "wasm"))]
 mod option_format_tsv;
 #[cfg(not(target_family = "wasm"))]
+mod option_missing_time;
+#[cfg(not(target_family = "wasm"))]
 mod option_no_recursive;
 #[cfg(not(target_family = "wasm"))]
 mod option_show_fflags;

--- a/cli/tests/cli/list/option_missing_time.rs
+++ b/cli/tests/cli/list/option_missing_time.rs
@@ -1,0 +1,184 @@
+use crate::utils::setup;
+use assert_cmd::cargo::cargo_bin_cmd;
+use std::fs;
+
+fn create_archive(dir: &str, timestamp_flag: &str) {
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+    fs::write(format!("{dir}/file.txt"), "content").unwrap();
+    let mut cmd = cargo_bin_cmd!("pna");
+    cmd.args([
+        "--quiet",
+        "c",
+        "-f",
+        &format!("{dir}/archive.pna"),
+        "--overwrite",
+        &format!("{dir}/file.txt"),
+        timestamp_flag,
+    ])
+    .assert()
+    .success();
+}
+
+/// Precondition: Archive entry has no mtime (mTIM chunk omitted).
+/// Action: Run `pna list` with a newer-mtime filter and `--missing-time exclude`.
+/// Expectation: The mtime-missing entry is hidden.
+#[test]
+fn list_missing_time_exclude_hides_entry() {
+    setup();
+    create_archive("list_missing_time_exclude", "--no-keep-timestamp");
+
+    let mut cmd = cargo_bin_cmd!("pna");
+    cmd.args([
+        "list",
+        "-f",
+        "list_missing_time_exclude/archive.pna",
+        "--unstable",
+        "--newer-mtime",
+        "@1000000000",
+        "--missing-time",
+        "exclude",
+    ])
+    .assert()
+    .success()
+    .stdout("");
+}
+
+/// Precondition: Archive entry has no mtime.
+/// Action: Run `pna list` with a newer-mtime filter and no `--missing-time`.
+/// Expectation: Default `include` policy shows the mtime-missing entry.
+#[test]
+fn list_missing_time_default_shows_entry() {
+    setup();
+    create_archive("list_missing_time_default", "--no-keep-timestamp");
+
+    let mut cmd = cargo_bin_cmd!("pna");
+    cmd.args([
+        "list",
+        "-f",
+        "list_missing_time_default/archive.pna",
+        "--unstable",
+        "--newer-mtime",
+        "@1000000000",
+    ])
+    .assert()
+    .success()
+    .stdout("list_missing_time_default/file.txt\n");
+}
+
+/// Precondition: Archive entry has no mtime.
+/// Action: Run `pna list` with a newer-mtime filter and `--missing-time epoch`.
+/// Expectation: The entry is assumed infinitely old and hidden.
+#[test]
+fn list_missing_time_assume_epoch_hides_with_newer_filter() {
+    setup();
+    create_archive("list_missing_time_epoch_newer", "--no-keep-timestamp");
+
+    let mut cmd = cargo_bin_cmd!("pna");
+    cmd.args([
+        "list",
+        "-f",
+        "list_missing_time_epoch_newer/archive.pna",
+        "--unstable",
+        "--newer-mtime",
+        "@1000000000",
+        "--missing-time",
+        "epoch",
+    ])
+    .assert()
+    .success()
+    .stdout("");
+}
+
+/// Precondition: Archive entry has no mtime.
+/// Action: Run `pna list` with an older-mtime filter and `--missing-time epoch`.
+/// Expectation: The entry is assumed infinitely old and shown.
+#[test]
+fn list_missing_time_assume_epoch_shows_with_older_filter() {
+    setup();
+    create_archive("list_missing_time_epoch_older", "--no-keep-timestamp");
+
+    let mut cmd = cargo_bin_cmd!("pna");
+    cmd.args([
+        "list",
+        "-f",
+        "list_missing_time_epoch_older/archive.pna",
+        "--unstable",
+        "--older-mtime",
+        "@1000000000",
+        "--missing-time",
+        "epoch",
+    ])
+    .assert()
+    .success()
+    .stdout("list_missing_time_epoch_older/file.txt\n");
+}
+
+/// Precondition: None.
+/// Action: Run `pna list --missing-time exclude` without any time-filter option.
+/// Expectation: Argument parsing fails.
+#[test]
+fn list_missing_time_requires_time_filter() {
+    setup();
+
+    let mut cmd = cargo_bin_cmd!("pna");
+    cmd.args([
+        "list",
+        "-f",
+        "archive.pna",
+        "--unstable",
+        "--missing-time",
+        "exclude",
+    ])
+    .assert()
+    .failure();
+}
+
+/// Precondition: Archive entry has no ctime.
+/// Action: Run `pna list` with a ctime filter (no mtime filter) and `--missing-time exclude`.
+/// Expectation: The option is accepted and the ctime-missing entry is hidden.
+#[test]
+fn list_missing_time_accepts_ctime_filter() {
+    setup();
+    create_archive("list_missing_time_ctime", "--no-keep-timestamp");
+
+    let mut cmd = cargo_bin_cmd!("pna");
+    cmd.args([
+        "list",
+        "-f",
+        "list_missing_time_ctime/archive.pna",
+        "--unstable",
+        "--newer-ctime",
+        "@1000000000",
+        "--missing-time",
+        "exclude",
+    ])
+    .assert()
+    .success()
+    .stdout("");
+}
+
+/// Precondition: Archive entry has an mtime newer than the filter threshold.
+/// Action: Run `pna list` with only a newer-mtime filter and `--missing-time exclude`.
+/// Expectation: The entry is shown; the exclude policy must not apply to the
+/// unbounded ctime filter even when the entry lacks ctime.
+#[test]
+fn list_missing_time_exclude_ignores_unbounded_ctime_filter() {
+    setup();
+    create_archive("list_missing_time_unbounded", "--keep-timestamp");
+
+    let mut cmd = cargo_bin_cmd!("pna");
+    cmd.args([
+        "list",
+        "-f",
+        "list_missing_time_unbounded/archive.pna",
+        "--unstable",
+        "--newer-mtime",
+        "@1000000000",
+        "--missing-time",
+        "exclude",
+    ])
+    .assert()
+    .success()
+    .stdout("list_missing_time_unbounded/file.txt\n");
+}

--- a/cli/tests/cli/update.rs
+++ b/cli/tests/cli/update.rs
@@ -2,13 +2,13 @@ mod encryption;
 mod entry_order;
 mod error;
 mod no_timestamp_archive;
-mod option_archive_missing_mtime;
 mod option_atime;
 mod option_ctime;
 mod option_exclude;
 mod option_exclude_vcs;
 #[cfg(not(target_family = "wasm"))]
 mod option_files_from_stdin;
+mod option_missing_time;
 mod option_mtime;
 mod option_newer_ctime;
 mod option_newer_ctime_than;

--- a/cli/tests/cli/update/option_missing_time.rs
+++ b/cli/tests/cli/update/option_missing_time.rs
@@ -158,3 +158,145 @@ fn update_missing_time_exclude_keeps_entry() {
         "exclude policy should keep mtime-missing entries"
     );
 }
+
+/// Precondition: Archive contains an entry without mtime.
+/// Action: Run `pna experimental update --missing-time=epoch`.
+/// Expectation: The entry is treated as infinitely old and re-archived; the
+/// latest copy holds the modified content.
+#[test]
+fn update_missing_time_epoch_updates_entry() {
+    setup();
+    let _ = fs::remove_dir_all("update_missing_time_epoch");
+    fs::create_dir_all("update_missing_time_epoch").unwrap();
+    let source = "update_missing_time_epoch/file.txt";
+    let archive_path = "update_missing_time_epoch/archive.pna";
+
+    fs::write(source, "old content").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        archive_path,
+        "--overwrite",
+        source,
+        "--no-keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    fs::write(source, "new content").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "--unstable",
+        "--missing-time=epoch",
+        "-f",
+        archive_path,
+        source,
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut contents: Vec<Vec<u8>> = Vec::new();
+    archive::for_each_entry(archive_path, |entry| {
+        if entry.header().path().as_str() == source {
+            let mut buf = Vec::new();
+            entry
+                .reader(ReadOptions::with_password::<&[u8]>(None))
+                .unwrap()
+                .read_to_end(&mut buf)
+                .unwrap();
+            contents.push(buf);
+        }
+    })
+    .unwrap();
+    assert_eq!(
+        contents.last().unwrap().as_slice(),
+        b"new content",
+        "epoch policy should treat mtime-missing entries as stale"
+    );
+}
+
+/// Precondition: Archive contains an entry without mtime.
+/// Action: Run `pna experimental update --missing-time=<far future datetime>`.
+/// Expectation: The entry is treated as newer than the filesystem copy and kept.
+#[test]
+fn update_missing_time_future_datetime_keeps_entry() {
+    setup();
+    let _ = fs::remove_dir_all("update_missing_time_future");
+    fs::create_dir_all("update_missing_time_future").unwrap();
+    let source = "update_missing_time_future/file.txt";
+    let archive_path = "update_missing_time_future/archive.pna";
+
+    fs::write(source, "old content").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        archive_path,
+        "--overwrite",
+        source,
+        "--no-keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    fs::write(source, "new content").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "--unstable",
+        "--missing-time=@4102444800",
+        "-f",
+        archive_path,
+        source,
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let entry = archive::extract_single_entry(archive_path, source)
+        .unwrap()
+        .expect("entry should exist");
+    let mut buf = Vec::new();
+    entry
+        .reader(ReadOptions::with_password::<&[u8]>(None))
+        .unwrap()
+        .read_to_end(&mut buf)
+        .unwrap();
+    assert_eq!(
+        buf.as_slice(),
+        b"old content",
+        "future assumed time should keep mtime-missing entries"
+    );
+}
+
+/// Precondition: None.
+/// Action: Parse `pna experimental update --missing-time=exclude` without `--unstable`.
+/// Expectation: Argument parsing fails.
+#[test]
+fn update_missing_time_requires_unstable() {
+    assert!(
+        cli::Cli::try_parse_from([
+            "pna",
+            "experimental",
+            "update",
+            "--missing-time=exclude",
+            "-f",
+            "archive.pna",
+            "file.txt",
+        ])
+        .is_err()
+    );
+}

--- a/cli/tests/cli/update/option_missing_time.rs
+++ b/cli/tests/cli/update/option_missing_time.rs
@@ -5,17 +5,17 @@ use portable_network_archive::cli;
 use std::{fs, io::prelude::*};
 
 /// Precondition: Archive contains an entry without mtime (mTIM chunk omitted).
-/// Action: Run `pna experimental update` without `--archive-missing-mtime`.
-/// Expectation: Default `Include` policy treats mtime-missing entries as stale,
+/// Action: Run `pna experimental update` without `--missing-time`.
+/// Expectation: Default `include` policy treats mtime-missing entries as stale,
 /// so under append-only update semantics a fresh copy with the modified content
 /// is appended; the latest copy of the entry holds `"new content"`.
 #[test]
 fn update_default_mtime_missing_still_updates() {
     setup();
-    let _ = fs::remove_dir_all("update_arc_missing_mtime_default");
-    fs::create_dir_all("update_arc_missing_mtime_default").unwrap();
-    let source = "update_arc_missing_mtime_default/file.txt";
-    let archive_path = "update_arc_missing_mtime_default/archive.pna";
+    let _ = fs::remove_dir_all("update_missing_time_default");
+    fs::create_dir_all("update_missing_time_default").unwrap();
+    let source = "update_missing_time_default/file.txt";
+    let archive_path = "update_missing_time_default/archive.pna";
 
     // Create an initial archive whose entry has no mTIM chunk.
     fs::write(source, "old content").unwrap();
@@ -46,7 +46,7 @@ fn update_default_mtime_missing_still_updates() {
     // Modify the source file.
     fs::write(source, "new content").unwrap();
 
-    // Default behavior: no `--archive-missing-mtime` flag.
+    // Default behavior: no `--missing-time` flag.
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -84,18 +84,18 @@ fn update_default_mtime_missing_still_updates() {
 }
 
 /// Precondition: Archive contains an entry without mtime.
-/// Action: Run `pna experimental update --archive-missing-mtime=exclude` on its own
-/// (no time-filter flag). Update's Path B staleness judgment fires for every entry
-/// regardless of time-filter flags, so the archive-missing policy takes effect.
+/// Action: Run `pna experimental update --missing-time=exclude` on its own
+/// (no time-filter flag). The staleness judgment fires for every entry
+/// regardless of time-filter flags, so the missing-time policy takes effect.
 /// Expectation: The entry is kept (pass-through) because `exclude` treats mtime-missing
 /// archive entries as NOT stale.
 #[test]
-fn update_archive_missing_mtime_exclude_keeps_entry() {
+fn update_missing_time_exclude_keeps_entry() {
     setup();
-    let _ = fs::remove_dir_all("update_arc_missing_mtime_exclude");
-    fs::create_dir_all("update_arc_missing_mtime_exclude").unwrap();
-    let source = "update_arc_missing_mtime_exclude/file.txt";
-    let archive_path = "update_arc_missing_mtime_exclude/archive.pna";
+    let _ = fs::remove_dir_all("update_missing_time_exclude");
+    fs::create_dir_all("update_missing_time_exclude").unwrap();
+    let source = "update_missing_time_exclude/file.txt";
+    let archive_path = "update_missing_time_exclude/archive.pna";
 
     // Create an initial archive whose entry has no mTIM chunk.
     fs::write(source, "old content").unwrap();
@@ -125,15 +125,15 @@ fn update_archive_missing_mtime_exclude_keeps_entry() {
     // Modify the source file.
     fs::write(source, "new content").unwrap();
 
-    // Run update with --archive-missing-mtime=exclude alone (no time filter);
-    // Path B staleness judgment consults the policy for every entry.
+    // Run update with --missing-time=exclude alone (no time filter);
+    // the staleness judgment consults the policy for every entry.
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "experimental",
         "update",
         "--unstable",
-        "--archive-missing-mtime=exclude",
+        "--missing-time=exclude",
         "-f",
         archive_path,
         source,


### PR DESCRIPTION
## Summary
Replaces `--archive-missing-ctime`/`--archive-missing-mtime` on `list`, `extract`, and `update` with a single `--missing-time` option that applies to every time judgment the command performs. All removed options were unstable.

## Notes
- On `update` the policy now also governs the staleness judgment when the filesystem mtime is unreadable (previously always treated as needing update) and the ctime side of the time filters (`--archive-missing-ctime` was declared but never consumed).
- A time filter with no bounds no longer consults the policy; without this guard, `--missing-time exclude` alone would drop every entry through the unbounded ctime filter on filesystems without birth time.