### PR TITLE
Remove experimental sort subcommand

### DIFF
--- a/cli/src/command/experimental.rs
+++ b/cli/src/command/experimental.rs
@@ -40,17 +40,6 @@ impl Command for ExperimentalCommand {
                 cmd.execute(ctx)
             }
             ExperimentalCommands::Chunk(cmd) => cmd.execute(ctx),
-            ExperimentalCommands::Sort(cmd) => {
-                log::warn!(
-                    "`{0} experimental sort` subcommand was stabilized, use `{0} sort` instead. this command will be removed in the future.",
-                    std::env::current_exe()
-                        .ok()
-                        .and_then(|it| it.file_name().map(|n| n.to_os_string()))
-                        .unwrap_or_default()
-                        .to_string_lossy()
-                );
-                cmd.execute(ctx)
-            }
             ExperimentalCommands::Diff(cmd) => cmd.execute(ctx),
             ExperimentalCommands::Verify(cmd) => cmd.execute(ctx),
         }
@@ -77,10 +66,6 @@ pub(crate) enum ExperimentalCommands {
     Migrate(command::migrate::MigrateCommand),
     #[command(about = "Chunk level operation")]
     Chunk(command::chunk::ChunkCommand),
-    #[command(
-        about = "Sort entries in archive (stabilized, use `pna sort` command instead. this command will be removed in the future)"
-    )]
-    Sort(command::sort::SortCommand),
     #[command(about = "Compare archive entries with filesystem")]
     Diff(command::diff::DiffCommand),
     #[command(about = "Verify archive integrity")]

--- a/cli/tests/cli/list/exclude_vcs.rs
+++ b/cli/tests/cli/list/exclude_vcs.rs
@@ -64,7 +64,6 @@ fn list_with_exclude_vcs() {
     let mut cmd = cargo_bin_cmd!("pna");
     cmd.args([
         "--quiet",
-        "experimental",
         "sort",
         "-f",
         "list_with_exclude_vcs/list_with_exclude_vcs.pna",
@@ -163,7 +162,6 @@ fn list_without_exclude_vcs() {
     let mut cmd = cargo_bin_cmd!("pna");
     cmd.args([
         "--quiet",
-        "experimental",
         "sort",
         "-f",
         "list_without_exclude_vcs/list_without_exclude_vcs.pna",

--- a/cli/tests/cli/sort/by_atime.rs
+++ b/cli/tests/cli/sort/by_atime.rs
@@ -5,7 +5,7 @@ use portable_network_archive::cli;
 use std::fs;
 
 /// Precondition: An archive contains entries with different access times.
-/// Action: Run `pna experimental sort` with `--by atime`.
+/// Action: Run `pna sort` with `--by atime`.
 /// Expectation: Entries are reordered by access time in ascending order.
 #[test]
 fn sort_by_atime() {
@@ -36,7 +36,6 @@ fn sort_by_atime() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "sort",
         "-f",
         "sort_by_atime/unsorted.pna",

--- a/cli/tests/cli/sort/by_ctime.rs
+++ b/cli/tests/cli/sort/by_ctime.rs
@@ -5,7 +5,7 @@ use portable_network_archive::cli;
 use std::fs;
 
 /// Precondition: An archive contains entries with different creation times.
-/// Action: Run `pna experimental sort` with `--by ctime`.
+/// Action: Run `pna sort` with `--by ctime`.
 /// Expectation: Entries are reordered by creation time in ascending order.
 #[test]
 fn sort_by_ctime() {
@@ -36,7 +36,6 @@ fn sort_by_ctime() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "sort",
         "-f",
         "sort_by_ctime/unsorted.pna",

--- a/cli/tests/cli/sort/by_mtime.rs
+++ b/cli/tests/cli/sort/by_mtime.rs
@@ -5,7 +5,7 @@ use portable_network_archive::cli;
 use std::fs;
 
 /// Precondition: An archive contains entries with different modification times.
-/// Action: Run `pna experimental sort` with `--by mtime`.
+/// Action: Run `pna sort` with `--by mtime`.
 /// Expectation: Entries are reordered by modification time in ascending order.
 #[test]
 fn sort_by_mtime() {
@@ -36,7 +36,6 @@ fn sort_by_mtime() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "sort",
         "-f",
         "sort_by_mtime/unsorted.pna",

--- a/cli/tests/cli/sort/by_name.rs
+++ b/cli/tests/cli/sort/by_name.rs
@@ -5,7 +5,7 @@ use portable_network_archive::cli;
 use std::fs;
 
 /// Precondition: An archive contains entries in non-alphabetical order.
-/// Action: Run `pna experimental sort` with the default sort key (name).
+/// Action: Run `pna sort` with the default sort key (name).
 /// Expectation: Entries are reordered alphabetically by path in ascending order.
 #[test]
 fn sort_by_name() {
@@ -19,17 +19,10 @@ fn sort_by_name() {
     archive.add_entry(entry_a.build().unwrap()).unwrap();
     archive.finalize().unwrap();
 
-    cli::Cli::try_parse_from([
-        "pna",
-        "--quiet",
-        "experimental",
-        "sort",
-        "-f",
-        "sort_by_name/unsorted.pna",
-    ])
-    .unwrap()
-    .execute()
-    .unwrap();
+    cli::Cli::try_parse_from(["pna", "--quiet", "sort", "-f", "sort_by_name/unsorted.pna"])
+        .unwrap()
+        .execute()
+        .unwrap();
 
     let mut names = Vec::new();
     for_each_entry("sort_by_name/unsorted.pna", |e| {

--- a/cli/tests/cli/sort/by_name_desc.rs
+++ b/cli/tests/cli/sort/by_name_desc.rs
@@ -5,7 +5,7 @@ use portable_network_archive::cli;
 use std::fs;
 
 /// Precondition: An archive contains entries in alphabetical order.
-/// Action: Run `pna experimental sort` with `--by name:desc`.
+/// Action: Run `pna sort` with `--by name:desc`.
 /// Expectation: Entries are reordered alphabetically by path in descending order.
 #[test]
 fn sort_by_name_desc() {
@@ -22,7 +22,6 @@ fn sort_by_name_desc() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "sort",
         "-f",
         "sort_by_name_desc/unsorted.pna",

--- a/cli/tests/cli/sort/multiple_keys.rs
+++ b/cli/tests/cli/sort/multiple_keys.rs
@@ -5,7 +5,7 @@ use portable_network_archive::cli;
 use std::fs;
 
 /// Precondition: An archive contains entries where the primary key has ties.
-/// Action: Run `pna experimental sort` with `--by ctime --by mtime`.
+/// Action: Run `pna sort` with `--by ctime --by mtime`.
 /// Expectation: Entries are ordered by ctime first, then by mtime as a tiebreaker.
 #[test]
 fn sort_by_multiple_keys() {
@@ -43,7 +43,6 @@ fn sort_by_multiple_keys() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "sort",
         "-f",
         "sort_by_multi/unsorted.pna",

--- a/cli/tests/cli/sort/order_combination.rs
+++ b/cli/tests/cli/sort/order_combination.rs
@@ -5,7 +5,7 @@ use portable_network_archive::cli;
 use std::fs;
 
 /// Precondition: An archive contains entries with distinct atime, mtime, ctime, and name values.
-/// Action: Run `pna experimental sort` with all four keys in different orderings.
+/// Action: Run `pna sort` with all four keys in different orderings.
 /// Expectation: Entries are ordered according to the specified key priority.
 #[test]
 fn sort_by_all_keys() {
@@ -46,7 +46,6 @@ fn sort_by_all_keys() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "sort",
         "-f",
         "sort_by_all/unsorted.pna",
@@ -74,7 +73,6 @@ fn sort_by_all_keys() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "sort",
         "-f",
         "sort_by_all/unsorted.pna",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -47,7 +47,6 @@ This document contains the help content for the `pna` command-line program.
 * [`pna experimental chunk help`↴](#pna-experimental-chunk-help)
 * [`pna experimental chunk help list`↴](#pna-experimental-chunk-help-list)
 * [`pna experimental chunk help help`↴](#pna-experimental-chunk-help-help)
-* [`pna experimental sort`↴](#pna-experimental-sort)
 * [`pna experimental diff`↴](#pna-experimental-diff)
 * [`pna experimental verify`↴](#pna-experimental-verify)
 * [`pna experimental help`↴](#pna-experimental-help)
@@ -61,7 +60,6 @@ This document contains the help content for the `pna` command-line program.
 * [`pna experimental help migrate`↴](#pna-experimental-help-migrate)
 * [`pna experimental help chunk`↴](#pna-experimental-help-chunk)
 * [`pna experimental help chunk list`↴](#pna-experimental-help-chunk-list)
-* [`pna experimental help sort`↴](#pna-experimental-help-sort)
 * [`pna experimental help diff`↴](#pna-experimental-help-diff)
 * [`pna experimental help verify`↴](#pna-experimental-help-verify)
 * [`pna experimental help help`↴](#pna-experimental-help-help)
@@ -94,7 +92,6 @@ This document contains the help content for the `pna` command-line program.
 * [`pna help experimental migrate`↴](#pna-help-experimental-migrate)
 * [`pna help experimental chunk`↴](#pna-help-experimental-chunk)
 * [`pna help experimental chunk list`↴](#pna-help-experimental-chunk-list)
-* [`pna help experimental sort`↴](#pna-help-experimental-sort)
 * [`pna help experimental diff`↴](#pna-help-experimental-diff)
 * [`pna help experimental verify`↴](#pna-help-experimental-verify)
 * [`pna help help`↴](#pna-help-help)
@@ -1561,7 +1558,6 @@ Unstable experimental commands; behavior and interface may change or be removed
 * `acl` — Manipulate ACLs of entries
 * `migrate` — Upgrade archives created by older PNA versions (stabilized, use `pna migrate` command instead. this command will be removed in the future)
 * `chunk` — Chunk level operation
-* `sort` — Sort entries in archive (stabilized, use `pna sort` command instead. this command will be removed in the future)
 * `diff` — Compare archive entries with filesystem
 * `verify` — Verify archive integrity
 * `help` — Print this message or the help of the given subcommand(s)
@@ -2413,46 +2409,6 @@ Print this message or the help of the given subcommand(s)
 
 
 
-## `pna experimental sort`
-
-Sort entries in archive (stabilized, use `pna sort` command instead. this command will be removed in the future)
-
-**Usage:** `pna experimental sort [OPTIONS] --file <ARCHIVE>`
-
-###### **Options:**
-
-* `-f`, `--file <ARCHIVE>` — Archive file path
-* `--output <OUTPUT>` — Output archive file path
-* `--by <KEY>` — Sort key in format KEY[:ORDER] (e.g., name, mtime:desc) [keys: name, ctime, mtime, atime] [orders: asc, desc]
-
-  Default value: `name`
-* `--password <PASSWORD>` [alias: `passphrase`] — Password of archive. If password is not given it's asked from the tty
-* `--password-file <FILE>` — Read password from specified file
-* `--quiet` — Make some output more quiet (alias for --log-level off)
-
-  Default value: `false`
-* `--verbose` — Make some output more verbose (alias for --log-level debug)
-
-  Default value: `false`
-* `--log-level <LEVEL>` — Set the log level
-
-  Default value: `warn`
-
-  Possible values: `off`, `error`, `warn`, `info`, `debug`, `trace`
-
-* `--color <WHEN>` — Control color output
-
-  Default value: `auto`
-
-  Possible values: `auto`, `always`, `never`
-
-* `--unstable` — Enable experimental options. Required for flags marked as unstable; behavior may change or be removed.
-
-  Default value: `false`
-* `-h`, `--help` — Print help
-
-
-
 ## `pna experimental diff`
 
 Compare archive entries with filesystem
@@ -2552,7 +2508,6 @@ Print this message or the help of the given subcommand(s)
 * `acl` — Manipulate ACLs of entries
 * `migrate` — Upgrade archives created by older PNA versions (stabilized, use `pna migrate` command instead. this command will be removed in the future)
 * `chunk` — Chunk level operation
-* `sort` — Sort entries in archive (stabilized, use `pna sort` command instead. this command will be removed in the future)
 * `diff` — Compare archive entries with filesystem
 * `verify` — Verify archive integrity
 * `help` — Print this message or the help of the given subcommand(s)
@@ -2645,14 +2600,6 @@ Chunk level operation
 List chunks
 
 **Usage:** `pna experimental help chunk list`
-
-
-
-## `pna experimental help sort`
-
-Sort entries in archive (stabilized, use `pna sort` command instead. this command will be removed in the future)
-
-**Usage:** `pna experimental help sort`
 
 
 
@@ -2867,7 +2814,6 @@ Unstable experimental commands; behavior and interface may change or be removed
 * `acl` — Manipulate ACLs of entries
 * `migrate` — Upgrade archives created by older PNA versions (stabilized, use `pna migrate` command instead. this command will be removed in the future)
 * `chunk` — Chunk level operation
-* `sort` — Sort entries in archive (stabilized, use `pna sort` command instead. this command will be removed in the future)
 * `diff` — Compare archive entries with filesystem
 * `verify` — Verify archive integrity
 
@@ -2959,14 +2905,6 @@ Chunk level operation
 List chunks
 
 **Usage:** `pna help experimental chunk list`
-
-
-
-## `pna help experimental sort`
-
-Sort entries in archive (stabilized, use `pna sort` command instead. this command will be removed in the future)
-
-**Usage:** `pna help experimental sort`
 
 
 


### PR DESCRIPTION
## Summary

- Remove the deprecated `pna experimental sort` subcommand now that `pna sort` is stable.
- Update tests to exercise the stable `pna sort` command instead of the experimental alias.
- Regenerate the CLI reference so the removed subcommand no longer appears in generated help docs.

## Impact

Users should call `pna sort` directly. The experimental alias is removed as a breaking CLI cleanup.

Fixes #2991.

## Validation

- `cargo fmt --check`
- `cargo check -p portable-network-archive`
- `cargo test -p portable-network-archive --test cli sort`
- `cargo test -p portable-network-archive --test cli list_with_exclude_vcs`
- `cargo test -p portable-network-archive --test cli list_without_exclude_vcs`
- `target/debug/pna experimental sort --help` rejects the removed subcommand
- `target/debug/pna sort --help` still works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The `sort` command is now available as a stable CLI command, with support for sorting by name, time, and multiple keys.

- **Bug Fixes**
  - Removed the deprecated `experimental sort` path from command handling.
  - Updated sorting tests to use the stable command, keeping expected output behavior unchanged.

- **Documentation**
  - Refreshed the CLI reference to reflect the updated command structure and remove the deprecated entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->