### PR TITLE
Harden chmod stabilization edge cases

### DIFF
--- a/cli/tests/cli/chmod.rs
+++ b/cli/tests/cli/chmod.rs
@@ -2,6 +2,7 @@ mod edge_cases;
 mod glob_pattern;
 mod keep_solid;
 mod missing_file;
+mod multipart;
 mod multiple_clauses;
 mod numeric;
 mod password;

--- a/cli/tests/cli/chmod/missing_file.rs
+++ b/cli/tests/cli/chmod/missing_file.rs
@@ -43,8 +43,9 @@ fn fail_with_missing_file() {
     .execute();
 
     assert!(result.is_err());
-    assert!(
-        fs::read("chmod_missing/archive.pna").unwrap() == before,
+    assert_eq!(
+        fs::read("chmod_missing/archive.pna").unwrap(),
+        before,
         "the archive must be left unchanged"
     );
 }

--- a/cli/tests/cli/chmod/multipart.rs
+++ b/cli/tests/cli/chmod/multipart.rs
@@ -1,0 +1,74 @@
+use crate::utils::{archive, archive::FileEntryDef, setup};
+use clap::Parser;
+use portable_network_archive::cli;
+use std::{fs, path::Path};
+
+const ENTRY_PATH: &str = "test.txt";
+
+/// Precondition: A multipart archive exists.
+/// Action: Run `pna experimental chmod` against the first part.
+/// Expectation: The command reads all parts and writes the updated consolidated archive.
+#[test]
+fn chmod_multipart_archive_updates_consolidated_output() {
+    setup();
+    fs::create_dir_all("chmod_multipart/split").unwrap();
+    let content = vec![b'x'; 4096];
+
+    archive::create_archive_with_permissions(
+        "chmod_multipart/archive.pna",
+        &[FileEntryDef {
+            path: ENTRY_PATH,
+            content: &content,
+            permission: 0o777,
+        }],
+    )
+    .unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "split",
+        "-f",
+        "chmod_multipart/archive.pna",
+        "--overwrite",
+        "--max-size",
+        "1kb",
+        "--out-dir",
+        "chmod_multipart/split",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    assert!(
+        Path::new("chmod_multipart/split/archive.part2.pna").exists(),
+        "test archive should be split into multiple parts"
+    );
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "chmod",
+        "-f",
+        "chmod_multipart/split/archive.part1.pna",
+        "600",
+        ENTRY_PATH,
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    assert_eq!(
+        archive::entry_mode("chmod_multipart/split/archive.pna", ENTRY_PATH),
+        0o600
+    );
+    assert_eq!(
+        archive::entry_contents_with_password(
+            "chmod_multipart/split/archive.pna",
+            ENTRY_PATH,
+            None,
+        ),
+        content,
+        "chmod must preserve content spanning multipart archive boundaries"
+    );
+}

--- a/cli/tests/cli/chmod/password.rs
+++ b/cli/tests/cli/chmod/password.rs
@@ -1,10 +1,12 @@
 use crate::utils::{archive, archive::FileEntryDef, setup};
 use clap::Parser;
 use portable_network_archive::cli;
+use std::fs;
 
 const ENTRY_PATH: &str = "test.txt";
 const ENTRY_CONTENT: &[u8] = b"test content";
 const PASSWORD: &str = "password";
+const WRONG_PASSWORD: &str = "wrong-password";
 
 /// Precondition: An encrypted archive contains a file with permission 0o777 (rwxrwxrwx).
 /// Action: Run `pna experimental chmod` with password and `-x` to remove execute.
@@ -55,4 +57,104 @@ fn chmod_with_password() {
     })
     .unwrap();
     assert!(found, "target entry not found in archive");
+}
+
+/// Precondition: A solid encrypted archive exists.
+/// Action: Run `pna experimental chmod` with an incorrect password.
+/// Expectation: The command fails and the archive bytes remain unchanged.
+#[test]
+fn chmod_wrong_password_on_solid_archive_fails_without_modifying_archive() {
+    setup();
+    fs::create_dir_all("chmod_solid_wrong_password").unwrap();
+    let archive_path = "chmod_solid_wrong_password/archive.pna";
+
+    archive::create_encrypted_solid_archive_with_permissions(
+        archive_path,
+        &[FileEntryDef {
+            path: ENTRY_PATH,
+            content: ENTRY_CONTENT,
+            permission: 0o777,
+        }],
+        PASSWORD,
+    )
+    .unwrap();
+    let original = fs::read(archive_path).unwrap();
+
+    let result = cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "chmod",
+        "-f",
+        archive_path,
+        "--password",
+        WRONG_PASSWORD,
+        "--",
+        "-x",
+        ENTRY_PATH,
+    ])
+    .unwrap()
+    .execute();
+
+    assert!(
+        result.is_err(),
+        "solid archive chmod should fail with a wrong password"
+    );
+    assert_eq!(
+        fs::read(archive_path).unwrap(),
+        original,
+        "failed chmod must leave the original archive untouched"
+    );
+    assert_eq!(
+        archive::entry_mode_with_password(archive_path, ENTRY_PATH, Some(PASSWORD)),
+        0o777
+    );
+}
+
+/// Precondition: A non-solid encrypted archive exists.
+/// Action: Run `pna experimental chmod` with an incorrect password.
+/// Expectation: The command succeeds because normal-entry metadata can be
+/// rewritten without decrypting file contents; the original password still
+/// decrypts the data.
+#[test]
+fn chmod_wrong_password_on_normal_encrypted_archive_updates_metadata_only() {
+    setup();
+    fs::create_dir_all("chmod_normal_wrong_password").unwrap();
+    let archive_path = "chmod_normal_wrong_password/archive.pna";
+
+    archive::create_encrypted_archive_with_permissions(
+        archive_path,
+        &[FileEntryDef {
+            path: ENTRY_PATH,
+            content: ENTRY_CONTENT,
+            permission: 0o777,
+        }],
+        PASSWORD,
+    )
+    .unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "chmod",
+        "-f",
+        archive_path,
+        "--password",
+        WRONG_PASSWORD,
+        "600",
+        ENTRY_PATH,
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    assert_eq!(
+        archive::entry_mode_with_password(archive_path, ENTRY_PATH, Some(PASSWORD)),
+        0o600
+    );
+    assert_eq!(
+        archive::entry_contents_with_password(archive_path, ENTRY_PATH, Some(PASSWORD)),
+        ENTRY_CONTENT
+    );
 }

--- a/cli/tests/cli/utils/archive.rs
+++ b/cli/tests/cli/utils/archive.rs
@@ -81,6 +81,46 @@ pub fn create_solid_archive_with_permissions(
     Ok(())
 }
 
+/// Creates an encrypted solid archive with file entries having specific permissions.
+pub fn create_encrypted_solid_archive_with_permissions(
+    archive_path: impl AsRef<Path>,
+    entries: &[FileEntryDef],
+    password: &str,
+) -> io::Result<()> {
+    let file = File::create(archive_path)?;
+    let mut archive = pna::Archive::write_header(file)?;
+
+    let write_options = pna::WriteOptions::builder()
+        .password(Some(password))
+        .encryption(pna::Encryption::AES)
+        .cipher_mode(pna::CipherMode::GCM)
+        .build();
+
+    let mut solid_builder = pna::SolidEntryBuilder::new(write_options)?;
+    for entry_def in entries {
+        let mut builder = pna::FileEntryBuilder::new_with_options(
+            entry_def.path.into(),
+            pna::WriteOptions::store(),
+        )?;
+        builder.metadata(
+            pna::Metadata::new()
+                .with_owner_uid(Some(pna::OwnerUid::from(1000)))
+                .with_owner_gid(Some(pna::OwnerGid::from(1000)))
+                .with_owner_user_name(Some(pna::OwnerUserName::new("user").unwrap()))
+                .with_owner_group_name(Some(pna::OwnerGroupName::new("group").unwrap()))
+                .with_permission_mode(Some(pna::PermissionMode::from(entry_def.permission))),
+        );
+        builder.write_all(entry_def.content)?;
+        let entry = builder.build()?;
+        solid_builder.add_entry(entry)?;
+    }
+    let solid_entry = solid_builder.build()?;
+    archive.add_entry(solid_entry)?;
+
+    archive.finalize()?;
+    Ok(())
+}
+
 /// Creates an encrypted archive with file entries having specific permissions.
 pub fn create_encrypted_archive_with_permissions(
     archive_path: impl AsRef<Path>,
@@ -156,6 +196,49 @@ where
         f(entry?);
     }
     Ok(())
+}
+
+pub fn entry_mode(path: impl AsRef<Path>, name: &str) -> u16 {
+    entry_mode_with_password(path, name, None)
+}
+
+pub fn entry_mode_with_password(path: impl AsRef<Path>, name: &str, password: Option<&str>) -> u16 {
+    let mut mode = None;
+    for_each_entry_with_password(path, password, |entry| {
+        if entry.name() == name {
+            mode = Some(
+                entry
+                    .metadata()
+                    .permission_mode()
+                    .expect("entry should have permission mode metadata")
+                    .get()
+                    & 0o777,
+            );
+        }
+    })
+    .unwrap();
+    mode.expect("target entry should exist")
+}
+
+pub fn entry_contents_with_password(
+    path: impl AsRef<Path>,
+    name: &str,
+    password: Option<&str>,
+) -> Vec<u8> {
+    let password_bytes = password.map(str::as_bytes);
+    let mut contents = None;
+    for_each_entry_with_password(path, password, |entry| {
+        if entry.name() == name {
+            let mut reader = entry
+                .reader(pna::ReadOptions::with_password(password_bytes))
+                .unwrap();
+            let mut data = Vec::new();
+            reader.read_to_end(&mut data).unwrap();
+            contents = Some(data);
+        }
+    })
+    .unwrap();
+    contents.expect("target entry should exist")
 }
 
 pub fn read_symlink_target(entry: &pna::NormalEntry) -> String {


### PR DESCRIPTION
## Summary

- avoid persisting chmod archive rewrites until all requested targets have matched
- cover solid encrypted wrong-password failure without modifying the archive
- document the normal encrypted-entry behavior where chmod can update metadata without decrypting file data
- add coverage for missing target atomicity and multipart archive consolidation

## Validation

- cargo test -p portable-network-archive chmod