### PR TITLE
:boom: Require password when encryption options are given

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -300,7 +300,7 @@ impl CompressionAlgorithmArgs {
 }
 
 #[derive(Parser, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[command(group(ArgGroup::new("cipher_algorithm").args(["aes", "camellia"])))]
+#[command(group(ArgGroup::new("cipher_algorithm").args(["aes", "camellia"]).requires("password_provider")))]
 pub(crate) struct CipherAlgorithmArgs {
     #[arg(long, value_name = "cipher mode", help = "Use aes for encryption")]
     pub(crate) aes: Option<Option<CipherMode>>,
@@ -338,7 +338,7 @@ pub(crate) enum CipherMode {
 }
 
 #[derive(Parser, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[command(group(ArgGroup::new("hash_algorithm").args(["argon2", "pbkdf2"])))]
+#[command(group(ArgGroup::new("hash_algorithm").args(["argon2", "pbkdf2"]).requires("password_provider")))]
 pub(crate) struct HashAlgorithmArgs {
     #[arg(long, value_name = "PARAMS", help = "Use argon2 for password hashing")]
     argon2: Option<Option<Argon2idParams>>,

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -453,4 +453,74 @@ mod tests {
             Cli::try_parse_from(["pna", "--log-level", "debug", "list", "-f", "a.pna"]).unwrap();
         assert_eq!(cli.global.verbosity.log_level_filter(), LevelFilter::Debug);
     }
+
+    #[test]
+    fn cipher_or_kdf_without_password_is_rejected() {
+        for args in [
+            vec!["pna", "c", "-f", "a.pna", "src", "--aes"],
+            vec!["pna", "c", "-f", "a.pna", "src", "--camellia"],
+            vec!["pna", "c", "-f", "a.pna", "src", "--argon2"],
+            vec!["pna", "c", "-f", "a.pna", "src", "--pbkdf2"],
+            vec!["pna", "c", "-f", "a.pna", "src", "--aes", "--argon2"],
+            vec!["pna", "a", "-f", "a.pna", "src", "--aes"],
+            vec![
+                "pna",
+                "experimental",
+                "update",
+                "-f",
+                "a.pna",
+                "src",
+                "--aes",
+            ],
+            vec![
+                "pna", "compat", "bsdtar", "-c", "-f", "out.pna", "src", "--aes",
+            ],
+        ] {
+            let err = Cli::try_parse_from(&args).unwrap_err();
+            assert_eq!(
+                err.kind(),
+                clap::error::ErrorKind::MissingRequiredArgument,
+                "args {args:?} produced unexpected error kind: {}",
+                err.render()
+            );
+        }
+    }
+
+    #[test]
+    fn cipher_or_kdf_with_password_is_accepted() {
+        for args in [
+            vec![
+                "pna",
+                "c",
+                "-f",
+                "a.pna",
+                "src",
+                "--aes",
+                "--password=secret",
+            ],
+            vec!["pna", "c", "-f", "a.pna", "src", "--aes", "--password"],
+            vec![
+                "pna",
+                "c",
+                "-f",
+                "a.pna",
+                "src",
+                "--aes",
+                "--password-file",
+                "pw.txt",
+            ],
+            vec![
+                "pna",
+                "c",
+                "-f",
+                "a.pna",
+                "src",
+                "--argon2",
+                "--password=secret",
+            ],
+            vec!["pna", "c", "-f", "a.pna", "src", "--password=secret"],
+        ] {
+            Cli::try_parse_from(&args).unwrap_or_else(|e| panic!("args {args:?} rejected: {e}"));
+        }
+    }
 }

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -23,7 +23,7 @@ pub mod update;
 pub(crate) mod verify;
 pub mod xattr;
 
-use crate::cli::{CipherAlgorithmArgs, Cli, Commands, GlobalContext, PasswordArgs};
+use crate::cli::{Cli, Commands, GlobalContext, PasswordArgs};
 use std::{fs, io};
 
 fn ask_password(args: PasswordArgs) -> io::Result<Option<Vec<u8>>> {
@@ -42,19 +42,6 @@ fn ask_password(args: PasswordArgs) -> io::Result<Option<Vec<u8>>> {
         ),
         None => None,
     })
-}
-
-fn check_password(password: &Option<Vec<u8>>, cipher_args: &CipherAlgorithmArgs) {
-    if password.is_some() {
-        return;
-    }
-    if cipher_args.aes.is_some() {
-        log::warn!("Using `--aes` option but, `--password` was not provided. It will not encrypt.");
-    } else if cipher_args.camellia.is_some() {
-        log::warn!(
-            "Using `--camellia` option but, `--password` was not provided. It will not encrypt."
-        );
-    }
 }
 
 pub(crate) trait Command {

--- a/cli/src/command/append.rs
+++ b/cli/src/command/append.rs
@@ -4,7 +4,7 @@ use crate::{
         MissingTimePolicy, PasswordArgs,
     },
     command::{
-        Command, ask_password, check_password,
+        Command, ask_password,
         core::{
             AclStrategy, CollectOptions, CollectedItem, CreateOptions, FflagsStrategy, KeepOptions,
             MacMetadataStrategy, PathFilter, PathTransformers, PathnameEditor,
@@ -379,7 +379,6 @@ impl Command for AppendCommand {
 #[hooq::hooq(anyhow)]
 fn append_to_archive(args: AppendCommand) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
-    check_password(&password, &args.cipher);
     let archive_path = args.file.archive;
     if !archive_path.exists() {
         anyhow::bail!("{} is not exists", archive_path.display());

--- a/cli/src/command/bsdtar.rs
+++ b/cli/src/command/bsdtar.rs
@@ -6,7 +6,7 @@ use crate::{
     command::{
         Command,
         append::{open_archive_then_seek_to_end, run_append_archive},
-        ask_password, check_password,
+        ask_password,
         core::{
             AclStrategy, CollectOptions, CreateOptions, FflagsStrategy, ItemSource, KeepOptions,
             MacMetadataStrategy, ModeStrategy, OwnerOptions, OwnerStrategy, PathFilter,
@@ -872,7 +872,6 @@ impl ExtractionPermissionStrategyResolver {
 fn run_create_archive(args: BsdtarCommand) -> anyhow::Result<()> {
     let current_dir = env::current_dir()?;
     let password = ask_password(args.password)?;
-    check_password(&password, &args.cipher);
     // NOTE: "-" will use stdout
     let mut file = args.file;
     file.take_if(|it| it == "-");
@@ -1264,7 +1263,6 @@ fn run_list_archive(args: BsdtarCommand) -> anyhow::Result<()> {
 fn run_append(args: BsdtarCommand) -> anyhow::Result<()> {
     let current_dir = env::current_dir()?;
     let password = ask_password(args.password)?;
-    check_password(&password, &args.cipher);
     let password = password.as_deref();
     let option = build_write_options(
         &args.compression,
@@ -1427,7 +1425,6 @@ fn resolve_name_id(
 fn run_update(args: BsdtarCommand) -> anyhow::Result<()> {
     let current_dir = env::current_dir()?;
     let password = ask_password(args.password)?;
-    check_password(&password, &args.cipher);
     let password = password.as_deref();
     let option = build_write_options(
         &args.compression,

--- a/cli/src/command/create.rs
+++ b/cli/src/command/create.rs
@@ -4,7 +4,7 @@ use crate::{
         MissingTimePolicy, PasswordArgs,
     },
     command::{
-        Command, ask_password, check_password,
+        Command, ask_password,
         core::{
             AclStrategy, CollectOptions, CollectedItem, CreateOptions, EntryResult, FflagsStrategy,
             KeepOptions, MIN_SPLIT_PART_BYTES, MacMetadataStrategy, PathFilter, PathTransformers,
@@ -404,7 +404,6 @@ impl Command for CreateCommand {
 fn create_archive(args: CreateCommand) -> anyhow::Result<()> {
     let current_dir = env::current_dir()?;
     let password = ask_password(args.password)?;
-    check_password(&password, &args.cipher);
     let start = Instant::now();
     let archive = &args.file.archive;
     let max_file_size = args

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -5,7 +5,7 @@ use crate::{
         SolidEntriesTransformStrategyArgs,
     },
     command::{
-        Command, ask_password, check_password,
+        Command, ask_password,
         core::{
             AclStrategy, CollectOptions, CollectedEntry, CreateOptions, FflagsStrategy,
             KeepOptions, MacMetadataStrategy, PathFilter, PathTransformers, PathnameEditor,
@@ -405,7 +405,6 @@ fn update_archive(args: UpdateCommand) -> anyhow::Result<()> {
     let sync = args.sync;
     let current_dir = env::current_dir()?;
     let password = ask_password(args.password)?;
-    check_password(&password, &args.cipher);
     let archive_path = &args.file.archive;
     if !archive_path.exists() {
         anyhow::bail!("{} is not exists", archive_path.display());


### PR DESCRIPTION
## Summary
Reject encryption-related options (`--aes`, `--camellia`, `--argon2`, `--pbkdf2`) at argument-parse time when no password source (`--password` / `--password-file`) is given. Previously `--aes`/`--camellia` only logged a warning and produced a plaintext archive, and `--argon2`/`--pbkdf2` were silently ignored.

## Notes
- Breaking change to the stable CLI surface: invocations that previously warned and succeeded now fail with a parse error naming both password options. Applies to `create`, `append`, `experimental update`, and `compat bsdtar` (the flags are pna-specific extensions, so bsdtar compatibility is unaffected).
- Bare `--password` (interactive prompt) still satisfies the requirement, and `--password` without cipher options keeps encrypting with the default algorithm.
- The now-dead `check_password` runtime warning is removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI validation for encryption and password-hashing options.
  * Selecting an encryption algorithm or key-derivation method without a password source now reports a clear missing-argument error.
  * Password-based archive creation, appending, and updating now proceed consistently when a password is supplied.

* **Tests**
  * Added coverage for rejected configurations without passwords and successful configurations with password providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->