### PR TITLE
:sparkles: Default to GCM cipher mode for new encrypted archives

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -346,8 +346,8 @@ impl CipherAlgorithmArgs {
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, ValueEnum)]
 pub(crate) enum CipherMode {
     Cbc,
-    #[default]
     Ctr,
+    #[default]
     Gcm,
 }
 
@@ -591,5 +591,23 @@ mod tests {
                 err.render()
             );
         }
+    }
+
+    /// `mode()` resolves the default in two separate arms. The one reached with
+    /// no algorithm flag at all is what `pna create --password …` takes, so it
+    /// carries most invocations, and nothing else exercises it.
+    #[test]
+    fn cipher_algorithm_args_default_to_gcm_when_no_mode_is_given() {
+        let flag_without_mode = CipherAlgorithmArgs {
+            aes: Some(None),
+            camellia: None,
+        };
+        let no_flag_at_all = CipherAlgorithmArgs {
+            aes: None,
+            camellia: None,
+        };
+
+        assert_eq!(flag_without_mode.mode(), pna::CipherMode::GCM);
+        assert_eq!(no_flag_at_all.mode(), pna::CipherMode::GCM);
     }
 }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -358,8 +358,8 @@ impl CipherAlgorithmArgs {
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default, ValueEnum)]
 pub(crate) enum CipherMode {
     Cbc,
-    #[default]
     Ctr,
+    #[default]
     Gcm,
 }
 
@@ -644,5 +644,23 @@ mod tests {
                 err.render()
             );
         }
+    }
+
+    /// `mode()` resolves the default in two separate arms: an algorithm flag
+    /// without a mode value, and no algorithm flag at all (the
+    /// `pna create --password …` path).
+    #[test]
+    fn cipher_algorithm_args_default_to_gcm_when_no_mode_is_given() {
+        let flag_without_mode = CipherAlgorithmArgs {
+            aes: Some(None),
+            camellia: None,
+        };
+        let no_flag_at_all = CipherAlgorithmArgs {
+            aes: None,
+            camellia: None,
+        };
+
+        assert_eq!(flag_without_mode.mode(), pna::CipherMode::GCM);
+        assert_eq!(no_flag_at_all.mode(), pna::CipherMode::GCM);
     }
 }

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -688,6 +688,31 @@ mod tests {
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
+    /// The cipher-mode byte carries no meaning for an unencrypted entry, but it
+    /// is on the wire, and the two builders deliberately disagree on it: the file
+    /// builder writes whatever the options report, while the link builders pin
+    /// CBC to match what their legacy constructors emitted. Changing either value
+    /// rewrites the `FHED` of every unencrypted entry already in the wild.
+    #[test]
+    fn unencrypted_entries_keep_their_cipher_mode_byte() {
+        let file = FileEntryBuilder::new_with_options("f".into(), WriteOptions::store())
+            .unwrap()
+            .build()
+            .unwrap();
+        let link = SymlinkEntryBuilder::new_with_options(
+            "l".into(),
+            EntryReference::from("target"),
+            WriteOptions::store(),
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+        // `FHED` data: major, minor, kind, compression, encryption, cipher_mode.
+        assert_eq!(&file.header().to_bytes()[4..6], &[0, 1], "unencrypted, CTR");
+        assert_eq!(&link.header().to_bytes()[4..6], &[0, 0], "unencrypted, CBC");
+    }
+
     #[test]
     fn entry_extra_chunk() {
         let mut builder = DirEntryBuilder::new("dir".into());

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -629,6 +629,32 @@ mod tests {
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
+    /// The cipher-mode byte carries no meaning for an unencrypted entry, but it
+    /// is on the wire, and the two builders deliberately disagree on it: the file
+    /// builder writes whatever the options report, while the link builders pin
+    /// CBC, the value they have always emitted. Changing either value diverges
+    /// the `FHED` bytes of new archives from every unencrypted entry already in
+    /// the wild.
+    #[test]
+    fn unencrypted_entries_keep_their_cipher_mode_byte() {
+        let file = FileEntryBuilder::new_with_options("f".into(), WriteOptions::store())
+            .unwrap()
+            .build()
+            .unwrap();
+        let link = SymlinkEntryBuilder::new_with_options(
+            "l".into(),
+            EntryReference::from("target"),
+            WriteOptions::store(),
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+        // `FHED` data: major, minor, kind, compression, encryption, cipher_mode.
+        assert_eq!(&file.header().to_bytes()[4..6], &[0, 1], "unencrypted, CTR");
+        assert_eq!(&link.header().to_bytes()[4..6], &[0, 0], "unencrypted, CBC");
+    }
+
     #[test]
     fn entry_extra_chunk() {
         let mut builder = DirEntryBuilder::new("dir".into());

--- a/lib/src/entry/options.rs
+++ b/lib/src/entry/options.rs
@@ -970,8 +970,10 @@ impl TryFrom<u8> for DataKind {
 /// - **Hash Algorithm**: Always use [`HashAlgorithm::argon2id()`] in production for password-based
 ///   encryption. [`HashAlgorithm::pbkdf2_sha256()`] is primarily for compatibility with older
 ///   systems or when Argon2 is not available.
-/// - **Cipher Mode**: CTR mode ([`CipherMode::CTR`]) is recommended over CBC for most use cases
-///   as it allows parallel processing and has simpler security requirements.
+/// - **Cipher Mode**: GCM ([`CipherMode::GCM`]) is the default and recommended mode: it
+///   authenticates the ciphertext, so tampering is detected instead of silently decrypting to
+///   garbage as with CBC/CTR. Use CBC/CTR only when interoperating with tools that require them;
+///   between the two, CTR is preferred over CBC.
 /// - **Per-Entry Randomness**: Each entry receives its own randomly generated encryption
 ///   material — an IV for CBC/CTR, or a salt and nonce prefix for GCM — generated using
 ///   cryptographically secure random number generation. You do not need to provide this yourself.
@@ -1007,7 +1009,7 @@ impl TryFrom<u8> for DataKind {
 ///
 /// let opts = WriteOptions::builder()
 ///     .encryption(Encryption::AES)
-///     .cipher_mode(CipherMode::CTR)
+///     .cipher_mode(CipherMode::GCM)
 ///     .hash_algorithm(HashAlgorithm::argon2id())
 ///     .password(Some("secure_password"))
 ///     .build();
@@ -1020,7 +1022,7 @@ impl TryFrom<u8> for DataKind {
 /// let opts = WriteOptions::builder()
 ///     .compression(Compression::ZSTANDARD)
 ///     .encryption(Encryption::AES)
-///     .cipher_mode(CipherMode::CTR)
+///     .cipher_mode(CipherMode::GCM)
 ///     .hash_algorithm(HashAlgorithm::argon2id())
 ///     .password(Some("secure_password"))
 ///     .build();
@@ -1086,16 +1088,23 @@ impl WriteOptions {
     }
 }
 
+const DEFAULT_CIPHER_MODE: CipherMode = CipherMode::GCM;
+const DEFAULT_HASH_ALGORITHM: HashAlgorithm = HashAlgorithm::argon2id();
+
 /// Builder for [`WriteOptions`].
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct WriteOptionsBuilder {
     compression: Compression,
     compression_level: CompressionLevel,
     encryption: Encryption,
-    cipher_mode: CipherMode,
-    hash_algorithm: HashAlgorithm,
+    /// `None` until a caller picks one, so that the default is resolved in one
+    /// place instead of being baked into every way of making a builder, and so
+    /// that an absence of choice stays absent across a round trip through
+    /// [`WriteOptions`] instead of becoming the fallback its accessors report.
+    cipher_mode: Option<CipherMode>,
+    hash_algorithm: Option<HashAlgorithm>,
     password: Option<Vec<u8>>,
-    segment_size: u32,
+    segment_size: Option<u32>,
 }
 
 impl Default for WriteOptionsBuilder {
@@ -1118,12 +1127,13 @@ impl From<WriteOptions> for WriteOptionsBuilder {
             compression,
             compression_level,
             encryption: value.encryption(),
-            cipher_mode: value.cipher_mode(),
-            hash_algorithm: value.hash_algorithm(),
+            // Unencrypted options carry nothing to inherit for these three, so
+            // leave the choice open rather than adopting the values they report
+            // — those are fallbacks, not decisions the caller made.
+            cipher_mode: value.cipher().map(|it| it.mode),
+            hash_algorithm: value.cipher().map(|it| it.hash_algorithm),
             password: value.password().map(|p| p.to_vec()),
-            segment_size: value
-                .cipher()
-                .map_or(DEFAULT_SEGMENT_SIZE, |it| it.segment_size.get()),
+            segment_size: value.cipher().map(|it| it.segment_size.get()),
         }
     }
 }
@@ -1134,10 +1144,10 @@ impl WriteOptionsBuilder {
             compression: Compression::NO,
             compression_level: CompressionLevel::DEFAULT,
             encryption: Encryption::NO,
-            cipher_mode: CipherMode::CTR,
-            hash_algorithm: HashAlgorithm::argon2id(),
+            cipher_mode: None,
+            hash_algorithm: None,
             password: None,
-            segment_size: DEFAULT_SEGMENT_SIZE,
+            segment_size: None,
         }
     }
 
@@ -1165,14 +1175,14 @@ impl WriteOptionsBuilder {
     /// Sets the [`CipherMode`].
     #[inline]
     pub fn cipher_mode(&mut self, cipher_mode: CipherMode) -> &mut Self {
-        self.cipher_mode = cipher_mode;
+        self.cipher_mode = Some(cipher_mode);
         self
     }
 
     /// Sets the [`HashAlgorithm`].
     #[inline]
     pub fn hash_algorithm(&mut self, algorithm: HashAlgorithm) -> &mut Self {
-        self.hash_algorithm = algorithm;
+        self.hash_algorithm = Some(algorithm);
         self
     }
 
@@ -1201,7 +1211,7 @@ impl WriteOptionsBuilder {
     #[cfg(test)]
     #[inline]
     pub(crate) fn segment_size(&mut self, size: u32) -> &mut Self {
-        self.segment_size = size;
+        self.segment_size = Some(size);
         self
     }
 
@@ -1254,20 +1264,21 @@ impl WriteOptionsBuilder {
             let password = self.password.as_deref().ok_or_else(|| {
                 io::Error::new(io::ErrorKind::InvalidInput, "Password was not provided.")
             })?;
-            let segment_size = SegmentSize::new(self.segment_size).ok_or_else(|| {
+            let requested = self.segment_size.unwrap_or(DEFAULT_SEGMENT_SIZE);
+            let segment_size = SegmentSize::new(requested).ok_or_else(|| {
                 io::Error::new(
                     io::ErrorKind::InvalidInput,
-                    format!("segment size out of range: {}", self.segment_size),
+                    format!("segment size out of range: {requested}"),
                 )
             })?;
-            let hash_algorithm = self.hash_algorithm;
+            let hash_algorithm = self.hash_algorithm.unwrap_or(DEFAULT_HASH_ALGORITHM);
             let derived = derive_key_material(cipher_algorithm, hash_algorithm, password)?;
             Some(Cipher::new(
                 password.into(),
                 derived,
                 hash_algorithm,
                 cipher_algorithm,
-                self.cipher_mode,
+                self.cipher_mode.unwrap_or(DEFAULT_CIPHER_MODE),
                 segment_size,
             ))
         } else {
@@ -1534,6 +1545,61 @@ mod tests {
     fn cipher_mode_gcm_roundtrips_through_byte() {
         let byte = CipherMode::GCM.to_byte();
         assert_eq!(CipherMode::from_byte(byte), CipherMode::GCM);
+    }
+
+    #[test]
+    fn default_cipher_mode_is_gcm() {
+        let options = WriteOptions::builder()
+            .encryption(Encryption::AES)
+            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .password(Some("password"))
+            .try_build()
+            .unwrap();
+        assert_eq!(options.cipher_mode(), CipherMode::GCM);
+    }
+
+    #[test]
+    fn explicit_hash_algorithm_is_preserved() {
+        let options = WriteOptions::builder()
+            .encryption(Encryption::AES)
+            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .password(Some("password"))
+            .try_build()
+            .unwrap();
+        assert_eq!(
+            options.hash_algorithm(),
+            HashAlgorithm::pbkdf2_sha256_with(Some(1))
+        );
+    }
+
+    #[test]
+    fn into_builder_of_unencrypted_options_keeps_the_default_cipher_mode() {
+        let options = WriteOptions::store()
+            .into_builder()
+            .encryption(Encryption::AES)
+            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .password(Some("password"))
+            .try_build()
+            .unwrap();
+        assert_eq!(options.cipher_mode(), CipherMode::GCM);
+    }
+
+    #[test]
+    fn into_builder_preserves_an_explicit_cipher_mode() {
+        let options = WriteOptions::builder()
+            .encryption(Encryption::AES)
+            .cipher_mode(CipherMode::CTR)
+            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .password(Some("password"))
+            .try_build()
+            .unwrap();
+        let rebuilt = options.into_builder().try_build().unwrap();
+        assert_eq!(rebuilt.cipher_mode(), CipherMode::CTR);
+    }
+
+    #[test]
+    fn unencrypted_options_report_the_ctr_cipher_mode() {
+        assert_eq!(WriteOptions::store().cipher_mode(), CipherMode::CTR);
     }
 
     fn test_output(byte: u8) -> Output {

--- a/lib/src/entry/options.rs
+++ b/lib/src/entry/options.rs
@@ -970,8 +970,10 @@ impl TryFrom<u8> for DataKind {
 /// - **Hash Algorithm**: Always use [`HashAlgorithm::argon2id()`] in production for password-based
 ///   encryption. [`HashAlgorithm::pbkdf2_sha256()`] is primarily for compatibility with older
 ///   systems or when Argon2 is not available.
-/// - **Cipher Mode**: CTR mode ([`CipherMode::CTR`]) is recommended over CBC for most use cases
-///   as it allows parallel processing and has simpler security requirements.
+/// - **Cipher Mode**: GCM ([`CipherMode::GCM`]) is the default and recommended mode: it
+///   authenticates the ciphertext, so tampering is detected instead of silently decrypting to
+///   garbage as with CBC/CTR. Use CBC/CTR only when interoperating with tools that require them;
+///   between the two, CTR is preferred over CBC.
 /// - **Per-Entry Randomness**: Each entry receives its own randomly generated encryption
 ///   material — an IV for CBC/CTR, or a salt and nonce prefix for GCM — generated using
 ///   cryptographically secure random number generation. You do not need to provide this yourself.
@@ -1007,7 +1009,7 @@ impl TryFrom<u8> for DataKind {
 ///
 /// let opts = WriteOptions::builder()
 ///     .encryption(Encryption::AES)
-///     .cipher_mode(CipherMode::CTR)
+///     .cipher_mode(CipherMode::GCM)
 ///     .hash_algorithm(HashAlgorithm::argon2id())
 ///     .password(Some("secure_password"))
 ///     .build();
@@ -1020,7 +1022,7 @@ impl TryFrom<u8> for DataKind {
 /// let opts = WriteOptions::builder()
 ///     .compression(Compression::ZSTANDARD)
 ///     .encryption(Encryption::AES)
-///     .cipher_mode(CipherMode::CTR)
+///     .cipher_mode(CipherMode::GCM)
 ///     .hash_algorithm(HashAlgorithm::argon2id())
 ///     .password(Some("secure_password"))
 ///     .build();
@@ -1086,16 +1088,19 @@ impl WriteOptions {
     }
 }
 
+const DEFAULT_CIPHER_MODE: CipherMode = CipherMode::GCM;
+const DEFAULT_HASH_ALGORITHM: HashAlgorithm = HashAlgorithm::argon2id();
+
 /// Builder for [`WriteOptions`].
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct WriteOptionsBuilder {
     compression: Compression,
     compression_level: CompressionLevel,
     encryption: Encryption,
-    cipher_mode: CipherMode,
-    hash_algorithm: HashAlgorithm,
+    cipher_mode: Option<CipherMode>,
+    hash_algorithm: Option<HashAlgorithm>,
     password: Option<Vec<u8>>,
-    segment_size: u32,
+    segment_size: Option<u32>,
 }
 
 impl Default for WriteOptionsBuilder {
@@ -1118,12 +1123,13 @@ impl From<WriteOptions> for WriteOptionsBuilder {
             compression,
             compression_level,
             encryption: value.encryption(),
-            cipher_mode: value.cipher_mode(),
-            hash_algorithm: value.hash_algorithm(),
+            // Unencrypted options carry nothing to inherit for these three, so
+            // leave the choice open rather than adopting the values they report
+            // — those are fallbacks, not decisions the caller made.
+            cipher_mode: value.cipher().map(|it| it.mode),
+            hash_algorithm: value.cipher().map(|it| it.hash_algorithm),
             password: value.password().map(|p| p.to_vec()),
-            segment_size: value
-                .cipher()
-                .map_or(DEFAULT_SEGMENT_SIZE, |it| it.segment_size.get()),
+            segment_size: value.cipher().map(|it| it.segment_size.get()),
         }
     }
 }
@@ -1134,10 +1140,10 @@ impl WriteOptionsBuilder {
             compression: Compression::NO,
             compression_level: CompressionLevel::DEFAULT,
             encryption: Encryption::NO,
-            cipher_mode: CipherMode::CTR,
-            hash_algorithm: HashAlgorithm::argon2id(),
+            cipher_mode: None,
+            hash_algorithm: None,
             password: None,
-            segment_size: DEFAULT_SEGMENT_SIZE,
+            segment_size: None,
         }
     }
 
@@ -1165,14 +1171,14 @@ impl WriteOptionsBuilder {
     /// Sets the [`CipherMode`].
     #[inline]
     pub fn cipher_mode(&mut self, cipher_mode: CipherMode) -> &mut Self {
-        self.cipher_mode = cipher_mode;
+        self.cipher_mode = Some(cipher_mode);
         self
     }
 
     /// Sets the [`HashAlgorithm`].
     #[inline]
     pub fn hash_algorithm(&mut self, algorithm: HashAlgorithm) -> &mut Self {
-        self.hash_algorithm = algorithm;
+        self.hash_algorithm = Some(algorithm);
         self
     }
 
@@ -1201,7 +1207,7 @@ impl WriteOptionsBuilder {
     #[cfg(test)]
     #[inline]
     pub(crate) fn segment_size(&mut self, size: u32) -> &mut Self {
-        self.segment_size = size;
+        self.segment_size = Some(size);
         self
     }
 
@@ -1254,20 +1260,21 @@ impl WriteOptionsBuilder {
             let password = self.password.as_deref().ok_or_else(|| {
                 io::Error::new(io::ErrorKind::InvalidInput, "Password was not provided.")
             })?;
-            let segment_size = SegmentSize::new(self.segment_size).ok_or_else(|| {
+            let requested = self.segment_size.unwrap_or(DEFAULT_SEGMENT_SIZE);
+            let segment_size = SegmentSize::new(requested).ok_or_else(|| {
                 io::Error::new(
                     io::ErrorKind::InvalidInput,
-                    format!("segment size out of range: {}", self.segment_size),
+                    format!("segment size out of range: {requested}"),
                 )
             })?;
-            let hash_algorithm = self.hash_algorithm;
+            let hash_algorithm = self.hash_algorithm.unwrap_or(DEFAULT_HASH_ALGORITHM);
             let derived = derive_key_material(cipher_algorithm, hash_algorithm, password)?;
             Some(Cipher::new(
                 password.into(),
                 derived,
                 hash_algorithm,
                 cipher_algorithm,
-                self.cipher_mode,
+                self.cipher_mode.unwrap_or(DEFAULT_CIPHER_MODE),
                 segment_size,
             ))
         } else {
@@ -1518,6 +1525,47 @@ mod tests {
     #[should_panic(expected = "Password was not provided.")]
     fn build_without_password_panics() {
         let _ = WriteOptions::builder().encryption(Encryption::AES).build();
+    }
+
+    #[test]
+    fn default_cipher_mode_is_gcm() {
+        let options = WriteOptions::builder()
+            .encryption(Encryption::AES)
+            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
+            .password(Some("password"))
+            .try_build()
+            .unwrap();
+        assert_eq!(options.cipher_mode(), CipherMode::GCM);
+        assert_eq!(
+            options.hash_algorithm(),
+            HashAlgorithm::pbkdf2_sha256_with(Some(1000))
+        );
+    }
+
+    #[test]
+    fn into_builder_of_unencrypted_options_keeps_the_default_cipher_mode() {
+        assert_eq!(WriteOptions::store().cipher_mode(), CipherMode::CTR);
+        let options = WriteOptions::store()
+            .into_builder()
+            .encryption(Encryption::AES)
+            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
+            .password(Some("password"))
+            .try_build()
+            .unwrap();
+        assert_eq!(options.cipher_mode(), CipherMode::GCM);
+    }
+
+    #[test]
+    fn into_builder_preserves_an_explicit_cipher_mode() {
+        let options = WriteOptions::builder()
+            .encryption(Encryption::AES)
+            .cipher_mode(CipherMode::CTR)
+            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
+            .password(Some("password"))
+            .try_build()
+            .unwrap();
+        let rebuilt = options.into_builder().try_build().unwrap();
+        assert_eq!(rebuilt.cipher_mode(), CipherMode::CTR);
     }
 
     fn test_output(byte: u8) -> Output {

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -71,11 +71,11 @@
 //!     .compression(Compression::ZSTANDARD)
 //!     .build();
 //!
-//! // Encrypted entry (AES-256-CTR with Argon2id key derivation)
+//! // Encrypted entry (AES-256-GCM with Argon2id key derivation)
 //! let encrypted = WriteOptions::builder()
 //!     .compression(Compression::ZSTANDARD)
 //!     .encryption(Encryption::AES)
-//!     .cipher_mode(CipherMode::CTR)
+//!     .cipher_mode(CipherMode::GCM)
 //!     .hash_algorithm(HashAlgorithm::argon2id())
 //!     .password(Some("secure_password"))
 //!     .build();


### PR DESCRIPTION
Stacked on #3193 (which is stacked on #3192).

## Summary

Switch the default cipher mode for newly created encrypted archives from `ctr` to `gcm` (both the CLI default and `WriteOptionsBuilder`), per the spec recommendation that new encrypted archives should use authenticated encryption.

## Notes

- Archives encrypted with defaults can no longer be read by pna versions without GCM support. `--aes ctr` / `--aes cbc` restores the previous format.
- Default password encryption becomes slower and more memory-hungry: with a fully-defaulted Argon2id, GCM applies the spec KDF profile (t=3, m=64 MiB, p=4) instead of the previous t=2, m=19 MiB, p=1. Explicit `--argon2`/`--pbkdf2` parameters are unaffected.
- Single-concern commit so the default switch can be reverted independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Encryption now defaults to AES-256-GCM when no cipher mode is specified.
  - Explicitly selected algorithms consistently use GCM by default.

- **Bug Fixes**
  - Improved handling of unencrypted files and symlinks to preserve their expected encryption metadata.
  - Encryption settings now retain explicitly selected hash algorithms and cipher modes correctly.

- **Documentation**
  - Updated encryption examples to demonstrate AES-256-GCM instead of AES-256-CTR.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->