### PR TITLE
:sparkles: Add --type/--exclude-type filters to `chunk list` 

### DIFF
--- a/cli/src/cli/value.rs
+++ b/cli/src/cli/value.rs
@@ -5,6 +5,7 @@
 //! command-line string inputs into strongly-typed values.
 
 mod argon2id_params;
+mod chunk_type;
 mod color_choice;
 mod compression_level;
 mod datetime;
@@ -16,6 +17,7 @@ mod pbkdf2_sha256_params;
 mod private_chunk_type;
 
 pub(crate) use argon2id_params::Argon2idParams;
+pub(crate) use chunk_type::ChunkType;
 pub(crate) use color_choice::ColorChoice;
 pub(crate) use compression_level::{DeflateLevel, XzLevel, ZstdLevel};
 pub use datetime::DateTime;

--- a/cli/src/cli/value/chunk_type.rs
+++ b/cli/src/cli/value/chunk_type.rs
@@ -1,0 +1,67 @@
+use std::str::FromStr;
+
+#[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
+pub(crate) struct ChunkType(pub(crate) pna::ChunkType);
+
+#[derive(thiserror::Error, Debug, Eq, PartialEq)]
+pub(crate) enum ParseChunkTypeError {
+    #[error("chunk type must be exactly 4 ASCII characters")]
+    InvalidLength,
+    #[error("chunk type must contain only ASCII alphabetic characters")]
+    NonAsciiAlphabetic,
+}
+
+impl FromStr for ChunkType {
+    type Err = ParseChunkTypeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let bytes: [u8; 4] = s
+            .as_bytes()
+            .try_into()
+            .map_err(|_| ParseChunkTypeError::InvalidLength)?;
+        if !bytes.iter().all(u8::is_ascii_alphabetic) {
+            return Err(ParseChunkTypeError::NonAsciiAlphabetic);
+        }
+        // SAFETY: All four bytes are ASCII alphabetic as verified above.
+        Ok(Self(unsafe { pna::ChunkType::from_unchecked(bytes) }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_str_valid_standard_chunk() {
+        let chunk_type = ChunkType::from_str("FHED").unwrap();
+        assert_eq!(chunk_type.0, pna::ChunkType::FHED);
+    }
+
+    #[test]
+    fn from_str_valid_private_chunk() {
+        let chunk_type = ChunkType::from_str("myTy").unwrap();
+        assert_eq!(chunk_type.0, unsafe {
+            pna::ChunkType::from_unchecked(*b"myTy")
+        });
+    }
+
+    #[test]
+    fn from_str_invalid_length() {
+        assert_eq!(
+            ChunkType::from_str("toolong").unwrap_err(),
+            ParseChunkTypeError::InvalidLength
+        );
+        assert_eq!(
+            ChunkType::from_str("abc").unwrap_err(),
+            ParseChunkTypeError::InvalidLength
+        );
+    }
+
+    #[test]
+    fn from_str_non_ascii_alphabetic() {
+        assert_eq!(
+            ChunkType::from_str("FH1D").unwrap_err(),
+            ParseChunkTypeError::NonAsciiAlphabetic
+        );
+    }
+}

--- a/cli/src/command/chunk.rs
+++ b/cli/src/command/chunk.rs
@@ -1,7 +1,7 @@
-use crate::command::Command;
+use crate::{cli::value::ChunkType, command::Command};
 use clap::{Parser, ValueHint};
 use pna::prelude::*;
-use std::{fs, path::PathBuf};
+use std::{collections::HashSet, fs, path::PathBuf};
 use tabled::{builder::Builder as TableBuilder, settings::Style as TableStyle};
 
 #[derive(Parser, Clone, Eq, PartialEq, Hash, Debug)]
@@ -26,13 +26,25 @@ pub(crate) enum ChunkCommands {
     List(ListCommand),
 }
 
-#[derive(Parser, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Parser, Clone, Eq, PartialEq, Hash, Debug)]
 #[clap(disable_help_flag = true)]
 pub(crate) struct ListCommand {
     #[arg(short, long, help = "Display chunk body")]
     pub(crate) long: bool,
     #[arg(short, long, help = "Add a header row to each column")]
     pub(crate) header: bool,
+    #[arg(
+        long = "type",
+        value_name = "TYPE",
+        help = "Only list chunks of the specified type (repeatable)"
+    )]
+    ty: Vec<ChunkType>,
+    #[arg(
+        long = "exclude-type",
+        value_name = "TYPE",
+        help = "Do not list chunks of the specified type (repeatable)"
+    )]
+    exclude_ty: Vec<ChunkType>,
     #[arg(short = 'f', long = "file", value_hint = ValueHint::FilePath)]
     archive: PathBuf,
     #[arg(long, action = clap::ArgAction::Help, help = "Print help")]
@@ -57,27 +69,33 @@ fn list_archive_chunks(args: ListCommand) -> anyhow::Result<()> {
                 .chain(args.long.then_some("Body")),
         )
     }
+    let include: HashSet<pna::ChunkType> = args.ty.iter().map(|ty| ty.0).collect();
+    let exclude: HashSet<pna::ChunkType> = args.exclude_ty.iter().map(|ty| ty.0).collect();
     let mut offset = pna::PNA_HEADER.len();
     let mut idx = 0;
     for chunk in pna::read_as_chunks(archive)? {
         let chunk = chunk?;
+        let ty = chunk.ty();
         idx += 1;
-        builder.push_record(
-            [
-                idx.to_string(),
-                chunk.ty().to_string(),
-                chunk.length().to_string(),
-                format!("{offset:#06x}"),
-            ]
-            .into_iter()
-            .chain(args.long.then(|| {
-                let data = chunk.data();
-                match std::str::from_utf8(data) {
-                    Ok(s) => s.to_string(),
-                    Err(_) => format!("{:#x}", const_hex::display(data)),
-                }
-            })),
-        );
+        let accepted = (include.is_empty() || include.contains(&ty)) && !exclude.contains(&ty);
+        if accepted {
+            builder.push_record(
+                [
+                    idx.to_string(),
+                    ty.to_string(),
+                    chunk.length().to_string(),
+                    format!("{offset:#06x}"),
+                ]
+                .into_iter()
+                .chain(args.long.then(|| {
+                    let data = chunk.data();
+                    match std::str::from_utf8(data) {
+                        Ok(s) => s.to_string(),
+                        Err(_) => format!("{:#x}", const_hex::display(data)),
+                    }
+                })),
+            );
+        }
         offset += chunk.length() as usize + std::mem::size_of::<u32>() * 3;
     }
     let mut table = builder.build();

--- a/cli/tests/cli/chunk/list.rs
+++ b/cli/tests/cli/chunk/list.rs
@@ -6,4 +6,6 @@ mod option_header;
 #[cfg(not(target_family = "wasm"))]
 mod option_long;
 #[cfg(not(target_family = "wasm"))]
+mod option_type;
+#[cfg(not(target_family = "wasm"))]
 mod solid_archive;

--- a/cli/tests/cli/chunk/list/option_type.rs
+++ b/cli/tests/cli/chunk/list/option_type.rs
@@ -1,0 +1,264 @@
+//! Tests for the --type and --exclude-type options.
+
+use crate::utils::{EmbedExt, TestResources, setup};
+use assert_cmd::cargo::cargo_bin_cmd;
+use clap::Parser;
+use portable_network_archive::cli;
+
+/// Precondition: A deflate-compressed PNA archive exists.
+/// Action: Run `pna experimental chunk list --type FHED -f <archive>`.
+/// Expectation: Only FHED chunks are listed.
+#[test]
+fn chunk_list_with_type() {
+    setup();
+    TestResources::extract_in("deflate.pna", "chunk_list_type_fhed/").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "chunk",
+            "list",
+            "--type",
+            "FHED",
+            "-f",
+            "chunk_list_type_fhed/deflate.pna",
+        ])
+        .assert()
+        .success()
+        .stdout(concat!(
+            " 2   FHED  19  0x001c  \n",
+            " 5   FHED  25  0x005b  \n",
+            " 8   FHED  25  0x8cce  \n",
+            " 11  FHED  25  0x9018  \n",
+            " 14  FHED  36  0xfe0a  \n",
+            " 17  FHED  23  0xfe5d  \n",
+            " 20  FHED  22  0xfec0  \n",
+            " 23  FHED  26  0x1d291 \n",
+            " 26  FHED  18  0x1d2d7 \n",
+        ));
+}
+
+/// Precondition: A deflate-compressed PNA archive exists.
+/// Action: Run `pna experimental chunk list --exclude-type FHED -f <archive>`.
+/// Expectation: FHED chunks are omitted while other chunk types remain.
+#[test]
+fn chunk_list_with_exclude_type() {
+    setup();
+    TestResources::extract_in("deflate.pna", "chunk_list_exclude_fhed/").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "chunk",
+            "list",
+            "--exclude-type",
+            "FHED",
+            "-f",
+            "chunk_list_exclude_fhed/deflate.pna",
+        ])
+        .assert()
+        .success()
+        .stdout(concat!(
+            " 1   AHED  8      0x0008  \n",
+            " 3   FDAT  8      0x003b  \n",
+            " 4   FEND  0      0x004f  \n",
+            " 6   FDAT  35894  0x0080  \n",
+            " 7   FEND  0      0x8cc2  \n",
+            " 9   FDAT  781    0x8cf3  \n",
+            " 10  FEND  0      0x900c  \n",
+            " 12  FDAT  28085  0x903d  \n",
+            " 13  FEND  0      0xfdfe  \n",
+            " 15  FDAT  11     0xfe3a  \n",
+            " 16  FEND  0      0xfe51  \n",
+            " 18  FDAT  40     0xfe80  \n",
+            " 19  FEND  0      0xfeb4  \n",
+            " 21  FDAT  54167  0xfee2  \n",
+            " 22  FEND  0      0x1d285 \n",
+            " 24  FDAT  8      0x1d2b7 \n",
+            " 25  FEND  0      0x1d2cb \n",
+            " 27  FDAT  18     0x1d2f5 \n",
+            " 28  FEND  0      0x1d313 \n",
+            " 29  AEND  0      0x1d31f \n",
+        ));
+}
+
+/// Precondition: A deflate-compressed PNA archive exists.
+/// Action: Run `pna experimental chunk list --type FHED --type FDAT -f <archive>`.
+/// Expectation: Both FHED and FDAT chunks are listed (OR semantics).
+#[test]
+fn chunk_list_with_multiple_types() {
+    setup();
+    TestResources::extract_in("deflate.pna", "chunk_list_type_multi/").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "chunk",
+            "list",
+            "--type",
+            "FHED",
+            "--type",
+            "FDAT",
+            "-f",
+            "chunk_list_type_multi/deflate.pna",
+        ])
+        .assert()
+        .success()
+        .stdout(concat!(
+            " 2   FHED  19     0x001c  \n",
+            " 3   FDAT  8      0x003b  \n",
+            " 5   FHED  25     0x005b  \n",
+            " 6   FDAT  35894  0x0080  \n",
+            " 8   FHED  25     0x8cce  \n",
+            " 9   FDAT  781    0x8cf3  \n",
+            " 11  FHED  25     0x9018  \n",
+            " 12  FDAT  28085  0x903d  \n",
+            " 14  FHED  36     0xfe0a  \n",
+            " 15  FDAT  11     0xfe3a  \n",
+            " 17  FHED  23     0xfe5d  \n",
+            " 18  FDAT  40     0xfe80  \n",
+            " 20  FHED  22     0xfec0  \n",
+            " 21  FDAT  54167  0xfee2  \n",
+            " 23  FHED  26     0x1d291 \n",
+            " 24  FDAT  8      0x1d2b7 \n",
+            " 26  FHED  18     0x1d2d7 \n",
+            " 27  FDAT  18     0x1d2f5 \n",
+        ));
+}
+
+/// Precondition: A deflate-compressed PNA archive exists.
+/// Action: Run `pna experimental chunk list --type FHED --exclude-type FHED -f <archive>`.
+/// Expectation: No rows are emitted because exclusions take precedence.
+#[test]
+fn chunk_list_exclude_overrides_include() {
+    setup();
+    TestResources::extract_in("deflate.pna", "chunk_list_type_exclude_priority/").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "chunk",
+            "list",
+            "--type",
+            "FHED",
+            "--exclude-type",
+            "FHED",
+            "-f",
+            "chunk_list_type_exclude_priority/deflate.pna",
+        ])
+        .assert()
+        .success()
+        .stdout("\n");
+}
+
+/// Precondition: A deflate-compressed PNA archive exists.
+/// Action: Run `pna experimental chunk list --type FHED -f <archive>`.
+/// Expectation: Index and Offset columns preserve archive positions, not display order.
+#[test]
+fn chunk_list_type_preserves_index_and_offset() {
+    setup();
+    TestResources::extract_in("deflate.pna", "chunk_list_type_index_offset/").unwrap();
+
+    let output = cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "chunk",
+            "list",
+            "--type",
+            "FHED",
+            "-f",
+            "chunk_list_type_index_offset/deflate.pna",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let output_str = String::from_utf8_lossy(&output);
+    assert!(
+        output_str.contains(" 2   FHED"),
+        "first FHED row should keep archive index 2, got:\n{output_str}"
+    );
+    assert!(
+        output_str.contains("0x001c"),
+        "first FHED row should keep archive offset 0x001c, got:\n{output_str}"
+    );
+    assert!(
+        !output_str.contains(" 1   FHED"),
+        "filtered rows must not be renumbered, got:\n{output_str}"
+    );
+}
+
+/// Precondition: A deflate-compressed PNA archive exists.
+/// Action: Run chunk list with an invalid --type value.
+/// Expectation: Argument parsing fails with a descriptive error.
+#[test]
+fn chunk_list_with_invalid_type_length() {
+    setup();
+    TestResources::extract_in("deflate.pna", "chunk_list_invalid_type_len/").unwrap();
+
+    let result = cli::Cli::try_parse_from([
+        "pna",
+        "experimental",
+        "chunk",
+        "list",
+        "--type",
+        "toolong",
+        "-f",
+        "chunk_list_invalid_type_len/deflate.pna",
+    ]);
+
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("chunk type must be exactly 4 ASCII characters"),
+        "unexpected error message: {err}"
+    );
+}
+
+/// Precondition: A deflate-compressed PNA archive exists.
+/// Action: Run chunk list with a non-alphabetic --type value.
+/// Expectation: Argument parsing fails with a descriptive error.
+#[test]
+fn chunk_list_with_invalid_type_chars() {
+    setup();
+    TestResources::extract_in("deflate.pna", "chunk_list_invalid_type_chars/").unwrap();
+
+    let result = cli::Cli::try_parse_from([
+        "pna",
+        "experimental",
+        "chunk",
+        "list",
+        "--type",
+        "FH1D",
+        "-f",
+        "chunk_list_invalid_type_chars/deflate.pna",
+    ]);
+
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("chunk type must contain only ASCII alphabetic characters"),
+        "unexpected error message: {err}"
+    );
+}
+
+/// Precondition: An empty PNA archive exists.
+/// Action: Run `pna experimental chunk list -f <archive>` without type filters.
+/// Expectation: All chunks are listed as before.
+#[test]
+fn chunk_list_without_type_filter() {
+    setup();
+    TestResources::extract_in("empty.pna", "chunk_list_no_type_filter/").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "chunk",
+            "list",
+            "-f",
+            "chunk_list_no_type_filter/empty.pna",
+        ])
+        .assert()
+        .success()
+        .stdout(concat!(" 1  AHED  8  0x0008 \n", " 2  AEND  0  0x001c \n",));
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for filtering chunk listings by chunk type with repeatable include and exclude options.
  * Improved type parsing so chunk types must be exactly four ASCII letters, with clear validation feedback.

* **Bug Fixes**
  * Chunk listing now respects include/exclude rules instead of showing every chunk.
  * Filtering preserves the original archive index and offset values in output.

* **Tests**
  * Added coverage for valid filters, multiple types, exclusion precedence, and invalid type input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->