### PR TITLE
Reject --sync combined with path transform options in update

### DIFF
--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -380,8 +380,11 @@ pub(crate) struct UpdateCommand {
         help = "Follow symbolic links named on the command line"
     )]
     follow_command_links: bool,
+    // Transformed names cannot be mapped back to a filesystem path, so --sync's
+    // existence check would treat files that still exist as missing and prune them.
     #[arg(
         long,
+        conflicts_with_all = ["substitutions", "transforms", "strip_components"],
         help = "Synchronize archive with source: remove entries for files that no longer exist in the source"
     )]
     sync: bool,
@@ -639,8 +642,9 @@ where
 // collection) no longer exists on disk. Entries merely filtered out of the
 // collected set (e.g. by --exclude or time filters) are kept. Ambiguous
 // errors such as PermissionDenied count as existing so pruning never risks
-// data loss. Known limitation: names produced by -s/--transform/
-// --strip-components do not correspond to filesystem paths and are pruned.
+// data loss. `--sync` is rejected together with -s/--transform/
+// --strip-components (see `sync`'s `conflicts_with_all` above), since those
+// options make the stored name diverge from a filesystem path.
 fn exists_on_disk(path: &Path) -> bool {
     match fs::symlink_metadata(path) {
         Ok(_) => true,

--- a/cli/tests/cli/update.rs
+++ b/cli/tests/cli/update.rs
@@ -25,4 +25,5 @@ mod option_older_mtime_than;
 mod option_recursive;
 mod option_sync;
 mod option_unsolid;
+mod path_transform;
 mod symlink_entry;

--- a/cli/tests/cli/update/option_sync.rs
+++ b/cli/tests/cli/update/option_sync.rs
@@ -317,3 +317,85 @@ fn update_with_sync_keeps_time_filtered_files() {
         "time-filtered but existing files should be kept under --sync"
     );
 }
+
+/// Precondition: None.
+/// Action: Parse `pna experimental update --sync` together with a `-s`
+/// substitution rule.
+/// Expectation: Argument parsing fails, since `--sync` prunes entries by
+/// checking whether the stored name exists on disk, and a substitution rule
+/// makes the stored name diverge from the original filesystem path.
+#[test]
+fn update_sync_conflicts_with_substitution() {
+    setup();
+
+    let result = cli::Cli::try_parse_from([
+        "pna",
+        "experimental",
+        "update",
+        "-f",
+        "dummy.pna",
+        "--sync",
+        "--unstable",
+        "-s",
+        "#a#b#",
+    ]);
+
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("cannot be used with"),
+        "expected a mutual exclusion error, got: {err}"
+    );
+}
+
+/// Precondition: None.
+/// Action: Parse `pna experimental update --sync` together with `--transform`.
+/// Expectation: Argument parsing fails for the same reason as `-s`.
+#[test]
+fn update_sync_conflicts_with_transform() {
+    setup();
+
+    let result = cli::Cli::try_parse_from([
+        "pna",
+        "experimental",
+        "update",
+        "-f",
+        "dummy.pna",
+        "--sync",
+        "--unstable",
+        "--transform",
+        "s#a#b#",
+    ]);
+
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("cannot be used with"),
+        "expected a mutual exclusion error, got: {err}"
+    );
+}
+
+/// Precondition: None.
+/// Action: Parse `pna experimental update --sync` together with
+/// `--strip-components`.
+/// Expectation: Argument parsing fails for the same reason as `-s`.
+#[test]
+fn update_sync_conflicts_with_strip_components() {
+    setup();
+
+    let result = cli::Cli::try_parse_from([
+        "pna",
+        "experimental",
+        "update",
+        "-f",
+        "dummy.pna",
+        "--sync",
+        "--unstable",
+        "--strip-components",
+        "1",
+    ]);
+
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("cannot be used with"),
+        "expected a mutual exclusion error, got: {err}"
+    );
+}

--- a/cli/tests/cli/update/path_transform.rs
+++ b/cli/tests/cli/update/path_transform.rs
@@ -1,0 +1,232 @@
+use crate::utils::{archive, setup};
+use clap::Parser;
+use portable_network_archive::cli;
+use std::{collections::HashSet, fs, io::prelude::*, time};
+
+const DURATION_24_HOURS: time::Duration = time::Duration::from_secs(24 * 60 * 60);
+
+fn write_newer(path: &str, content: &[u8]) {
+    let mut file = fs::File::options()
+        .write(true)
+        .truncate(true)
+        .open(path)
+        .unwrap();
+    file.write_all(content).unwrap();
+    file.set_modified(time::SystemTime::now() + DURATION_24_HOURS)
+        .unwrap();
+}
+
+fn read_entry_content(archive_path: &str, name: &str) -> Vec<u8> {
+    let mut found = None;
+    archive::for_each_entry(archive_path, |entry| {
+        if *entry.header().path() == name {
+            let mut buf = Vec::new();
+            entry
+                .reader(pna::ReadOptions::with_password::<&[u8]>(None))
+                .unwrap()
+                .read_to_end(&mut buf)
+                .unwrap();
+            found = Some(buf);
+        }
+    })
+    .unwrap();
+    found.unwrap_or_else(|| panic!("entry {name} not found in {archive_path}"))
+}
+
+/// Precondition: An archive is created without any path transform, so the
+/// stored entry name matches the file's original path.
+/// Action: Make the source file newer, then run `pna experimental update`
+/// with a `-s` substitution that renames the stored path.
+/// Expectation: Like bsdtar's `-u`, update matches entries by the original
+/// disk path, not by the transformed stored name. The original entry is
+/// kept unchanged and a new entry is appended under the transformed name
+/// carrying the updated content.
+#[test]
+fn update_with_substitution_appends_transformed_name() {
+    setup();
+    let base = "update_with_substitution_appends_transformed_name";
+    let _ = fs::remove_dir_all(base);
+    fs::create_dir_all(format!("{base}/src")).unwrap();
+    fs::write(format!("{base}/src/a.txt"), b"old").unwrap();
+    let archive_path = format!("{base}/archive.pna");
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        &archive_path,
+        "--overwrite",
+        &format!("{base}/src/a.txt"),
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    write_newer(&format!("{base}/src/a.txt"), b"new");
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "-f",
+        &archive_path,
+        &format!("{base}/src/a.txt"),
+        "--keep-timestamp",
+        "--unstable",
+        "-s",
+        "#src/#dst/#",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut seen = HashSet::new();
+    archive::for_each_entry(&archive_path, |entry| {
+        seen.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+
+    let original = format!("{base}/src/a.txt");
+    let transformed = format!("{base}/dst/a.txt");
+    assert_eq!(
+        seen,
+        HashSet::from([original.clone(), transformed.clone()]),
+        "original entry should be kept and a transformed-name entry appended"
+    );
+    assert_eq!(read_entry_content(&archive_path, &original), b"old");
+    assert_eq!(read_entry_content(&archive_path, &transformed), b"new");
+}
+
+/// Precondition: An archive is created with a `-s` substitution already
+/// applied, so the stored entry name is the transformed name rather than
+/// the file's original disk path.
+/// Action: Without modifying the source file, run `pna experimental update`
+/// again with the same substitution.
+/// Expectation: Update matches entries by the original disk path, so the
+/// already-transformed stored name never matches an update target. The file
+/// is treated as new and re-appended under the same transformed name,
+/// duplicating the entry even though it was not modified.
+#[test]
+fn update_with_substitution_reappends_entry_that_cannot_match_transformed_name() {
+    setup();
+    let base = "update_with_substitution_reappends_entry_that_cannot_match_transformed_name";
+    let _ = fs::remove_dir_all(base);
+    fs::create_dir_all(format!("{base}/src")).unwrap();
+    fs::write(format!("{base}/src/a.txt"), b"unchanged").unwrap();
+    let archive_path = format!("{base}/archive.pna");
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        &archive_path,
+        "--overwrite",
+        &format!("{base}/src/a.txt"),
+        "--keep-timestamp",
+        "--unstable",
+        "-s",
+        "#src/#dst/#",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "-f",
+        &archive_path,
+        &format!("{base}/src/a.txt"),
+        "--keep-timestamp",
+        "--unstable",
+        "-s",
+        "#src/#dst/#",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut seen = Vec::new();
+    archive::for_each_entry(&archive_path, |entry| {
+        seen.push(entry.header().path().to_string());
+    })
+    .unwrap();
+
+    let transformed = format!("{base}/dst/a.txt");
+    assert_eq!(
+        seen,
+        vec![transformed.clone(), transformed],
+        "unmatched entry should be duplicated even though the source was not modified"
+    );
+}
+
+/// Precondition: An archive is created without any path transform.
+/// Action: Make the source file newer, then run `pna experimental update`
+/// with `--strip-components` removing a leading path element.
+/// Expectation: Same matching behavior as with `-s`: matching uses the
+/// original disk path, so the original entry is kept and a new entry is
+/// appended under the stripped name.
+#[test]
+fn update_with_strip_components_appends_transformed_name() {
+    setup();
+    let base = "update_with_strip_components_appends_transformed_name";
+    let _ = fs::remove_dir_all(base);
+    fs::create_dir_all(format!("{base}/src")).unwrap();
+    fs::write(format!("{base}/src/a.txt"), b"old").unwrap();
+    let archive_path = format!("{base}/archive.pna");
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        &archive_path,
+        "--overwrite",
+        &format!("{base}/src/a.txt"),
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    write_newer(&format!("{base}/src/a.txt"), b"new");
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "-f",
+        &archive_path,
+        &format!("{base}/src/a.txt"),
+        "--keep-timestamp",
+        "--unstable",
+        "--strip-components",
+        "1",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut seen = HashSet::new();
+    archive::for_each_entry(&archive_path, |entry| {
+        seen.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+
+    let original = format!("{base}/src/a.txt");
+    let transformed = "src/a.txt".to_string();
+    assert_eq!(
+        seen,
+        HashSet::from([original.clone(), transformed.clone()]),
+        "original entry should be kept and a stripped-name entry appended"
+    );
+    assert_eq!(read_entry_content(&archive_path, &original), b"old");
+    assert_eq!(read_entry_content(&archive_path, &transformed), b"new");
+}


### PR DESCRIPTION
## Summary
Pins `update`'s bsdtar-faithful matching behavior under path transforms with tests (entries are matched by the original disk path, so transformed names are appended rather than matched, verified identical to bsdtar 3.5.3 for file entries), and rejects `--sync` combined with `-s`/`--transform`/`--strip-components` at parse time.

## Notes
- Behavior change: the rejected combination was previously accepted and silently pruned entries whose files still exist on disk, because `--sync`'s existence check ran against transformed stored names that never correspond to filesystem paths. Transformed names are not invertible to disk paths, so the combination now fails loudly instead of losing data. All transform options are `--unstable`-gated.

Refs #1547