### PR TITLE
Restrict update --sync pruning to entries missing on disk

### DIFF
--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -23,7 +23,10 @@ use crate::{
 use clap::{ArgGroup, Parser, ValueHint};
 use indexmap::IndexMap;
 use pna::{Archive, EntryName, Metadata, prelude::*};
-use std::{env, fs, io, path::PathBuf};
+use std::{
+    env, fs, io,
+    path::{Path, PathBuf},
+};
 
 #[derive(Parser, Clone, Debug)]
 #[command(
@@ -594,7 +597,7 @@ where
                         } else {
                             Ok(Some(entry))
                         }
-                    } else if sync {
+                    } else if sync && !exists_on_disk(entry.header().path().as_path()) {
                         log::debug!("Removing (sync): {}", entry.header().path());
                         Ok(None)
                     } else {
@@ -629,6 +632,23 @@ where
     }
 
     Ok(())
+}
+
+// `--sync` realigns the archive to the disk state: an entry is pruned only
+// when its name (resolved against the current directory, the same base as
+// collection) no longer exists on disk. Entries merely filtered out of the
+// collected set (e.g. by --exclude or time filters) are kept. Ambiguous
+// errors such as PermissionDenied count as existing so pruning never risks
+// data loss. Known limitation: names produced by -s/--transform/
+// --strip-components do not correspond to filesystem paths and are pruned.
+fn exists_on_disk(path: &Path) -> bool {
+    match fs::symlink_metadata(path) {
+        Ok(_) => true,
+        Err(e) => !matches!(
+            e.kind(),
+            io::ErrorKind::NotFound | io::ErrorKind::NotADirectory | io::ErrorKind::InvalidFilename
+        ),
+    }
 }
 
 // The missing-time policy applies to whichever side lacks an mtime: the

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -674,3 +674,56 @@ fn is_newer_than_archive(
     };
     archive_mtime < fs_mtime
 }
+
+#[cfg(test)]
+#[cfg(not(target_family = "wasm"))]
+mod tests {
+    use super::*;
+
+    fn test_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir()
+            .join("pna_update_exists_on_disk")
+            .join(name);
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn exists_on_disk_regular_file() {
+        let dir = test_dir("regular_file");
+        let file = dir.join("file.txt");
+        fs::write(&file, "content").unwrap();
+        assert!(exists_on_disk(&file));
+    }
+
+    #[test]
+    fn exists_on_disk_directory() {
+        let dir = test_dir("directory");
+        assert!(exists_on_disk(&dir));
+    }
+
+    #[test]
+    fn exists_on_disk_missing_path() {
+        let dir = test_dir("missing");
+        assert!(!exists_on_disk(&dir.join("no_such_file")));
+    }
+
+    #[test]
+    fn exists_on_disk_regular_file_as_parent() {
+        let dir = test_dir("regular_file_as_parent");
+        let file = dir.join("file.txt");
+        fs::write(&file, "content").unwrap();
+        assert!(!exists_on_disk(&file.join("child")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exists_on_disk_broken_symlink() {
+        let dir = test_dir("broken_symlink");
+        let link = dir.join("link");
+        std::os::unix::fs::symlink(dir.join("no_such_target"), &link).unwrap();
+        assert!(!link.exists());
+        assert!(exists_on_disk(&link));
+    }
+}

--- a/cli/tests/cli/update/option_sync.rs
+++ b/cli/tests/cli/update/option_sync.rs
@@ -222,7 +222,6 @@ fn update_with_sync_keeps_excluded_but_existing_file() {
         initial_entries.insert(entry.header().path().to_string());
     })
     .unwrap();
-    let initial_count = initial_entries.len();
 
     // empty.txt stays on disk but is excluded from collection.
     cli::Cli::try_parse_from([
@@ -254,8 +253,7 @@ fn update_with_sync_keeps_excluded_but_existing_file() {
         "excluded but existing empty.txt should be kept under --sync"
     );
     assert_eq!(
-        seen.len(),
-        initial_count,
+        seen, initial_entries,
         "no entry should be pruned when all files exist on disk"
     );
 }
@@ -288,7 +286,6 @@ fn update_with_sync_keeps_time_filtered_files() {
         initial_entries.insert(entry.header().path().to_string());
     })
     .unwrap();
-    let initial_count = initial_entries.len();
 
     // The far-future threshold filters every file out of collection.
     cli::Cli::try_parse_from([
@@ -316,8 +313,7 @@ fn update_with_sync_keeps_time_filtered_files() {
     .unwrap();
 
     assert_eq!(
-        seen.len(),
-        initial_count,
+        seen, initial_entries,
         "time-filtered but existing files should be kept under --sync"
     );
 }

--- a/cli/tests/cli/update/option_sync.rs
+++ b/cli/tests/cli/update/option_sync.rs
@@ -193,3 +193,131 @@ fn update_with_sync() {
         "text.txt should exist in extracted output"
     );
 }
+
+/// Precondition: An archive contains multiple files, all of which exist on disk.
+/// Action: Run `pna experimental update --sync` with `--exclude` matching one file.
+/// Expectation: The excluded entry is kept; --sync prunes only entries whose
+/// files no longer exist on disk, not entries filtered out of collection.
+#[test]
+fn update_with_sync_keeps_excluded_but_existing_file() {
+    setup();
+    TestResources::extract_in("raw/", "update_sync_exclude_existing/in/").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "update_sync_exclude_existing/archive.pna",
+        "--overwrite",
+        "update_sync_exclude_existing/in/",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut initial_entries = HashSet::new();
+    archive::for_each_entry("update_sync_exclude_existing/archive.pna", |entry| {
+        initial_entries.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+    let initial_count = initial_entries.len();
+
+    // empty.txt stays on disk but is excluded from collection.
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "--sync",
+        "-f",
+        "update_sync_exclude_existing/archive.pna",
+        "update_sync_exclude_existing/in/",
+        "--keep-timestamp",
+        "--exclude",
+        "update_sync_exclude_existing/in/raw/empty.txt",
+        "--unstable",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut seen = HashSet::new();
+    archive::for_each_entry("update_sync_exclude_existing/archive.pna", |entry| {
+        seen.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+
+    assert!(
+        seen.iter().any(|p| p.ends_with("raw/empty.txt")),
+        "excluded but existing empty.txt should be kept under --sync"
+    );
+    assert_eq!(
+        seen.len(),
+        initial_count,
+        "no entry should be pruned when all files exist on disk"
+    );
+}
+
+/// Precondition: An archive contains multiple files, all of which exist on disk.
+/// Action: Run `pna experimental update --sync` with a future `--newer-mtime`
+/// filter so that no file is collected.
+/// Expectation: All entries are kept; time-filtered files still exist on disk.
+#[test]
+fn update_with_sync_keeps_time_filtered_files() {
+    setup();
+    TestResources::extract_in("raw/", "update_sync_time_filtered/in/").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "update_sync_time_filtered/archive.pna",
+        "--overwrite",
+        "update_sync_time_filtered/in/",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut initial_entries = HashSet::new();
+    archive::for_each_entry("update_sync_time_filtered/archive.pna", |entry| {
+        initial_entries.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+    let initial_count = initial_entries.len();
+
+    // The far-future threshold filters every file out of collection.
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "--sync",
+        "-f",
+        "update_sync_time_filtered/archive.pna",
+        "update_sync_time_filtered/in/",
+        "--keep-timestamp",
+        "--newer-mtime",
+        "@4102444800",
+        "--unstable",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut seen = HashSet::new();
+    archive::for_each_entry("update_sync_time_filtered/archive.pna", |entry| {
+        seen.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+
+    assert_eq!(
+        seen.len(),
+        initial_count,
+        "time-filtered but existing files should be kept under --sync"
+    );
+}


### PR DESCRIPTION
## Summary
`update --sync` now prunes an archive entry only when its path no longer exists on disk. Previously any entry absent from the collected set was pruned, so entries filtered out by `--exclude`/`--include` or time filters were deleted even though their files still exist.

## Notes
- `--sync` is a stable option, so this changes stable-surface behavior.
- Ambiguous stat errors (e.g. `PermissionDenied`) keep the entry to avoid data loss; only `NotFound`/`NotADirectory`/`InvalidFilename` prune.
- Names produced by `-s`/`--transform`/`--strip-components` do not correspond to filesystem paths and are still pruned, as before.
- Stacked on #3164.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `--sync` now avoids removing archive entries just because they were skipped by filters, as long as the source files still exist on disk.
  * Improved handling of missing-file checks to reduce accidental pruning when file access fails for reasons other than “not found.”
* **Tests**
  * Added coverage for `--sync` with excluded files and time-based filters to confirm existing files remain in the archive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->