### PR TITLE
:white_check_mark: Fixed invalid encryption flag in `camellia_cbc_archive`

### DIFF
--- a/cli/tests/cli/encrypt.rs
+++ b/cli/tests/cli/encrypt.rs
@@ -139,7 +139,7 @@ fn camellia_cbc_archive() {
         "zstd_camellia_cbc/in/",
         "--password",
         "password",
-        "--aes",
+        "--camellia",
         "cbc",
     ])
     .unwrap()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated encryption archive coverage to select the Camellia algorithm correctly when testing Camellia CBC archives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->