### PR TITLE
Harden negative-path test coverage for chunk/archive/cipher parsing and CLI cipher wiring

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -365,6 +365,47 @@ mod tests {
     use super::*;
 
     #[test]
+    fn camellia_flag_maps_to_camellia_algorithm() {
+        let args = CipherAlgorithmArgs {
+            aes: None,
+            camellia: Some(Some(CipherMode::Cbc)),
+        };
+        assert_eq!(args.algorithm(), pna::Encryption::Camellia);
+    }
+
+    #[test]
+    fn aes_flag_maps_to_aes_algorithm() {
+        let args = CipherAlgorithmArgs {
+            aes: Some(Some(CipherMode::Cbc)),
+            camellia: None,
+        };
+        assert_eq!(args.algorithm(), pna::Encryption::Aes);
+    }
+
+    #[test]
+    fn no_cipher_flag_defaults_to_aes_algorithm() {
+        let args = CipherAlgorithmArgs {
+            aes: None,
+            camellia: None,
+        };
+        assert_eq!(args.algorithm(), pna::Encryption::Aes);
+    }
+
+    #[test]
+    fn cipher_mode_reflects_selected_flag_value() {
+        let cbc = CipherAlgorithmArgs {
+            aes: None,
+            camellia: Some(Some(CipherMode::Cbc)),
+        };
+        assert_eq!(cbc.mode(), pna::CipherMode::CBC);
+        let ctr = CipherAlgorithmArgs {
+            aes: Some(Some(CipherMode::Ctr)),
+            camellia: None,
+        };
+        assert_eq!(ctr.mode(), pna::CipherMode::CTR);
+    }
+
+    #[test]
     fn context_captures_umask() {
         let args = GlobalArgs::default();
         let ctx = GlobalContext::new(args);

--- a/lib/src/archive/read.rs
+++ b/lib/src/archive/read.rs
@@ -451,6 +451,7 @@ impl<R: Read + Seek> Archive<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::chunk::ChunkExt;
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
@@ -460,6 +461,64 @@ mod tests {
         let mut reader = Archive::read_header(&file_bytes[..]).unwrap();
         let mut entries = reader.entries();
         assert!(entries.next().is_none());
+    }
+
+    #[test]
+    fn read_header_rejects_bad_magic() {
+        let mut bytes = include_bytes!("../../../resources/test/empty.pna").to_vec();
+        bytes[0] ^= 0xFF;
+        let err = Archive::read_header(&bytes[..]).err().unwrap();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn read_header_rejects_truncated_header() {
+        let bytes = include_bytes!("../../../resources/test/empty.pna");
+        let err = Archive::read_header(&bytes[..4]).err().unwrap();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn read_header_rejects_non_ahed_first_chunk() {
+        let mut bytes = PNA_HEADER.to_vec();
+        bytes.extend_from_slice(&RawChunk::from_data(ChunkType::FEND, Vec::new()).to_bytes());
+        let err = Archive::read_header(&bytes[..]).err().unwrap();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    fn archive_bytes(header: ArchiveHeader) -> Vec<u8> {
+        let mut bytes = PNA_HEADER.to_vec();
+        bytes.extend_from_slice(
+            &RawChunk::from_data(ChunkType::AHED, header.to_bytes().to_vec()).to_bytes(),
+        );
+        bytes.extend_from_slice(&RawChunk::from_data(ChunkType::AEND, Vec::new()).to_bytes());
+        bytes
+    }
+
+    #[test]
+    fn read_next_archive_accepts_consecutive_number() {
+        let first_bytes = archive_bytes(ArchiveHeader::new(0, 0, 0));
+        let first = Archive::read_header(&first_bytes[..]).unwrap();
+        let next = archive_bytes(ArchiveHeader::new(0, 0, 1));
+        assert!(first.read_next_archive(&next[..]).is_ok());
+    }
+
+    #[test]
+    fn read_next_archive_rejects_non_consecutive_number() {
+        let first_bytes = archive_bytes(ArchiveHeader::new(0, 0, 0));
+        let first = Archive::read_header(&first_bytes[..]).unwrap();
+        let next = archive_bytes(ArchiveHeader::new(0, 0, 5));
+        let err = first.read_next_archive(&next[..]).err().unwrap();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn read_next_archive_rejects_number_overflow() {
+        let first_bytes = archive_bytes(ArchiveHeader::new(0, 0, u32::MAX));
+        let first = Archive::read_header(&first_bytes[..]).unwrap();
+        let next = archive_bytes(ArchiveHeader::new(0, 0, 0));
+        let err = first.read_next_archive(&next[..]).err().unwrap();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 
     #[cfg(feature = "unstable-async")]

--- a/lib/src/chunk/read.rs
+++ b/lib/src/chunk/read.rs
@@ -203,3 +203,80 @@ pub(crate) fn read_chunk_from_slice(bytes: &[u8]) -> io::Result<(RawChunk<&[u8]>
         r,
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chunk::ChunkExt;
+    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    use wasm_bindgen_test::wasm_bindgen_test as test;
+
+    fn valid_chunk_bytes() -> Vec<u8> {
+        RawChunk::from_data(ChunkType::FDAT, vec![0xAA, 0xBB, 0xCC, 0xDD]).to_bytes()
+    }
+
+    #[test]
+    fn read_from_slice_roundtrips_valid_chunk() {
+        let bytes = valid_chunk_bytes();
+        let (chunk, rest) = read_chunk_from_slice(&bytes).unwrap();
+        assert_eq!(chunk.ty, ChunkType::FDAT);
+        assert_eq!(chunk.data, &[0xAA, 0xBB, 0xCC, 0xDD]);
+        assert!(rest.is_empty());
+    }
+
+    #[test]
+    fn read_from_slice_rejects_crc_mismatch() {
+        let mut bytes = valid_chunk_bytes();
+        *bytes.last_mut().unwrap() ^= 0xFF;
+        let err = read_chunk_from_slice(&bytes).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn read_from_slice_rejects_data_corruption_with_intact_crc() {
+        let mut bytes = valid_chunk_bytes();
+        bytes[8] ^= 0xFF;
+        let err = read_chunk_from_slice(&bytes).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn read_from_slice_rejects_truncated_crc() {
+        let bytes = valid_chunk_bytes();
+        let truncated = &bytes[..bytes.len() - 2];
+        let err = read_chunk_from_slice(truncated).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn read_from_slice_rejects_length_exceeding_input() {
+        let mut bytes = valid_chunk_bytes();
+        bytes[3] = 0xFF;
+        let err = read_chunk_from_slice(&bytes).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn read_from_reader_roundtrips_valid_chunk() {
+        let bytes = valid_chunk_bytes();
+        let chunk = read_chunk(io::Cursor::new(bytes), None).unwrap();
+        assert_eq!(chunk.ty, ChunkType::FDAT);
+        assert_eq!(chunk.data, vec![0xAA, 0xBB, 0xCC, 0xDD]);
+    }
+
+    #[test]
+    fn read_from_reader_rejects_crc_mismatch() {
+        let mut bytes = valid_chunk_bytes();
+        *bytes.last_mut().unwrap() ^= 0xFF;
+        let err = read_chunk(io::Cursor::new(bytes), None).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn read_from_reader_rejects_length_exceeding_input() {
+        let mut bytes = valid_chunk_bytes();
+        bytes[3] = 0xFF;
+        let err = read_chunk(io::Cursor::new(bytes), None).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+}

--- a/lib/src/cipher.rs
+++ b/lib/src/cipher.rs
@@ -220,4 +220,60 @@ mod tests {
 
         assert_eq!(plain_text.as_slice(), decrypted_text.as_slice())
     }
+
+    const KAT_KEY: [u8; 32] = [0x11; 32];
+    const KAT_IV: [u8; 16] = [0x22; 16];
+    const KAT_PLAINTEXT: &[u8; 16] = b"PNA test vector!";
+
+    #[test]
+    fn aes256_cbc_matches_openssl_known_answer() {
+        // openssl enc -aes-256-cbc -K <0x11 x32> -iv <0x22 x16>
+        const EXPECTED: [u8; 32] = [
+            0xb4, 0xea, 0x96, 0xc2, 0xfc, 0x15, 0x82, 0x5c, 0xe8, 0x56, 0x90, 0x38, 0x5d, 0x8b,
+            0x6c, 0x5f, 0x92, 0xbf, 0x89, 0x6b, 0x07, 0xe1, 0xeb, 0xee, 0xe0, 0xf6, 0x84, 0x38,
+            0xae, 0xd6, 0xb6, 0x3e,
+        ];
+        let ct = encrypt_aes256_cbc(&KAT_KEY, &KAT_IV, KAT_PLAINTEXT).unwrap();
+        assert_eq!(&ct[..16], &KAT_IV[..]);
+        assert_eq!(&ct[16..], &EXPECTED[..]);
+        assert_eq!(
+            decrypt_aes256_cbc(&KAT_KEY, &ct).unwrap().as_slice(),
+            KAT_PLAINTEXT.as_slice()
+        );
+    }
+
+    #[test]
+    fn camellia256_cbc_matches_openssl_known_answer() {
+        // openssl enc -camellia-256-cbc -K <0x11 x32> -iv <0x22 x16>
+        const EXPECTED: [u8; 32] = [
+            0x47, 0xd8, 0x90, 0x0a, 0xce, 0x45, 0x56, 0xef, 0xf9, 0xff, 0x32, 0xa5, 0xb9, 0x60,
+            0x53, 0x29, 0xfe, 0xab, 0xcb, 0x55, 0x93, 0x91, 0x0c, 0xb9, 0xac, 0xfc, 0x2f, 0xcb,
+            0x86, 0xc8, 0xa7, 0x8b,
+        ];
+        let ct = encrypt_camellia256_cbc(&KAT_KEY, &KAT_IV, KAT_PLAINTEXT).unwrap();
+        assert_eq!(&ct[..16], &KAT_IV[..]);
+        assert_eq!(&ct[16..], &EXPECTED[..]);
+        assert_eq!(
+            decrypt_camellia256_cbc(&KAT_KEY, &ct).unwrap().as_slice(),
+            KAT_PLAINTEXT.as_slice()
+        );
+    }
+
+    #[test]
+    fn aes256_cbc_wrong_key_does_not_recover_plaintext() {
+        let ct = encrypt_aes256_cbc(&KAT_KEY, &KAT_IV, KAT_PLAINTEXT).unwrap();
+        let wrong_key = [0x99u8; 32];
+        if let Ok(recovered) = decrypt_aes256_cbc(&wrong_key, &ct) {
+            assert_ne!(recovered.as_slice(), KAT_PLAINTEXT.as_slice())
+        }
+    }
+
+    #[test]
+    fn camellia256_cbc_wrong_key_does_not_recover_plaintext() {
+        let ct = encrypt_camellia256_cbc(&KAT_KEY, &KAT_IV, KAT_PLAINTEXT).unwrap();
+        let wrong_key = [0x99u8; 32];
+        if let Ok(recovered) = decrypt_camellia256_cbc(&wrong_key, &ct) {
+            assert_ne!(recovered.as_slice(), KAT_PLAINTEXT.as_slice())
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Add rejection tests for chunk reading: CRC mismatch, data corruption with intact CRC, truncated CRC, and oversized length prefix (both reader and slice APIs).
- Add archive header rejection tests: bad magic, truncated header, non-AHED first chunk.
- Add multipart sequencing regression tests: consecutive archive numbers accepted, non-consecutive numbers rejected, `u32::MAX` overflow rejected.
- Add AES-256-CBC and Camellia-256-CBC known-answer tests validated against independently generated OpenSSL ciphertext, plus wrong-key tests confirming decryption does not silently recover the original plaintext.
- Add unit tests for `CipherAlgorithmArgs::algorithm()`/`mode()` wiring, covering the `--aes`/`--camellia`/default dispatch that a prior refactor had silently broken (see `camellia_cbc_archive` fix in the preceding commit).

## Verification
- Each new test was confirmed to fail under a targeted mutation (CRC check disabled, magic/AHED check disabled, DoS-guard `checked_add`/number-match removed, cipher wiring branch swapped) before being restored, to confirm it detects the intended defect rather than passing vacuously.
- `cargo test --workspace --all-features`: all tests pass.