### PR TITLE
:sparkles: Add --output option to update subcommand

### DIFF
--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -55,6 +55,8 @@ use std::{
     group(ArgGroup::new("mtime-newer-than-source").args(["newer_mtime", "newer_mtime_than"])),
 )]
 pub(crate) struct UpdateCommand {
+    #[arg(long, help = "Output file path", value_hint = ValueHint::FilePath)]
+    output: Option<PathBuf>,
     #[arg(
         long,
         requires = "unstable",
@@ -504,8 +506,9 @@ fn update_archive(args: UpdateCommand) -> anyhow::Result<()> {
     let mut resolver = HardlinkResolver::new(collect_options.follow_links);
     let target_items = collect_items_from_paths(&files, &collect_options, &mut resolver)?;
 
+    let output_path = args.output.unwrap_or_else(|| archive_path.remove_part());
     let mut temp_file =
-        NamedTempFile::new(|| archive_path.parent().unwrap_or_else(|| ".".as_ref()))?;
+        NamedTempFile::new(|| output_path.parent().unwrap_or_else(|| ".".as_ref()))?;
     let mut out_archive = Archive::write_header(temp_file.as_file_mut())?;
 
     let mut source = SplitArchiveReader::new(archives)?;
@@ -538,7 +541,7 @@ fn update_archive(args: UpdateCommand) -> anyhow::Result<()> {
     out_archive.finalize()?;
     drop(source);
 
-    temp_file.persist(archive_path.remove_part())?;
+    temp_file.persist(output_path)?;
 
     Ok(())
 }

--- a/cli/tests/cli/update.rs
+++ b/cli/tests/cli/update.rs
@@ -23,6 +23,7 @@ mod option_older_ctime;
 mod option_older_ctime_than;
 mod option_older_mtime;
 mod option_older_mtime_than;
+mod option_output;
 mod option_recursive;
 mod option_sync;
 mod option_unsolid;

--- a/cli/tests/cli/update/option_output.rs
+++ b/cli/tests/cli/update/option_output.rs
@@ -1,0 +1,164 @@
+use crate::utils::{archive, setup};
+use clap::Parser;
+use portable_network_archive::cli;
+use std::{fs, io::prelude::*, time};
+
+const DURATION_24_HOURS: time::Duration = time::Duration::from_secs(24 * 60 * 60);
+
+fn write_newer(path: &str, content: &[u8]) {
+    let mut file = fs::File::options()
+        .write(true)
+        .truncate(true)
+        .open(path)
+        .unwrap();
+    file.write_all(content).unwrap();
+    file.set_modified(time::SystemTime::now() + DURATION_24_HOURS)
+        .unwrap();
+}
+
+/// Precondition: An archive contains multiple files.
+/// Action: Run `pna experimental update` with `--output` after modifying one
+/// of the source files.
+/// Expectation: The source archive is left untouched, and a new archive is
+/// written to the given output path reflecting the updated content.
+#[test]
+fn update_with_output() {
+    setup();
+    let _ = fs::remove_dir_all("update_with_output");
+    fs::create_dir_all("update_with_output/in").unwrap();
+    fs::write("update_with_output/in/a.txt", b"old-a").unwrap();
+    fs::write("update_with_output/in/b.txt", b"old-b").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "update_with_output/archive.pna",
+        "--overwrite",
+        "update_with_output/in/",
+        "--keep-timestamp",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let initial_archive = fs::read("update_with_output/archive.pna").unwrap();
+    let mut initial_entries = Vec::new();
+    archive::for_each_entry("update_with_output/archive.pna", |entry| {
+        initial_entries.push(entry.header().path().to_string());
+    })
+    .unwrap();
+
+    write_newer("update_with_output/in/a.txt", b"new-a");
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "-f",
+        "update_with_output/archive.pna",
+        "update_with_output/in/",
+        "--keep-timestamp",
+        "--output",
+        "update_with_output/updated.pna",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    assert_eq!(
+        fs::read("update_with_output/archive.pna").unwrap(),
+        initial_archive,
+        "source archive bytes should be unchanged when --output is given"
+    );
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        "-f",
+        "update_with_output/archive.pna",
+        "--overwrite",
+        "--out-dir",
+        "update_with_output/src-out/",
+        "--strip-components",
+        "2",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    assert_eq!(
+        fs::read("update_with_output/src-out/a.txt").unwrap(),
+        b"old-a",
+        "source archive content should remain unchanged"
+    );
+
+    let updated_path = "update_with_output/in/a.txt";
+    let unchanged_path = "update_with_output/in/b.txt";
+    let mut output_entries = Vec::new();
+    let mut updated_contents = Vec::new();
+    let mut unchanged_contents = Vec::new();
+    archive::for_each_entry("update_with_output/updated.pna", |entry| {
+        let path = entry.header().path().to_string();
+        if path == updated_path || path == unchanged_path {
+            let mut content = Vec::new();
+            entry
+                .reader(pna::ReadOptions::with_password::<&[u8]>(None))
+                .unwrap()
+                .read_to_end(&mut content)
+                .unwrap();
+            if path == updated_path {
+                updated_contents.push(content);
+            } else {
+                unchanged_contents.push(content);
+            }
+        }
+        output_entries.push(path);
+    })
+    .unwrap();
+
+    let mut expected_entries = initial_entries;
+    expected_entries.push(updated_path.to_owned());
+    assert_eq!(
+        output_entries, expected_entries,
+        "output archive should preserve the original entry order and append the updated entry"
+    );
+    assert_eq!(
+        updated_contents,
+        [b"old-a".to_vec(), b"new-a".to_vec()],
+        "updated path should retain the old entry and append the new entry"
+    );
+    assert_eq!(
+        unchanged_contents,
+        [b"old-b".to_vec()],
+        "unchanged path should occur exactly once"
+    );
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        "-f",
+        "update_with_output/updated.pna",
+        "--overwrite",
+        "--out-dir",
+        "update_with_output/out-out/",
+        "--strip-components",
+        "2",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    assert_eq!(
+        fs::read("update_with_output/out-out/a.txt").unwrap(),
+        b"new-a",
+        "output archive should reflect the updated content"
+    );
+    assert_eq!(
+        fs::read("update_with_output/out-out/b.txt").unwrap(),
+        b"old-b",
+        "output archive should keep unmodified file content"
+    );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `--output` option to the archive update command to write the updated archive to a separate path.
* **Bug Fixes**
  * Ensures the original archive stays unchanged when using a separate output destination, while the specified entries are updated correctly (including preserving entry ordering).
* **Tests**
  * Added an integration test covering updating with `--output` and verifying both the untouched original and the contents of the generated archive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->