### PR TITLE
Expand test coverage for the update command

### DIFF
--- a/cli/tests/cli/update.rs
+++ b/cli/tests/cli/update.rs
@@ -1,6 +1,7 @@
 mod encryption;
 mod entry_order;
 mod error;
+mod multipart;
 mod no_timestamp_archive;
 mod option_atime;
 mod option_ctime;

--- a/cli/tests/cli/update.rs
+++ b/cli/tests/cli/update.rs
@@ -1,3 +1,4 @@
+mod directory_entry;
 mod encryption;
 mod entry_order;
 mod error;
@@ -9,6 +10,7 @@ mod option_exclude;
 mod option_exclude_vcs;
 #[cfg(not(target_family = "wasm"))]
 mod option_files_from_stdin;
+mod option_include;
 mod option_keep_solid;
 mod option_missing_time;
 mod option_mtime;
@@ -23,3 +25,4 @@ mod option_older_mtime_than;
 mod option_recursive;
 mod option_sync;
 mod option_unsolid;
+mod symlink_entry;

--- a/cli/tests/cli/update.rs
+++ b/cli/tests/cli/update.rs
@@ -9,6 +9,7 @@ mod option_exclude;
 mod option_exclude_vcs;
 #[cfg(not(target_family = "wasm"))]
 mod option_files_from_stdin;
+mod option_keep_solid;
 mod option_missing_time;
 mod option_mtime;
 mod option_newer_ctime;
@@ -21,3 +22,4 @@ mod option_older_mtime;
 mod option_older_mtime_than;
 mod option_recursive;
 mod option_sync;
+mod option_unsolid;

--- a/cli/tests/cli/update/directory_entry.rs
+++ b/cli/tests/cli/update/directory_entry.rs
@@ -1,0 +1,122 @@
+use crate::utils::{archive, setup};
+use clap::Parser;
+use portable_network_archive::cli;
+use std::{collections::HashSet, fs};
+
+fn create_directory_archive(dir: &str) {
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(format!("{dir}/in/sub")).unwrap();
+    fs::write(format!("{dir}/in/keep.txt"), b"keep content").unwrap();
+    fs::write(format!("{dir}/in/sub/inner.txt"), b"inner content").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        &format!("{dir}/archive.pna"),
+        "--overwrite",
+        &format!("{dir}/in"),
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+}
+
+/// Precondition: An archive contains a directory entry and its contained
+/// file, then the directory is removed from disk.
+/// Action: Run `pna experimental update` with `--sync`.
+/// Expectation: The directory entry and its contained file entry are pruned
+/// while other entries remain.
+#[test]
+fn update_with_sync_prunes_missing_directory() {
+    setup();
+    create_directory_archive("update_sync_missing_dir");
+
+    let mut initial_entries = HashSet::new();
+    archive::for_each_entry("update_sync_missing_dir/archive.pna", |entry| {
+        initial_entries.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+
+    fs::remove_dir_all("update_sync_missing_dir/in/sub").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "--sync",
+        "-f",
+        "update_sync_missing_dir/archive.pna",
+        "update_sync_missing_dir/in",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut seen = HashSet::new();
+    archive::for_each_entry("update_sync_missing_dir/archive.pna", |entry| {
+        seen.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+
+    let mut expected = initial_entries;
+    assert!(
+        expected.remove("update_sync_missing_dir/in/sub"),
+        "precondition: initial archive should contain the directory entry"
+    );
+    assert!(
+        expected.remove("update_sync_missing_dir/in/sub/inner.txt"),
+        "precondition: initial archive should contain the contained file entry"
+    );
+    assert_eq!(
+        seen, expected,
+        "the directory missing on disk and its contents should be pruned"
+    );
+}
+
+/// Precondition: An archive contains a directory entry and its contained
+/// file, then the directory is removed from disk.
+/// Action: Run `pna experimental update` without `--sync`.
+/// Expectation: All entries including the removed directory are preserved.
+#[test]
+fn update_without_sync_keeps_missing_directory() {
+    setup();
+    create_directory_archive("update_no_sync_missing_dir");
+
+    let mut initial_entries = HashSet::new();
+    archive::for_each_entry("update_no_sync_missing_dir/archive.pna", |entry| {
+        initial_entries.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+
+    fs::remove_dir_all("update_no_sync_missing_dir/in/sub").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "-f",
+        "update_no_sync_missing_dir/archive.pna",
+        "update_no_sync_missing_dir/in",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut seen = HashSet::new();
+    archive::for_each_entry("update_no_sync_missing_dir/archive.pna", |entry| {
+        seen.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+
+    assert_eq!(
+        seen, initial_entries,
+        "entries for removed directories should be preserved without --sync"
+    );
+}

--- a/cli/tests/cli/update/multipart.rs
+++ b/cli/tests/cli/update/multipart.rs
@@ -1,0 +1,209 @@
+use crate::utils::{EmbedExt, TestResources, archive, setup};
+use clap::Parser;
+use portable_network_archive::cli;
+use std::{collections::HashSet, fs, io::prelude::*, path::Path, time};
+
+const DURATION_24_HOURS: time::Duration = time::Duration::from_secs(24 * 60 * 60);
+
+/// Precondition: The source tree is archived and split into multiple parts,
+/// then a source file is modified with a newer mtime.
+/// Action: Run `pna experimental update` on the first part of the multipart archive.
+/// Expectation: All parts are read as one archive, the result is written as a
+/// single unsplit archive, the entry set is unchanged, and extraction yields
+/// the updated content. The original part files remain on disk.
+#[test]
+fn update_multipart_archive() {
+    setup();
+    TestResources::extract_in("raw/", "update_multipart/in/").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "update_multipart/archive.pna",
+        "--overwrite",
+        "update_multipart/in/",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "split",
+        "-f",
+        "update_multipart/archive.pna",
+        "--overwrite",
+        "--max-size",
+        "1kb",
+        "--out-dir",
+        "update_multipart/split/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    assert!(
+        Path::new("update_multipart/split/archive.part2.pna").exists(),
+        "precondition: the archive should be split into multiple parts"
+    );
+
+    let mut initial_entries = HashSet::new();
+    archive::for_each_entry("update_multipart/archive.pna", |entry| {
+        initial_entries.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+
+    let mut file = fs::File::options()
+        .write(true)
+        .truncate(true)
+        .open("update_multipart/in/raw/text.txt")
+        .unwrap();
+    file.write_all(b"updated content for multipart test")
+        .unwrap();
+    file.set_modified(time::SystemTime::now() + DURATION_24_HOURS)
+        .unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "-f",
+        "update_multipart/split/archive.part1.pna",
+        "update_multipart/in/",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    // Rewriting commands persist to the part-less path, merging all parts.
+    assert!(
+        Path::new("update_multipart/split/archive.pna").exists(),
+        "update on a multipart archive should write a single unsplit archive"
+    );
+    assert!(
+        Path::new("update_multipart/split/archive.part1.pna").exists()
+            && Path::new("update_multipart/split/archive.part2.pna").exists(),
+        "original part files should remain on disk"
+    );
+
+    let mut seen = HashSet::new();
+    archive::for_each_entry("update_multipart/split/archive.pna", |entry| {
+        seen.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+    assert_eq!(
+        seen, initial_entries,
+        "entry set should be unchanged after update"
+    );
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        "-f",
+        "update_multipart/split/archive.pna",
+        "--overwrite",
+        "--out-dir",
+        "update_multipart/out/",
+        "--strip-components",
+        "2",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    assert_eq!(
+        fs::read("update_multipart/out/raw/text.txt").unwrap(),
+        b"updated content for multipart test",
+        "extraction should yield the updated content"
+    );
+}
+
+/// Precondition: The source tree is archived and split into multiple parts,
+/// then a source file is deleted from disk.
+/// Action: Run `pna experimental update --sync` on the first part of the
+/// multipart archive.
+/// Expectation: Only the entry whose file is missing on disk is pruned from
+/// the merged archive; entries from all parts are otherwise preserved.
+#[test]
+fn update_multipart_archive_with_sync() {
+    setup();
+    TestResources::extract_in("raw/", "update_multipart_sync/in/").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "update_multipart_sync/archive.pna",
+        "--overwrite",
+        "update_multipart_sync/in/",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "split",
+        "-f",
+        "update_multipart_sync/archive.pna",
+        "--overwrite",
+        "--max-size",
+        "1kb",
+        "--out-dir",
+        "update_multipart_sync/split/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    assert!(
+        Path::new("update_multipart_sync/split/archive.part2.pna").exists(),
+        "precondition: the archive should be split into multiple parts"
+    );
+
+    let mut initial_entries = HashSet::new();
+    archive::for_each_entry("update_multipart_sync/archive.pna", |entry| {
+        initial_entries.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+
+    fs::remove_file("update_multipart_sync/in/raw/empty.txt").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "--sync",
+        "-f",
+        "update_multipart_sync/split/archive.part1.pna",
+        "update_multipart_sync/in/",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut seen = HashSet::new();
+    archive::for_each_entry("update_multipart_sync/split/archive.pna", |entry| {
+        seen.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+
+    let mut expected = initial_entries;
+    assert!(
+        expected.remove("update_multipart_sync/in/raw/empty.txt"),
+        "precondition: initial archive should contain the deleted file"
+    );
+    assert_eq!(
+        seen, expected,
+        "only the entry missing on disk should be pruned from the merged archive"
+    );
+}

--- a/cli/tests/cli/update/option_include.rs
+++ b/cli/tests/cli/update/option_include.rs
@@ -1,0 +1,112 @@
+use crate::utils::{archive, setup};
+use clap::Parser;
+use portable_network_archive::cli;
+use std::{collections::HashSet, fs, io::prelude::*, time};
+
+const DURATION_24_HOURS: time::Duration = time::Duration::from_secs(24 * 60 * 60);
+
+fn write_newer(path: &str, content: &[u8]) {
+    let mut file = fs::File::options()
+        .write(true)
+        .truncate(true)
+        .open(path)
+        .unwrap();
+    file.write_all(content).unwrap();
+    file.set_modified(time::SystemTime::now() + DURATION_24_HOURS)
+        .unwrap();
+}
+
+/// Precondition: An archive contains multiple files and all of them are
+/// modified with newer mtimes.
+/// Action: Run `pna experimental update` on the files with `--include`
+/// matching one of them. Note that include patterns are matched against
+/// each visited path (bsdtar-compatible), so a directory whose name does
+/// not match the pattern is not descended into.
+/// Expectation: Only the included file is updated; entries outside the
+/// include pattern keep their original content.
+#[test]
+fn update_with_include() {
+    setup();
+    let _ = fs::remove_dir_all("update_with_include");
+    fs::create_dir_all("update_with_include/in").unwrap();
+    fs::write("update_with_include/in/a.txt", b"old-a").unwrap();
+    fs::write("update_with_include/in/b.txt", b"old-b").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "update_with_include/archive.pna",
+        "--overwrite",
+        "update_with_include/in/a.txt",
+        "update_with_include/in/b.txt",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut initial_entries = HashSet::new();
+    archive::for_each_entry("update_with_include/archive.pna", |entry| {
+        initial_entries.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+
+    write_newer("update_with_include/in/a.txt", b"new-a");
+    write_newer("update_with_include/in/b.txt", b"new-b");
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "-f",
+        "update_with_include/archive.pna",
+        "update_with_include/in/a.txt",
+        "update_with_include/in/b.txt",
+        "--keep-timestamp",
+        "--include",
+        "**/a.txt",
+        "--unstable",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut seen = HashSet::new();
+    archive::for_each_entry("update_with_include/archive.pna", |entry| {
+        seen.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+    assert_eq!(
+        seen, initial_entries,
+        "entry set should be unchanged after update"
+    );
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        "-f",
+        "update_with_include/archive.pna",
+        "--overwrite",
+        "--out-dir",
+        "update_with_include/out/",
+        "--strip-components",
+        "2",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    assert_eq!(
+        fs::read("update_with_include/out/a.txt").unwrap(),
+        b"new-a",
+        "included file should be updated"
+    );
+    assert_eq!(
+        fs::read("update_with_include/out/b.txt").unwrap(),
+        b"old-b",
+        "file outside the include pattern should keep its original content"
+    );
+}

--- a/cli/tests/cli/update/option_keep_solid.rs
+++ b/cli/tests/cli/update/option_keep_solid.rs
@@ -1,0 +1,193 @@
+use crate::utils::{EmbedExt, TestResources, archive, setup};
+use clap::Parser;
+use pna::prelude::*;
+use portable_network_archive::cli;
+use std::{collections::HashSet, fs, io::prelude::*, time};
+
+const DURATION_24_HOURS: time::Duration = time::Duration::from_secs(24 * 60 * 60);
+
+/// Precondition: A solid mode archive exists and a source file is modified
+/// with a newer mtime.
+/// Action: Run `pna experimental update` with `--keep-solid`.
+/// Expectation: The solid group is preserved as a solid entry and the updated
+/// file is appended as a normal entry (mixed mode archive). The entry path set
+/// is unchanged and extraction yields the updated content.
+#[test]
+fn update_with_keep_solid() {
+    setup();
+    TestResources::extract_in("raw/", "update_with_keep_solid/in/").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "update_with_keep_solid/archive.pna",
+        "--overwrite",
+        "--solid",
+        "--no-keep-dir",
+        "update_with_keep_solid/in/",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut initial_entries = HashSet::new();
+    archive::for_each_entry("update_with_keep_solid/archive.pna", |entry| {
+        initial_entries.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+
+    let mut file = fs::File::options()
+        .write(true)
+        .truncate(true)
+        .open("update_with_keep_solid/in/raw/text.txt")
+        .unwrap();
+    file.write_all(b"updated content for keep-solid test")
+        .unwrap();
+    file.set_modified(time::SystemTime::now() + DURATION_24_HOURS)
+        .unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "--keep-solid",
+        "-f",
+        "update_with_keep_solid/archive.pna",
+        "update_with_keep_solid/in/",
+        "--no-keep-dir",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut archive = pna::Archive::open("update_with_keep_solid/archive.pna").unwrap();
+    let entries = archive.entries().collect::<Result<Vec<_>, _>>().unwrap();
+    assert_eq!(
+        entries
+            .iter()
+            .filter(|entry| matches!(entry, pna::ReadEntry::Solid(_)))
+            .count(),
+        1,
+        "the solid group should be preserved as a single solid entry"
+    );
+    assert!(
+        entries
+            .iter()
+            .any(|entry| matches!(entry, pna::ReadEntry::Normal(_))),
+        "the updated file should be appended as a normal entry"
+    );
+
+    let mut seen = HashSet::new();
+    archive::for_each_entry("update_with_keep_solid/archive.pna", |entry| {
+        seen.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+    assert_eq!(
+        seen, initial_entries,
+        "entry path set should be unchanged after update"
+    );
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        "-f",
+        "update_with_keep_solid/archive.pna",
+        "--overwrite",
+        "--out-dir",
+        "update_with_keep_solid/out/",
+        "--strip-components",
+        "2",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    assert_eq!(
+        fs::read("update_with_keep_solid/out/raw/text.txt").unwrap(),
+        b"updated content for keep-solid test",
+        "extraction should yield the updated content"
+    );
+}
+
+/// Precondition: A solid mode archive exists and a source file is deleted
+/// from disk.
+/// Action: Run `pna experimental update` with `--keep-solid` and `--sync`.
+/// Expectation: The entry whose file is missing on disk is pruned from inside
+/// the solid group, and the result remains a single solid entry.
+#[test]
+fn update_with_keep_solid_and_sync() {
+    setup();
+    TestResources::extract_in("raw/", "update_keep_solid_sync/in/").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "update_keep_solid_sync/archive.pna",
+        "--overwrite",
+        "--solid",
+        "--no-keep-dir",
+        "update_keep_solid_sync/in/",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut initial_entries = HashSet::new();
+    archive::for_each_entry("update_keep_solid_sync/archive.pna", |entry| {
+        initial_entries.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+
+    fs::remove_file("update_keep_solid_sync/in/raw/empty.txt").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "--keep-solid",
+        "--sync",
+        "-f",
+        "update_keep_solid_sync/archive.pna",
+        "update_keep_solid_sync/in/",
+        "--no-keep-dir",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut archive = pna::Archive::open("update_keep_solid_sync/archive.pna").unwrap();
+    let entries = archive.entries().collect::<Result<Vec<_>, _>>().unwrap();
+    assert!(
+        entries
+            .iter()
+            .all(|entry| matches!(entry, pna::ReadEntry::Solid(_))),
+        "all entries should remain in solid mode"
+    );
+    assert_eq!(entries.len(), 1);
+
+    let mut seen = HashSet::new();
+    archive::for_each_entry("update_keep_solid_sync/archive.pna", |entry| {
+        seen.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+
+    let mut expected = initial_entries;
+    assert!(
+        expected.remove("update_keep_solid_sync/in/raw/empty.txt"),
+        "precondition: initial archive should contain the deleted file"
+    );
+    assert_eq!(
+        seen, expected,
+        "only the entry missing on disk should be pruned from the solid group"
+    );
+}

--- a/cli/tests/cli/update/option_unsolid.rs
+++ b/cli/tests/cli/update/option_unsolid.rs
@@ -1,0 +1,105 @@
+use crate::utils::{EmbedExt, TestResources, archive, setup};
+use clap::Parser;
+use pna::prelude::*;
+use portable_network_archive::cli;
+use std::{collections::HashSet, fs, io::prelude::*, time};
+
+const DURATION_24_HOURS: time::Duration = time::Duration::from_secs(24 * 60 * 60);
+
+/// Precondition: A solid mode archive exists and a source file is modified
+/// with a newer mtime.
+/// Action: Run `pna experimental update` with `--unsolid`.
+/// Expectation: All entries are converted to normal entries, the entry path
+/// set is unchanged, and extraction yields the updated content.
+#[test]
+fn update_with_unsolid() {
+    setup();
+    TestResources::extract_in("raw/", "update_with_unsolid/in/").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "update_with_unsolid/archive.pna",
+        "--overwrite",
+        "--solid",
+        "--no-keep-dir",
+        "update_with_unsolid/in/",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut initial_entries = HashSet::new();
+    archive::for_each_entry("update_with_unsolid/archive.pna", |entry| {
+        initial_entries.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+
+    let mut file = fs::File::options()
+        .write(true)
+        .truncate(true)
+        .open("update_with_unsolid/in/raw/text.txt")
+        .unwrap();
+    file.write_all(b"updated content for unsolid test").unwrap();
+    file.set_modified(time::SystemTime::now() + DURATION_24_HOURS)
+        .unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "--unsolid",
+        "-f",
+        "update_with_unsolid/archive.pna",
+        "update_with_unsolid/in/",
+        "--no-keep-dir",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut archive = pna::Archive::open("update_with_unsolid/archive.pna").unwrap();
+    let entries = archive.entries().collect::<Result<Vec<_>, _>>().unwrap();
+    assert!(
+        entries
+            .iter()
+            .all(|entry| matches!(entry, pna::ReadEntry::Normal(_))),
+        "all entries should be converted to normal entries"
+    );
+
+    let mut seen = HashSet::new();
+    archive::for_each_entry("update_with_unsolid/archive.pna", |entry| {
+        seen.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+    assert_eq!(
+        seen, initial_entries,
+        "entry path set should be unchanged after update"
+    );
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        "-f",
+        "update_with_unsolid/archive.pna",
+        "--overwrite",
+        "--out-dir",
+        "update_with_unsolid/out/",
+        "--strip-components",
+        "2",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    assert_eq!(
+        fs::read("update_with_unsolid/out/raw/text.txt").unwrap(),
+        b"updated content for unsolid test",
+        "extraction should yield the updated content"
+    );
+}

--- a/cli/tests/cli/update/symlink_entry.rs
+++ b/cli/tests/cli/update/symlink_entry.rs
@@ -1,0 +1,180 @@
+use crate::utils::{archive, setup};
+use clap::Parser;
+use portable_network_archive::cli;
+use std::{collections::HashSet, fs, path::Path};
+
+fn create_symlink_archive(dir: &str) {
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(format!("{dir}/in")).unwrap();
+    fs::write(format!("{dir}/in/target.txt"), b"target content").unwrap();
+    pna::fs::symlink(Path::new("target.txt"), format!("{dir}/in/link.txt")).unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        &format!("{dir}/archive.pna"),
+        "--overwrite",
+        &format!("{dir}/in"),
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+}
+
+/// Precondition: An archive contains a symlink entry and the source tree is
+/// unchanged.
+/// Action: Run `pna experimental update`.
+/// Expectation: The symlink entry is preserved with its symlink kind and the
+/// entry set is unchanged.
+#[test]
+fn update_keeps_symlink_entry() {
+    setup();
+    create_symlink_archive("update_keeps_symlink");
+
+    let mut initial_entries = HashSet::new();
+    archive::for_each_entry("update_keeps_symlink/archive.pna", |entry| {
+        initial_entries.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "-f",
+        "update_keeps_symlink/archive.pna",
+        "update_keeps_symlink/in",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut seen = HashSet::new();
+    let mut symlink_kind = false;
+    archive::for_each_entry("update_keeps_symlink/archive.pna", |entry| {
+        if entry.header().path().as_str() == "update_keeps_symlink/in/link.txt" {
+            symlink_kind = entry.header().data_kind() == pna::DataKind::SymbolicLink;
+        }
+        seen.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+
+    assert!(
+        symlink_kind,
+        "link.txt should remain a symlink entry after update"
+    );
+    assert_eq!(
+        seen, initial_entries,
+        "entry set should be unchanged after update"
+    );
+}
+
+/// Precondition: An archive contains a symlink entry and the symlink is
+/// removed from disk.
+/// Action: Run `pna experimental update` with `--sync`.
+/// Expectation: The symlink entry is pruned while the target file entry
+/// remains.
+#[test]
+fn update_with_sync_prunes_missing_symlink() {
+    setup();
+    create_symlink_archive("update_sync_missing_symlink");
+
+    let mut initial_entries = HashSet::new();
+    archive::for_each_entry("update_sync_missing_symlink/archive.pna", |entry| {
+        initial_entries.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+
+    fs::remove_file("update_sync_missing_symlink/in/link.txt").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "--sync",
+        "-f",
+        "update_sync_missing_symlink/archive.pna",
+        "update_sync_missing_symlink/in",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut seen = HashSet::new();
+    archive::for_each_entry("update_sync_missing_symlink/archive.pna", |entry| {
+        seen.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+
+    let mut expected = initial_entries;
+    assert!(
+        expected.remove("update_sync_missing_symlink/in/link.txt"),
+        "precondition: initial archive should contain the symlink entry"
+    );
+    assert_eq!(
+        seen, expected,
+        "only the symlink missing on disk should be pruned"
+    );
+}
+
+/// Precondition: An archive contains a symlink entry whose target is removed
+/// from disk, leaving the symlink itself broken but present.
+/// Action: Run `pna experimental update` with `--sync`.
+/// Expectation: The broken symlink entry is kept (the link itself exists on
+/// disk) while the removed target file entry is pruned.
+#[cfg(unix)]
+#[test]
+fn update_with_sync_keeps_broken_symlink() {
+    setup();
+    create_symlink_archive("update_sync_broken_symlink");
+
+    let mut initial_entries = HashSet::new();
+    archive::for_each_entry("update_sync_broken_symlink/archive.pna", |entry| {
+        initial_entries.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+
+    fs::remove_file("update_sync_broken_symlink/in/target.txt").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "--sync",
+        "-f",
+        "update_sync_broken_symlink/archive.pna",
+        "update_sync_broken_symlink/in",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut seen = HashSet::new();
+    archive::for_each_entry("update_sync_broken_symlink/archive.pna", |entry| {
+        seen.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+
+    assert!(
+        seen.contains("update_sync_broken_symlink/in/link.txt"),
+        "broken symlink existing on disk should be kept under --sync"
+    );
+    let mut expected = initial_entries;
+    assert!(
+        expected.remove("update_sync_broken_symlink/in/target.txt"),
+        "precondition: initial archive should contain the target file entry"
+    );
+    assert_eq!(
+        seen, expected,
+        "only the target file missing on disk should be pruned"
+    );
+}


### PR DESCRIPTION
## Summary
Add CLI integration tests for `pna experimental update` covering previously untested dimensions: multipart (split) archive input, solid archives (`--keep-solid` / `--unsolid`, including `--sync` pruning inside a solid group), symlink and directory entries, and `--include` filtering. Test coverage groundwork for stabilization (#1547).