### PR TITLE
:sparkles: Report differences via exit code in diff subcommand

### DIFF
--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -24,7 +24,56 @@ pub(crate) mod verify;
 pub mod xattr;
 
 use crate::cli::{Cli, Commands, GlobalContext, PasswordArgs};
-use std::{fs, io};
+use std::{fmt, fs, io};
+
+/// Error that maps to a specific process exit code in `main`.
+#[derive(Debug)]
+pub struct ExitCodeError {
+    code: u8,
+    source: Option<anyhow::Error>,
+}
+
+impl ExitCodeError {
+    /// Exit with `code` without printing anything.
+    pub(crate) fn silent(code: u8) -> Self {
+        Self { code, source: None }
+    }
+
+    /// Exit with `code` after `main` prints `source`.
+    pub(crate) fn with_source(code: u8, source: anyhow::Error) -> Self {
+        Self {
+            code,
+            source: Some(source),
+        }
+    }
+
+    /// Process exit code to terminate with.
+    pub fn code(&self) -> u8 {
+        self.code
+    }
+
+    /// Consumes self and returns the wrapped error to print, if any.
+    pub fn into_source(self) -> Option<anyhow::Error> {
+        self.source
+    }
+}
+
+impl fmt::Display for ExitCodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.source {
+            Some(err) => fmt::Display::fmt(err, f),
+            None => write!(f, "process exited with code {}", self.code),
+        }
+    }
+}
+
+impl std::error::Error for ExitCodeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source
+            .as_ref()
+            .map(|err| -> &(dyn std::error::Error + 'static) { err.as_ref() })
+    }
+}
 
 fn ask_password(args: PasswordArgs) -> io::Result<Option<Vec<u8>>> {
     if let Some(path) = args.password_file {

--- a/cli/src/command/diff.rs
+++ b/cli/src/command/diff.rs
@@ -1,7 +1,7 @@
 use crate::{
     cli::{FileArgs, PasswordArgs},
     command::{
-        Command, ask_password,
+        Command, ExitCodeError, ask_password,
         core::{SplitArchiveReader, collect_split_archives},
     },
     utils::{BsdGlobMatcher, io::streams_equal},
@@ -36,12 +36,16 @@ pub(crate) struct DiffCommand {
 impl Command for DiffCommand {
     #[inline]
     fn execute(self, _ctx: &crate::cli::GlobalContext) -> anyhow::Result<()> {
-        diff_archive(self)
+        match diff_archive(self) {
+            Ok(0) => Ok(()),
+            Ok(_) => Err(ExitCodeError::silent(1).into()),
+            Err(err) => Err(ExitCodeError::with_source(2, err).into()),
+        }
     }
 }
 
 #[hooq::hooq(anyhow)]
-fn diff_archive(args: DiffCommand) -> anyhow::Result<()> {
+fn diff_archive(args: DiffCommand) -> anyhow::Result<usize> {
     let password = ask_password(args.password)?;
     let archives = collect_split_archives(&args.file.archive)?;
     let options = CompareOptions {
@@ -53,6 +57,7 @@ fn diff_archive(args: DiffCommand) -> anyhow::Result<()> {
 
     let read_options = ReadOptions::with_password(password.as_deref());
     let mut source = SplitArchiveReader::new(archives)?;
+    let mut diff_count = 0usize;
     source.for_each_entry(
         &read_options,
         #[hooq::skip_all]
@@ -64,13 +69,14 @@ fn diff_archive(args: DiffCommand) -> anyhow::Result<()> {
                 return Ok(());
             }
 
-            compare_entry(entry, &read_options, &options)
+            diff_count += compare_entry(entry, &read_options, &options)?;
+            Ok(())
         },
     )?;
 
     globs.ensure_all_matched()?;
 
-    Ok(())
+    Ok(diff_count)
 }
 
 /// Difference types detected during archive-filesystem comparison.
@@ -268,7 +274,7 @@ fn compare_entry<T: AsRef<[u8]>>(
     entry: NormalEntry<T>,
     read_options: &ReadOptions,
     options: &CompareOptions,
-) -> io::Result<()> {
+) -> io::Result<usize> {
     let data_kind = entry.header().data_kind();
     let path = entry.header().path();
     let path_str = path.as_str();
@@ -276,14 +282,16 @@ fn compare_entry<T: AsRef<[u8]>>(
         Ok(meta) => meta,
         Err(e) if e.kind() == io::ErrorKind::NotFound => {
             println!("{}", DiffKind::Missing.display(path_str));
-            return Ok(());
+            return Ok(1);
         }
         Err(e) => return Err(e),
     };
+    let mut diff_count = 0usize;
     match data_kind {
         DataKind::File if meta.is_file() => {
             // Compare metadata first
             let meta_diffs = compare_file_metadata(&entry, &meta, options);
+            diff_count += meta_diffs.len();
             for diff in meta_diffs {
                 println!("{}", diff.display(path_str));
             }
@@ -293,16 +301,19 @@ fn compare_entry<T: AsRef<[u8]>>(
             let archive_size = entry.metadata().raw_file_size();
             if archive_size.is_some_and(|s| s != fs_size as u128) {
                 println!("{}", DiffKind::SizeDiffers.display(path_str));
+                diff_count += 1;
             } else {
                 let fs_file = fs::File::open(path)?;
                 let archive_reader = entry.reader(read_options)?;
                 if !streams_equal(fs_file, archive_reader)? {
                     println!("{}", DiffKind::ContentsDiffer.display(path_str));
+                    diff_count += 1;
                 }
             }
         }
         DataKind::Directory if meta.is_dir() => {
             let diffs = compare_directory_metadata(&entry, &meta, options);
+            diff_count += diffs.len();
             for diff in diffs {
                 println!("{}", diff.display(path_str));
             }
@@ -314,10 +325,12 @@ fn compare_entry<T: AsRef<[u8]>>(
             };
             if link.as_path() != Path::new(stored.as_str()) {
                 println!("{}", DiffKind::SymlinkDiffers.display(path_str));
+                diff_count += 1;
             }
         }
         DataKind::File | DataKind::Directory | DataKind::SymbolicLink => {
             println!("{}", DiffKind::TypeMismatch.display(path_str));
+            diff_count += 1;
         }
         DataKind::HardLink if meta.is_file() => {
             let EntryContent::HardLink(stored) = entry.content(read_options)? else {
@@ -330,19 +343,23 @@ fn compare_entry<T: AsRef<[u8]>>(
                         "{}",
                         DiffKind::NotLinked(stored.to_string()).display(path_str)
                     );
+                    diff_count += 1;
                 }
                 Err(e) if e.kind() == io::ErrorKind::NotFound => {
                     println!("{}", DiffKind::Missing.display(path_str));
+                    diff_count += 1;
                 }
                 Err(e) => return Err(e),
             }
         }
         DataKind::HardLink => {
             println!("{}", DiffKind::TypeMismatch.display(path_str));
+            diff_count += 1;
         }
         _ => {
             println!("{}", DiffKind::TypeMismatch.display(path_str));
+            diff_count += 1;
         }
     }
-    Ok(())
+    Ok(diff_count)
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use portable_network_archive::cli;
+use portable_network_archive::command::ExitCodeError;
 use std::io;
 
 #[hooq::hooq(anyhow)]
@@ -12,10 +13,23 @@ fn run() -> anyhow::Result<()> {
     cli.execute()
 }
 
-fn main() -> anyhow::Result<()> {
+fn main() -> std::process::ExitCode {
     match run() {
-        Err(err) if is_broken_pipe(&err) => Ok(()),
-        other => other,
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(err) if is_broken_pipe(&err) => std::process::ExitCode::SUCCESS,
+        Err(err) => match err.downcast::<ExitCodeError>() {
+            Ok(exit_err) => {
+                let code = exit_err.code();
+                if let Some(source) = exit_err.into_source() {
+                    eprintln!("Error: {source:?}");
+                }
+                std::process::ExitCode::from(code)
+            }
+            Err(err) => {
+                eprintln!("Error: {err:?}");
+                std::process::ExitCode::FAILURE
+            }
+        },
     }
 }
 

--- a/cli/tests/cli/diff.rs
+++ b/cli/tests/cli/diff.rs
@@ -1,4 +1,5 @@
 mod content;
+mod exit_code;
 mod hardlink;
 mod metadata;
 mod missing;

--- a/cli/tests/cli/diff/content.rs
+++ b/cli/tests/cli/diff/content.rs
@@ -27,7 +27,7 @@ fn diff_detects_content_change_same_size() {
     cargo_bin_cmd!("pna")
         .args(["experimental", "diff", "-f", &archive_path])
         .assert()
-        .success()
+        .code(1)
         .stdout(predicate::str::contains("Contents differ"));
 }
 
@@ -55,6 +55,6 @@ fn diff_detects_size_change() {
     cargo_bin_cmd!("pna")
         .args(["experimental", "diff", "-f", &archive_path])
         .assert()
-        .success()
+        .code(1)
         .stdout(predicate::str::contains("Size differs"));
 }

--- a/cli/tests/cli/diff/exit_code.rs
+++ b/cli/tests/cli/diff/exit_code.rs
@@ -1,0 +1,107 @@
+use crate::utils::{EmbedExt, TestResources, setup};
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use std::fs;
+
+/// Precondition: Archive matches the filesystem exactly.
+/// Action: Run `pna experimental diff`.
+/// Expectation: Exits with status 0 and produces no stdout.
+#[test]
+fn diff_without_differences_exits_zero() {
+    setup();
+    TestResources::extract_in("raw/", "diff_exit_code_zero/in/").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "-f",
+            "diff_exit_code_zero/diff.pna",
+            "--overwrite",
+            "diff_exit_code_zero/in/",
+        ])
+        .assert()
+        .success();
+
+    cargo_bin_cmd!("pna")
+        .args(["experimental", "diff", "-f", "diff_exit_code_zero/diff.pna"])
+        .assert()
+        .success()
+        .stdout("");
+}
+
+/// Precondition: Archive contains a file whose content is later changed on disk.
+/// Action: Run `pna experimental diff`.
+/// Expectation: Exits with status 1, reports the difference on stdout, and writes nothing to stderr.
+#[test]
+fn diff_with_content_difference_exits_one() {
+    setup();
+    let dir = "diff_exit_code_content_test";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let file_path = format!("{dir}/file.txt");
+    fs::write(&file_path, "aaaaa").unwrap();
+
+    let archive_path = format!("{dir}/test.pna");
+    cargo_bin_cmd!("pna")
+        .args(["create", "-f", &archive_path, "--overwrite", &file_path])
+        .assert()
+        .success();
+
+    fs::write(&file_path, "bbbbb").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args(["experimental", "diff", "-f", &archive_path])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("Contents differ"))
+        .stderr("");
+}
+
+/// Precondition: Archive contains a file that is later removed from disk.
+/// Action: Run `pna experimental diff`.
+/// Expectation: Exits with status 1 and writes nothing to stderr.
+#[test]
+fn diff_with_missing_file_exits_one() {
+    setup();
+    let dir = "diff_exit_code_missing_test";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let file_path = format!("{dir}/file.txt");
+    fs::write(&file_path, "content").unwrap();
+
+    let archive_path = format!("{dir}/test.pna");
+    cargo_bin_cmd!("pna")
+        .args(["create", "-f", &archive_path, "--overwrite", &file_path])
+        .assert()
+        .success();
+
+    fs::remove_file(&file_path).unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args(["experimental", "diff", "-f", &archive_path])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("Cannot stat"))
+        .stderr("");
+}
+
+/// Precondition: The given archive path does not exist.
+/// Action: Run `pna experimental diff`.
+/// Expectation: Exits with status 2.
+#[test]
+fn diff_with_nonexistent_archive_exits_two() {
+    setup();
+    let dir = "diff_exit_code_nonexistent_test";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let archive_path = format!("{dir}/does_not_exist.pna");
+
+    cargo_bin_cmd!("pna")
+        .args(["experimental", "diff", "-f", &archive_path])
+        .assert()
+        .code(2);
+}

--- a/cli/tests/cli/diff/hardlink.rs
+++ b/cli/tests/cli/diff/hardlink.rs
@@ -35,7 +35,7 @@ fn diff_detects_hardlink_to_directory_mismatch() {
     cargo_bin_cmd!("pna")
         .args(["experimental", "diff", "-f", &archive_path])
         .assert()
-        .success()
+        .code(1)
         .stdout(predicate::str::contains(format!(
             "{link}: File type mismatch"
         )));
@@ -71,5 +71,7 @@ fn diff_detects_broken_hardlink() {
         .args(["experimental", "diff", "-f", &archive_path])
         .assert();
 
-    assert.stdout(predicate::str::contains("Not linked to"));
+    assert
+        .code(1)
+        .stdout(predicate::str::contains("Not linked to"));
 }

--- a/cli/tests/cli/diff/metadata.rs
+++ b/cli/tests/cli/diff/metadata.rs
@@ -44,6 +44,7 @@ fn diff_detects_file_mode_change() {
     cargo_bin_cmd!("pna")
         .args(["experimental", "diff", "-f", &archive_path])
         .assert()
+        .code(1)
         .stdout(predicate::str::contains("Mode differs"));
 }
 
@@ -79,6 +80,7 @@ fn diff_detects_directory_mode_change() {
     cargo_bin_cmd!("pna")
         .args(["experimental", "diff", "-f", &archive_path])
         .assert()
+        .code(1)
         .stdout(predicate::str::contains("Mode differs"));
 }
 
@@ -163,6 +165,6 @@ fn diff_detects_directory_mtime_with_full_compare() {
             "--full-compare",
         ])
         .assert()
-        .success()
+        .code(1)
         .stdout(predicate::str::contains("Mod time differs"));
 }

--- a/cli/tests/cli/diff/missing.rs
+++ b/cli/tests/cli/diff/missing.rs
@@ -35,7 +35,7 @@ fn diff_missing_in_archive() {
         ])
         .assert();
 
-    assert.stdout("");
+    assert.success().stdout("");
 }
 
 /// Precondition: The source tree contains files and directories.
@@ -69,7 +69,7 @@ fn diff_missing_in_disk() {
         ])
         .assert();
 
-    assert.stdout(
+    assert.code(1).stdout(
         "diff_missing_in_disk/in/raw/images/icon.svg: Warning: Cannot stat: No such file or directory\n",
     );
 }

--- a/cli/tests/cli/diff/no_diff.rs
+++ b/cli/tests/cli/diff/no_diff.rs
@@ -26,5 +26,5 @@ fn diff_to_current_dir() {
         .args(["experimental", "diff", "-f", "diff/diff.pna"])
         .assert();
 
-    assert.stdout("");
+    assert.success().stdout("");
 }

--- a/cli/tests/cli/diff/path_filter.rs
+++ b/cli/tests/cli/diff/path_filter.rs
@@ -38,12 +38,14 @@ fn diff_filters_by_path_argument() {
     let mut cmd = cargo_bin_cmd!("pna");
     cmd.args(["experimental", "diff", "-f", &archive_path])
         .assert()
+        .code(1)
         .stdout(predicate::str::contains("Size differs"));
 
     // With filter for file_b only: no difference
     let mut cmd = cargo_bin_cmd!("pna");
     cmd.args(["experimental", "diff", "-f", &archive_path, &file_b])
         .assert()
+        .success()
         .stdout("");
 }
 
@@ -75,7 +77,7 @@ fn diff_reports_path_not_in_archive() {
         "nonexistent.txt",
     ])
     .assert()
-    .failure()
+    .code(2)
     .stderr(predicate::str::contains("not found in archive"));
 }
 
@@ -119,6 +121,7 @@ fn diff_filters_by_directory_prefix() {
         .assert();
 
     assert
+        .code(1)
         .stdout(predicate::str::contains("subdir/b.txt: Size differs"))
         .stdout(predicate::str::contains("a.txt: Size differs").not());
 }

--- a/cli/tests/cli/diff/symlink.rs
+++ b/cli/tests/cli/diff/symlink.rs
@@ -40,5 +40,7 @@ fn diff_detects_symlink_change() {
         .args(["experimental", "diff", "-f", &archive_path])
         .assert();
 
-    assert.stdout(predicate::str::contains("Symlink differs"));
+    assert
+        .code(1)
+        .stdout(predicate::str::contains("Symlink differs"));
 }

--- a/cli/tests/cli/diff/type_mismatch.rs
+++ b/cli/tests/cli/diff/type_mismatch.rs
@@ -33,7 +33,7 @@ fn diff_detects_symlink_to_file_mismatch() {
     cargo_bin_cmd!("pna")
         .args(["experimental", "diff", "-f", &archive_path])
         .assert()
-        .success()
+        .code(1)
         .stdout(predicate::str::contains(format!(
             "{link}: File type mismatch"
         )));
@@ -64,7 +64,7 @@ fn diff_detects_file_to_directory_mismatch() {
     cargo_bin_cmd!("pna")
         .args(["experimental", "diff", "-f", &archive_path])
         .assert()
-        .success()
+        .code(1)
         .stdout(predicate::str::contains(format!(
             "{file_path}: File type mismatch"
         )));
@@ -102,7 +102,7 @@ fn diff_detects_directory_to_file_mismatch() {
     cargo_bin_cmd!("pna")
         .args(["experimental", "diff", "-f", &archive_path])
         .assert()
-        .success()
+        .code(1)
         .stdout(predicate::str::contains(format!(
             "{subdir}: File type mismatch"
         )));


### PR DESCRIPTION
## Summary
`pna experimental diff` now reports its result via exit status: 0 when no differences were found, 1 when differences were found (a missing filesystem entry counts as a difference), and 2 on errors. Previously it always exited 0, so scripts could not detect differences.

## Notes
- Differences are still printed to stdout only; the exit-1 path writes nothing to stderr.
- No other command's exit behavior or stderr output changes.
- The contract is documented in the command's `--help` (long help).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The `experimental diff` command now returns meaningful exit codes:
    - `0` when no differences are found
    - `1` when differences are detected
    - `2` when an error prevents comparison
  - Exit statuses are documented in the command help.
  - Diff results continue to display detailed difference messages.

- **Tests**
  - Expanded coverage for content, metadata, missing files, links, type mismatches, filtering, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->