### PR TITLE
:zap: Derive encryption key once per WriteOptions build

### DIFF
--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -350,6 +350,62 @@ mod tests {
         .unwrap()
     }
 
+    /// Precondition: encryption-enabled WriteOptions built once.
+    /// Action: write two entries with the same options and read them back.
+    /// Expectation: entries share the PHSF (derived key), have distinct
+    /// ciphertext for identical plaintext (unique IVs), and both decrypt.
+    #[test]
+    fn entries_share_derived_key_with_unique_iv() {
+        let options = WriteOptions::builder()
+            .encryption(Encryption::Aes)
+            .password(Some("password"))
+            .build();
+        let mut writer = Archive::write_header(Vec::new()).unwrap();
+        for name in ["test/first", "test/second"] {
+            writer
+                .add_entry({
+                    let mut builder = EntryBuilder::new_file(name.into(), &options).unwrap();
+                    builder.write_all(b"same plaintext").unwrap();
+                    builder.build().unwrap()
+                })
+                .unwrap();
+        }
+        let archived = writer.finalize().unwrap();
+
+        let mut reader = Archive::read_header(archived.as_slice()).unwrap();
+        let entries = reader
+            .entries()
+            .skip_solid()
+            .collect::<io::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(entries.len(), 2);
+        assert!(entries[0].phsf.is_some());
+        assert_eq!(entries[0].phsf, entries[1].phsf);
+        assert_ne!(entries[0].data, entries[1].data);
+        for entry in &entries {
+            let mut data_reader = entry
+                .reader(ReadOptions::with_password(Some("password")))
+                .unwrap();
+            let mut dist = Vec::new();
+            io::copy(&mut data_reader, &mut dist).unwrap();
+            assert_eq!(dist.as_slice(), b"same plaintext");
+        }
+    }
+
+    /// Precondition: encryption-enabled WriteOptions built once.
+    /// Action: create multiple archives reusing the same options.
+    /// Expectation: every archive round-trips with the original password.
+    #[test]
+    fn write_options_reusable_across_archives() {
+        let options = WriteOptions::builder()
+            .encryption(Encryption::Aes)
+            .password(Some("password"))
+            .build();
+        for _ in 0..2 {
+            archive(b"some text", options.clone()).unwrap();
+        }
+    }
+
     fn create_archive(src: &[u8], options: WriteOptions) -> io::Result<Vec<u8>> {
         let mut writer = Archive::write_header(Vec::with_capacity(src.len()))?;
         writer.add_entry({

--- a/lib/src/entry/options.rs
+++ b/lib/src/entry/options.rs
@@ -692,7 +692,7 @@ impl TryFrom<u8> for DataKind {
 /// When reading an archive, use [`ReadOptions`] to provide the password for decryption.
 /// The compression algorithm and cipher mode are stored in the archive metadata, so you
 /// only need to provide the password.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Clone, Debug)]
 pub struct WriteOptions {
     compress: Compress,
     cipher: Option<Cipher>,

--- a/lib/src/entry/options.rs
+++ b/lib/src/entry/options.rs
@@ -1,8 +1,9 @@
 //! Read and write options for archive entries.
 
-use crate::{compress, error::UnknownValueError};
+use crate::{compress, entry::write::derive_key_material, error::UnknownValueError};
+use password_hash::Output;
 pub(crate) use private::*;
-use std::str::FromStr;
+use std::{io, str::FromStr};
 
 mod private {
     use super::*;
@@ -17,9 +18,10 @@ mod private {
     }
 
     /// Cipher options.
-    #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+    #[derive(Clone, Debug)]
     pub struct Cipher {
         pub(crate) password: Password,
+        pub(crate) derived: DerivedKeyMaterial,
         pub(crate) hash_algorithm: HashAlgorithm,
         pub(crate) cipher_algorithm: CipherAlgorithm,
         pub(crate) mode: CipherMode,
@@ -30,17 +32,30 @@ mod private {
         #[inline]
         pub(crate) const fn new(
             password: Password,
+            derived: DerivedKeyMaterial,
             hash_algorithm: HashAlgorithm,
             cipher_algorithm: CipherAlgorithm,
             mode: CipherMode,
         ) -> Self {
             Self {
                 password,
+                derived,
                 hash_algorithm,
                 cipher_algorithm,
                 mode,
             }
         }
+    }
+
+    /// Key material derived from a password when [`WriteOptions`] is built.
+    ///
+    /// `phsf` is the PHC string (salt and KDF parameters included) recorded in the
+    /// PHSF chunk of every entry written with the owning [`WriteOptions`]; `key` is
+    /// the KDF output used as the cipher key.
+    #[derive(Clone, Debug)]
+    pub struct DerivedKeyMaterial {
+        pub(crate) phsf: String,
+        pub(crate) key: Output,
     }
 
     /// Accessors for write options.
@@ -640,6 +655,11 @@ impl TryFrom<u8> for DataKind {
 ///   as it allows parallel processing and has simpler security requirements.
 /// - **IV Generation**: Initialization vectors (IVs) are automatically generated using
 ///   cryptographically secure random number generation. You do not need to provide IVs.
+/// - **Key Derivation**: The encryption key is derived from the password once when the
+///   options are built ([`WriteOptionsBuilder::build()`] / [`WriteOptionsBuilder::try_build()`]),
+///   and shared by every entry written with the same [`WriteOptions`]. Each entry still
+///   receives a unique, randomly generated IV. Build a fresh [`WriteOptions`] per archive
+///   so that each archive uses an independent salt and key.
 /// - **Password Strength**: Use strong passwords (12+ characters, mixed case, numbers, symbols)
 ///   as the encryption key is derived from the password.
 ///
@@ -853,6 +873,83 @@ impl WriteOptionsBuilder {
         self
     }
 
+    /// Creates a new [`WriteOptions`] from this builder, deriving the encryption
+    /// key when encryption is enabled.
+    ///
+    /// The key derivation function (KDF) runs once here with a freshly generated
+    /// random salt. Every entry written with the resulting [`WriteOptions`] shares
+    /// the derived key and salt; a unique random IV is still generated per entry.
+    ///
+    /// # Errors
+    ///
+    /// - Encryption is enabled but no password was provided.
+    /// - The configured KDF parameters are invalid.
+    /// - An unsupported encryption or compression method was specified.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use libpna::{Encryption, WriteOptions};
+    ///
+    /// # fn main() -> std::io::Result<()> {
+    /// let opts = WriteOptions::builder()
+    ///     .encryption(Encryption::Aes)
+    ///     .password(Some("password"))
+    ///     .try_build()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    #[must_use = "building options without using them is wasteful"]
+    pub fn try_build(&self) -> io::Result<WriteOptions> {
+        let cipher = if self.encryption != Encryption::No {
+            let cipher_algorithm = match self.encryption {
+                Encryption::Aes => CipherAlgorithm::Aes,
+                Encryption::Camellia => CipherAlgorithm::Camellia,
+                other => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Unsupported,
+                        format!(
+                            "unsupported encryption method for writing: byte={}",
+                            other.to_byte()
+                        ),
+                    ));
+                }
+            };
+            let password = self.password.as_deref().ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidInput, "Password was not provided.")
+            })?;
+            let derived = derive_key_material(cipher_algorithm, self.hash_algorithm, password)?;
+            Some(Cipher::new(
+                password.into(),
+                derived,
+                self.hash_algorithm,
+                cipher_algorithm,
+                self.cipher_mode,
+            ))
+        } else {
+            None
+        };
+        Ok(WriteOptions {
+            compress: match self.compression {
+                Compression::No => Compress::No,
+                Compression::Deflate => Compress::Deflate(self.compression_level.into()),
+                Compression::ZStandard => Compress::ZStandard(self.compression_level.into()),
+                Compression::XZ => Compress::XZ(self.compression_level.into()),
+                other => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Unsupported,
+                        format!(
+                            "unsupported compression method for writing: byte={}",
+                            other.to_byte()
+                        ),
+                    ));
+                }
+            },
+            cipher,
+        })
+    }
+
     /// Creates a new [`WriteOptions`] from this builder.
     ///
     /// This finalizes the builder configuration and creates an immutable [`WriteOptions`]
@@ -862,7 +959,8 @@ impl WriteOptionsBuilder {
     ///
     /// Panics if [`encryption()`](Self::encryption) was set to [`Encryption::Aes`] or
     /// [`Encryption::Camellia`] but [`password()`](Self::password) was not called with
-    /// a password.
+    /// a password, or if key derivation fails (see [`try_build()`](Self::try_build) for
+    /// the fallible variant).
     ///
     /// **Always provide a password when enabling encryption.** The following code will panic:
     /// ```no_run
@@ -885,38 +983,9 @@ impl WriteOptionsBuilder {
     #[inline]
     #[must_use = "building options without using them is wasteful"]
     pub fn build(&self) -> WriteOptions {
-        let cipher = if self.encryption != Encryption::No {
-            Some(Cipher::new(
-                self.password
-                    .as_deref()
-                    .expect("Password was not provided.")
-                    .into(),
-                self.hash_algorithm,
-                match self.encryption {
-                    Encryption::Aes => CipherAlgorithm::Aes,
-                    Encryption::Camellia => CipherAlgorithm::Camellia,
-                    other => panic!(
-                        "unsupported encryption method for writing: byte={}",
-                        other.to_byte()
-                    ),
-                },
-                self.cipher_mode,
-            ))
-        } else {
-            None
-        };
-        WriteOptions {
-            compress: match self.compression {
-                Compression::No => Compress::No,
-                Compression::Deflate => Compress::Deflate(self.compression_level.into()),
-                Compression::ZStandard => Compress::ZStandard(self.compression_level.into()),
-                Compression::XZ => Compress::XZ(self.compression_level.into()),
-                other => panic!(
-                    "unsupported compression method for writing: byte={}",
-                    other.to_byte()
-                ),
-            },
-            cipher,
+        match self.try_build() {
+            Ok(options) => options,
+            Err(e) => panic!("{e}"),
         }
     }
 }
@@ -1006,5 +1075,63 @@ impl ReadOptionsBuilder {
         ReadOptions {
             password: self.password.clone(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    use wasm_bindgen_test::wasm_bindgen_test as test;
+
+    #[test]
+    fn try_build_derives_key_at_build() {
+        let options = WriteOptions::builder()
+            .encryption(Encryption::Aes)
+            .password(Some("password"))
+            .try_build()
+            .unwrap();
+        let cipher = options.cipher.unwrap();
+        assert!(!cipher.derived.phsf.is_empty());
+        assert_eq!(cipher.derived.key.len(), 32);
+    }
+
+    #[test]
+    fn each_build_generates_fresh_salt() {
+        let mut builder = WriteOptions::builder();
+        builder
+            .encryption(Encryption::Aes)
+            .password(Some("password"));
+        let first = builder.try_build().unwrap();
+        let second = builder.try_build().unwrap();
+        assert_ne!(
+            first.cipher.unwrap().derived.phsf,
+            second.cipher.unwrap().derived.phsf,
+        );
+    }
+
+    #[test]
+    fn try_build_without_password_returns_error() {
+        let err = WriteOptions::builder()
+            .encryption(Encryption::Aes)
+            .try_build()
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn try_build_with_invalid_kdf_params_returns_error() {
+        let result = WriteOptions::builder()
+            .encryption(Encryption::Aes)
+            .hash_algorithm(HashAlgorithm::argon2id_with(Some(0), None, None))
+            .password(Some("password"))
+            .try_build();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    #[should_panic(expected = "Password was not provided.")]
+    fn build_without_password_panics() {
+        let _ = WriteOptions::builder().encryption(Encryption::Aes).build();
     }
 }

--- a/lib/src/entry/write.rs
+++ b/lib/src/entry/write.rs
@@ -4,7 +4,7 @@ use crate::{
     Cipher, CipherAlgorithm, HashAlgorithm,
     cipher::{CipherWriter, Ctr128BEWriter, EncryptCbcAes256Writer, EncryptCbcCamellia256Writer},
     compress::CompressionWriter,
-    entry::{CipherMode, Compress, HashAlgorithmParams, WriteOption},
+    entry::{CipherMode, Compress, DerivedKeyMaterial, HashAlgorithmParams, WriteOption},
     hash, random,
 };
 use aes::Aes256;
@@ -33,15 +33,18 @@ pub(crate) struct EntryWriterContext {
     pub(crate) cipher: Option<WriteCipher>,
 }
 
+pub(crate) fn derive_key_material(
+    cipher_algorithm: CipherAlgorithm,
+    hash_algorithm: HashAlgorithm,
+    password: &[u8],
+) -> io::Result<DerivedKeyMaterial> {
+    let salt = random::salt_string();
+    let (key, phsf) = hash(cipher_algorithm, hash_algorithm, password, &salt)?;
+    Ok(DerivedKeyMaterial { phsf, key })
+}
+
 #[inline]
 fn to_hashed(cipher: &Cipher) -> io::Result<WriteCipher> {
-    let salt = random::salt_string();
-    let (key, phsf) = hash(
-        cipher.cipher_algorithm,
-        cipher.hash_algorithm,
-        cipher.password.as_bytes(),
-        &salt,
-    )?;
     let iv = match cipher.cipher_algorithm {
         CipherAlgorithm::Aes => random::random_vec(Aes256::block_size()),
         CipherAlgorithm::Camellia => random::random_vec(Camellia256::block_size()),
@@ -49,9 +52,9 @@ fn to_hashed(cipher: &Cipher) -> io::Result<WriteCipher> {
     Ok(WriteCipher {
         algorithm: cipher.cipher_algorithm,
         context: CipherContext {
-            phsf,
+            phsf: cipher.derived.phsf.clone(),
             iv,
-            key,
+            key: cipher.derived.key,
             mode: cipher.mode,
         },
     })


### PR DESCRIPTION
## Summary
Derive the encryption key once when `WriteOptions` is built instead of once per entry, removing the per-entry KDF cost of writing encrypted archives (500-entry create: 2.19s → 0.08s real, 14.2s → 0.04s CPU). Adds `WriteOptionsBuilder::try_build()` as the fallible variant and removes comparison trait impls from `WriteOptions`.

## Notes
- Entries written with one `WriteOptions` now share the derived key and PHSF (salt); each entry still gets a unique random IV. Docs recommend building a fresh `WriteOptions` per archive so archives stay on independent keys.
- Breaking: `Eq`/`PartialEq`/`Ord`/`PartialOrd`/`Hash` removed from `WriteOptions` — equality would be misleading now that every build derives a fresh salt. No usage existed in the workspace.
- KDF failures (invalid parameters) now surface at build time: `try_build()` returns `io::Error`; `build()` keeps its existing panic behavior, including the "Password was not provided." message.

## Verification
- An unmodified pre-change `pna` binary extracts archives created by this branch (500/500 files match after round-trip).
- Manual timing with 500 small files (`--password`, `--aes ctr`): 2.189s → 0.076s real.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved encryption handling so the same write settings can be reused safely across entries and across multiple archive creations.
  * Each encrypted entry now keeps a unique encrypted payload while still decrypting correctly with the same password.
  * Added stronger validation for encryption setup, including clearer failures when required settings are missing or unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->