### PR TITLE
Add EntryContent decoded view for NormalEntry

### DIFF
--- a/cli/src/command/diff.rs
+++ b/cli/src/command/diff.rs
@@ -10,7 +10,7 @@ use crate::{
 use clap::Parser;
 #[cfg(unix)]
 use pna::prelude::MetadataTimeExt;
-use pna::{DataKind, NormalEntry, ReadOptions};
+use pna::{DataKind, EntryContent, NormalEntry, ReadOptions};
 use same_file::is_same_file;
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
@@ -18,11 +18,7 @@ use std::os::unix::fs::MetadataExt;
 use std::os::unix::fs::PermissionsExt;
 #[cfg(unix)]
 use std::time::SystemTime;
-use std::{
-    fmt, fs,
-    io::{self, prelude::*},
-    path::Path,
-};
+use std::{fmt, fs, io, path::Path};
 
 #[derive(Parser, Clone, Debug)]
 pub(crate) struct DiffCommand {
@@ -313,10 +309,10 @@ fn compare_entry<T: AsRef<[u8]>>(
         }
         DataKind::SymbolicLink if meta.is_symlink() => {
             let link = fs::read_link(path)?;
-            let mut reader = entry.reader(read_options)?;
-            let mut link_str = String::new();
-            reader.read_to_string(&mut link_str)?;
-            if link.as_path() != Path::new(&link_str) {
+            let EntryContent::SymbolicLink(stored) = entry.content(read_options)? else {
+                unreachable!("data_kind() returned SymbolicLink");
+            };
+            if link.as_path() != Path::new(stored.as_str()) {
                 println!("{}", DiffKind::SymlinkDiffers.display(path_str));
             }
         }
@@ -324,14 +320,16 @@ fn compare_entry<T: AsRef<[u8]>>(
             println!("{}", DiffKind::TypeMismatch.display(path_str));
         }
         DataKind::HardLink if meta.is_file() => {
-            let mut reader = entry.reader(read_options)?;
-            let mut target = String::new();
-            reader.read_to_string(&mut target)?;
-
-            match is_same_file(path, &target) {
+            let EntryContent::HardLink(stored) = entry.content(read_options)? else {
+                unreachable!("data_kind() returned HardLink");
+            };
+            match is_same_file(path, stored.as_str()) {
                 Ok(true) => (),
                 Ok(false) => {
-                    println!("{}", DiffKind::NotLinked(target).display(path_str));
+                    println!(
+                        "{}",
+                        DiffKind::NotLinked(stored.to_string()).display(path_str)
+                    );
                 }
                 Err(e) if e.kind() == io::ErrorKind::NotFound => {
                     println!("{}", DiffKind::Missing.display(path_str));

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -27,7 +27,8 @@ use crate::{
 use anyhow::Context;
 use clap::{ArgGroup, Parser, ValueHint};
 use pna::{
-    DataKind, EntryName, EntryReference, LinkTargetType, NormalEntry, ReadOptions, prelude::*,
+    DataKind, EntryContent, EntryName, EntryReference, LinkTargetType, NormalEntry, ReadOptions,
+    prelude::*,
 };
 #[cfg(target_os = "macos")]
 use std::os::macos::fs::FileTimesExt;
@@ -1393,11 +1394,9 @@ where
         return Ok(());
     };
 
-    match item.header().data_kind() {
-        DataKind::SymbolicLink => {
-            let reader = item.reader(read_options)?;
-            let original = io::read_to_string(reader)?;
-            let original = pathname_editor.edit_symlink(original.as_ref());
+    match item.content(read_options)? {
+        EntryContent::SymbolicLink(stored) => {
+            let original = pathname_editor.edit_symlink(Path::new(stored.as_str()));
             if !allow_unsafe_links && is_unsafe_link(&original) {
                 log::warn!(
                     "Skipped extracting a symbolic link that contains an unsafe link. If you need to extract it, use `--allow-unsafe-links`."
@@ -1410,14 +1409,13 @@ where
             let link_target_type = item.metadata().link_target_type();
             symlink_with_type(&original, &path, link_target_type)?;
         }
-        DataKind::HardLink => {
-            let reader = item.reader(read_options)?;
-            let original = io::read_to_string(reader)?;
-            let Some((original, had_root)) = pathname_editor.edit_hardlink(original.as_ref())
+        EntryContent::HardLink(stored) => {
+            let Some((original, had_root)) =
+                pathname_editor.edit_hardlink(Path::new(stored.as_str()))
             else {
                 log::warn!(
                     "Skipped extracting a hard link that pointed at a file which was skipped.: {}",
-                    original
+                    stored
                 );
                 return Ok(());
             };
@@ -1440,7 +1438,7 @@ where
             }
             fs::hard_link(original, &path)?;
         }
-        kind => unreachable!("extract_link_entry called with {kind:?}"),
+        content => unreachable!("extract_link_entry called with {content:?}"),
     }
 
     restore_metadata(&item, &path, keep_options)?;

--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -18,8 +18,8 @@ use clap::{
 };
 use jiff::{Timestamp, Zoned, tz::TimeZone};
 use pna::{
-    Compression, DataKind, Encryption, ExtendedAttribute, NormalEntry, RawChunk, ReadEntry,
-    ReadOptions, SolidHeader, prelude::*,
+    Compression, DataKind, Encryption, EntryContent, ExtendedAttribute, NormalEntry, RawChunk,
+    ReadEntry, ReadOptions, SolidHeader, prelude::*,
 };
 use rayon::prelude::*;
 use serde::Serialize;
@@ -420,10 +420,10 @@ impl TableRow {
                     entry.name().to_string(),
                     // Only read link target if needed (requires decompression)
                     if collect.link_target {
-                        entry
-                            .reader(read_options)
-                            .and_then(io::read_to_string)
-                            .unwrap_or_else(|_| "-".into())
+                        match entry.content(read_options) {
+                            Ok(EntryContent::SymbolicLink(target)) => target.to_string(),
+                            _ => "-".into(),
+                        }
                     } else {
                         String::new()
                     },
@@ -432,10 +432,10 @@ impl TableRow {
                     entry.name().to_string(),
                     // Only read link target if needed (requires decompression)
                     if collect.link_target {
-                        entry
-                            .reader(read_options)
-                            .and_then(io::read_to_string)
-                            .unwrap_or_else(|_| "-".into())
+                        match entry.content(read_options) {
+                            Ok(EntryContent::HardLink(target)) => target.to_string(),
+                            _ => "-".into(),
+                        }
                     } else {
                         String::new()
                     },

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -2,6 +2,7 @@
 
 mod attr;
 mod builder;
+mod content;
 mod header;
 mod meta;
 mod name;
@@ -13,6 +14,7 @@ mod write;
 pub use self::{
     attr::*,
     builder::{EntryBuilder, SolidEntryBuilder},
+    content::*,
     header::*,
     meta::*,
     name::*,

--- a/lib/src/entry/content.rs
+++ b/lib/src/entry/content.rs
@@ -1,0 +1,210 @@
+//! Decoded view of entry data.
+
+use super::*;
+use std::fmt;
+
+/// Decoded content of a [`NormalEntry`], interpreted according to its
+/// [`DataKind`].
+///
+/// Returned by [`NormalEntry::content`]. Link targets are decoded eagerly;
+/// file contents and unknown kinds are exposed as streaming readers.
+///
+/// # Examples
+///
+/// ```rust
+/// use libpna::{EntryBuilder, EntryContent, EntryName, ReadOptions, WriteOptions};
+/// use std::io::{self, Write};
+///
+/// # fn main() -> io::Result<()> {
+/// let mut builder = EntryBuilder::new_file(EntryName::try_from("f.txt").unwrap(), WriteOptions::store())?;
+/// builder.write_all(b"abc")?;
+/// let entry = builder.build()?;
+/// match entry.content(ReadOptions::builder().build())? {
+///     EntryContent::File(reader) => assert_eq!("abc", io::read_to_string(reader)?),
+///     _ => unreachable!(),
+/// }
+/// # Ok(())
+/// # }
+/// ```
+#[non_exhaustive]
+pub enum EntryContent<'a> {
+    /// Regular file. Streaming reader over the decoded file contents.
+    File(EntryDataReader<'a>),
+    /// Directory. Directories carry no content.
+    Directory,
+    /// Symbolic link. Decoded link target.
+    SymbolicLink(EntryReference),
+    /// Hard link. Decoded path of the target entry within the same archive.
+    HardLink(EntryReference),
+    /// Reserved or private kind. Streaming reader over the decoded raw
+    /// bytes; interpretation is left to the caller.
+    Unknown(DataKind, EntryDataReader<'a>),
+}
+
+impl fmt::Debug for EntryContent<'_> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::File(_) => f.debug_tuple("File").finish(),
+            Self::Directory => f.write_str("Directory"),
+            Self::SymbolicLink(r) => f.debug_tuple("SymbolicLink").field(r).finish(),
+            Self::HardLink(r) => f.debug_tuple("HardLink").field(r).finish(),
+            Self::Unknown(kind, _) => f.debug_tuple("Unknown").field(kind).finish(),
+        }
+    }
+}
+
+fn read_reference(reader: EntryDataReader<'_>) -> io::Result<EntryReference> {
+    let target = io::read_to_string(reader)?;
+    Ok(EntryReference::from_utf8_preserve_root(&target))
+}
+
+impl<T: AsRef<[u8]>> NormalEntry<T> {
+    /// Decodes this entry's data according to its [`DataKind`].
+    ///
+    /// Directories never touch the entry data, so they decode without a
+    /// password even when the entry is encrypted. Link targets are read,
+    /// validated as UTF-8, and restored without sanitization, preserving
+    /// the exact target recorded at write time.
+    ///
+    /// # Errors
+    ///
+    /// Propagates errors from [`NormalEntry::reader`] (e.g. a missing or
+    /// wrong password). Returns [`io::ErrorKind::InvalidData`] if a link
+    /// target is not valid UTF-8.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use libpna::{EntryBuilder, EntryContent, EntryName, EntryReference, ReadOptions};
+    ///
+    /// # fn main() -> std::io::Result<()> {
+    /// let entry = EntryBuilder::new_symlink(
+    ///     EntryName::try_from("path/of/link").unwrap(),
+    ///     EntryReference::try_from("path/of/target").unwrap(),
+    /// )?
+    /// .build()?;
+    /// match entry.content(ReadOptions::builder().build())? {
+    ///     EntryContent::SymbolicLink(target) => assert_eq!("path/of/target", target),
+    ///     _ => unreachable!(),
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn content(&self, option: impl ReadOption) -> io::Result<EntryContent<'_>> {
+        match self.header.data_kind {
+            DataKind::File => Ok(EntryContent::File(self.reader(option)?)),
+            DataKind::Directory => Ok(EntryContent::Directory),
+            DataKind::SymbolicLink => Ok(EntryContent::SymbolicLink(read_reference(
+                self.reader(option)?,
+            )?)),
+            DataKind::HardLink => Ok(EntryContent::HardLink(read_reference(
+                self.reader(option)?,
+            )?)),
+            kind @ (DataKind::Reserved(_) | DataKind::Private(_)) => {
+                Ok(EntryContent::Unknown(kind, self.reader(option)?))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    use wasm_bindgen_test::wasm_bindgen_test as test;
+
+    fn read_options() -> ReadOptions {
+        ReadOptions::builder().build()
+    }
+
+    #[test]
+    fn file_reads_contents() {
+        let mut builder = EntryBuilder::new_file("f.txt".into(), WriteOptions::store()).unwrap();
+        builder.write_all(b"abc").unwrap();
+        let entry = builder.build().unwrap();
+        let EntryContent::File(reader) = entry.content(read_options()).unwrap() else {
+            panic!("expected File");
+        };
+        assert_eq!("abc", io::read_to_string(reader).unwrap());
+    }
+
+    #[test]
+    fn empty_file_reads_empty() {
+        let builder = EntryBuilder::new_file("f.txt".into(), WriteOptions::store()).unwrap();
+        let entry = builder.build().unwrap();
+        let EntryContent::File(reader) = entry.content(read_options()).unwrap() else {
+            panic!("expected File");
+        };
+        assert_eq!("", io::read_to_string(reader).unwrap());
+    }
+
+    #[test]
+    fn directory_has_no_content() {
+        let entry = EntryBuilder::new_dir("d".into()).build().unwrap();
+        assert!(matches!(
+            entry.content(read_options()).unwrap(),
+            EntryContent::Directory
+        ));
+    }
+
+    #[test]
+    fn symlink_target_roundtrips() {
+        let entry = EntryBuilder::new_symlink(
+            "l".into(),
+            EntryReference::from_utf8_preserve_root("target/path"),
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+        let EntryContent::SymbolicLink(target) = entry.content(read_options()).unwrap() else {
+            panic!("expected SymbolicLink");
+        };
+        assert_eq!("target/path", target);
+    }
+
+    #[test]
+    fn absolute_symlink_target_is_preserved() {
+        let entry = EntryBuilder::new_symlink(
+            "l".into(),
+            EntryReference::from_utf8_preserve_root("/usr/bin/env"),
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+        let EntryContent::SymbolicLink(target) = entry.content(read_options()).unwrap() else {
+            panic!("expected SymbolicLink");
+        };
+        assert_eq!("/usr/bin/env", target);
+    }
+
+    #[test]
+    fn empty_symlink_target_roundtrips() {
+        let entry =
+            EntryBuilder::new_symlink("l".into(), EntryReference::from_utf8_preserve_root(""))
+                .unwrap()
+                .build()
+                .unwrap();
+        let EntryContent::SymbolicLink(target) = entry.content(read_options()).unwrap() else {
+            panic!("expected SymbolicLink");
+        };
+        assert_eq!("", target);
+    }
+
+    #[test]
+    fn hard_link_target_roundtrips() {
+        let entry = EntryBuilder::new_hard_link(
+            "l".into(),
+            EntryReference::from_utf8_preserve_root("target"),
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+        let EntryContent::HardLink(target) = entry.content(read_options()).unwrap() else {
+            panic!("expected HardLink");
+        };
+        assert_eq!("target", target);
+    }
+}

--- a/lib/src/entry/content.rs
+++ b/lib/src/entry/content.rs
@@ -207,4 +207,64 @@ mod tests {
         };
         assert_eq!("target", target);
     }
+
+    #[test]
+    fn directory_with_stray_data_is_still_directory() {
+        let mut entry = EntryBuilder::new_dir("d".into()).build().unwrap();
+        entry.data = vec![b"junk".to_vec()];
+        assert!(matches!(
+            entry.content(read_options()).unwrap(),
+            EntryContent::Directory
+        ));
+    }
+
+    #[test]
+    fn non_utf8_symlink_target_is_invalid_data() {
+        let mut entry =
+            EntryBuilder::new_symlink("l".into(), EntryReference::from_utf8_preserve_root("t"))
+                .unwrap()
+                .build()
+                .unwrap();
+        entry.data = vec![vec![0xFF, 0xFE, 0xFD]];
+        let err = entry.content(read_options()).unwrap_err();
+        assert_eq!(io::ErrorKind::InvalidData, err.kind());
+    }
+
+    #[test]
+    fn non_utf8_hard_link_target_is_invalid_data() {
+        let mut entry =
+            EntryBuilder::new_hard_link("l".into(), EntryReference::from_utf8_preserve_root("t"))
+                .unwrap()
+                .build()
+                .unwrap();
+        entry.data = vec![vec![0xFF, 0xFE, 0xFD]];
+        let err = entry.content(read_options()).unwrap_err();
+        assert_eq!(io::ErrorKind::InvalidData, err.kind());
+    }
+
+    #[test]
+    fn reserved_kind_yields_unknown_with_raw_bytes() {
+        let mut builder = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
+        builder.write_all(b"raw").unwrap();
+        let mut entry = builder.build().unwrap();
+        entry.header.data_kind = DataKind::Reserved(42);
+        let EntryContent::Unknown(kind, reader) = entry.content(read_options()).unwrap() else {
+            panic!("expected Unknown");
+        };
+        assert_eq!(DataKind::Reserved(42), kind);
+        assert_eq!("raw", io::read_to_string(reader).unwrap());
+    }
+
+    #[test]
+    fn private_kind_yields_unknown_with_raw_bytes() {
+        let mut builder = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
+        builder.write_all(b"raw").unwrap();
+        let mut entry = builder.build().unwrap();
+        entry.header.data_kind = DataKind::Private(200);
+        let EntryContent::Unknown(kind, reader) = entry.content(read_options()).unwrap() else {
+            panic!("expected Unknown");
+        };
+        assert_eq!(DataKind::Private(200), kind);
+        assert_eq!("raw", io::read_to_string(reader).unwrap());
+    }
 }

--- a/lib/src/entry/content.rs
+++ b/lib/src/entry/content.rs
@@ -112,6 +112,7 @@ impl<T: AsRef<[u8]>> NormalEntry<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::io::TryIntoInner;
     use std::io::Write;
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
@@ -266,5 +267,71 @@ mod tests {
         };
         assert_eq!(DataKind::Private(200), kind);
         assert_eq!("raw", io::read_to_string(reader).unwrap());
+    }
+
+    /// Wire format allows encrypted link entries, but the public builder
+    /// always writes links with store options; assemble one manually the
+    /// same way `EntryBuilder::build` does.
+    fn encrypted_symlink_entry(target: &str, password: &str) -> NormalEntry {
+        let options = WriteOptions::builder()
+            .encryption(Encryption::Aes)
+            .password(Some(password))
+            .try_build()
+            .unwrap();
+        let context = get_writer_context(&options).unwrap();
+        let mut writer = get_writer(crate::io::FlattenWriter::new(), &context).unwrap();
+        writer.write_all(target.as_bytes()).unwrap();
+        let mut data = writer
+            .try_into_inner()
+            .unwrap()
+            .try_into_inner()
+            .unwrap()
+            .inner;
+        let (iv, phsf) = match context.cipher {
+            None => (None, None),
+            Some(WriteCipher { context: c, .. }) => (Some(c.iv), Some(c.phsf)),
+        };
+        if let Some(iv) = iv {
+            data.insert(0, iv);
+        }
+        let mut entry =
+            EntryBuilder::new_symlink("l".into(), EntryReference::from_utf8_preserve_root(target))
+                .unwrap()
+                .build()
+                .unwrap();
+        entry.header.encryption = options.encryption();
+        entry.header.cipher_mode = options.cipher_mode();
+        entry.phsf = phsf;
+        entry.data = data;
+        entry
+    }
+
+    #[test]
+    fn encrypted_symlink_with_password_decodes_target() {
+        let entry = encrypted_symlink_entry("enc/target", "password");
+        let EntryContent::SymbolicLink(target) = entry
+            .content(ReadOptions::with_password(Some("password")))
+            .unwrap()
+        else {
+            panic!("expected SymbolicLink");
+        };
+        assert_eq!("enc/target", target);
+    }
+
+    #[test]
+    fn encrypted_symlink_without_password_errors() {
+        let entry = encrypted_symlink_entry("enc/target", "password");
+        assert!(entry.content(read_options()).is_err());
+    }
+
+    #[test]
+    fn encrypted_directory_decodes_without_password() {
+        let mut entry = EntryBuilder::new_dir("d".into()).build().unwrap();
+        entry.header.encryption = Encryption::Aes;
+        entry.header.cipher_mode = CipherMode::CTR;
+        assert!(matches!(
+            entry.content(read_options()).unwrap(),
+            EntryContent::Directory
+        ));
     }
 }


### PR DESCRIPTION
## Summary

Add `EntryContent`, a decoded view enum for `NormalEntry` that interprets entry data according to its `DataKind`, and migrate the manual link-target decoding in `extract`, `diff` and `list` to it. This moves per-kind payload interpretation (decrypt → UTF-8 validation → `EntryReference` restoration) from CLI call sites into libpna.

## Notes

- Link targets are restored with `EntryReference::from_utf8_preserve_root`, so absolute targets round-trip without sanitization.
- `Directory` never touches entry data: it decodes without a password even when the header claims encryption, and stray data on malformed archives is ignored.
- `EntryContent` is `#[non_exhaustive]`; `Reserved`/`Private` kinds surface as `Unknown(kind, reader)` with the raw decoded bytes.
- CLI behavior is unchanged (same error kinds, output strings, and `list`'s `"-"` fallback).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified way to read archive entry content, including files, directories, symbolic links, and hard links.
  * Link targets are now decoded and validated consistently, including encrypted entries.

* **Bug Fixes**
  * Improved archive comparisons for symbolic and hard links.
  * Improved extraction and listing of link targets.
  * Directories can be read correctly even when encrypted or containing unexpected data.
  * Invalid link encoding is reported clearly instead of being silently misinterpreted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->