### PR TITLE
Lib/read options key cache

### DIFF
--- a/cli/src/command/acl.rs
+++ b/cli/src/command/acl.rs
@@ -21,7 +21,7 @@ use nom::{
     character::complete::char,
     combinator::{map, opt},
 };
-use pna::{Chunk, NormalEntry, RawChunk};
+use pna::{Chunk, NormalEntry, RawChunk, ReadOptions};
 use regex::Regex;
 use std::{
     collections::{HashMap, HashSet},
@@ -289,9 +289,10 @@ fn archive_get_acl(args: GetAclCommand) -> anyhow::Result<()> {
     let numeric_owner = args.numeric;
 
     let mut source = SplitArchiveReader::new(collect_split_archives(args.file.archive)?)?;
+    let read_options = ReadOptions::with_password(password.as_deref());
 
     source.for_each_entry(
-        password.as_deref(),
+        &read_options,
         #[hooq::skip_all]
         |entry| {
             let entry = entry?;

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -1257,11 +1257,25 @@ pub(crate) fn split_to_parts(
     Ok(parts)
 }
 
+pub(crate) struct TransformContext<'a> {
+    password: Option<&'a [u8]>,
+    read_options: ReadOptions,
+}
+
+impl<'a> TransformContext<'a> {
+    #[inline]
+    pub(crate) fn new(password: Option<&'a [u8]>) -> Self {
+        Self {
+            password,
+            read_options: ReadOptions::with_password(password),
+        }
+    }
+}
+
 pub(crate) trait TransformStrategy {
     fn transform<W, T, F>(
         archive: &mut Archive<W>,
-        password: Option<&[u8]>,
-        read_options: &ReadOptions,
+        context: &TransformContext<'_>,
         read_entry: io::Result<ReadEntry<T>>,
         transformer: F,
     ) -> io::Result<()>
@@ -1278,8 +1292,7 @@ pub(crate) struct TransformStrategyUnSolid;
 impl TransformStrategy for TransformStrategyUnSolid {
     fn transform<W, T, F>(
         archive: &mut Archive<W>,
-        _password: Option<&[u8]>,
-        read_options: &ReadOptions,
+        context: &TransformContext<'_>,
         read_entry: io::Result<ReadEntry<T>>,
         mut transformer: F,
     ) -> io::Result<()>
@@ -1292,7 +1305,7 @@ impl TransformStrategy for TransformStrategyUnSolid {
     {
         match read_entry? {
             ReadEntry::Solid(s) => {
-                for n in s.entries(read_options)? {
+                for n in s.entries(&context.read_options)? {
                     if let Some(entry) = transformer(n.map(Into::into))? {
                         archive.add_entry(entry)?;
                     }
@@ -1314,8 +1327,7 @@ pub(crate) struct TransformStrategyKeepSolid;
 impl TransformStrategy for TransformStrategyKeepSolid {
     fn transform<W, T, F>(
         archive: &mut Archive<W>,
-        password: Option<&[u8]>,
-        read_options: &ReadOptions,
+        context: &TransformContext<'_>,
         read_entry: io::Result<ReadEntry<T>>,
         mut transformer: F,
     ) -> io::Result<()>
@@ -1334,10 +1346,10 @@ impl TransformStrategy for TransformStrategyKeepSolid {
                         .compression(header.compression())
                         .encryption(header.encryption())
                         .cipher_mode(header.cipher_mode())
-                        .password(password)
+                        .password(context.password)
                         .build(),
                 )?;
-                for n in s.entries(read_options)? {
+                for n in s.entries(&context.read_options)? {
                     if let Some(entry) = transformer(n.map(Into::into))? {
                         builder.add_entry(entry)?;
                     }
@@ -1655,19 +1667,11 @@ where
     Transform: TransformStrategy,
 {
     let password = password_provider();
-    let read_options = ReadOptions::with_password(password);
+    let context = TransformContext::new(password);
     let mut out_archive = Archive::write_header(writer)?;
     run_read_entries_mem(
         archives,
-        |entry| {
-            Transform::transform(
-                &mut out_archive,
-                password,
-                &read_options,
-                entry,
-                &mut processor,
-            )
-        },
+        |entry| Transform::transform(&mut out_archive, &context, entry, &mut processor),
         false,
     )?;
     out_archive.finalize()?;
@@ -1727,19 +1731,11 @@ where
     Transform: TransformStrategy,
 {
     let password = password_provider();
-    let read_options = ReadOptions::with_password(password);
+    let context = TransformContext::new(password);
     let mut out_archive = Archive::write_header(writer)?;
     run_read_entries(
         archives,
-        |entry| {
-            Transform::transform(
-                &mut out_archive,
-                password,
-                &read_options,
-                entry,
-                &mut processor,
-            )
-        },
+        |entry| Transform::transform(&mut out_archive, &context, entry, &mut processor),
         false,
     )?;
     out_archive.finalize()?;

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -28,7 +28,7 @@ use path_slash::*;
 pub(crate) use path_transformer::PathTransformers;
 use pna::{
     Archive, EntryBuilder, EntryPart, LinkTargetType, MIN_CHUNK_BYTES_SIZE, NormalEntry,
-    PNA_HEADER, ReadEntry, SolidEntryBuilder, WriteOptions, prelude::*,
+    PNA_HEADER, ReadEntry, ReadOptions, SolidEntryBuilder, WriteOptions, prelude::*,
 };
 use std::{
     borrow::Cow,
@@ -1261,6 +1261,7 @@ pub(crate) trait TransformStrategy {
     fn transform<W, T, F>(
         archive: &mut Archive<W>,
         password: Option<&[u8]>,
+        read_options: &ReadOptions,
         read_entry: io::Result<ReadEntry<T>>,
         transformer: F,
     ) -> io::Result<()>
@@ -1277,7 +1278,8 @@ pub(crate) struct TransformStrategyUnSolid;
 impl TransformStrategy for TransformStrategyUnSolid {
     fn transform<W, T, F>(
         archive: &mut Archive<W>,
-        password: Option<&[u8]>,
+        _password: Option<&[u8]>,
+        read_options: &ReadOptions,
         read_entry: io::Result<ReadEntry<T>>,
         mut transformer: F,
     ) -> io::Result<()>
@@ -1290,7 +1292,7 @@ impl TransformStrategy for TransformStrategyUnSolid {
     {
         match read_entry? {
             ReadEntry::Solid(s) => {
-                for n in s.entries(password)? {
+                for n in s.entries(read_options)? {
                     if let Some(entry) = transformer(n.map(Into::into))? {
                         archive.add_entry(entry)?;
                     }
@@ -1313,6 +1315,7 @@ impl TransformStrategy for TransformStrategyKeepSolid {
     fn transform<W, T, F>(
         archive: &mut Archive<W>,
         password: Option<&[u8]>,
+        read_options: &ReadOptions,
         read_entry: io::Result<ReadEntry<T>>,
         mut transformer: F,
     ) -> io::Result<()>
@@ -1334,7 +1337,7 @@ impl TransformStrategy for TransformStrategyKeepSolid {
                         .password(password)
                         .build(),
                 )?;
-                for n in s.entries(password)? {
+                for n in s.entries(read_options)? {
                     if let Some(entry) = transformer(n.map(Into::into))? {
                         builder.add_entry(entry)?;
                     }
@@ -1426,43 +1429,39 @@ where
     Ok(())
 }
 
-pub(crate) fn run_process_archive<'p, Provider, F>(
+pub(crate) fn run_process_archive<F>(
     archive_provider: impl IntoIterator<Item = impl Read>,
-    mut password_provider: Provider,
+    read_options: &ReadOptions,
     mut processor: F,
     allow_concatenated_archives: bool,
 ) -> io::Result<()>
 where
-    Provider: FnMut() -> Option<&'p [u8]>,
     F: FnMut(io::Result<NormalEntry>) -> io::Result<()>,
 {
-    let password = password_provider();
     run_read_entries(
         archive_provider,
         |entry| match entry? {
-            ReadEntry::Solid(solid) => solid.entries(password)?.try_for_each(&mut processor),
+            ReadEntry::Solid(solid) => solid.entries(read_options)?.try_for_each(&mut processor),
             ReadEntry::Normal(regular) => processor(Ok(regular)),
         },
         allow_concatenated_archives,
     )
 }
 
-pub(crate) fn run_process_archive_stoppable<'p, Provider, F>(
+pub(crate) fn run_process_archive_stoppable<F>(
     archive_provider: impl IntoIterator<Item = impl Read>,
-    mut password_provider: Provider,
+    read_options: &ReadOptions,
     mut processor: F,
     allow_concatenated_archives: bool,
 ) -> io::Result<()>
 where
-    Provider: FnMut() -> Option<&'p [u8]>,
     F: FnMut(io::Result<NormalEntry>) -> io::Result<ProcessAction>,
 {
-    let password = password_provider();
     run_read_entries_stoppable(
         archive_provider,
         |entry| match entry? {
             ReadEntry::Solid(solid) => {
-                for n in solid.entries(password)? {
+                for n in solid.entries(read_options)? {
                     match processor(n)? {
                         ProcessAction::Continue => {}
                         ProcessAction::Stop => return Ok(ProcessAction::Stop),
@@ -1530,21 +1529,19 @@ where
 }
 
 #[cfg(feature = "memmap")]
-pub(crate) fn run_entries<'d, 'p, Provider, F>(
+pub(crate) fn run_entries<'d, F>(
     archives: impl IntoIterator<Item = &'d [u8]>,
-    mut password_provider: Provider,
+    read_options: &ReadOptions,
     mut processor: F,
 ) -> io::Result<()>
 where
-    Provider: FnMut() -> Option<&'p [u8]>,
     F: FnMut(io::Result<NormalEntry<Cow<'d, [u8]>>>) -> io::Result<()>,
 {
-    let password = password_provider();
     run_read_entries_mem(
         archives,
         |entry| match entry? {
             ReadEntry::Solid(s) => s
-                .entries(password)?
+                .entries(read_options)?
                 .try_for_each(|r| processor(r.map(Into::into))),
             ReadEntry::Normal(r) => processor(Ok(r)),
         },
@@ -1615,21 +1612,19 @@ where
 }
 
 #[cfg(feature = "memmap")]
-pub(crate) fn run_entries_stoppable<'d, 'p, Provider, F>(
+pub(crate) fn run_entries_stoppable<'d, F>(
     archives: impl IntoIterator<Item = &'d [u8]>,
-    mut password_provider: Provider,
+    read_options: &ReadOptions,
     mut processor: F,
 ) -> io::Result<()>
 where
-    Provider: FnMut() -> Option<&'p [u8]>,
     F: FnMut(io::Result<NormalEntry<Cow<'d, [u8]>>>) -> io::Result<ProcessAction>,
 {
-    let password = password_provider();
     run_read_entries_mem_stoppable(
         archives,
         |entry| match entry? {
             ReadEntry::Solid(s) => {
-                for n in s.entries(password)? {
+                for n in s.entries(read_options)? {
                     match processor(n.map(Into::into))? {
                         ProcessAction::Continue => {}
                         ProcessAction::Stop => return Ok(ProcessAction::Stop),
@@ -1660,10 +1655,19 @@ where
     Transform: TransformStrategy,
 {
     let password = password_provider();
+    let read_options = ReadOptions::with_password(password);
     let mut out_archive = Archive::write_header(writer)?;
     run_read_entries_mem(
         archives,
-        |entry| Transform::transform(&mut out_archive, password, entry, &mut processor),
+        |entry| {
+            Transform::transform(
+                &mut out_archive,
+                password,
+                &read_options,
+                entry,
+                &mut processor,
+            )
+        },
         false,
     )?;
     out_archive.finalize()?;
@@ -1723,10 +1727,19 @@ where
     Transform: TransformStrategy,
 {
     let password = password_provider();
+    let read_options = ReadOptions::with_password(password);
     let mut out_archive = Archive::write_header(writer)?;
     run_read_entries(
         archives,
-        |entry| Transform::transform(&mut out_archive, password, entry, &mut processor),
+        |entry| {
+            Transform::transform(
+                &mut out_archive,
+                password,
+                &read_options,
+                entry,
+                &mut processor,
+            )
+        },
         false,
     )?;
     out_archive.finalize()?;
@@ -1898,9 +1911,10 @@ pub(crate) fn transform_archive_entries<R: io::Read>(
     allow_concatenated_archives: bool,
 ) -> io::Result<Vec<io::Result<Option<NormalEntry>>>> {
     let mut results = Vec::new();
+    let read_options = ReadOptions::with_password(password);
     run_process_archive(
         std::iter::once(reader),
-        || password,
+        &read_options,
         |entry| {
             let entry = entry?;
             if filter.excluded(entry.header().path()) {

--- a/cli/src/command/core/archive_source.rs
+++ b/cli/src/command/core/archive_source.rs
@@ -2,7 +2,7 @@
 use std::borrow::Cow;
 use std::{fs, io};
 
-use pna::{NormalEntry, ReadEntry};
+use pna::{NormalEntry, ReadEntry, ReadOptions};
 
 use super::TransformStrategy;
 
@@ -78,23 +78,23 @@ impl SplitArchiveReader {
     #[cfg(not(feature = "memmap"))]
     pub(crate) fn for_each_entry(
         &mut self,
-        password: Option<&[u8]>,
+        read_options: &ReadOptions,
         processor: impl FnMut(io::Result<NormalEntry>) -> io::Result<()>,
     ) -> io::Result<()> {
-        super::run_process_archive(self.files.drain(..), || password, processor, false)
+        super::run_process_archive(self.files.drain(..), read_options, processor, false)
     }
 
     #[cfg(feature = "memmap")]
     pub(crate) fn for_each_entry<'s>(
         &'s mut self,
-        password: Option<&[u8]>,
+        read_options: &ReadOptions,
         mut processor: impl FnMut(io::Result<NormalEntry<Cow<'s, [u8]>>>) -> io::Result<()>,
     ) -> io::Result<()> {
         super::run_read_entries_mem(
             self.mmaps.iter().map(|m| m.as_ref()),
             |entry| match entry? {
                 ReadEntry::Solid(s) => s
-                    .entries(password)?
+                    .entries(read_options)?
                     .try_for_each(|r| processor(r.map(Into::into))),
                 ReadEntry::Normal(n) => processor(Ok(n)),
             },

--- a/cli/src/command/diff.rs
+++ b/cli/src/command/diff.rs
@@ -55,6 +55,7 @@ fn diff_archive(args: DiffCommand) -> anyhow::Result<()> {
     let mut globs = BsdGlobMatcher::new(args.file.files.iter().map(|s| s.as_str()));
     let filter_enabled = !globs.is_empty();
 
+    let read_options = ReadOptions::with_password(password.as_deref());
     let mut source = SplitArchiveReader::new(archives)?;
     source.for_each_entry(
         password.as_deref(),
@@ -67,7 +68,7 @@ fn diff_archive(args: DiffCommand) -> anyhow::Result<()> {
                 return Ok(());
             }
 
-            compare_entry(entry, password.as_deref(), &options)
+            compare_entry(entry, &read_options, &options)
         },
     )?;
 
@@ -269,7 +270,7 @@ fn compare_directory_metadata<T: AsRef<[u8]>>(
 
 fn compare_entry<T: AsRef<[u8]>>(
     entry: NormalEntry<T>,
-    password: Option<&[u8]>,
+    read_options: &ReadOptions,
     options: &CompareOptions,
 ) -> io::Result<()> {
     let data_kind = entry.header().data_kind();
@@ -298,7 +299,7 @@ fn compare_entry<T: AsRef<[u8]>>(
                 println!("{}", DiffKind::SizeDiffers.display(path_str));
             } else {
                 let fs_file = fs::File::open(path)?;
-                let archive_reader = entry.reader(ReadOptions::with_password(password))?;
+                let archive_reader = entry.reader(read_options)?;
                 if !streams_equal(fs_file, archive_reader)? {
                     println!("{}", DiffKind::ContentsDiffer.display(path_str));
                 }
@@ -312,7 +313,7 @@ fn compare_entry<T: AsRef<[u8]>>(
         }
         DataKind::SymbolicLink if meta.is_symlink() => {
             let link = fs::read_link(path)?;
-            let mut reader = entry.reader(ReadOptions::with_password(password))?;
+            let mut reader = entry.reader(read_options)?;
             let mut link_str = String::new();
             reader.read_to_string(&mut link_str)?;
             if link.as_path() != Path::new(&link_str) {
@@ -323,7 +324,7 @@ fn compare_entry<T: AsRef<[u8]>>(
             println!("{}", DiffKind::TypeMismatch.display(path_str));
         }
         DataKind::HardLink if meta.is_file() => {
-            let mut reader = entry.reader(ReadOptions::with_password(password))?;
+            let mut reader = entry.reader(read_options)?;
             let mut target = String::new();
             reader.read_to_string(&mut target)?;
 

--- a/cli/src/command/diff.rs
+++ b/cli/src/command/diff.rs
@@ -58,7 +58,7 @@ fn diff_archive(args: DiffCommand) -> anyhow::Result<()> {
     let read_options = ReadOptions::with_password(password.as_deref());
     let mut source = SplitArchiveReader::new(archives)?;
     source.for_each_entry(
-        password.as_deref(),
+        &read_options,
         #[hooq::skip_all]
         |entry| {
             let entry = entry?;

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -595,6 +595,10 @@ where
     Provider: FnMut() -> Option<&'p [u8]> + Send,
 {
     let password = password_provider();
+    let read_options = ReadOptions::with_password(password);
+    // Bind as a shared reference so `move` closures below (rayon::spawn_fifo)
+    // can capture a `Copy` reference instead of moving the `ReadOptions` value.
+    let read_options = &read_options;
     let patterns = files;
     let mut globs =
         BsdGlobMatcher::new(patterns.iter().map(|it| it.as_str())).with_no_recursive(no_recursive);
@@ -624,7 +628,7 @@ where
                             eprintln!("x {}", name);
                         }
                         if args.to_stdout {
-                            extract_entry_to_stdout(&item, password)?;
+                            extract_entry_to_stdout(&item, read_options)?;
                             if globs.all_matched() {
                                 return Ok(ProcessAction::Stop);
                             }
@@ -659,7 +663,7 @@ where
                         s.spawn_fifo(move |_| {
                             let _guard = ticket.wait_for_turn();
                             tx.send(
-                                extract_file_entry(item, &name, password, &args)
+                                extract_file_entry(item, &name, read_options, &args)
                                     .with_context(|| format!("extracting {}", item_path)),
                             )
                             .unwrap_or_else(|_| unreachable!("receiver is held by scope owner"));
@@ -687,7 +691,7 @@ where
                             eprintln!("x {}", name);
                         }
                         if args.to_stdout {
-                            return extract_entry_to_stdout(&item, password);
+                            return extract_entry_to_stdout(&item, read_options);
                         }
                         if matches!(
                             item.header().data_kind(),
@@ -712,7 +716,7 @@ where
                         s.spawn_fifo(move |_| {
                             let _guard = ticket.wait_for_turn();
                             tx.send(
-                                extract_file_entry(item, &name, password, &args)
+                                extract_file_entry(item, &name, read_options, &args)
                                     .with_context(|| format!("extracting {}", item_path)),
                             )
                             .unwrap_or_else(|_| unreachable!("receiver is held by scope owner"));
@@ -750,7 +754,7 @@ where
                         eprintln!("x {}", name);
                     }
                     if args.to_stdout {
-                        extract_entry_to_stdout(&item, password)?;
+                        extract_entry_to_stdout(&item, read_options)?;
                         if globs.all_matched() {
                             return Ok(ProcessAction::Stop);
                         }
@@ -777,7 +781,7 @@ where
                         }
                         return Ok(ProcessAction::Continue);
                     }
-                    extract_file_entry(item, &name, password, &args).map_err(|e| {
+                    extract_file_entry(item, &name, read_options, &args).map_err(|e| {
                         io::Error::new(e.kind(), format!("extracting {}: {e}", item_path))
                     })?;
                     if globs.all_matched() {
@@ -803,7 +807,7 @@ where
                         eprintln!("x {}", name);
                     }
                     if args.to_stdout {
-                        return extract_entry_to_stdout(&item, password);
+                        return extract_entry_to_stdout(&item, read_options);
                     }
                     if matches!(
                         item.header().data_kind(),
@@ -820,7 +824,7 @@ where
                         }
                         return Ok(());
                     }
-                    extract_file_entry(item, &name, password, &args).map_err(|e| {
+                    extract_file_entry(item, &name, read_options, &args).map_err(|e| {
                         io::Error::new(e.kind(), format!("extracting {}: {e}", name))
                     })?;
                     Ok(())
@@ -832,7 +836,7 @@ where
     }
 
     for (name, item) in link_entries {
-        extract_link_entry(item, &name, password, &args)
+        extract_link_entry(item, &name, read_options, &args)
             .with_context(|| format!("extracting deferred link {name}"))?;
     }
 
@@ -864,6 +868,10 @@ where
     Provider: FnMut() -> Option<&'p [u8]> + Send,
 {
     let password = password_provider();
+    let read_options = ReadOptions::with_password(password);
+    // Bind as a shared reference so `move` closures below (rayon::spawn_fifo)
+    // can capture a `Copy` reference instead of moving the `ReadOptions` value.
+    let read_options = &read_options;
     let mut globs =
         BsdGlobMatcher::new(files.iter().map(|it| it.as_str())).with_no_recursive(no_recursive);
 
@@ -887,7 +895,7 @@ where
                     eprintln!("x {}", name);
                 }
                 if args.to_stdout {
-                    extract_entry_to_stdout(&item, password)?;
+                    extract_entry_to_stdout(&item, read_options)?;
                     if globs.all_matched() {
                         return Ok(ProcessAction::Stop);
                     }
@@ -922,7 +930,7 @@ where
                 s.spawn_fifo(move |_| {
                     let _guard = ticket.wait_for_turn();
                     tx.send(
-                        extract_file_entry(item, &name, password, &args)
+                        extract_file_entry(item, &name, read_options, &args)
                             .with_context(|| format!("extracting {}", item_path)),
                     )
                     .unwrap_or_else(|_| unreachable!("receiver is held by scope owner"));
@@ -945,7 +953,7 @@ where
                     eprintln!("x {}", name);
                 }
                 if args.to_stdout {
-                    return extract_entry_to_stdout(&item, password);
+                    return extract_entry_to_stdout(&item, read_options);
                 }
                 if matches!(
                     item.header().data_kind(),
@@ -970,7 +978,7 @@ where
                 s.spawn_fifo(move |_| {
                     let _guard = ticket.wait_for_turn();
                     tx.send(
-                        extract_file_entry(item, &name, password, &args)
+                        extract_file_entry(item, &name, read_options, &args)
                             .with_context(|| format!("extracting {}", item_path)),
                     )
                     .unwrap_or_else(|_| unreachable!("receiver is held by scope owner"));
@@ -987,7 +995,7 @@ where
     }
 
     for (name, item) in link_entries {
-        extract_link_entry(item, &name, password, &args)
+        extract_link_entry(item, &name, read_options, &args)
             .with_context(|| format!("extracting deferred link {name}"))?;
     }
 
@@ -1287,7 +1295,7 @@ where
 pub(crate) fn extract_file_entry<'a, T>(
     item: NormalEntry<T>,
     item_path: &EntryName,
-    password: Option<&'a [u8]>,
+    read_options: &'a ReadOptions,
     OutputOption {
         overwrite_strategy,
         out_dir,
@@ -1324,7 +1332,7 @@ where
         let mut safe_writer = SafeWriter::new(&path)?;
         {
             let mut writer = io::BufWriter::with_capacity(64 * 1024, safe_writer.as_file_mut());
-            let mut reader = item.reader(ReadOptions::with_password(password))?;
+            let mut reader = item.reader(read_options)?;
             io::copy(&mut reader, &mut writer)?;
             writer.flush()?;
         }
@@ -1336,7 +1344,7 @@ where
         }
         let file = utils::fs::file_create(&path, remove_existing)?;
         let mut writer = io::BufWriter::with_capacity(64 * 1024, file);
-        let mut reader = item.reader(ReadOptions::with_password(password))?;
+        let mut reader = item.reader(read_options)?;
         io::copy(&mut reader, &mut writer)?;
         let mut file = writer.into_inner().map_err(|e| e.into_error())?;
         restore_timestamps(&mut file, item.metadata(), keep_options)?;
@@ -1355,7 +1363,7 @@ where
 pub(crate) fn extract_link_entry<'a, T>(
     item: NormalEntry<T>,
     item_path: &EntryName,
-    password: Option<&'a [u8]>,
+    read_options: &'a ReadOptions,
     OutputOption {
         overwrite_strategy,
         allow_unsafe_links,
@@ -1387,7 +1395,7 @@ where
 
     match item.header().data_kind() {
         DataKind::SymbolicLink => {
-            let reader = item.reader(ReadOptions::with_password(password))?;
+            let reader = item.reader(read_options)?;
             let original = io::read_to_string(reader)?;
             let original = pathname_editor.edit_symlink(original.as_ref());
             if !allow_unsafe_links && is_unsafe_link(&original) {
@@ -1403,7 +1411,7 @@ where
             symlink_with_type(&original, &path, link_target_type)?;
         }
         DataKind::HardLink => {
-            let reader = item.reader(ReadOptions::with_password(password))?;
+            let reader = item.reader(read_options)?;
             let original = io::read_to_string(reader)?;
             let Some((original, had_root)) = pathname_editor.edit_hardlink(original.as_ref())
             else {
@@ -1854,7 +1862,7 @@ where
     }
 }
 
-fn extract_entry_to_stdout<T>(item: &NormalEntry<T>, password: Option<&[u8]>) -> io::Result<()>
+fn extract_entry_to_stdout<T>(item: &NormalEntry<T>, read_options: &ReadOptions) -> io::Result<()>
 where
     T: AsRef<[u8]>,
     pna::RawChunk<T>: Chunk,
@@ -1863,7 +1871,7 @@ where
         return Ok(());
     }
 
-    let mut reader = item.reader(ReadOptions::with_password(password))?;
+    let mut reader = item.reader(read_options)?;
     let mut stdout = io::stdout().lock();
     io::copy(&mut reader, &mut stdout)?;
     stdout.flush()?;

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -613,7 +613,7 @@ where
             if fast_read && !globs.is_empty() {
                 run_process_archive_stoppable(
                     reader,
-                    password_provider,
+                    read_options,
                     |entry| {
                         let item = entry.map_err(|e| {
                             io::Error::new(e.kind(), format!("reading archive entry: {e}"))
@@ -679,7 +679,7 @@ where
             } else {
                 run_process_archive(
                     reader,
-                    password_provider,
+                    read_options,
                     |entry| {
                         let item = entry.map_err(|e| {
                             io::Error::new(e.kind(), format!("reading archive entry: {e}"))
@@ -740,7 +740,7 @@ where
         if fast_read && !globs.is_empty() {
             run_process_archive_stoppable(
                 reader,
-                password_provider,
+                read_options,
                 |entry| {
                     let item = entry.map_err(|e| {
                         io::Error::new(e.kind(), format!("reading archive entry: {e}"))
@@ -795,7 +795,7 @@ where
         } else {
             run_process_archive(
                 reader,
-                password_provider,
+                read_options,
                 |entry| {
                     let item = entry.map_err(|e| {
                         io::Error::new(e.kind(), format!("reading archive entry: {e}"))
@@ -883,7 +883,7 @@ where
     rayon::scope_fifo(|s| -> anyhow::Result<()> {
         if fast_read && !globs.is_empty() {
             #[hooq::skip_all]
-            run_entries_stoppable(archives, password_provider, |entry| {
+            run_entries_stoppable(archives, read_options, |entry| {
                 let item = entry
                     .map_err(|e| io::Error::new(e.kind(), format!("reading archive entry: {e}")))?;
                 let item_path = item.name().to_string();
@@ -943,7 +943,7 @@ where
             .with_context(|| "streaming archive entries")?;
         } else {
             #[hooq::skip_all]
-            run_entries(archives, password_provider, |entry| {
+            run_entries(archives, read_options, |entry| {
                 let item = entry
                     .map_err(|e| io::Error::new(e.kind(), format!("reading archive entry: {e}")))?;
                 let Some(name) = filter_entry(&item, &mut globs, &args) else {

--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -374,7 +374,7 @@ impl TableRow {
     #[inline]
     fn from_entry<T>(
         entry: &NormalEntry<T>,
-        password: Option<&[u8]>,
+        read_options: &ReadOptions,
         solid: Option<&SolidHeader>,
         collect: CollectOptions,
     ) -> io::Result<Self>
@@ -421,7 +421,7 @@ impl TableRow {
                     // Only read link target if needed (requires decompression)
                     if collect.link_target {
                         entry
-                            .reader(ReadOptions::with_password(password))
+                            .reader(read_options)
                             .and_then(io::read_to_string)
                             .unwrap_or_else(|_| "-".into())
                     } else {
@@ -433,7 +433,7 @@ impl TableRow {
                     // Only read link target if needed (requires decompression)
                     if collect.link_target {
                         entry
-                            .reader(ReadOptions::with_password(password))
+                            .reader(read_options)
                             .and_then(io::read_to_string)
                             .unwrap_or_else(|_| "-".into())
                     } else {
@@ -543,6 +543,7 @@ fn list_archive(ctx: &crate::cli::GlobalContext, args: ListCommand) -> anyhow::R
 
     let mut source = SplitArchiveReader::new(collect_split_archives(&archive)?)?;
     let password = password.as_deref();
+    let read_options = ReadOptions::with_password(password);
     let mut entries = Vec::new();
     let collect_opts = CollectOptions::from_list_options(&options);
     source.for_each_read_entry(
@@ -553,7 +554,7 @@ fn list_archive(ctx: &crate::cli::GlobalContext, args: ListCommand) -> anyhow::R
                 for entry in solid.entries(password)? {
                     entries.push(TableRow::from_entry(
                         &entry?,
-                        password,
+                        &read_options,
                         Some(solid.header()),
                         collect_opts,
                     )?)
@@ -565,7 +566,7 @@ fn list_archive(ctx: &crate::cli::GlobalContext, args: ListCommand) -> anyhow::R
                 );
             }
             ReadEntry::Normal(item) => {
-                entries.push(TableRow::from_entry(&item, password, None, collect_opts)?)
+                entries.push(TableRow::from_entry(&item, &read_options, None, collect_opts)?)
             }
         }
             Ok(())
@@ -649,6 +650,7 @@ pub(crate) fn run_list_archive<'a>(
     allow_concatenated_archives: bool,
 ) -> anyhow::Result<()> {
     let collect_opts = CollectOptions::from_list_options(&args);
+    let read_options = ReadOptions::with_password(password);
 
     if !fast_read || files_globs.is_empty() {
         let mut entries = Vec::new();
@@ -660,7 +662,7 @@ pub(crate) fn run_list_archive<'a>(
                         for entry in solid.entries(password)? {
                             entries.push(TableRow::from_entry(
                                 &entry?,
-                                password,
+                                &read_options,
                                 Some(solid.header()),
                                 collect_opts,
                             )?)
@@ -671,9 +673,12 @@ pub(crate) fn run_list_archive<'a>(
                             "This archive contain solid mode entry. if you need to show it use --solid option."
                         );
                     }
-                    ReadEntry::Normal(item) => {
-                        entries.push(TableRow::from_entry(&item, password, None, collect_opts)?)
-                    }
+                    ReadEntry::Normal(item) => entries.push(TableRow::from_entry(
+                        &item,
+                        &read_options,
+                        None,
+                        collect_opts,
+                    )?),
                 }
                 Ok(())
             },
@@ -698,7 +703,7 @@ pub(crate) fn run_list_archive<'a>(
                         }
                         let row = TableRow::from_entry(
                             &entry,
-                            password,
+                            &read_options,
                             Some(solid.header()),
                             collect_opts,
                         )?;
@@ -722,7 +727,7 @@ pub(crate) fn run_list_archive<'a>(
                     if !globs.matches_any_pattern(&entry_path) {
                         return Ok(ProcessAction::Continue);
                     }
-                    let row = TableRow::from_entry(&item, password, None, collect_opts)?;
+                    let row = TableRow::from_entry(&item, &read_options, None, collect_opts)?;
                     let time_ok = args.time_filters.matches(row.created, row.modified);
                     if time_ok && !filter_ref.excluded(row.entry_type.name()) {
                         globs.mark_satisfied(&entry_path);

--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -551,7 +551,7 @@ fn list_archive(ctx: &crate::cli::GlobalContext, args: ListCommand) -> anyhow::R
         |entry| {
         match entry? {
             ReadEntry::Solid(solid) if options.solid => {
-                for entry in solid.entries(password)? {
+                for entry in solid.entries(&read_options)? {
                     entries.push(TableRow::from_entry(
                         &entry?,
                         &read_options,
@@ -659,7 +659,7 @@ pub(crate) fn run_list_archive<'a>(
             |entry| {
                 match entry? {
                     ReadEntry::Solid(solid) if args.solid => {
-                        for entry in solid.entries(password)? {
+                        for entry in solid.entries(&read_options)? {
                             entries.push(TableRow::from_entry(
                                 &entry?,
                                 &read_options,
@@ -695,7 +695,7 @@ pub(crate) fn run_list_archive<'a>(
         |entry| {
             match entry? {
                 ReadEntry::Solid(solid) if args.solid => {
-                    for entry in solid.entries(password)? {
+                    for entry in solid.entries(&read_options)? {
                         let entry = entry?;
                         let entry_path = entry.name().to_string();
                         if !globs.matches_any_pattern(&entry_path) {

--- a/cli/src/command/sort.rs
+++ b/cli/src/command/sort.rs
@@ -7,7 +7,7 @@ use crate::{
     utils::{PathPartExt, env::NamedTempFile},
 };
 use clap::{Parser, ValueHint};
-use pna::{Archive, NormalEntry};
+use pna::{Archive, NormalEntry, ReadOptions};
 use std::{
     fmt::{self, Display, Formatter},
     path::PathBuf,
@@ -148,9 +148,10 @@ fn sort_archive(args: SortCommand) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
     let archives = collect_split_archives(&args.archive)?;
     let mut source = SplitArchiveReader::new(archives)?;
+    let read_options = ReadOptions::with_password(password.as_deref());
     let mut entries = Vec::<NormalEntry<_>>::new();
     source.for_each_entry(
-        password.as_deref(),
+        &read_options,
         #[hooq::skip_all]
         |entry| {
             entries.push(entry?);

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 use clap::{ArgGroup, Parser, ValueHint};
 use indexmap::IndexMap;
-use pna::{Archive, EntryName, Metadata, prelude::*};
+use pna::{Archive, EntryName, Metadata, ReadOptions, prelude::*};
 use std::{
     env, fs, io,
     path::{Path, PathBuf},
@@ -561,6 +561,7 @@ where
     W: io::Write + Send,
 {
     let (tx, rx) = std::sync::mpsc::channel();
+    let read_options = ReadOptions::with_password(password);
 
     // Overlapping source arguments (e.g. a directory and a file within it)
     // routinely collect the same path spelling twice; that case is
@@ -599,7 +600,7 @@ where
     rayon::scope_fifo(|s| -> anyhow::Result<()> {
         source.for_each_read_entry(
             |entry| {
-                Strategy::transform(out_archive, password, entry, |entry| {
+                Strategy::transform(out_archive, password, &read_options, entry, |entry| {
                     let entry = entry?;
                     if let Some((idx, item)) = target_files_mapping
                         .get_mut(entry.header().path())

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -10,9 +10,9 @@ use crate::{
             AclStrategy, CollectOptions, CollectedEntry, CreateOptions, FflagsStrategy,
             KeepOptions, MacMetadataStrategy, PathFilter, PathTransformers, PathnameEditor,
             PermissionStrategyResolver, SplitArchiveReader, TimeFilterResolver,
-            TimestampStrategyResolver, TransformStrategy, TransformStrategyKeepSolid,
-            TransformStrategyUnSolid, XattrStrategy, collect_items_from_paths,
-            collect_split_archives, create_entry, entry_option,
+            TimestampStrategyResolver, TransformContext, TransformStrategy,
+            TransformStrategyKeepSolid, TransformStrategyUnSolid, XattrStrategy,
+            collect_items_from_paths, collect_split_archives, create_entry, entry_option,
             iter::ReorderByIndex,
             re::{bsd::SubstitutionRule, gnu::TransformRule},
             read_paths, read_paths_stdin,
@@ -22,7 +22,7 @@ use crate::{
 };
 use clap::{ArgGroup, Parser, ValueHint};
 use indexmap::IndexMap;
-use pna::{Archive, EntryName, Metadata, ReadOptions, prelude::*};
+use pna::{Archive, EntryName, Metadata, prelude::*};
 use std::{
     env, fs, io,
     path::{Path, PathBuf},
@@ -561,7 +561,7 @@ where
     W: io::Write + Send,
 {
     let (tx, rx) = std::sync::mpsc::channel();
-    let read_options = ReadOptions::with_password(password);
+    let context = TransformContext::new(password);
 
     // Overlapping source arguments (e.g. a directory and a file within it)
     // routinely collect the same path spelling twice; that case is
@@ -600,7 +600,7 @@ where
     rayon::scope_fifo(|s| -> anyhow::Result<()> {
         source.for_each_read_entry(
             |entry| {
-                Strategy::transform(out_archive, password, &read_options, entry, |entry| {
+                Strategy::transform(out_archive, &context, entry, |entry| {
                     let entry = entry?;
                     if let Some((idx, item)) = target_files_mapping
                         .get_mut(entry.header().path())

--- a/cli/src/command/verify.rs
+++ b/cli/src/command/verify.rs
@@ -127,7 +127,7 @@ fn verify_solid(
     fast: bool,
     report: &mut VerifyReport,
 ) -> io::Result<()> {
-    for entry in solid.entries(password)? {
+    for entry in solid.entries(read_options)? {
         verify_entry(&entry?, password, read_options, fast, report);
     }
     Ok(())

--- a/cli/src/command/verify.rs
+++ b/cli/src/command/verify.rs
@@ -51,6 +51,7 @@ fn verify_archive(args: VerifyCommand) -> anyhow::Result<()> {
     let fast = args.fast;
     let password = ask_password(args.password)?;
     let password = password.as_deref();
+    let read_options = ReadOptions::with_password(password);
     let archives = collect_split_archives(&args.archive)?;
     let mut report = VerifyReport::default();
     let mut solid_blocks = 0usize;
@@ -85,14 +86,16 @@ fn verify_archive(args: VerifyCommand) -> anyhow::Result<()> {
                                 report.skipped += 1;
                                 return Ok(());
                             }
-                            if let Err(err) = verify_solid(&solid, password, fast, &mut report) {
+                            if let Err(err) =
+                                verify_solid(&solid, password, &read_options, fast, &mut report)
+                            {
                                 println!("<solid block #{solid_blocks}>: FAILED ({err})");
                                 report.failed += 1;
                                 report.encrypted_failure |= solid.encryption() != Encryption::No;
                             }
                         }
                         ReadEntry::Normal(entry) => {
-                            verify_entry(&entry, password, fast, &mut report)
+                            verify_entry(&entry, password, &read_options, fast, &mut report)
                         }
                     }
                     Ok(())
@@ -120,11 +123,12 @@ fn verify_archive(args: VerifyCommand) -> anyhow::Result<()> {
 fn verify_solid(
     solid: &SolidEntry,
     password: Option<&[u8]>,
+    read_options: &ReadOptions,
     fast: bool,
     report: &mut VerifyReport,
 ) -> io::Result<()> {
     for entry in solid.entries(password)? {
-        verify_entry(&entry?, password, fast, report);
+        verify_entry(&entry?, password, read_options, fast, report);
     }
     Ok(())
 }
@@ -132,6 +136,7 @@ fn verify_solid(
 fn verify_entry(
     entry: &NormalEntry,
     password: Option<&[u8]>,
+    read_options: &ReadOptions,
     fast: bool,
     report: &mut VerifyReport,
 ) {
@@ -146,7 +151,7 @@ fn verify_entry(
         report.skipped += 1;
         return;
     }
-    match read_through(entry, password) {
+    match read_through(entry, read_options) {
         Ok(size) => {
             if let Some(hint) = entry.metadata().raw_file_size()
                 && hint != u128::from(size)
@@ -167,8 +172,8 @@ fn verify_entry(
     }
 }
 
-fn read_through(entry: &NormalEntry, password: Option<&[u8]>) -> io::Result<u64> {
-    let mut reader = entry.reader(ReadOptions::with_password(password))?;
+fn read_through(entry: &NormalEntry, read_options: &ReadOptions) -> io::Result<u64> {
+    let mut reader = entry.reader(read_options)?;
     io::copy(&mut reader, &mut io::sink())
 }
 

--- a/cli/src/command/xattr.rs
+++ b/cli/src/command/xattr.rs
@@ -15,7 +15,7 @@ use base64::Engine;
 use bstr::{ByteSlice, io::BufReadExt};
 use clap::{ArgGroup, Parser, ValueEnum, ValueHint};
 use indexmap::IndexMap;
-use pna::NormalEntry;
+use pna::{NormalEntry, ReadOptions};
 use regex::Regex;
 use std::{
     collections::HashMap,
@@ -196,9 +196,10 @@ fn archive_get_xattr(args: GetXattrCommand) -> anyhow::Result<()> {
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
 
     let mut source = SplitArchiveReader::new(collect_split_archives(&args.file.archive)?)?;
+    let read_options = ReadOptions::with_password(password.as_deref());
 
     source.for_each_entry(
-        password.as_deref(),
+        &read_options,
         #[hooq::skip_all]
         |entry| {
             let entry = entry?;

--- a/cli/tests/cli/stdio/option_ignore_zeros.rs
+++ b/cli/tests/cli/stdio/option_ignore_zeros.rs
@@ -68,7 +68,7 @@ fn read_archive_entries(path: impl AsRef<Path>) -> Vec<(String, String)> {
     let mut archive = Archive::read_header(fs::File::open(path).unwrap()).unwrap();
     archive
         .entries()
-        .extract_solid_entries(None)
+        .extract_solid_entries(&ReadOptions::builder().build())
         .map(|entry| {
             let entry = entry.unwrap();
             let mut reader = entry.reader(ReadOptions::builder().build()).unwrap();
@@ -89,13 +89,18 @@ fn read_all_archive_entries_from_bytes(bytes: &[u8]) -> Vec<(String, String)> {
             Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => break,
             Err(err) => panic!("unexpected archive read error: {err}"),
         };
-        entries.extend(archive.entries().extract_solid_entries(None).map(|entry| {
-            let entry = entry.unwrap();
-            let mut reader = entry.reader(ReadOptions::builder().build()).unwrap();
-            let mut content = String::new();
-            reader.read_to_string(&mut content).unwrap();
-            (entry.name().to_string(), content)
-        }));
+        entries.extend(
+            archive
+                .entries()
+                .extract_solid_entries(&ReadOptions::builder().build())
+                .map(|entry| {
+                    let entry = entry.unwrap();
+                    let mut reader = entry.reader(ReadOptions::builder().build()).unwrap();
+                    let mut content = String::new();
+                    reader.read_to_string(&mut content).unwrap();
+                    (entry.name().to_string(), content)
+                }),
+        );
         let _ = archive.into_inner();
     }
 

--- a/cli/tests/cli/stdio/option_mac_metadata.rs
+++ b/cli/tests/cli/stdio/option_mac_metadata.rs
@@ -11,7 +11,7 @@ fn read_archive_entries(bytes: &[u8]) -> Vec<(String, String)> {
     let mut archive = Archive::read_header(Cursor::new(bytes)).unwrap();
     archive
         .entries()
-        .extract_solid_entries(None)
+        .extract_solid_entries(&ReadOptions::builder().build())
         .map(|entry| {
             let entry = entry.unwrap();
             let mut reader = entry.reader(ReadOptions::builder().build()).unwrap();

--- a/cli/tests/cli/utils/archive.rs
+++ b/cli/tests/cli/utils/archive.rs
@@ -1,3 +1,4 @@
+use pna::ReadOptions;
 use pna::prelude::*;
 use std::{
     fs::File,
@@ -113,7 +114,9 @@ pub fn extract_single_entry(
     name: &str,
 ) -> io::Result<Option<pna::NormalEntry>> {
     let mut archive = pna::Archive::open(path)?;
-    let entries = archive.entries().extract_solid_entries(None);
+    let entries = archive
+        .entries()
+        .extract_solid_entries(&ReadOptions::builder().build());
     for entry in entries {
         let entry = entry?;
         if entry.header().path() == name {
@@ -140,7 +143,8 @@ where
 {
     let password = password.into().map(|p| p.as_bytes());
     let mut archive = pna::Archive::open(path)?;
-    let entries = archive.entries().extract_solid_entries(password);
+    let read_options = ReadOptions::with_password(password);
+    let entries = archive.entries().extract_solid_entries(&read_options);
     for entry in entries {
         f(entry?);
     }

--- a/fuzz/fuzz_targets/split_archive.rs
+++ b/fuzz/fuzz_targets/split_archive.rs
@@ -34,7 +34,10 @@ fuzz_target!(|data: (&[u8], usize)| {
     let archive_bytes = archive.finalize().unwrap();
     let mut archive = Archive::read_header_from_slice(&archive_bytes).unwrap();
 
-    for entry in archive.entries_slice().extract_solid_entries(None) {
+    for entry in archive
+        .entries_slice()
+        .extract_solid_entries(&ReadOptions::builder().build())
+    {
         let entry = entry.unwrap();
         let read_option = ReadOptions::builder().build();
         let mut reader = entry.reader(read_option).unwrap();

--- a/lib/examples/async_io.rs
+++ b/lib/examples/async_io.rs
@@ -38,7 +38,7 @@ async fn extract(path: String) -> io::Result<()> {
     while let Some(entry) = archive.read_entry_async().await? {
         match entry {
             ReadEntry::Solid(solid_entry) => {
-                for entry in solid_entry.entries(None)? {
+                for entry in solid_entry.entries(ReadOptions::builder().build())? {
                     let entry = entry?;
                     let mut file = io::Cursor::new(Vec::new());
                     let mut reader = entry.reader(ReadOptions::builder().build())?.compat();

--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -392,6 +392,89 @@ mod tests {
         }
     }
 
+    /// Precondition: encryption-enabled WriteOptions built once, reused for
+    /// multiple entries so every entry carries the same PHSF.
+    /// Action: read all entries back with a single, shared ReadOptions.
+    /// Expectation: every entry decrypts correctly and the key derivation
+    /// function ran only once, since the derived key was cached.
+    #[test]
+    fn read_options_derives_key_once_per_archive() {
+        let options = WriteOptions::builder()
+            .encryption(Encryption::Aes)
+            .password(Some("password"))
+            .try_build()
+            .unwrap();
+        let mut writer = Archive::write_header(Vec::new()).unwrap();
+        for name in ["test/first", "test/second", "test/third"] {
+            writer
+                .add_entry({
+                    let mut builder = EntryBuilder::new_file(name.into(), &options).unwrap();
+                    builder.write_all(b"some text").unwrap();
+                    builder.build().unwrap()
+                })
+                .unwrap();
+        }
+        let archived = writer.finalize().unwrap();
+
+        let read_options = ReadOptions::with_password(Some("password"));
+        let mut reader = Archive::read_header(archived.as_slice()).unwrap();
+        let entries = reader
+            .entries()
+            .skip_solid()
+            .collect::<io::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(entries.len(), 3);
+        for entry in &entries {
+            let mut data_reader = entry.reader(&read_options).unwrap();
+            let mut dist = Vec::new();
+            io::copy(&mut data_reader, &mut dist).unwrap();
+            assert_eq!(dist.as_slice(), b"some text");
+        }
+        assert_eq!(read_options.cached_key_count(), 1);
+    }
+
+    /// Precondition: entries with distinct PHSF values (as in archives
+    /// written before key derivation moved to WriteOptions build time, where
+    /// each entry gets its own salt).
+    /// Action: read all entries back with a single, shared ReadOptions.
+    /// Expectation: every entry decrypts correctly and the cache holds one
+    /// entry per distinct PHSF.
+    #[test]
+    fn read_options_cache_handles_distinct_phsf_entries() {
+        let mut options_builder = WriteOptions::builder();
+        options_builder
+            .encryption(Encryption::Aes)
+            .password(Some("password"));
+        let mut writer = Archive::write_header(Vec::new()).unwrap();
+        for name in ["test/first", "test/second"] {
+            let options = options_builder.try_build().unwrap();
+            writer
+                .add_entry({
+                    let mut builder = EntryBuilder::new_file(name.into(), &options).unwrap();
+                    builder.write_all(b"some text").unwrap();
+                    builder.build().unwrap()
+                })
+                .unwrap();
+        }
+        let archived = writer.finalize().unwrap();
+
+        let read_options = ReadOptions::with_password(Some("password"));
+        let mut reader = Archive::read_header(archived.as_slice()).unwrap();
+        let entries = reader
+            .entries()
+            .skip_solid()
+            .collect::<io::Result<Vec<_>>>()
+            .unwrap();
+        assert_ne!(entries[0].phsf, entries[1].phsf);
+        for entry in &entries {
+            let mut data_reader = entry.reader(&read_options).unwrap();
+            let mut dist = Vec::new();
+            io::copy(&mut data_reader, &mut dist).unwrap();
+            assert_eq!(dist.as_slice(), b"some text");
+        }
+        assert_eq!(read_options.cached_key_count(), 2);
+    }
+
     /// Precondition: encryption-enabled WriteOptions built once.
     /// Action: create multiple archives reusing the same options.
     /// Expectation: every archive round-trips with the original password.

--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -475,6 +475,46 @@ mod tests {
         assert_eq!(read_options.cached_key_count(), 2);
     }
 
+    /// Precondition: multiple encrypted solid blocks share one WriteOptions,
+    /// and therefore one PHSF.
+    /// Action: decode every block with one shared ReadOptions.
+    /// Expectation: all blocks decode and the derived key is cached once.
+    #[test]
+    fn read_options_cache_is_reused_across_solid_blocks() {
+        let write_options = WriteOptions::builder()
+            .encryption(Encryption::Aes)
+            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .password(Some("password"))
+            .try_build()
+            .unwrap();
+        let mut writer = Archive::write_header(Vec::new()).unwrap();
+        for i in 0..2 {
+            let mut solid = SolidEntryBuilder::new(&write_options).unwrap();
+            solid
+                .write_file(format!("test/file-{i}").into(), Metadata::new(), |w| {
+                    w.write_all(b"some text")
+                })
+                .unwrap();
+            writer.add_entry(solid.build().unwrap()).unwrap();
+        }
+        let archived = writer.finalize().unwrap();
+
+        let read_options = ReadOptions::with_password(Some("password"));
+        let mut reader = Archive::read_header(archived.as_slice()).unwrap();
+        for entry in reader.entries() {
+            let ReadEntry::Solid(solid) = entry.unwrap() else {
+                panic!("expected a solid entry");
+            };
+            let entries = solid
+                .entries(&read_options)
+                .unwrap()
+                .collect::<io::Result<Vec<_>>>()
+                .unwrap();
+            assert_eq!(entries.len(), 1);
+        }
+        assert_eq!(read_options.cached_key_count(), 1);
+    }
+
     /// Precondition: encryption-enabled WriteOptions built once.
     /// Action: create multiple archives reusing the same options.
     /// Expectation: every archive round-trips with the original password.
@@ -534,7 +574,8 @@ mod tests {
         let mut entries = archive.entries();
         let entry = entries.next().unwrap().unwrap();
         if let ReadEntry::Solid(entry) = entry {
-            let mut entries = entry.entries(password.as_deref()).unwrap();
+            let read_options = ReadOptions::with_password(password.as_deref());
+            let mut entries = entry.entries(&read_options).unwrap();
             for i in 0..200 {
                 let entry = entries.next().unwrap().unwrap();
                 let mut reader = entry.reader(ReadOptions::builder().build()).unwrap();
@@ -586,7 +627,8 @@ mod tests {
         };
 
         let mut archive_reader = Archive::read_header(archive.as_slice()).unwrap();
-        let mut entries = archive_reader.entries_with_password(Some(b"password"));
+        let options = ReadOptions::with_password(Some(b"password"));
+        let mut entries = archive_reader.entries_with_options(&options);
         entries.next().unwrap().expect("failed to read entry");
         entries.next().unwrap().expect("failed to read entry");
         assert!(entries.next().is_none());
@@ -666,7 +708,7 @@ mod tests {
 
         let mut archive = Archive::read_header(buf.as_slice()).unwrap();
 
-        let mut entries = archive.entries_with_password(None);
+        let mut entries = archive.entries_with_options(&ReadOptions::builder().build());
         let read_entry = entries.next().unwrap().unwrap();
 
         assert_eq!(

--- a/lib/src/archive/read.rs
+++ b/lib/src/archive/read.rs
@@ -5,7 +5,7 @@ mod slice;
 use crate::{
     archive::{Archive, ArchiveHeader, PNA_HEADER},
     chunk::{Chunk, ChunkReader, ChunkType, RawChunk, read_chunk},
-    entry::{Entry, NormalEntry, RawEntry, ReadEntry},
+    entry::{Entry, NormalEntry, RawEntry, ReadEntry, ReadOptions},
 };
 #[cfg(feature = "unstable-async")]
 use futures_util::AsyncReadExt;
@@ -127,14 +127,14 @@ impl<R: Read> Archive<R> {
         RawEntries(self)
     }
 
-    /// Returns an iterator over entries including those in solid mode, decrypting
-    /// solid entries with the provided password.
+    /// Returns an iterator over entries including those in solid mode, using
+    /// the supplied read options for decryption.
     #[inline]
-    pub fn entries_with_password<'a>(
+    pub fn entries_with_options<'a>(
         &'a mut self,
-        password: Option<&'a [u8]>,
+        options: &ReadOptions,
     ) -> impl Iterator<Item = io::Result<NormalEntry>> + 'a {
-        self.entries().extract_solid_entries(password)
+        self.entries().extract_solid_entries(options)
     }
 
     /// Reads the next archive from the provided reader and returns a new [`Archive`].
@@ -308,7 +308,8 @@ impl<'r, R> Entries<'r, R> {
     /// # fn main() -> io::Result<()> {
     /// let file = fs::File::open("foo.pna")?;
     /// let mut archive = Archive::read_header(file)?;
-    /// for entry in archive.entries().extract_solid_entries(Some(b"password")) {
+    /// let options = ReadOptions::with_password(Some(b"password"));
+    /// for entry in archive.entries().extract_solid_entries(&options) {
     ///     let mut reader = entry?.reader(ReadOptions::builder().build());
     ///     // process the entry
     /// }
@@ -316,8 +317,8 @@ impl<'r, R> Entries<'r, R> {
     /// # }
     /// ```
     #[inline]
-    pub fn extract_solid_entries(self, password: Option<&'r [u8]>) -> NormalEntries<'r, R> {
-        NormalEntries::new(self.reader, password)
+    pub fn extract_solid_entries(self, options: &ReadOptions) -> NormalEntries<'r, R> {
+        NormalEntries::new(self.reader, options)
     }
 }
 
@@ -363,16 +364,16 @@ impl<R: futures_io::AsyncRead + Unpin> futures_util::Stream for Entries<'_, R> {
 /// An iterator over the entries in the archive.
 pub struct NormalEntries<'r, R> {
     reader: &'r mut Archive<R>,
-    password: Option<&'r [u8]>,
+    read_options: ReadOptions,
     solid_iter: Option<crate::entry::SolidIntoEntries>,
 }
 
 impl<'r, R> NormalEntries<'r, R> {
     #[inline]
-    pub(crate) fn new(reader: &'r mut Archive<R>, password: Option<&'r [u8]>) -> Self {
+    pub(crate) fn new(reader: &'r mut Archive<R>, options: &ReadOptions) -> Self {
         Self {
             reader,
-            password,
+            read_options: options.clone(),
             solid_iter: None,
         }
     }
@@ -393,13 +394,15 @@ impl<R: Read> Iterator for NormalEntries<'_, R> {
 
             match self.reader.read_entry() {
                 Ok(Some(ReadEntry::Normal(entry))) => return Some(Ok(entry)),
-                Ok(Some(ReadEntry::Solid(entry))) => match entry.into_entries(self.password) {
-                    Ok(iter) => {
-                        self.solid_iter = Some(iter);
-                        continue;
+                Ok(Some(ReadEntry::Solid(entry))) => {
+                    match entry.into_entries_with_options(&self.read_options) {
+                        Ok(iter) => {
+                            self.solid_iter = Some(iter);
+                            continue;
+                        }
+                        Err(e) => return Some(Err(e)),
                     }
-                    Err(e) => return Some(Err(e)),
-                },
+                }
                 Ok(None) => return None,
                 Err(e) => return Some(Err(e)),
             }
@@ -494,7 +497,7 @@ mod tests {
         while let Some(entry) = archive.read_entry_async().await? {
             match entry {
                 ReadEntry::Solid(solid_entry) => {
-                    for entry in solid_entry.entries(None)? {
+                    for entry in solid_entry.entries(ReadOptions::builder().build())? {
                         let entry = entry?;
                         let mut file = io::Cursor::new(Vec::new());
                         let mut reader = entry.reader(ReadOptions::builder().build())?.compat();

--- a/lib/src/archive/read/slice.rs
+++ b/lib/src/archive/read/slice.rs
@@ -1,7 +1,7 @@
 //! Slice-based archive reading for memory-mapped access.
 
 use crate::{
-    Archive, Chunk, ChunkType, Entry, NormalEntry, PNA_HEADER, RawChunk, ReadEntry,
+    Archive, Chunk, ChunkType, Entry, NormalEntry, PNA_HEADER, RawChunk, ReadEntry, ReadOptions,
     archive::ArchiveHeader, chunk::read_chunk_from_slice, entry::RawEntry,
 };
 use std::borrow::Cow;
@@ -204,9 +204,10 @@ impl<'a, 'r> Entries<'a, 'r> {
     /// # fn main() -> io::Result<()> {
     /// let file = fs::read("foo.pna")?;
     /// let mut archive = Archive::read_header_from_slice(&file[..])?;
+    /// let options = ReadOptions::with_password(Some(b"password"));
     /// for entry in archive
     ///     .entries_slice()
-    ///     .extract_solid_entries(Some(b"password"))
+    ///     .extract_solid_entries(&options)
     /// {
     ///     let mut reader = entry?.reader(ReadOptions::builder().build());
     ///     // process the entry
@@ -217,14 +218,15 @@ impl<'a, 'r> Entries<'a, 'r> {
     #[inline]
     pub fn extract_solid_entries(
         self,
-        password: Option<&'r [u8]>,
+        options: &ReadOptions,
     ) -> impl Iterator<Item = io::Result<NormalEntry>> + 'a
     where
         'a: 'r,
     {
+        let read_options = options.clone();
         self.flat_map(move |f| match f {
             Ok(ReadEntry::Normal(r)) => vec![Ok(r.into())],
-            Ok(ReadEntry::Solid(r)) => match r.entries(password) {
+            Ok(ReadEntry::Solid(r)) => match r.entries(&read_options) {
                 Ok(entries) => entries.collect(),
                 Err(e) => vec![Err(e)],
             },
@@ -278,7 +280,7 @@ mod tests {
         let mut entries = archive.entries_slice();
         let solid_entry = entries.next().unwrap().unwrap();
         if let ReadEntry::Solid(solid_entry) = solid_entry {
-            let mut entries = solid_entry.entries(None).unwrap();
+            let mut entries = solid_entry.entries(ReadOptions::builder().build()).unwrap();
             assert!(entries.next().is_some());
             assert!(entries.next().is_some());
             assert!(entries.next().is_some());

--- a/lib/src/archive/write.rs
+++ b/lib/src/archive/write.rs
@@ -636,7 +636,7 @@ mod tests {
             .expect("failed to write");
         let file = writer.finalize().expect("failed to finalize");
         let mut reader = Archive::read_header(&file[..]).expect("failed to read archive");
-        let mut entries = reader.entries_with_password(None);
+        let mut entries = reader.entries_with_options(&ReadOptions::builder().build());
         let entry = entries
             .next()
             .expect("failed to get entry")
@@ -717,7 +717,7 @@ mod tests {
             .expect("failed to write");
         let file = writer.finalize().expect("failed to finalize");
         let mut reader = Archive::read_header(&file[..]).expect("failed to read archive");
-        let mut entries = reader.entries_with_password(None);
+        let mut entries = reader.entries_with_options(&ReadOptions::builder().build());
         let entry = entries
             .next()
             .expect("failed to get entry")
@@ -747,7 +747,7 @@ mod tests {
         let mut reader = Archive::read_header(&file[..]).expect("failed to read archive");
         let entry = reader
             .entries()
-            .extract_solid_entries(None)
+            .extract_solid_entries(&ReadOptions::builder().build())
             .next()
             .expect("failed to get entry")
             .expect("failed to read entry");
@@ -784,7 +784,7 @@ mod tests {
         );
 
         let mut reader = Archive::read_header(&file[..]).expect("failed to read archive");
-        let mut entries = reader.entries_with_password(None);
+        let mut entries = reader.entries_with_options(&ReadOptions::builder().build());
         let entry = entries
             .next()
             .expect("failed to get entry")
@@ -825,7 +825,7 @@ mod tests {
         );
 
         let mut reader = Archive::read_header(&file[..]).expect("failed to read archive");
-        let mut entries = reader.entries_with_password(None);
+        let mut entries = reader.entries_with_options(&ReadOptions::builder().build());
         let entry = entries
             .next()
             .expect("failed to get entry")
@@ -856,7 +856,7 @@ mod tests {
             .expect("failed to write");
         let file = writer.finalize().expect("failed to finalize");
         let mut reader = Archive::read_header(&file[..]).expect("failed to read archive");
-        let mut entries = reader.entries_with_password(None);
+        let mut entries = reader.entries_with_options(&ReadOptions::builder().build());
         let entry = entries
             .next()
             .expect("failed to get entry")
@@ -899,7 +899,7 @@ mod tests {
         );
 
         let mut reader = Archive::read_header(&file[..]).expect("failed to read archive");
-        let mut entries = reader.entries_with_password(None);
+        let mut entries = reader.entries_with_options(&ReadOptions::builder().build());
         let entry = entries
             .next()
             .expect("failed to get entry")

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -484,6 +484,7 @@ impl<T: AsRef<[u8]>> SolidEntry<T> {
             self.header.cipher_mode,
             self.phsf.as_deref(),
             password,
+            None,
         )?;
         let reader = decompress_reader(reader, self.header.compression)?;
 
@@ -512,6 +513,7 @@ where
             self.header.cipher_mode,
             self.phsf.as_deref(),
             password,
+            None,
         )?;
         let reader = decompress_reader(reader, self.header.compression)?;
         Ok(SolidIntoEntries(EntryReader(reader)))
@@ -1198,6 +1200,7 @@ impl<T: AsRef<[u8]>> NormalEntry<T> {
             self.header.cipher_mode,
             self.phsf.as_deref(),
             option.password(),
+            option.key_cache(),
         )?;
         let reader = decompress_reader(decrypt_reader, self.header.compression)?;
         Ok(EntryDataReader(EntryReader(reader)))

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -459,7 +459,8 @@ impl<T: AsRef<[u8]>> SolidEntry<T> {
     /// for entry in archive.entries() {
     ///     match entry? {
     ///         ReadEntry::Solid(solid_entry) => {
-    ///             for entry in solid_entry.entries(Some(b"password"))? {
+    ///             let options = ReadOptions::with_password(Some(b"password"));
+    ///             for entry in solid_entry.entries(&options)? {
     ///                 let entry = entry?;
     ///                 let mut reader = entry.reader(ReadOptions::builder().build());
     ///                 // process the entry
@@ -474,17 +475,17 @@ impl<T: AsRef<[u8]>> SolidEntry<T> {
     /// # }
     /// ```
     #[inline]
-    pub fn entries(
-        &self,
-        password: Option<&[u8]>,
-    ) -> io::Result<impl Iterator<Item = io::Result<NormalEntry>> + '_> {
+    pub fn entries<'a, O: ReadOption>(
+        &'a self,
+        options: O,
+    ) -> io::Result<impl Iterator<Item = io::Result<NormalEntry>> + use<'a, T, O>> {
         let reader = decrypt_reader(
             self.encoded_reader(),
             self.header.encryption,
             self.header.cipher_mode,
             self.phsf.as_deref(),
-            password,
-            None,
+            options.password(),
+            options.key_cache(),
         )?;
         let reader = decompress_reader(reader, self.header.compression)?;
 
@@ -496,11 +497,13 @@ impl<T> SolidEntry<T>
 where
     T: Into<Vec<u8>>,
 {
-    /// Consumes this solid entry and returns a streaming iterator of normal entries.
-    ///
-    /// This variant owns the underlying buffers, enabling streaming without borrowing from `self`.
+    /// Consumes this solid entry and returns a streaming iterator of normal
+    /// entries, reusing derived keys cached in the supplied options.
     #[inline]
-    pub(crate) fn into_entries(self, password: Option<&[u8]>) -> io::Result<SolidIntoEntries> {
+    pub(crate) fn into_entries_with_options(
+        self,
+        options: &ReadOptions,
+    ) -> io::Result<SolidIntoEntries> {
         let bufs = self
             .data
             .into_iter()
@@ -512,8 +515,8 @@ where
             self.header.encryption,
             self.header.cipher_mode,
             self.phsf.as_deref(),
-            password,
-            None,
+            options.password(),
+            options.key_cache(),
         )?;
         let reader = decompress_reader(reader, self.header.compression)?;
         Ok(SolidIntoEntries(EntryReader(reader)))

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -823,7 +823,7 @@ mod tests {
             })
             .unwrap();
         let solid_entry = builder.build_as_entry().unwrap();
-        let mut entries = solid_entry.entries(None).unwrap();
+        let mut entries = solid_entry.entries(ReadOptions::builder().build()).unwrap();
         let entry = entries.next().unwrap().unwrap();
         let mut reader = entry.reader(ReadOptions::builder().build()).unwrap();
         let mut buf = Vec::new();
@@ -845,7 +845,7 @@ mod tests {
             .unwrap();
         let solid_entry = builder.build_as_entry().unwrap();
 
-        let mut entries = solid_entry.entries(None).unwrap();
+        let mut entries = solid_entry.entries(ReadOptions::builder().build()).unwrap();
         let entry = entries.next().unwrap().unwrap();
         let mut reader = entry.reader(ReadOptions::builder().build()).unwrap();
         let mut buf = Vec::new();

--- a/lib/src/entry/options.rs
+++ b/lib/src/entry/options.rs
@@ -991,7 +991,7 @@ impl WriteOptionsBuilder {
 }
 
 /// Options for reading an entry.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Clone, Debug)]
 pub struct ReadOptions {
     password: Option<Vec<u8>>,
 }

--- a/lib/src/entry/options.rs
+++ b/lib/src/entry/options.rs
@@ -3,7 +3,12 @@
 use crate::{compress, entry::write::derive_key_material, error::UnknownValueError};
 use password_hash::Output;
 pub(crate) use private::*;
-use std::{io, str::FromStr};
+use std::{
+    collections::HashMap,
+    fmt, io,
+    str::FromStr,
+    sync::{Arc, Mutex, MutexGuard, PoisonError},
+};
 
 mod private {
     use super::*;
@@ -44,6 +49,64 @@ mod private {
                 cipher_algorithm,
                 mode,
             }
+        }
+    }
+
+    /// Maximum number of derived keys retained per cache.
+    ///
+    /// Archives written after key derivation moved to WriteOptions build time
+    /// share a single PHSF across entries, so realistic archives hold only a
+    /// few distinct PHSF values. The bound prevents unbounded growth when
+    /// reading legacy archives that carry a distinct salt per entry.
+    const KEY_CACHE_CAP: usize = 16;
+
+    /// Cache of keys derived from PHC strings.
+    ///
+    /// Clones share the same underlying storage, so a [`ReadOptions`] and its
+    /// clones derive a key at most once per distinct PHC string. Correctness
+    /// relies on all sharers holding the same password: [`ReadOptions`] has no
+    /// password setter and rebuilding via a builder always starts a new cache.
+    #[derive(Clone)]
+    pub struct KeyCache {
+        inner: Arc<Mutex<HashMap<String, Output>>>,
+    }
+
+    impl KeyCache {
+        pub(crate) fn new() -> Self {
+            Self {
+                inner: Arc::new(Mutex::new(HashMap::new())),
+            }
+        }
+
+        pub(crate) fn get(&self, phsf: &str) -> Option<Output> {
+            self.lock().get(phsf).copied()
+        }
+
+        pub(crate) fn insert(&self, phsf: &str, key: Output) {
+            let mut map = self.lock();
+            if map.len() >= KEY_CACHE_CAP {
+                map.clear();
+            }
+            map.insert(phsf.into(), key);
+        }
+
+        fn lock(&self) -> MutexGuard<'_, HashMap<String, Output>> {
+            // Critical sections only get/insert; state stays consistent after a
+            // poisoning panic, so recover instead of propagating.
+            self.inner.lock().unwrap_or_else(PoisonError::into_inner)
+        }
+
+        #[cfg(test)]
+        pub(crate) fn len(&self) -> usize {
+            self.lock().len()
+        }
+    }
+
+    impl fmt::Debug for KeyCache {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("KeyCache")
+                .field("entries", &self.lock().len())
+                .finish()
         }
     }
 
@@ -128,6 +191,7 @@ mod private {
     /// Entry read option getter trait.
     pub trait ReadOption {
         fn password(&self) -> Option<&[u8]>;
+        fn key_cache(&self) -> Option<&KeyCache>;
     }
 
     impl<T: ReadOption> ReadOption for &T {
@@ -135,12 +199,22 @@ mod private {
         fn password(&self) -> Option<&[u8]> {
             T::password(self)
         }
+
+        #[inline]
+        fn key_cache(&self) -> Option<&KeyCache> {
+            T::key_cache(self)
+        }
     }
 
     impl ReadOption for ReadOptions {
         #[inline]
         fn password(&self) -> Option<&[u8]> {
             self.password.as_deref()
+        }
+
+        #[inline]
+        fn key_cache(&self) -> Option<&KeyCache> {
+            Some(&self.key_cache)
         }
     }
 }
@@ -991,9 +1065,16 @@ impl WriteOptionsBuilder {
 }
 
 /// Options for reading an entry.
+///
+/// Derived encryption keys are cached inside the options and shared between
+/// clones: reading many entries that carry the same PHC string (the default
+/// for archives written by this crate) runs the key derivation function only
+/// once. Rebuilding via [`ReadOptions::into_builder`] always starts with an
+/// empty cache.
 #[derive(Clone, Debug)]
 pub struct ReadOptions {
     password: Option<Vec<u8>>,
+    key_cache: KeyCache,
 }
 
 impl ReadOptions {
@@ -1016,6 +1097,7 @@ impl ReadOptions {
     pub fn with_password<B: AsRef<[u8]>>(password: Option<B>) -> Self {
         Self {
             password: password.map(|p| p.as_ref().to_vec()),
+            key_cache: KeyCache::new(),
         }
     }
 
@@ -1044,6 +1126,11 @@ impl ReadOptions {
     #[inline]
     pub fn into_builder(self) -> ReadOptionsBuilder {
         self.into()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn cached_key_count(&self) -> usize {
+        self.key_cache.len()
     }
 }
 
@@ -1074,6 +1161,7 @@ impl ReadOptionsBuilder {
     pub fn build(&self) -> ReadOptions {
         ReadOptions {
             password: self.password.clone(),
+            key_cache: KeyCache::new(),
         }
     }
 }
@@ -1133,5 +1221,46 @@ mod tests {
     #[should_panic(expected = "Password was not provided.")]
     fn build_without_password_panics() {
         let _ = WriteOptions::builder().encryption(Encryption::Aes).build();
+    }
+
+    fn test_output(byte: u8) -> Output {
+        Output::new(&[byte; 32]).unwrap()
+    }
+
+    #[test]
+    fn key_cache_returns_inserted_key() {
+        let cache = KeyCache::new();
+        assert!(cache.get("phsf-a").is_none());
+        cache.insert("phsf-a", test_output(1));
+        assert_eq!(cache.get("phsf-a").unwrap(), test_output(1));
+    }
+
+    #[test]
+    fn key_cache_clears_when_full() {
+        let cache = KeyCache::new();
+        for i in 0..16 {
+            cache.insert(&format!("phsf-{i}"), test_output(i as u8));
+        }
+        assert_eq!(cache.len(), 16);
+        cache.insert("phsf-16", test_output(16));
+        assert_eq!(cache.len(), 1);
+        assert!(cache.get("phsf-0").is_none());
+        assert_eq!(cache.get("phsf-16").unwrap(), test_output(16));
+    }
+
+    #[test]
+    fn read_options_clone_shares_key_cache() {
+        let options = ReadOptions::with_password(Some("password"));
+        let cloned = options.clone();
+        cloned.key_cache.insert("phsf-a", test_output(1));
+        assert_eq!(options.cached_key_count(), 1);
+    }
+
+    #[test]
+    fn rebuilt_read_options_starts_with_empty_cache() {
+        let options = ReadOptions::with_password(Some("password"));
+        options.key_cache.insert("phsf-a", test_output(1));
+        let rebuilt = options.clone().into_builder().build();
+        assert_eq!(rebuilt.cached_key_count(), 0);
     }
 }

--- a/lib/src/entry/read.rs
+++ b/lib/src/entry/read.rs
@@ -4,12 +4,36 @@ use crate::{
     CipherMode, Compression, Encryption,
     cipher::{Ctr128BEReader, DecryptCbcAes256Reader, DecryptCbcCamellia256Reader, DecryptReader},
     compress::DecompressReader,
+    entry::KeyCache,
     hash::derive_password_hash,
 };
 use aes::Aes256;
 use camellia::Camellia256;
 use crypto_common::BlockSizeUser;
+use password_hash::Output;
 use std::io::{self, Read};
+
+/// Resolves the cipher key for a PHC string, reusing a previously derived
+/// key when the cache holds one.
+///
+/// The KDF runs outside the cache lock: concurrent readers may derive the
+/// same key more than once on first contact, but the result is
+/// deterministic so the race is benign.
+fn resolve_key(phsf: &str, password: &[u8], key_cache: Option<&KeyCache>) -> io::Result<Output> {
+    if let Some(cache) = key_cache
+        && let Some(key) = cache.get(phsf)
+    {
+        return Ok(key);
+    }
+    let password_hash = derive_password_hash(phsf, password)?;
+    let key = password_hash
+        .hash
+        .ok_or_else(|| io::Error::new(io::ErrorKind::Unsupported, "failed to get hash"))?;
+    if let Some(cache) = key_cache {
+        cache.insert(phsf, key);
+    }
+    Ok(key)
+}
 
 /// Decrypt reader according to an encryption type.
 pub(crate) fn decrypt_reader<R: Read>(
@@ -18,6 +42,7 @@ pub(crate) fn decrypt_reader<R: Read>(
     cipher_mode: CipherMode,
     phsf: Option<&str>,
     password: Option<&[u8]>,
+    key_cache: Option<&KeyCache>,
 ) -> io::Result<DecryptReader<R>> {
     Ok(match encryption {
         Encryption::No => DecryptReader::No(reader),
@@ -25,15 +50,10 @@ pub(crate) fn decrypt_reader<R: Read>(
             let s = phsf.ok_or_else(|| {
                 io::Error::new(io::ErrorKind::InvalidData, "`PHSF` chunk not found")
             })?;
-            let phsf = derive_password_hash(
-                s,
-                password.ok_or_else(|| {
-                    io::Error::new(io::ErrorKind::InvalidInput, "password was not provided")
-                })?,
-            )?;
-            let hash = phsf
-                .hash
-                .ok_or_else(|| io::Error::new(io::ErrorKind::Unsupported, "failed to get hash"))?;
+            let password = password.ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidInput, "password was not provided")
+            })?;
+            let hash = resolve_key(s, password, key_cache)?;
             let key = hash.as_bytes();
             match (encryption, cipher_mode) {
                 (Encryption::Aes, CipherMode::CBC) => {

--- a/lib/tests/extract_solid_compatibility.rs
+++ b/lib/tests/extract_solid_compatibility.rs
@@ -50,7 +50,8 @@ fn assert_entry(item: NormalEntry, password: Option<&[u8]>) {
 fn extract_all(bytes: &[u8], password: Option<&[u8]>) {
     let mut n = 0;
     let mut archive_reader = Archive::read_header(bytes).unwrap();
-    for entry in archive_reader.entries_with_password(password) {
+    let read_options = ReadOptions::with_password(password);
+    for entry in archive_reader.entries_with_options(&read_options) {
         let item = entry.unwrap();
         if item.header().data_kind() == DataKind::Directory {
             continue;
@@ -66,7 +67,7 @@ fn extract_all(bytes: &[u8], password: Option<&[u8]>) {
         let item = entry.unwrap();
         match item {
             ReadEntry::Solid(item) => {
-                for item in item.entries(password).unwrap() {
+                for item in item.entries(&read_options).unwrap() {
                     let item = item.unwrap();
                     if item.header().data_kind() == DataKind::Directory {
                         continue;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved reading of password-protected archives across listing, extraction, verification, comparison, sorting, updating, and ACL/metadata operations.
  * Added key reuse during encrypted entry reads, reducing repeated key derivation and improving performance when processing multiple entries or solid archive blocks.
  * Standardized archive reading options for more consistent encrypted and unencrypted archive handling.
* **Tests**
  * Expanded coverage for encrypted archive reading and key-cache behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->