### PR TITLE
Warn on duplicate update targets and avoid quadratic entry matching

### DIFF
--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -564,23 +564,31 @@ where
     // idempotent and not worth a warning. Only warn when two *different*
     // source paths collapse onto the same archive entry name, since one of
     // them silently loses.
-    let mut target_files_mapping: IndexMap<EntryName, (usize, CollectedEntry)> =
+    // The value is `Option`-wrapped so a match can be taken out in O(1) via
+    // `Option::take` (below) instead of `shift_remove`, which is O(n) per
+    // call and made archive-side matching quadratic in the number of entries.
+    let mut target_files_mapping: IndexMap<EntryName, Option<(usize, CollectedEntry)>> =
         IndexMap::with_capacity(target_items.len());
     for (idx, item) in target_items.into_iter().enumerate() {
         match target_files_mapping.entry(EntryName::from_lossy(&item.path)) {
             indexmap::map::Entry::Occupied(mut occupied) => {
-                if occupied.get().1.path != item.path {
+                // Matching against archive entries happens after this loop,
+                // so `occupied.get()` is always `Some` here; guard
+                // defensively rather than assume it.
+                if let Some((_, old)) = occupied.get()
+                    && old.path != item.path
+                {
                     log::warn!(
                         "Multiple update sources map to the same archive entry \"{}\": \"{}\" is used, \"{}\" is discarded",
                         occupied.key(),
                         item.path.display(),
-                        occupied.get().1.path.display(),
+                        old.path.display(),
                     );
                 }
-                occupied.insert((idx, item));
+                occupied.insert(Some((idx, item)));
             }
             indexmap::map::Entry::Vacant(vacant) => {
-                vacant.insert((idx, item));
+                vacant.insert(Some((idx, item)));
             }
         }
     }
@@ -590,8 +598,9 @@ where
             |entry| {
                 Strategy::transform(out_archive, password, entry, |entry| {
                     let entry = entry?;
-                    if let Some((idx, item)) =
-                        target_files_mapping.shift_remove(entry.header().path())
+                    if let Some((idx, item)) = target_files_mapping
+                        .get_mut(entry.header().path())
+                        .and_then(Option::take)
                     {
                         let need_update =
                             is_newer_than_archive(missing_time, &item.metadata, entry.metadata());
@@ -628,8 +637,8 @@ where
             allow_concatenated_archives,
         )?;
 
-        // NOTE: Add new entries
-        for (_, (idx, item)) in target_files_mapping {
+        // Add entries that were never matched against an archive entry above.
+        for (idx, item) in target_files_mapping.into_values().flatten() {
             let tx = tx.clone();
             let create_options = create_options.clone();
             s.spawn_fifo(move |_| {

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -559,11 +559,31 @@ where
 {
     let (tx, rx) = std::sync::mpsc::channel();
 
-    let mut target_files_mapping = target_items
-        .into_iter()
-        .enumerate()
-        .map(|(idx, item)| (EntryName::from_lossy(&item.path), (idx, item)))
-        .collect::<IndexMap<_, _>>();
+    // Overlapping source arguments (e.g. a directory and a file within it)
+    // routinely collect the same path spelling twice; that case is
+    // idempotent and not worth a warning. Only warn when two *different*
+    // source paths collapse onto the same archive entry name, since one of
+    // them silently loses.
+    let mut target_files_mapping: IndexMap<EntryName, (usize, CollectedEntry)> =
+        IndexMap::with_capacity(target_items.len());
+    for (idx, item) in target_items.into_iter().enumerate() {
+        match target_files_mapping.entry(EntryName::from_lossy(&item.path)) {
+            indexmap::map::Entry::Occupied(mut occupied) => {
+                if occupied.get().1.path != item.path {
+                    log::warn!(
+                        "Multiple update sources map to the same archive entry \"{}\": \"{}\" is used, \"{}\" is discarded",
+                        occupied.key(),
+                        item.path.display(),
+                        occupied.get().1.path.display(),
+                    );
+                }
+                occupied.insert((idx, item));
+            }
+            indexmap::map::Entry::Vacant(vacant) => {
+                vacant.insert((idx, item));
+            }
+        }
+    }
 
     rayon::scope_fifo(|s| -> anyhow::Result<()> {
         source.for_each_read_entry(

--- a/cli/tests/cli/update.rs
+++ b/cli/tests/cli/update.rs
@@ -1,4 +1,5 @@
 mod directory_entry;
+mod duplicate_targets;
 mod encryption;
 mod entry_order;
 mod error;

--- a/cli/tests/cli/update/duplicate_targets.rs
+++ b/cli/tests/cli/update/duplicate_targets.rs
@@ -1,0 +1,223 @@
+#![cfg(not(target_family = "wasm"))]
+use crate::utils::{archive, setup};
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use std::{
+    fs,
+    io::Write,
+    time::{Duration, SystemTime},
+};
+
+const DURATION_24_HOURS: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Precondition: An archive contains an entry created from a single file.
+/// Action: Run `pna experimental update --sync` naming that same file twice
+/// while it has a newer mtime than the archived entry.
+/// Expectation: No duplicate-target warning is emitted (the same path
+/// specified twice is treated as idempotent), and the archive ends up with
+/// a single, correctly updated entry.
+#[test]
+fn update_with_duplicate_source_argument_is_idempotent() {
+    setup();
+    let dir = "update_with_duplicate_source_argument_is_idempotent";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let file = format!("{dir}/a.txt");
+    let archive_path = format!("{dir}/archive.pna");
+    fs::write(&file, b"original").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "create",
+            "-f",
+            &archive_path,
+            "--overwrite",
+            "--keep-timestamp",
+            &file,
+        ])
+        .assert()
+        .success();
+
+    let threshold = SystemTime::now();
+    let mut handle = fs::File::options()
+        .write(true)
+        .truncate(true)
+        .open(&file)
+        .unwrap();
+    handle.write_all(b"updated").unwrap();
+    handle.set_modified(threshold + DURATION_24_HOURS).unwrap();
+    drop(handle);
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "update",
+            "-f",
+            &archive_path,
+            "--sync",
+            "--keep-timestamp",
+            &file,
+            &file,
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Multiple update sources").not());
+
+    assert_eq!(
+        archive::get_archive_entry_names(&archive_path),
+        vec![file.clone()],
+        "duplicate source argument should collapse to a single archive entry"
+    );
+
+    let out_dir = format!("{dir}/out");
+    cargo_bin_cmd!("pna")
+        .args([
+            "x",
+            "-f",
+            &archive_path,
+            "--overwrite",
+            "--out-dir",
+            &out_dir,
+        ])
+        .assert()
+        .success();
+    assert_eq!(
+        fs::read_to_string(format!("{out_dir}/{file}")).unwrap(),
+        "updated"
+    );
+}
+
+/// Precondition: An archive contains a directory and a file inside it.
+/// Action: Run `pna experimental update --sync` naming both the directory
+/// and the contained file while the file has a newer mtime than the archive.
+/// Expectation: No duplicate-target warning is emitted because the repeated
+/// collected path came from overlapping source arguments and is idempotent.
+#[test]
+fn update_with_overlapping_directory_and_file_arguments_does_not_warn() {
+    setup();
+    let dir = "update_with_overlapping_directory_and_file_arguments_does_not_warn";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let file = format!("{dir}/a.txt");
+    let archive_path = format!("{dir}/archive.pna");
+    fs::write(&file, b"original").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "create",
+            "-f",
+            &archive_path,
+            "--overwrite",
+            "--keep-timestamp",
+            dir,
+        ])
+        .assert()
+        .success();
+
+    let threshold = SystemTime::now();
+    let mut handle = fs::File::options()
+        .write(true)
+        .truncate(true)
+        .open(&file)
+        .unwrap();
+    handle.write_all(b"updated").unwrap();
+    handle.set_modified(threshold + DURATION_24_HOURS).unwrap();
+    drop(handle);
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "update",
+            "-f",
+            &archive_path,
+            "--sync",
+            "--keep-timestamp",
+            dir,
+            &file,
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Multiple update sources").not());
+}
+
+/// Precondition: An archive contains multiple entries.
+/// Action: Run a normal `pna experimental update` with no overlapping or
+/// colliding source arguments.
+/// Expectation: No duplicate-target warning is emitted.
+#[test]
+fn update_without_duplicate_targets_does_not_warn() {
+    setup();
+    let dir = "update_without_duplicate_targets_does_not_warn";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let file_a = format!("{dir}/a.txt");
+    let file_b = format!("{dir}/b.txt");
+    let archive_path = format!("{dir}/archive.pna");
+    fs::write(&file_a, b"a").unwrap();
+    fs::write(&file_b, b"b").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "create",
+            "-f",
+            &archive_path,
+            "--overwrite",
+            &file_a,
+            &file_b,
+        ])
+        .assert()
+        .success();
+
+    fs::write(&file_a, b"a-updated").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args(["experimental", "update", "-f", &archive_path, &file_a])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Multiple update sources").not());
+}
+
+/// Precondition: An archive contains an entry created from a single file.
+/// Action: Run `pna experimental update` naming that file twice with
+/// different literal spellings ("dir/a.txt" and "./dir/a.txt") that resolve
+/// to the same archive entry name.
+/// Expectation: A warning is emitted identifying the colliding archive entry
+/// since two distinct source paths - not merely the same path repeated -
+/// collapsed onto it.
+#[test]
+fn update_with_conflicting_source_spellings_warns() {
+    setup();
+    let dir = "update_with_conflicting_source_spellings_warns";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let file = format!("{dir}/a.txt");
+    let file_dotted = format!("./{dir}/a.txt");
+    let archive_path = format!("{dir}/archive.pna");
+    fs::write(&file, b"content").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args(["create", "-f", &archive_path, "--overwrite", &file])
+        .assert()
+        .success();
+
+    fs::write(&file, b"updated").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "update",
+            "-f",
+            &archive_path,
+            &file,
+            &file_dotted,
+        ])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains(format!(
+            "Multiple update sources map to the same archive entry \"{file}\": \"{file_dotted}\" is used, \"{file}\" is discarded"
+        )));
+}


### PR DESCRIPTION
## Summary
Resolves two review leftovers from #3007 in `update`'s entry matching: a warning is now emitted when different source paths collapse onto the same archive entry name (identical-path duplicates from overlapping sources stay silent), and the matching loop is rewritten from O(N×M) `shift_remove` to O(1) lookups while preserving insertion order.

## Notes
- Archive output is unchanged; the only user-visible delta is the new stderr warning, which also applies to the shared `compat bsdtar -u` path.

Refs #1547

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update behavior when multiple source paths map to the same archive entry, including idempotent handling of duplicate source arguments.
  * Added clearer stderr warnings when different source spellings resolve to the same target, while preserving the first mapping.
  * Prevented already-matched archive entries from being re-added during updates, avoiding inconsistencies.

* **Tests**
  * Added CLI integration coverage for duplicate and overlapping update sources, including warning assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->