### PR TITLE
:memo: Clarify update --sync help text

### DIFF
--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -385,7 +385,7 @@ pub(crate) struct UpdateCommand {
     #[arg(
         long,
         conflicts_with_all = ["substitutions", "transforms", "strip_components"],
-        help = "Synchronize archive with source: remove entries for files that no longer exist in the source"
+        help = "Synchronize archive with source: replace updated entries instead of appending, and remove entries for files that no longer exist on disk."
     )]
     sync: bool,
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the `--sync` CLI help text to better explain how synchronization works, including replacing updated entries and removing entries for files that no longer exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->