### PR TITLE
:bug: Refuse or re-encrypt renames of GCM-encrypted entries

### DIFF
--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -29,12 +29,14 @@ pub(crate) use path_filter::PathFilter;
 use path_slash::*;
 pub(crate) use path_transformer::PathTransformers;
 use pna::{
-    Archive, DirEntryBuilder, EntryPart, FileEntryBuilder, HardLinkEntryBuilder, LinkTargetType,
-    MIN_CHUNK_BYTES_SIZE, Metadata, NormalEntry, PNA_HEADER, ReadEntry, ReadOptions,
-    SolidEntryBuilder, SymlinkEntryBuilder, WriteOptions, prelude::*,
+    Archive, DataKind, DirEntryBuilder, EntryContent, EntryPart, FileEntryBuilder,
+    HardLinkEntryBuilder, LinkTargetType, MIN_CHUNK_BYTES_SIZE, Metadata, NormalEntry,
+    OpaqueEntryBuilder, PNA_HEADER, ReadEntry, ReadOptions, SolidEntryBuilder, SymlinkEntryBuilder,
+    WriteOptions, prelude::*,
 };
 use std::{
     borrow::Cow,
+    collections::HashMap,
     fmt, fs,
     io::{self, prelude::*},
     path::{Path, PathBuf},
@@ -1945,7 +1947,10 @@ pub(crate) fn apply_chroot(chroot: bool) -> anyhow::Result<()> {
 /// if a password is provided; without a password they will cause an error.
 ///
 /// The entry data (FDAT chunks) is preserved as-is, maintaining the original
-/// compression and encryption. Only the entry headers (paths, ownership) are modified.
+/// compression and encryption. Only the entry headers (paths, ownership) are
+/// modified. The exception is renaming a cipher mode 2 (GCM) entry, whose data
+/// is bound to the header bytes: it is decrypted and re-encrypted under the new
+/// name using the provided password, and refused when no password is available.
 ///
 /// Entries whose path matches the filter exclusion rules will be skipped.
 /// Time filters are also applied to filter entries by timestamps.
@@ -1958,6 +1963,7 @@ pub(crate) fn transform_archive_entries<R: io::Read>(
     allow_concatenated_archives: bool,
 ) -> io::Result<Vec<io::Result<Option<NormalEntry>>>> {
     let mut results = Vec::new();
+    let mut reencrypt_options = HashMap::new();
     let read_options = ReadOptions::with_password(password);
     run_process_archive(
         std::iter::once(reader),
@@ -1972,7 +1978,12 @@ pub(crate) fn transform_archive_entries<R: io::Read>(
             if !time_filters.matches(ctime, mtime) {
                 return Ok(());
             }
-            results.push(transform_normal_entry(entry, create_options));
+            results.push(transform_normal_entry(
+                entry,
+                create_options,
+                password,
+                &mut reencrypt_options,
+            ));
             Ok(())
         },
         allow_concatenated_archives,
@@ -2099,10 +2110,12 @@ pub(crate) fn read_archive_source(
 fn transform_normal_entry(
     entry: NormalEntry,
     CreateOptions {
+        option,
         pathname_editor,
         keep_options,
-        ..
     }: &CreateOptions,
+    password: Option<&[u8]>,
+    reencrypt_options: &mut ReencryptOptionsCache,
 ) -> io::Result<Option<NormalEntry>> {
     // The editor applies the name policy, which may be to keep the name exactly as
     // received, so it has to see the stored name. A sanitized path arrives with the
@@ -2113,7 +2126,28 @@ fn transform_normal_entry(
         return Ok(None);
     };
 
-    let mut result = entry.with_name(new_name);
+    let mut result = if new_name == *entry.name() {
+        // A name that did not change is not a rename, so it must not be sent
+        // through the re-encryption path below.
+        entry
+    } else if entry.encryption() != pna::Encryption::NO
+        && !entry.cipher_mode().allows_header_rewrite()
+    {
+        // The stream key is bound to the header bytes, so a renamed entry is
+        // only readable if it is decrypted and re-encrypted under the new name.
+        let Some(password) = password else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "cannot rename encrypted entry {original_name}: an entry encrypted in cipher mode {:?} must be re-encrypted under the new name, which requires the password",
+                    entry.cipher_mode()
+                ),
+            ));
+        };
+        re_encrypt_entry_with_name(&entry, new_name, password, option, reencrypt_options)?
+    } else {
+        entry.try_with_name(new_name)?
+    };
 
     let mut metadata = result.metadata().clone();
     match keep_options.timestamp_strategy {
@@ -2190,6 +2224,83 @@ fn transform_normal_entry(
     Ok(Some(result))
 }
 
+type ReencryptOptionsKey = (pna::Compression, pna::Encryption, pna::CipherMode);
+type ReencryptOptionsCache = HashMap<ReencryptOptionsKey, WriteOptions>;
+
+/// Decrypts `entry` and rebuilds it under `new_name`, re-encrypted with the
+/// same encryption algorithm, cipher mode, and compression as the source entry.
+///
+/// Everything else — the hash algorithm and its cost parameters, the compression
+/// level, the GCM segment size — is inherited from `create_options` so that the
+/// flags the user passed on this command line are honored. Those settings live
+/// inside the cipher of `create_options`, so they are only available to inherit
+/// when this run also selected an encryption algorithm; otherwise the defaults
+/// apply. The source entry's own KDF cost parameters are never recoverable from a
+/// parsed entry, so they cannot be carried over either way.
+fn re_encrypt_entry_with_name(
+    entry: &NormalEntry,
+    new_name: pna::EntryName,
+    password: &[u8],
+    create_options: &WriteOptions,
+    reencrypt_options: &mut ReencryptOptionsCache,
+) -> io::Result<NormalEntry> {
+    let header = entry.header();
+    let key = (
+        header.compression(),
+        header.encryption(),
+        header.cipher_mode(),
+    );
+    let options = match reencrypt_options.entry(key) {
+        std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+        std::collections::hash_map::Entry::Vacant(entry) => {
+            log::warn!(
+                "re-encrypting entries under their new names: the key derivation parameters recorded in the source cannot be recovered, so this run's settings are used instead"
+            );
+            let options = create_options
+                .clone()
+                .into_builder()
+                .compression(header.compression())
+                .encryption(header.encryption())
+                .cipher_mode(header.cipher_mode())
+                .password(Some(password))
+                .try_build()?;
+            entry.insert(options)
+        }
+    };
+    let read_options = pna::ReadOptions::with_password(Some(password));
+    let built = match entry.header().data_kind() {
+        DataKind::SYMBOLIC_LINK => {
+            let EntryContent::SymbolicLink(reference) = entry.content(read_options)? else {
+                unreachable!("data kind is SYMBOLIC_LINK")
+            };
+            SymlinkEntryBuilder::new_with_options(new_name, reference, &*options)?.build()?
+        }
+        DataKind::HARD_LINK => {
+            let EntryContent::HardLink(reference) = entry.content(read_options)? else {
+                unreachable!("data kind is HARD_LINK")
+            };
+            HardLinkEntryBuilder::new_with_options(new_name, reference, &*options)?.build()?
+        }
+        DataKind::FILE => {
+            let mut builder = FileEntryBuilder::new_with_options(new_name, &*options)?;
+            io::copy(&mut entry.reader(read_options)?, &mut builder)?;
+            builder.build()?
+        }
+        // Kinds with no builder that takes both a payload and write options —
+        // directories, and private or reserved kinds. Re-encrypting the opaque
+        // byte stream preserves data that another tool may have attached to a
+        // kind this build does not model, instead of dropping it.
+        kind => {
+            let mut builder = OpaqueEntryBuilder::new_with_options(new_name, kind, &*options)?;
+            io::copy(&mut entry.reader(read_options)?, &mut builder)?;
+            builder.build()?
+        }
+    };
+    Ok(built
+        .with_metadata(entry.metadata().clone())
+        .with_extra_chunks(entry.extra_chunks()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2212,6 +2323,280 @@ mod tests {
                 TimeRange::new_strict(None, None),
                 MissingTimePolicy::Include,
             ),
+        }
+    }
+
+    #[test]
+    fn gcm_reencrypt_options_are_reused_for_matching_entries() {
+        let source_options = WriteOptions::builder()
+            .encryption(pna::Encryption::AES)
+            .cipher_mode(pna::CipherMode::GCM)
+            .hash_algorithm(pna::HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .password(Some("password"))
+            .build();
+        let mut source =
+            FileEntryBuilder::new_with_options("original".into(), &source_options).unwrap();
+        source.write_all(b"secret payload").unwrap();
+        let source = source.build().unwrap();
+        let mut cache = ReencryptOptionsCache::new();
+
+        let first = re_encrypt_entry_with_name(
+            &source,
+            "first".into(),
+            b"password",
+            &gcm_write_options(),
+            &mut cache,
+        )
+        .unwrap();
+        let second = re_encrypt_entry_with_name(
+            &source,
+            "second".into(),
+            b"password",
+            &gcm_write_options(),
+            &mut cache,
+        )
+        .unwrap();
+
+        assert_eq!(cache.len(), 1);
+        for entry in [first, second] {
+            let mut reader = entry
+                .reader(pna::ReadOptions::with_password(Some("password")))
+                .unwrap();
+            let mut out = Vec::new();
+            reader.read_to_end(&mut out).unwrap();
+            assert_eq!(out, b"secret payload");
+        }
+    }
+
+    #[test]
+    fn gcm_reencrypt_inherits_the_hash_algorithm_from_create_options() {
+        let source_options = WriteOptions::builder()
+            .encryption(pna::Encryption::AES)
+            .cipher_mode(pna::CipherMode::GCM)
+            .hash_algorithm(pna::HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .password(Some("password"))
+            .build();
+        let mut source =
+            FileEntryBuilder::new_with_options("original".into(), &source_options).unwrap();
+        source.write_all(b"secret payload").unwrap();
+        let source = source.build().unwrap();
+        let create_options = WriteOptions::builder()
+            .encryption(pna::Encryption::AES)
+            .cipher_mode(pna::CipherMode::GCM)
+            .hash_algorithm(pna::HashAlgorithm::pbkdf2_sha256_with(Some(2)))
+            .password(Some("password"))
+            .build();
+        let mut cache = ReencryptOptionsCache::new();
+
+        let renamed = re_encrypt_entry_with_name(
+            &source,
+            "renamed".into(),
+            b"password",
+            &create_options,
+            &mut cache,
+        )
+        .unwrap();
+
+        let mut archive = pna::Archive::write_header(Vec::new()).unwrap();
+        archive.add_entry(renamed).unwrap();
+        let bytes = archive.finalize().unwrap();
+        let text = String::from_utf8_lossy(&bytes);
+        assert!(text.contains("$pbkdf2-sha256$i=2"), "{text}");
+        assert!(!text.contains("$pbkdf2-sha256$i=1"), "{text}");
+    }
+
+    fn gcm_write_options() -> WriteOptions {
+        WriteOptions::builder()
+            .encryption(pna::Encryption::AES)
+            .cipher_mode(pna::CipherMode::GCM)
+            .hash_algorithm(pna::HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .password(Some("password"))
+            .build()
+    }
+
+    #[test]
+    fn gcm_reencrypt_preserves_file_kind() {
+        let mut source =
+            FileEntryBuilder::new_with_options("original".into(), gcm_write_options()).unwrap();
+        source.write_all(b"secret payload").unwrap();
+        let source = source.build().unwrap();
+        let mut cache = ReencryptOptionsCache::new();
+
+        let renamed = re_encrypt_entry_with_name(
+            &source,
+            "renamed".into(),
+            b"password",
+            &gcm_write_options(),
+            &mut cache,
+        )
+        .unwrap();
+
+        assert_eq!(renamed.data_kind(), pna::DataKind::FILE);
+        assert_eq!(renamed.header().path().as_str(), "renamed");
+        let mut reader = renamed
+            .reader(pna::ReadOptions::with_password(Some("password")))
+            .unwrap();
+        let mut out = Vec::new();
+        reader.read_to_end(&mut out).unwrap();
+        assert_eq!(out, b"secret payload");
+    }
+
+    #[test]
+    fn gcm_reencrypt_preserves_symlink_kind() {
+        let source = SymlinkEntryBuilder::new_with_options(
+            "link".into(),
+            pna::EntryReference::from("target/path"),
+            gcm_write_options(),
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+        let mut cache = ReencryptOptionsCache::new();
+
+        let renamed = re_encrypt_entry_with_name(
+            &source,
+            "renamed".into(),
+            b"password",
+            &gcm_write_options(),
+            &mut cache,
+        )
+        .unwrap();
+
+        assert_eq!(renamed.data_kind(), pna::DataKind::SYMBOLIC_LINK);
+        assert_eq!(renamed.header().path().as_str(), "renamed");
+        match renamed
+            .content(pna::ReadOptions::with_password(Some("password")))
+            .unwrap()
+        {
+            EntryContent::SymbolicLink(target) => assert_eq!(target, "target/path"),
+            other => panic!("expected symlink, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn gcm_reencrypt_preserves_hardlink_kind() {
+        let source = HardLinkEntryBuilder::new_with_options(
+            "link".into(),
+            pna::EntryReference::from("target/entry"),
+            gcm_write_options(),
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+        let mut cache = ReencryptOptionsCache::new();
+
+        let renamed = re_encrypt_entry_with_name(
+            &source,
+            "renamed".into(),
+            b"password",
+            &gcm_write_options(),
+            &mut cache,
+        )
+        .unwrap();
+
+        assert_eq!(renamed.data_kind(), pna::DataKind::HARD_LINK);
+        assert_eq!(renamed.header().path().as_str(), "renamed");
+        match renamed
+            .content(pna::ReadOptions::with_password(Some("password")))
+            .unwrap()
+        {
+            EntryContent::HardLink(target) => assert_eq!(target, "target/entry"),
+            other => panic!("expected hardlink, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn gcm_reencrypt_preserves_directory_kind() {
+        let source = DirEntryBuilder::new("dir".into()).build().unwrap();
+        let mut cache = ReencryptOptionsCache::new();
+
+        let renamed = re_encrypt_entry_with_name(
+            &source,
+            "renamed".into(),
+            b"password",
+            &gcm_write_options(),
+            &mut cache,
+        )
+        .unwrap();
+
+        assert_eq!(renamed.data_kind(), pna::DataKind::DIRECTORY);
+        assert_eq!(renamed.header().path().as_str(), "renamed");
+        assert!(matches!(
+            renamed
+                .content(pna::ReadOptions::with_password(Some("password")))
+                .unwrap(),
+            EntryContent::Directory
+        ));
+    }
+
+    #[test]
+    fn gcm_reencrypt_preserves_an_encrypted_directory_payload() {
+        // libpna's own directory builder takes neither a payload nor write
+        // options, but the wire format allows both, so an archive from another
+        // tool can carry an encrypted directory entry with data attached.
+        let mut source = OpaqueEntryBuilder::new_with_options(
+            "dir".into(),
+            pna::DataKind::DIRECTORY,
+            gcm_write_options(),
+        )
+        .unwrap();
+        source.write_all(b"directory payload").unwrap();
+        let source = source.build().unwrap();
+        let mut cache = ReencryptOptionsCache::new();
+
+        let renamed = re_encrypt_entry_with_name(
+            &source,
+            "renamed".into(),
+            b"password",
+            &gcm_write_options(),
+            &mut cache,
+        )
+        .unwrap();
+
+        assert_eq!(renamed.data_kind(), pna::DataKind::DIRECTORY);
+        assert_eq!(renamed.header().path().as_str(), "renamed");
+        assert_eq!(renamed.header().encryption(), pna::Encryption::AES);
+        assert_eq!(renamed.header().cipher_mode(), pna::CipherMode::GCM);
+        let mut reader = renamed
+            .reader(pna::ReadOptions::with_password(Some("password")))
+            .unwrap();
+        let mut out = Vec::new();
+        reader.read_to_end(&mut out).unwrap();
+        assert_eq!(out, b"directory payload");
+    }
+
+    #[test]
+    fn gcm_reencrypt_preserves_private_kind() {
+        let kind = pna::DataKind::new_private(200).unwrap();
+        let mut source =
+            OpaqueEntryBuilder::new_with_options("original".into(), kind, gcm_write_options())
+                .unwrap();
+        source.write_all(b"opaque payload").unwrap();
+        let source = source.build().unwrap();
+        let mut cache = ReencryptOptionsCache::new();
+
+        let renamed = re_encrypt_entry_with_name(
+            &source,
+            "renamed".into(),
+            b"password",
+            &gcm_write_options(),
+            &mut cache,
+        )
+        .unwrap();
+
+        assert_eq!(renamed.data_kind(), kind);
+        assert_eq!(renamed.header().path().as_str(), "renamed");
+        match renamed
+            .content(pna::ReadOptions::with_password(Some("password")))
+            .unwrap()
+        {
+            EntryContent::Unknown(k, mut reader) => {
+                assert_eq!(k, kind);
+                let mut out = Vec::new();
+                reader.read_to_end(&mut out).unwrap();
+                assert_eq!(out, b"opaque payload");
+            }
+            other => panic!("expected unknown kind, got {other:?}"),
         }
     }
 

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -2368,6 +2368,100 @@ mod tests {
         }
     }
 
+    /// Deliberately runs with an algorithm, a mode and a compression the source
+    /// does not use: all three must come from the source entry, or a rename
+    /// silently re-encodes it under whatever this run happens to be writing.
+    #[test]
+    fn gcm_reencrypt_takes_the_cipher_and_compression_from_the_source_entry() {
+        let source_options = WriteOptions::builder()
+            .compression(pna::Compression::ZSTANDARD)
+            .encryption(pna::Encryption::AES)
+            .cipher_mode(pna::CipherMode::GCM)
+            .hash_algorithm(pna::HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .password(Some("password"))
+            .build();
+        let mut source =
+            FileEntryBuilder::new_with_options("original".into(), &source_options).unwrap();
+        source.write_all(b"secret payload").unwrap();
+        let source = source.build().unwrap();
+        let run_options = WriteOptions::builder()
+            .compression(pna::Compression::NO)
+            .encryption(pna::Encryption::CAMELLIA)
+            .cipher_mode(pna::CipherMode::CTR)
+            .hash_algorithm(pna::HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .password(Some("password"))
+            .build();
+        let mut cache = ReencryptOptionsCache::new();
+
+        let renamed = re_encrypt_entry_with_name(
+            &source,
+            "renamed".into(),
+            b"password",
+            &run_options,
+            &mut cache,
+        )
+        .unwrap();
+
+        assert_eq!(renamed.header().encryption(), pna::Encryption::AES);
+        assert_eq!(renamed.header().cipher_mode(), pna::CipherMode::GCM);
+        assert_eq!(renamed.header().compression(), pna::Compression::ZSTANDARD);
+        // The header only means anything if the payload actually decodes under
+        // it: a header can name a codec the data was not written with.
+        let mut reader = renamed
+            .reader(pna::ReadOptions::with_password(Some("password")))
+            .unwrap();
+        let mut out = Vec::new();
+        reader.read_to_end(&mut out).unwrap();
+        assert_eq!(out, b"secret payload");
+    }
+
+    /// An archive may mix cipher algorithms, so entries that differ in one must
+    /// not share a cache slot: the second would be re-encrypted with the first's
+    /// algorithm and, because its header is rewritten to match, would still
+    /// decrypt.
+    #[test]
+    fn gcm_reencrypt_options_are_not_shared_across_cipher_algorithms() {
+        let camellia_options = WriteOptions::builder()
+            .encryption(pna::Encryption::CAMELLIA)
+            .cipher_mode(pna::CipherMode::GCM)
+            .hash_algorithm(pna::HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .password(Some("password"))
+            .build();
+        let mut aes_source =
+            FileEntryBuilder::new_with_options("aes".into(), gcm_write_options()).unwrap();
+        aes_source.write_all(b"secret payload").unwrap();
+        let aes_source = aes_source.build().unwrap();
+        let mut camellia_source =
+            FileEntryBuilder::new_with_options("camellia".into(), &camellia_options).unwrap();
+        camellia_source.write_all(b"secret payload").unwrap();
+        let camellia_source = camellia_source.build().unwrap();
+        let mut cache = ReencryptOptionsCache::new();
+
+        let renamed_aes = re_encrypt_entry_with_name(
+            &aes_source,
+            "renamed_aes".into(),
+            b"password",
+            &gcm_write_options(),
+            &mut cache,
+        )
+        .unwrap();
+        let renamed_camellia = re_encrypt_entry_with_name(
+            &camellia_source,
+            "renamed_camellia".into(),
+            b"password",
+            &gcm_write_options(),
+            &mut cache,
+        )
+        .unwrap();
+
+        assert_eq!(cache.len(), 2);
+        assert_eq!(renamed_aes.header().encryption(), pna::Encryption::AES);
+        assert_eq!(
+            renamed_camellia.header().encryption(),
+            pna::Encryption::CAMELLIA
+        );
+    }
+
     #[test]
     fn gcm_reencrypt_inherits_the_hash_algorithm_from_create_options() {
         let source_options = WriteOptions::builder()
@@ -2598,6 +2692,53 @@ mod tests {
             }
             other => panic!("expected unknown kind, got {other:?}"),
         }
+    }
+
+    /// Re-encryption rebuilds the entry from its payload, so everything the wire
+    /// format carries outside the datastream — including chunks belonging to a
+    /// type this build does not model — survives only by being copied over.
+    #[test]
+    fn gcm_reencrypt_preserves_metadata_and_extra_chunks() {
+        let xattr = pna::ExtendedAttribute::new(
+            pna::XattrName::try_from("user.k").unwrap(),
+            pna::XattrValue::try_from(b"v".as_slice()).unwrap(),
+        );
+        let private_chunk = pna::RawChunk::from_data(
+            pna::ChunkType::private(*b"abCd").unwrap(),
+            b"private payload".as_slice(),
+        );
+        let mut source =
+            FileEntryBuilder::new_with_options("original".into(), gcm_write_options()).unwrap();
+        source.write_all(b"secret payload").unwrap();
+        source.metadata(
+            Metadata::new()
+                .with_xattrs(vec![xattr.clone()])
+                .with_permission_mode(Some(pna::PermissionMode::from(0o644)))
+                .with_modified(Some(pna::Duration::seconds(1_000))),
+        );
+        source.add_extra_chunk(private_chunk.clone());
+        let source = source.build().unwrap();
+        let mut cache = ReencryptOptionsCache::new();
+
+        let renamed = re_encrypt_entry_with_name(
+            &source,
+            "renamed".into(),
+            b"password",
+            &gcm_write_options(),
+            &mut cache,
+        )
+        .unwrap();
+
+        assert_eq!(renamed.metadata().xattrs(), &[xattr]);
+        assert_eq!(
+            renamed.metadata().permission_mode().map(|it| it.get()),
+            Some(0o644)
+        );
+        assert_eq!(
+            renamed.metadata().modified(),
+            Some(pna::Duration::seconds(1_000))
+        );
+        assert_eq!(renamed.extra_chunks(), &[private_chunk]);
     }
 
     fn default_collect_options<'a>(

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -2126,8 +2126,8 @@ fn transform_normal_entry(
         return Ok(None);
     };
 
-    let mut result = if new_name == *entry.name() {
-        // A name that did not change is not a rename, so it must not be sent
+    let mut result = if new_name == *original_name {
+        // A name the editor left alone is not a rename, so it must not be sent
         // through the re-encryption path below.
         entry
     } else if entry.encryption() != pna::Encryption::NO
@@ -2139,7 +2139,7 @@ fn transform_normal_entry(
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 format!(
-                    "cannot rename encrypted entry {original_name}: an entry encrypted in cipher mode {:?} must be re-encrypted under the new name, which requires the password",
+                    "entry {original_name} is written as {new_name}, and an entry encrypted in cipher mode {:?} must be re-encrypted when its header changes, which requires the password",
                     entry.cipher_mode()
                 ),
             ));

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -2130,23 +2130,25 @@ fn transform_normal_entry(
         // A name the editor left alone is not a rename, so it must not be sent
         // through the re-encryption path below.
         entry
-    } else if entry.encryption() != pna::Encryption::NO
-        && !entry.cipher_mode().allows_header_rewrite()
-    {
-        // The stream key is bound to the header bytes, so a renamed entry is
-        // only readable if it is decrypted and re-encrypted under the new name.
-        let Some(password) = password else {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!(
-                    "entry {original_name} is written as {new_name}, and an entry encrypted in cipher mode {:?} must be re-encrypted when its header changes, which requires the password",
-                    entry.cipher_mode()
-                ),
-            ));
-        };
-        re_encrypt_entry_with_name(&entry, new_name, password, option, reencrypt_options)?
     } else {
-        entry.try_with_name(new_name)?
+        match entry.try_with_name(new_name.clone()) {
+            Ok(renamed) => renamed,
+            // The stream key is bound to the header bytes, so a renamed entry is
+            // only readable if it is decrypted and re-encrypted under the new name.
+            Err(entry) => {
+                let Some(password) = password else {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!(
+                            "entry {} is written as {new_name}, and an entry encrypted in cipher mode {:?} must be re-encrypted when its header changes, which requires the password",
+                            entry.name(),
+                            entry.cipher_mode()
+                        ),
+                    ));
+                };
+                re_encrypt_entry_with_name(&entry, new_name, password, option, reencrypt_options)?
+            }
+        }
     };
 
     let mut metadata = result.metadata().clone();

--- a/cli/tests/cli/bsdtar.rs
+++ b/cli/tests/cli/bsdtar.rs
@@ -1,6 +1,7 @@
 mod archive_inclusion;
 mod archive_source_name_policy;
 mod archive_source_uid_override;
+mod encrypted_rename;
 mod files_from;
 mod list_line_ending;
 mod missing_file;

--- a/cli/tests/cli/bsdtar/encrypted_rename.rs
+++ b/cli/tests/cli/bsdtar/encrypted_rename.rs
@@ -1,0 +1,211 @@
+use crate::utils::{archive::for_each_entry_with_password, setup};
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::{PredicateBooleanExt, predicate};
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::path::Path;
+
+const PASSWORD: &str = "testpass";
+
+fn create_encrypted_archive(
+    path: impl AsRef<Path>,
+    cipher_mode: pna::CipherMode,
+    entries: &[(&str, &str)],
+) {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    let options = pna::WriteOptions::builder()
+        .encryption(pna::Encryption::AES)
+        .cipher_mode(cipher_mode)
+        .hash_algorithm(pna::HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+        .password(Some(PASSWORD))
+        .build();
+    let file = File::create(path).unwrap();
+    let mut writer = pna::Archive::write_header(file).unwrap();
+    for (name, contents) in entries {
+        writer
+            .add_entry({
+                let mut builder =
+                    pna::FileEntryBuilder::new_with_options((*name).into(), &options).unwrap();
+                builder.write_all(contents.as_bytes()).unwrap();
+                builder.build().unwrap()
+            })
+            .unwrap();
+    }
+    writer.finalize().unwrap();
+}
+
+fn read_entry_data(entry: &pna::NormalEntry, password: &str) -> Vec<u8> {
+    let mut reader = entry
+        .reader(pna::ReadOptions::with_password(Some(password)))
+        .unwrap();
+    let mut data = Vec::new();
+    reader.read_to_end(&mut data).unwrap();
+    data
+}
+
+/// Precondition: A source archive contains an AES-256-GCM (cipher mode 2) encrypted entry.
+/// Action: Copy it into a new archive via compat bsdtar with a `-s` rename and the password.
+/// Expectation: The command succeeds and the renamed entry decrypts to the original content.
+#[test]
+fn bsdtar_rename_gcm_entry_reencrypts_with_password() {
+    setup();
+    let base = "bsdtar_rename_gcm_entry_reencrypts_with_password";
+    fs::create_dir_all(base).unwrap();
+    create_encrypted_archive(
+        format!("{base}/source.pna"),
+        pna::CipherMode::GCM,
+        &[("dir/secret.txt", "secret content")],
+    );
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "compat",
+            "bsdtar",
+            "--unstable",
+            "-c",
+            "--overwrite",
+            "-f",
+            &format!("{base}/output.pna"),
+            "-C",
+            base,
+            "-s",
+            ",dir/,renamed/,",
+            "--password",
+            PASSWORD,
+            "@source.pna",
+        ])
+        .assert()
+        .success();
+
+    let mut names = Vec::new();
+    for_each_entry_with_password(format!("{base}/output.pna"), PASSWORD, |entry| {
+        names.push(entry.header().path().to_string());
+        assert_eq!(read_entry_data(&entry, PASSWORD), b"secret content");
+    })
+    .unwrap();
+    assert_eq!(names, ["renamed/secret.txt"]);
+}
+
+/// Precondition: A source archive contains an AES-256-GCM (cipher mode 2) encrypted entry.
+/// Action: Copy it into a new archive via compat bsdtar with a `-s` rename but without a password.
+/// Expectation: The command fails instead of silently emitting an undecryptable entry.
+#[test]
+fn bsdtar_rename_gcm_entry_without_password_fails() {
+    setup();
+    let base = "bsdtar_rename_gcm_entry_without_password_fails";
+    fs::create_dir_all(base).unwrap();
+    create_encrypted_archive(
+        format!("{base}/source.pna"),
+        pna::CipherMode::GCM,
+        &[("dir/secret.txt", "secret content")],
+    );
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "compat",
+            "bsdtar",
+            "--unstable",
+            "-c",
+            "--overwrite",
+            "-f",
+            &format!("{base}/output.pna"),
+            "-C",
+            base,
+            "-s",
+            ",dir/,renamed/,",
+            "@source.pna",
+        ])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("requires the password")
+                .and(predicate::str::contains("panicked").not()),
+        );
+}
+
+/// Precondition: A source archive contains an AES-256-GCM (cipher mode 2) encrypted entry.
+/// Action: Copy it into a new archive via compat bsdtar without any rename option and without a password.
+/// Expectation: The command succeeds and the entry is passed through still decryptable.
+#[test]
+fn bsdtar_copy_gcm_entry_without_rename_stays_readable() {
+    setup();
+    let base = "bsdtar_copy_gcm_entry_without_rename_stays_readable";
+    fs::create_dir_all(base).unwrap();
+    create_encrypted_archive(
+        format!("{base}/source.pna"),
+        pna::CipherMode::GCM,
+        &[("dir/secret.txt", "secret content")],
+    );
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "compat",
+            "bsdtar",
+            "--unstable",
+            "-c",
+            "--overwrite",
+            "-f",
+            &format!("{base}/output.pna"),
+            "-C",
+            base,
+            "@source.pna",
+        ])
+        .assert()
+        .success();
+
+    let mut names = Vec::new();
+    for_each_entry_with_password(format!("{base}/output.pna"), PASSWORD, |entry| {
+        names.push(entry.header().path().to_string());
+        assert_eq!(read_entry_data(&entry, PASSWORD), b"secret content");
+    })
+    .unwrap();
+    assert_eq!(names, ["dir/secret.txt"]);
+}
+
+/// Precondition: A source archive contains an AES-256-CBC encrypted entry.
+/// Action: Copy it into a new archive via compat bsdtar with a `-s` rename and without a password.
+/// Expectation: The command succeeds (CBC is not header-bound) and the renamed entry decrypts.
+#[test]
+fn bsdtar_rename_cbc_entry_stays_readable() {
+    setup();
+    let base = "bsdtar_rename_cbc_entry_stays_readable";
+    fs::create_dir_all(base).unwrap();
+    create_encrypted_archive(
+        format!("{base}/source.pna"),
+        pna::CipherMode::CBC,
+        &[("dir/secret.txt", "secret content")],
+    );
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "compat",
+            "bsdtar",
+            "--unstable",
+            "-c",
+            "--overwrite",
+            "-f",
+            &format!("{base}/output.pna"),
+            "-C",
+            base,
+            "-s",
+            ",dir/,renamed/,",
+            "@source.pna",
+        ])
+        .assert()
+        .success();
+
+    let mut names = Vec::new();
+    for_each_entry_with_password(format!("{base}/output.pna"), PASSWORD, |entry| {
+        names.push(entry.header().path().to_string());
+        assert_eq!(read_entry_data(&entry, PASSWORD), b"secret content");
+    })
+    .unwrap();
+    assert_eq!(names, ["renamed/secret.txt"]);
+}

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -1127,6 +1127,13 @@ impl<T> NormalEntry<T> {
     /// This is useful for path transformations during archive-to-archive copying
     /// where the entry data should remain unchanged.
     ///
+    /// # Panics
+    ///
+    /// Panics when the entry is encrypted in a cipher mode that does not
+    /// [allow a header rewrite](CipherMode::allows_header_rewrite), because the
+    /// rename would make the entry's data undecryptable. See
+    /// [`NormalEntry::try_with_name`] for the fallible variant.
+    ///
     /// # Examples
     /// ```rust
     /// # use std::io;
@@ -1140,9 +1147,52 @@ impl<T> NormalEntry<T> {
     /// # }
     /// ```
     #[inline]
-    pub fn with_name(mut self, name: EntryName) -> Self {
+    pub fn with_name(self, name: EntryName) -> Self {
+        self.try_with_name(name)
+            .expect("renaming this entry would make its data undecryptable")
+    }
+
+    /// Returns this entry with a new name, refusing renames that
+    /// would make the entry's data undecryptable.
+    ///
+    /// [`CipherMode::GCM`] derives its stream key from the `FHED` bytes, so a
+    /// renamed entry can no longer be decrypted; this method returns an error
+    /// instead of producing one. Cipher modes this build does not implement are
+    /// refused as well, since their key derivation may bind the header too. See
+    /// [`NormalEntry::with_name`] for the panicking variant.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the entry is encrypted in a cipher mode that does
+    /// not [allow a header rewrite](CipherMode::allows_header_rewrite).
+    ///
+    /// # Examples
+    /// ```rust
+    /// # use std::io;
+    /// use libpna::DirEntryBuilder;
+    ///
+    /// # fn main() -> io::Result<()> {
+    /// let entry = DirEntryBuilder::new("original/path".into()).build()?;
+    /// let renamed = entry.try_with_name("new/path".into())?;
+    /// assert_eq!(renamed.header().path().as_str(), "new/path");
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn try_with_name(mut self, name: EntryName) -> io::Result<Self> {
+        if self.header.encryption != Encryption::NO
+            && !self.header.cipher_mode.allows_header_rewrite()
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "cannot rename an entry encrypted in cipher mode {:?}: only CBC and CTR derive keys independently of the entry header",
+                    self.header.cipher_mode
+                ),
+            ));
+        }
         self.header = self.header.with_name(name);
-        self
+        Ok(self)
     }
 }
 
@@ -1549,6 +1599,117 @@ mod tests {
         let renamed = entry.with_name("new".into());
         assert_eq!(renamed.header().path().as_str(), "new");
         assert_eq!(renamed.name().as_str(), "new");
+    }
+
+    #[test]
+    fn normal_entry_with_name_supports_borrowed_data() {
+        let header = EntryHeader::for_file(
+            Compression::NO,
+            Encryption::NO,
+            CipherMode::CTR,
+            "original".into(),
+        )
+        .to_bytes();
+        let raw = RawEntry(vec![
+            RawChunk::from_slice(ChunkType::FHED, &header),
+            RawChunk::from_slice(ChunkType::FEND, &[]),
+        ]);
+        let entry: NormalEntry<&[u8]> = raw.try_into().unwrap();
+
+        let renamed = entry.with_name("renamed".into());
+
+        assert_eq!(renamed.header().path().as_str(), "renamed");
+    }
+
+    #[test]
+    #[should_panic(expected = "renaming this entry would make its data undecryptable")]
+    fn with_name_panics_on_gcm_encrypted_entry() {
+        let options = WriteOptions::builder()
+            .encryption(Encryption::AES)
+            .cipher_mode(CipherMode::GCM)
+            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .password(Some("password"))
+            .build();
+        let mut builder =
+            FileEntryBuilder::new_with_options("dir/original".into(), &options).unwrap();
+        builder.write_all(b"secret payload").unwrap();
+        let entry = builder.build().unwrap();
+
+        let _ = entry.with_name("dir/renamed".into());
+    }
+
+    #[test]
+    fn try_with_name_refuses_gcm_encrypted_entry() {
+        let options = WriteOptions::builder()
+            .encryption(Encryption::AES)
+            .cipher_mode(CipherMode::GCM)
+            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .password(Some("password"))
+            .build();
+        let mut builder =
+            FileEntryBuilder::new_with_options("dir/original".into(), &options).unwrap();
+        builder.write_all(b"secret payload").unwrap();
+        let entry = builder.build().unwrap();
+
+        let err = entry.try_with_name("dir/renamed".into()).unwrap_err();
+        assert_eq!(io::ErrorKind::InvalidInput, err.kind());
+        assert!(err.to_string().contains("GCM"), "{err}");
+    }
+
+    #[test]
+    fn try_with_name_refuses_an_unsupported_cipher_mode() {
+        let mut entry = DirEntryBuilder::new("dir/original".into()).build().unwrap();
+        entry.header.encryption = Encryption::AES;
+        entry.header.cipher_mode = CipherMode::from_byte(3);
+
+        let err = entry.try_with_name("dir/renamed".into()).unwrap_err();
+        assert_eq!(io::ErrorKind::InvalidInput, err.kind());
+        assert!(err.to_string().contains("Reserved(3)"), "{err}");
+    }
+
+    #[test]
+    fn try_with_name_renames_cbc_entry() {
+        let options = WriteOptions::builder()
+            .encryption(Encryption::AES)
+            .cipher_mode(CipherMode::CBC)
+            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .password(Some("password"))
+            .build();
+        let mut builder =
+            FileEntryBuilder::new_with_options("dir/original".into(), &options).unwrap();
+        builder.write_all(b"secret payload").unwrap();
+        let entry = builder.build().unwrap();
+
+        let renamed = entry.try_with_name("dir/renamed".into()).unwrap();
+        assert_eq!(renamed.header().path().as_str(), "dir/renamed");
+        let mut reader = renamed
+            .reader(ReadOptions::with_password(Some("password")))
+            .unwrap();
+        let mut out = Vec::new();
+        reader.read_to_end(&mut out).unwrap();
+        assert_eq!(out, b"secret payload");
+    }
+
+    #[test]
+    fn cbc_entry_is_readable_after_rename() {
+        let options = WriteOptions::builder()
+            .encryption(Encryption::AES)
+            .cipher_mode(CipherMode::CBC)
+            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .password(Some("password"))
+            .build();
+        let mut builder =
+            FileEntryBuilder::new_with_options("dir/original".into(), &options).unwrap();
+        builder.write_all(b"secret payload").unwrap();
+        let entry = builder.build().unwrap();
+
+        let renamed = entry.with_name("dir/renamed".into());
+        let mut reader = renamed
+            .reader(ReadOptions::with_password(Some("password")))
+            .unwrap();
+        let mut out = Vec::new();
+        reader.read_to_end(&mut out).unwrap();
+        assert_eq!(out, b"secret payload");
     }
 
     #[test]

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -1149,7 +1149,7 @@ impl<T> NormalEntry<T> {
     #[inline]
     pub fn with_name(self, name: EntryName) -> Self {
         self.try_with_name(name)
-            .expect("renaming this entry would make its data undecryptable")
+            .unwrap_or_else(|_| panic!("renaming this entry would make its data undecryptable"))
     }
 
     /// Returns this entry with a new name, refusing renames that
@@ -1163,8 +1163,10 @@ impl<T> NormalEntry<T> {
     ///
     /// # Errors
     ///
-    /// Returns an error when the entry is encrypted in a cipher mode that does
-    /// not [allow a header rewrite](CipherMode::allows_header_rewrite).
+    /// Returns the entry unchanged when it is encrypted in a cipher mode that
+    /// does not [allow a header rewrite](CipherMode::allows_header_rewrite), so
+    /// that a caller can copy it verbatim or re-encrypt it instead of having to
+    /// ask whether the rename is possible beforehand.
     ///
     /// # Examples
     /// ```rust
@@ -1173,23 +1175,22 @@ impl<T> NormalEntry<T> {
     ///
     /// # fn main() -> io::Result<()> {
     /// let entry = DirEntryBuilder::new("original/path".into()).build()?;
-    /// let renamed = entry.try_with_name("new/path".into())?;
+    /// let Ok(renamed) = entry.try_with_name("new/path".into()) else {
+    ///     unreachable!("an unencrypted entry can always be renamed")
+    /// };
     /// assert_eq!(renamed.header().path().as_str(), "new/path");
     /// # Ok(())
     /// # }
     /// ```
+    // `result_large_err` guards against a large `Err` taxing the common `Ok`
+    // path, which cannot happen when both variants are the same type.
+    #[allow(clippy::result_large_err)]
     #[inline]
-    pub fn try_with_name(mut self, name: EntryName) -> io::Result<Self> {
+    pub fn try_with_name(mut self, name: EntryName) -> Result<Self, Self> {
         if self.header.encryption != Encryption::NO
             && !self.header.cipher_mode.allows_header_rewrite()
         {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!(
-                    "cannot rename an entry encrypted in cipher mode {:?}: only CBC and CTR derive keys independently of the entry header",
-                    self.header.cipher_mode
-                ),
-            ));
+            return Err(self);
         }
         self.header = self.header.with_name(name);
         Ok(self)
@@ -1651,9 +1652,9 @@ mod tests {
         builder.write_all(b"secret payload").unwrap();
         let entry = builder.build().unwrap();
 
-        let err = entry.try_with_name("dir/renamed".into()).unwrap_err();
-        assert_eq!(io::ErrorKind::InvalidInput, err.kind());
-        assert!(err.to_string().contains("GCM"), "{err}");
+        let refused = entry.try_with_name("dir/renamed".into()).unwrap_err();
+        assert_eq!(refused.header().path().as_str(), "dir/original");
+        assert_eq!(refused.header().cipher_mode(), CipherMode::GCM);
     }
 
     #[test]
@@ -1662,9 +1663,9 @@ mod tests {
         entry.header.encryption = Encryption::AES;
         entry.header.cipher_mode = CipherMode::from_byte(3);
 
-        let err = entry.try_with_name("dir/renamed".into()).unwrap_err();
-        assert_eq!(io::ErrorKind::InvalidInput, err.kind());
-        assert!(err.to_string().contains("Reserved(3)"), "{err}");
+        let refused = entry.try_with_name("dir/renamed".into()).unwrap_err();
+        assert_eq!(refused.header().path().as_str(), "dir/original");
+        assert_eq!(refused.header().cipher_mode(), CipherMode::from_byte(3));
     }
 
     #[test]

--- a/lib/src/entry/options.rs
+++ b/lib/src/entry/options.rs
@@ -660,6 +660,19 @@ impl CipherMode {
     pub const fn is_private(self) -> bool {
         self.0 >= 128
     }
+
+    /// Returns `true` if an entry's header can be rewritten without making its
+    /// encrypted data unreadable.
+    ///
+    /// [`CipherMode::GCM`] derives its stream key from the entry header bytes,
+    /// so rewriting the header — renaming the entry, for instance — leaves data
+    /// that no key can decrypt. Modes this build does not implement answer
+    /// `false`, so a caller that rewrites headers refuses rather than silently
+    /// destroying data.
+    #[inline]
+    pub const fn allows_header_rewrite(self) -> bool {
+        matches!(self, Self::CBC | Self::CTR)
+    }
 }
 
 impl fmt::Debug for CipherMode {
@@ -1831,6 +1844,23 @@ mod tests {
         assert!(!CipherMode::from_byte(128).is_reserved());
         assert!(CipherMode::from_byte(128).is_private());
         assert!(CipherMode::from_byte(255).is_private());
+    }
+
+    #[test]
+    fn allows_header_rewrite_only_for_cbc_and_ctr() {
+        assert!(CipherMode::CBC.allows_header_rewrite());
+        assert!(CipherMode::CTR.allows_header_rewrite());
+        assert!(!CipherMode::GCM.allows_header_rewrite());
+    }
+
+    #[test]
+    fn allows_header_rewrite_is_false_for_unassigned_cipher_modes() {
+        for byte in [3u8, 63, 128, 255] {
+            assert!(
+                !CipherMode::from_byte(byte).allows_header_rewrite(),
+                "byte={byte}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Renaming a cipher mode 2 (GCM) entry silently produced an undecryptable entry because the stream key is bound to the raw FHED bytes (#3283). `NormalEntry::try_with_name` now refuses such renames (returning an error) while `with_name` panics instead of silently corrupting data; `@archive` rename during archive copy now decrypts and re-encrypts with the source entry's algorithm and compression when a password is available, and fails otherwise.

## Notes

- A no-op rename (name unchanged) keeps the raw header bytes untouched, avoiding unnecessary re-encryption.
- Re-encryption `WriteOptions` are cached per (compression, encryption, cipher mode) so the KDF runs once per combination instead of per entry.
- Re-encryption uses the default Argon2id parameters, even when the source archive used stronger custom parameters; the original KDF parameters cannot be recovered from an already-encrypted entry.