### PR TITLE
:boom: Replace wire-scalar enums with byte-backed newtypes

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -311,11 +311,11 @@ pub(crate) struct CipherAlgorithmArgs {
 impl CipherAlgorithmArgs {
     pub(crate) const fn algorithm(&self) -> pna::Encryption {
         if self.aes.is_some() {
-            pna::Encryption::Aes
+            pna::Encryption::AES
         } else if self.camellia.is_some() {
-            pna::Encryption::Camellia
+            pna::Encryption::CAMELLIA
         } else {
-            pna::Encryption::Aes
+            pna::Encryption::AES
         }
     }
 

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -286,15 +286,15 @@ pub(crate) struct CompressionAlgorithmArgs {
 impl CompressionAlgorithmArgs {
     pub(crate) fn algorithm(&self) -> (pna::Compression, Option<pna::CompressionLevel>) {
         if self.store {
-            (pna::Compression::No, None)
+            (pna::Compression::NO, None)
         } else if let Some(level) = self.xz {
             (pna::Compression::XZ, level.map(Into::into))
         } else if let Some(level) = self.zstd {
-            (pna::Compression::ZStandard, level.map(Into::into))
+            (pna::Compression::ZSTANDARD, level.map(Into::into))
         } else if let Some(level) = self.deflate {
-            (pna::Compression::Deflate, level.map(Into::into))
+            (pna::Compression::DEFLATE, level.map(Into::into))
         } else {
-            (pna::Compression::ZStandard, None)
+            (pna::Compression::ZSTANDARD, None)
         }
     }
 }

--- a/cli/src/command/bsdtar.rs
+++ b/cli/src/command/bsdtar.rs
@@ -708,7 +708,7 @@ fn build_write_options(
         .encryption(if password.is_some() {
             cipher.algorithm()
         } else {
-            pna::Encryption::No
+            pna::Encryption::NO
         })
         .cipher_mode(cipher.mode())
         .hash_algorithm(hash.algorithm())

--- a/cli/src/command/bsdtar.rs
+++ b/cli/src/command/bsdtar.rs
@@ -55,7 +55,7 @@ impl CompressionAlgorithmArgs {
         options: Option<&crate::cli::ArchiveOptions>,
     ) -> (pna::Compression, Option<pna::CompressionLevel>) {
         let (compression, module_level) = if self.store {
-            (pna::Compression::No, None)
+            (pna::Compression::NO, None)
         } else if self.xz {
             (
                 pna::Compression::XZ,
@@ -63,16 +63,16 @@ impl CompressionAlgorithmArgs {
             )
         } else if self.zstd {
             (
-                pna::Compression::ZStandard,
+                pna::Compression::ZSTANDARD,
                 options.and_then(|o| o.zstd_compression_level.map(Into::into)),
             )
         } else if self.deflate {
             (
-                pna::Compression::Deflate,
+                pna::Compression::DEFLATE,
                 options.and_then(|o| o.deflate_compression_level.map(Into::into)),
             )
         } else {
-            (pna::Compression::ZStandard, None)
+            (pna::Compression::ZSTANDARD, None)
         };
 
         let global_level = options.and_then(|o| o.compression_level);

--- a/cli/src/command/chmod.rs
+++ b/cli/src/command/chmod.rs
@@ -135,9 +135,9 @@ fn transform_entry<T>(entry: NormalEntry<T>, mode: &Mode) -> NormalEntry<T> {
 #[inline]
 const fn default_permission_mode(kind: DataKind) -> u16 {
     match kind {
-        DataKind::Directory => 0o755,
-        DataKind::File | DataKind::SymbolicLink | DataKind::HardLink => 0o644,
-        DataKind::Reserved(_) | DataKind::Private(_) => 0,
+        DataKind::DIRECTORY => 0o755,
+        DataKind::FILE | DataKind::SYMBOLIC_LINK | DataKind::HARD_LINK => 0o644,
+        _ => 0,
     }
 }
 

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -998,7 +998,7 @@ pub(crate) fn entry_option(
         .encryption(if password.is_some() {
             cipher.algorithm()
         } else {
-            pna::Encryption::No
+            pna::Encryption::NO
         })
         .cipher_mode(cipher.mode())
         .hash_algorithm(hash.algorithm())

--- a/cli/src/command/diff.rs
+++ b/cli/src/command/diff.rs
@@ -281,7 +281,7 @@ fn compare_entry<T: AsRef<[u8]>>(
         Err(e) => return Err(e),
     };
     match data_kind {
-        DataKind::File if meta.is_file() => {
+        DataKind::FILE if meta.is_file() => {
             // Compare metadata first
             let meta_diffs = compare_file_metadata(&entry, &meta, options);
             for diff in meta_diffs {
@@ -301,13 +301,13 @@ fn compare_entry<T: AsRef<[u8]>>(
                 }
             }
         }
-        DataKind::Directory if meta.is_dir() => {
+        DataKind::DIRECTORY if meta.is_dir() => {
             let diffs = compare_directory_metadata(&entry, &meta, options);
             for diff in diffs {
                 println!("{}", diff.display(path_str));
             }
         }
-        DataKind::SymbolicLink if meta.is_symlink() => {
+        DataKind::SYMBOLIC_LINK if meta.is_symlink() => {
             let link = fs::read_link(path)?;
             let EntryContent::SymbolicLink(stored) = entry.content(read_options)? else {
                 unreachable!("data_kind() returned SymbolicLink");
@@ -316,10 +316,10 @@ fn compare_entry<T: AsRef<[u8]>>(
                 println!("{}", DiffKind::SymlinkDiffers.display(path_str));
             }
         }
-        DataKind::File | DataKind::Directory | DataKind::SymbolicLink => {
+        DataKind::FILE | DataKind::DIRECTORY | DataKind::SYMBOLIC_LINK => {
             println!("{}", DiffKind::TypeMismatch.display(path_str));
         }
-        DataKind::HardLink if meta.is_file() => {
+        DataKind::HARD_LINK if meta.is_file() => {
             let EntryContent::HardLink(stored) = entry.content(read_options)? else {
                 unreachable!("data_kind() returned HardLink");
             };
@@ -337,7 +337,7 @@ fn compare_entry<T: AsRef<[u8]>>(
                 Err(e) => return Err(e),
             }
         }
-        DataKind::HardLink => {
+        DataKind::HARD_LINK => {
             println!("{}", DiffKind::TypeMismatch.display(path_str));
         }
         _ => {

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -637,7 +637,7 @@ where
                         }
                         if matches!(
                             item.header().data_kind(),
-                            DataKind::SymbolicLink | DataKind::HardLink
+                            DataKind::SYMBOLIC_LINK | DataKind::HARD_LINK
                         ) {
                             link_entries.push((name, item));
                             if globs.all_matched() {
@@ -645,7 +645,7 @@ where
                             }
                             return Ok(ProcessAction::Continue);
                         }
-                        if item.header().data_kind() == DataKind::Directory {
+                        if item.header().data_kind() == DataKind::DIRECTORY {
                             if extract_directory_structure(&item, &name, &args).map_err(|e| {
                                 io::Error::new(e.kind(), format!("extracting {}: {e}", item.name()))
                             })? {
@@ -696,12 +696,12 @@ where
                         }
                         if matches!(
                             item.header().data_kind(),
-                            DataKind::SymbolicLink | DataKind::HardLink
+                            DataKind::SYMBOLIC_LINK | DataKind::HARD_LINK
                         ) {
                             link_entries.push((name, item));
                             return Ok(());
                         }
-                        if item.header().data_kind() == DataKind::Directory {
+                        if item.header().data_kind() == DataKind::DIRECTORY {
                             if extract_directory_structure(&item, &name, &args).map_err(|e| {
                                 io::Error::new(e.kind(), format!("extracting {}: {e}", item.name()))
                             })? {
@@ -763,7 +763,7 @@ where
                     }
                     if matches!(
                         item.header().data_kind(),
-                        DataKind::SymbolicLink | DataKind::HardLink
+                        DataKind::SYMBOLIC_LINK | DataKind::HARD_LINK
                     ) {
                         link_entries.push((name, item));
                         if globs.all_matched() {
@@ -771,7 +771,7 @@ where
                         }
                         return Ok(ProcessAction::Continue);
                     }
-                    if item.header().data_kind() == DataKind::Directory {
+                    if item.header().data_kind() == DataKind::DIRECTORY {
                         if extract_directory_structure(&item, &name, &args).map_err(|e| {
                             io::Error::new(e.kind(), format!("extracting {}: {e}", item.name()))
                         })? {
@@ -812,12 +812,12 @@ where
                     }
                     if matches!(
                         item.header().data_kind(),
-                        DataKind::SymbolicLink | DataKind::HardLink
+                        DataKind::SYMBOLIC_LINK | DataKind::HARD_LINK
                     ) {
                         link_entries.push((name, item));
                         return Ok(());
                     }
-                    if item.header().data_kind() == DataKind::Directory {
+                    if item.header().data_kind() == DataKind::DIRECTORY {
                         if extract_directory_structure(&item, &name, &args).map_err(|e| {
                             io::Error::new(e.kind(), format!("extracting {}: {e}", item.name()))
                         })? {
@@ -904,7 +904,7 @@ where
                 }
                 if matches!(
                     item.header().data_kind(),
-                    DataKind::SymbolicLink | DataKind::HardLink
+                    DataKind::SYMBOLIC_LINK | DataKind::HARD_LINK
                 ) {
                     link_entries.push((name, item.into()));
                     if globs.all_matched() {
@@ -912,7 +912,7 @@ where
                     }
                     return Ok(ProcessAction::Continue);
                 }
-                if item.header().data_kind() == DataKind::Directory {
+                if item.header().data_kind() == DataKind::DIRECTORY {
                     if extract_directory_structure(&item, &name, &args).map_err(|e| {
                         io::Error::new(e.kind(), format!("extracting {}: {e}", item.name()))
                     })? {
@@ -958,12 +958,12 @@ where
                 }
                 if matches!(
                     item.header().data_kind(),
-                    DataKind::SymbolicLink | DataKind::HardLink
+                    DataKind::SYMBOLIC_LINK | DataKind::HARD_LINK
                 ) {
                     link_entries.push((name, item.into()));
                     return Ok(());
                 }
-                if item.header().data_kind() == DataKind::Directory {
+                if item.header().data_kind() == DataKind::DIRECTORY {
                     if extract_directory_structure(&item, &name, &args).map_err(|e| {
                         io::Error::new(e.kind(), format!("extracting {}: {e}", item.name()))
                     })? {
@@ -1176,7 +1176,7 @@ where
         })
         .unwrap_or((false, false));
     let unlink_existing =
-        unlink_first && had_existing && (entry_kind != DataKind::Directory || !existing_is_dir);
+        unlink_first && had_existing && (entry_kind != DataKind::DIRECTORY || !existing_is_dir);
     let should_overwrite_existing = matches!(
         overwrite_strategy,
         OverwriteStrategy::Always | OverwriteStrategy::KeepNewer
@@ -1194,11 +1194,11 @@ where
 
     // Handle type conflicts (symlink blocking file, file blocking directory)
     if let Some(meta) = metadata
-        && (meta.is_symlink() || (meta.is_file() && entry_kind == DataKind::Directory))
+        && (meta.is_symlink() || (meta.is_file() && entry_kind == DataKind::DIRECTORY))
     {
         let follow_symlink = !secure_symlinks
             && meta.is_symlink()
-            && entry_kind == DataKind::Directory
+            && entry_kind == DataKind::DIRECTORY
             && path.metadata().is_ok_and(|m| m.is_dir());
         if !follow_symlink {
             match utils::fs::remove_path(path) {
@@ -1228,7 +1228,7 @@ where
     T: AsRef<[u8]>,
     pna::RawChunk<T>: Chunk,
 {
-    if item.header().data_kind() != DataKind::Directory {
+    if item.header().data_kind() != DataKind::DIRECTORY {
         unreachable!(
             "extract_directory_structure called with {:?}",
             item.header().data_kind()
@@ -1239,7 +1239,7 @@ where
 
     let ExtractionDecision::Proceed { .. } = check_and_prepare_target(
         &path,
-        DataKind::Directory,
+        DataKind::DIRECTORY,
         item,
         args.overwrite_strategy,
         args.unlink_first,
@@ -1311,7 +1311,7 @@ where
     T: AsRef<[u8]>,
     pna::RawChunk<T>: Chunk,
 {
-    if item.header().data_kind() != DataKind::File {
+    if item.header().data_kind() != DataKind::FILE {
         unreachable!(
             "extract_file_entry called with {:?}",
             item.header().data_kind()
@@ -1570,7 +1570,7 @@ where
     // Regular files are handled by restore_timestamps() with an open file handle.
     // On WASM, path-based timestamp restoration is not supported (filetime limitation).
     #[cfg(not(target_family = "wasm"))]
-    if item.header().data_kind() != DataKind::File {
+    if item.header().data_kind() != DataKind::FILE {
         restore_path_timestamps(path, item.metadata(), keep_options)?;
     }
     let ownership = crate::ext::ResolvedOwnership::from_metadata(item.metadata());
@@ -1585,7 +1585,7 @@ where
     // Restore mode bits when configured.
     // Skip for symlinks: symlink permissions are not settable via chmod() on most
     // platforms, and chmod() follows symlinks, which would corrupt the target's permissions.
-    if item.header().data_kind() != DataKind::SymbolicLink
+    if item.header().data_kind() != DataKind::SYMBOLIC_LINK
         && let Some(mode) = ownership.mode
     {
         match keep_options.mode_strategy {
@@ -1625,7 +1625,7 @@ where
     }
     #[cfg(feature = "acl")]
     if !skip_xattr_acl {
-        let follow_links = item.header().data_kind() != DataKind::SymbolicLink;
+        let follow_links = item.header().data_kind() != DataKind::SYMBOLIC_LINK;
         restore_acls(path, item.acl()?, keep_options.acl_strategy, follow_links)?;
     }
     #[cfg(not(feature = "acl"))]
@@ -1865,7 +1865,7 @@ where
     T: AsRef<[u8]>,
     pna::RawChunk<T>: Chunk,
 {
-    if !matches!(item.header().data_kind(), DataKind::File) {
+    if !matches!(item.header().data_kind(), DataKind::FILE) {
         return Ok(());
     }
 

--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -404,8 +404,8 @@ impl TableRow {
                 solid.map_or(entry.compression(), |s| s.compression()),
                 solid,
             ) {
-                (Compression::No, None) => "-".into(),
-                (Compression::No, Some(_)) => "-(solid)".into(),
+                (Compression::NO, None) => "-".into(),
+                (Compression::NO, Some(_)) => "-(solid)".into(),
                 (method, None) => format!("{method:?}").to_ascii_lowercase(),
                 (method, Some(_)) => format!("{method:?}(solid)").to_ascii_lowercase(),
             },

--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -395,7 +395,7 @@ impl TableRow {
                 || (entry.encryption(), entry.cipher_mode()),
                 |s| (s.encryption(), s.cipher_mode()),
             ) {
-                (Encryption::No, _) => "-".into(),
+                (Encryption::NO, _) => "-".into(),
                 (encryption, cipher_mode) => {
                     format!("{encryption:?}({cipher_mode:?})").to_ascii_lowercase()
                 }

--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -416,7 +416,7 @@ impl TableRow {
             modified: metadata.saturating_modified_time(),
             accessed: metadata.saturating_accessed_time(),
             entry_type: match entry.data_kind() {
-                DataKind::SymbolicLink => EntryType::SymbolicLink(
+                DataKind::SYMBOLIC_LINK => EntryType::SymbolicLink(
                     entry.name().to_string(),
                     // Only read link target if needed (requires decompression)
                     if collect.link_target {
@@ -428,7 +428,7 @@ impl TableRow {
                         String::new()
                     },
                 ),
-                DataKind::HardLink => EntryType::HardLink(
+                DataKind::HARD_LINK => EntryType::HardLink(
                     entry.name().to_string(),
                     // Only read link target if needed (requires decompression)
                     if collect.link_target {
@@ -440,8 +440,8 @@ impl TableRow {
                         String::new()
                     },
                 ),
-                DataKind::Directory => EntryType::Directory(entry.name().to_string()),
-                DataKind::File => EntryType::File(entry.name().to_string()),
+                DataKind::DIRECTORY => EntryType::Directory(entry.name().to_string()),
+                DataKind::FILE => EntryType::File(entry.name().to_string()),
                 kind => EntryType::Unknown(entry.name().to_string(), kind),
             },
             // Only collect xattrs if needed
@@ -1518,14 +1518,14 @@ fn tree_entries_to(
     mut out: impl Write,
 ) -> io::Result<()> {
     let entries = entries.iter().map(|it| match &it.entry_type {
-        EntryType::File(name) => (name.as_str(), DataKind::File),
-        EntryType::Directory(name) => (name.as_str(), DataKind::Directory),
-        EntryType::SymbolicLink(name, _) => (name.as_str(), DataKind::SymbolicLink),
-        EntryType::HardLink(name, _) => (name.as_str(), DataKind::HardLink),
+        EntryType::File(name) => (name.as_str(), DataKind::FILE),
+        EntryType::Directory(name) => (name.as_str(), DataKind::DIRECTORY),
+        EntryType::SymbolicLink(name, _) => (name.as_str(), DataKind::SYMBOLIC_LINK),
+        EntryType::HardLink(name, _) => (name.as_str(), DataKind::HARD_LINK),
         EntryType::Unknown(name, kind) => (name.as_str(), *kind),
     });
     let map = build_tree_map(entries);
-    let tree = build_term_tree(&map, Cow::Borrowed(""), None, DataKind::Directory, options);
+    let tree = build_term_tree(&map, Cow::Borrowed(""), None, DataKind::DIRECTORY, options);
     writeln!(out, "{tree}")
 }
 
@@ -1538,7 +1538,7 @@ fn build_tree_map<'s>(
         let indices = path
             .char_indices()
             .filter(|(_, c)| *c == '/')
-            .map(|(idx, _)| (idx, DataKind::Directory))
+            .map(|(idx, _)| (idx, DataKind::DIRECTORY))
             .chain([(path.len(), kind)]);
         let mut start = 0;
         for (end, k) in indices {
@@ -1587,8 +1587,8 @@ fn build_term_tree<'a>(
 
 fn format_name<'a>(name: &'a str, kind: DataKind, options: &ListOptions) -> Cow<'a, str> {
     let name = match kind {
-        DataKind::Directory if options.classify => Cow::Owned(format!("{name}/")),
-        DataKind::SymbolicLink if options.classify => Cow::Owned(format!("{name}@")),
+        DataKind::DIRECTORY if options.classify => Cow::Owned(format!("{name}/")),
+        DataKind::SYMBOLIC_LINK if options.classify => Cow::Owned(format!("{name}@")),
         _ => Cow::Borrowed(name),
     };
     if options.hide_control_chars {
@@ -1647,7 +1647,8 @@ mod tests {
 
     #[test]
     fn unknown_entry_type_does_not_render_as_file() {
-        let entry_type = EntryType::Unknown("private-entry".into(), DataKind::Private(128));
+        let entry_type =
+            EntryType::Unknown("private-entry".into(), DataKind::new_private(128).unwrap());
 
         assert_eq!(entry_type.name(), "private-entry");
         assert_eq!(

--- a/cli/src/command/verify.rs
+++ b/cli/src/command/verify.rs
@@ -81,7 +81,7 @@ fn verify_archive(args: VerifyCommand) -> anyhow::Result<()> {
                     match read_entry {
                         ReadEntry::Solid(solid) => {
                             solid_blocks += 1;
-                            if solid.encryption() != Encryption::No && password.is_none() {
+                            if solid.encryption() != Encryption::NO && password.is_none() {
                                 println!("<solid block #{solid_blocks}>: skipped (encrypted)");
                                 report.skipped += 1;
                                 return Ok(());
@@ -91,7 +91,7 @@ fn verify_archive(args: VerifyCommand) -> anyhow::Result<()> {
                             {
                                 println!("<solid block #{solid_blocks}>: FAILED ({err})");
                                 report.failed += 1;
-                                report.encrypted_failure |= solid.encryption() != Encryption::No;
+                                report.encrypted_failure |= solid.encryption() != Encryption::NO;
                             }
                         }
                         ReadEntry::Normal(entry) => {
@@ -145,7 +145,7 @@ fn verify_entry(
         report.ok += 1;
         return;
     }
-    let encrypted = entry.header().encryption() != Encryption::No;
+    let encrypted = entry.header().encryption() != Encryption::NO;
     if encrypted && password.is_none() {
         // Decoding is impossible without the password.
         report.skipped += 1;

--- a/cli/tests/cli/bsdtar/option_update_strip_components.rs
+++ b/cli/tests/cli/bsdtar/option_update_strip_components.rs
@@ -120,9 +120,9 @@ fn collect_paths_with_mtime(archive: &Path) -> Vec<(String, Option<PnaDuration>)
             // pna's `EntryName::Display` does not append a trailing `/` to
             // directory entries, while bsdtar's `-tf` output does. To make
             // the two backends comparable, normalize to bsdtar's convention
-            // by suffixing `/` for `DataKind::Directory` entries.
+            // by suffixing `/` for `DataKind::DIRECTORY` entries.
             let mut p = e.header().path().to_string();
-            if matches!(e.header().data_kind(), pna::DataKind::Directory) && !p.ends_with('/') {
+            if matches!(e.header().data_kind(), pna::DataKind::DIRECTORY) && !p.ends_with('/') {
                 p.push('/');
             }
             let m = e.metadata().modified();

--- a/cli/tests/cli/bsdtar/symlink.rs
+++ b/cli/tests/cli/bsdtar/symlink.rs
@@ -37,7 +37,7 @@ fn archive_entries(path: &Path) -> HashMap<String, (DataKind, Option<String>)> {
     for_each_entry(path, |entry| {
         let kind = entry.header().data_kind();
         let link_target = match kind {
-            DataKind::SymbolicLink => Some(normalize_link_target(&read_symlink_target(&entry))),
+            DataKind::SYMBOLIC_LINK => Some(normalize_link_target(&read_symlink_target(&entry))),
             _ => None,
         };
         let prev = entries.insert(entry.header().path().to_string(), (kind, link_target));
@@ -97,11 +97,11 @@ fn bsdtar_broken_symlink_no_follow_roundtrip() {
     let entries = archive_entries(&archive);
     assert_eq!(
         entries.get("source/broken.txt"),
-        Some(&(DataKind::SymbolicLink, Some("missing.txt".to_string())))
+        Some(&(DataKind::SYMBOLIC_LINK, Some("missing.txt".to_string())))
     );
     assert_eq!(
         entries.get("source/broken_dir"),
-        Some(&(DataKind::SymbolicLink, Some("missing_dir".to_string())))
+        Some(&(DataKind::SYMBOLIC_LINK, Some("missing_dir".to_string())))
     );
 
     cargo_bin_cmd!("pna")

--- a/cli/tests/cli/create/empty_entries.rs
+++ b/cli/tests/cli/create/empty_entries.rs
@@ -45,19 +45,19 @@ fn empty_file_and_directory_round_trip() {
     assert!(
         entries
             .iter()
-            .any(|(p, k)| p.ends_with("empty.txt") && *k == pna::DataKind::File),
+            .any(|(p, k)| p.ends_with("empty.txt") && *k == pna::DataKind::FILE),
         "empty file should be in archive as File"
     );
     assert!(
         entries
             .iter()
-            .any(|(p, k)| p.ends_with("empty_dir") && *k == pna::DataKind::Directory),
+            .any(|(p, k)| p.ends_with("empty_dir") && *k == pna::DataKind::DIRECTORY),
         "empty directory should be in archive as Directory"
     );
     assert!(
         entries
             .iter()
-            .any(|(p, k)| p.ends_with("data.txt") && *k == pna::DataKind::File),
+            .any(|(p, k)| p.ends_with("data.txt") && *k == pna::DataKind::FILE),
         "non-empty file should be in archive as File"
     );
 

--- a/cli/tests/cli/create/symlink.rs
+++ b/cli/tests/cli/create/symlink.rs
@@ -64,27 +64,27 @@ fn symlink_no_follow() {
         "symlink_no_follow/symlink_no_follow.pna",
         |entry| match entry.header().path().as_str() {
             "symlink_no_follow/source" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::Directory)
+                assert_eq!(entry.header().data_kind(), pna::DataKind::DIRECTORY)
             }
             "symlink_no_follow/source/text.txt" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::File)
+                assert_eq!(entry.header().data_kind(), pna::DataKind::FILE)
             }
             "symlink_no_follow/source/dir" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::Directory)
+                assert_eq!(entry.header().data_kind(), pna::DataKind::DIRECTORY)
             }
             "symlink_no_follow/source/dir/in_dir_text.txt" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::File)
+                assert_eq!(entry.header().data_kind(), pna::DataKind::FILE)
             }
             "symlink_no_follow/source/dir/in_dir_link.txt" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::SymbolicLink);
+                assert_eq!(entry.header().data_kind(), pna::DataKind::SYMBOLIC_LINK);
                 assert_eq!(archive::read_symlink_target(&entry), "in_dir_text.txt");
             }
             "symlink_no_follow/source/link_dir" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::SymbolicLink);
+                assert_eq!(entry.header().data_kind(), pna::DataKind::SYMBOLIC_LINK);
                 assert_eq!(archive::read_symlink_target(&entry), "dir");
             }
             "symlink_no_follow/source/link.txt" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::SymbolicLink);
+                assert_eq!(entry.header().data_kind(), pna::DataKind::SYMBOLIC_LINK);
                 assert_eq!(archive::read_symlink_target(&entry), "text.txt");
             }
             path => unreachable!("unexpected entry found: {path}"),
@@ -155,31 +155,31 @@ fn symlink_follow() {
     archive::for_each_entry("symlink_follow/symlink_follow.pna", |entry| {
         match entry.header().path().as_str() {
             "symlink_follow/source" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::Directory)
+                assert_eq!(entry.header().data_kind(), pna::DataKind::DIRECTORY)
             }
             "symlink_follow/source/text.txt" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::File)
+                assert_eq!(entry.header().data_kind(), pna::DataKind::FILE)
             }
             "symlink_follow/source/dir" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::Directory)
+                assert_eq!(entry.header().data_kind(), pna::DataKind::DIRECTORY)
             }
             "symlink_follow/source/dir/in_dir_text.txt" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::File)
+                assert_eq!(entry.header().data_kind(), pna::DataKind::FILE)
             }
             "symlink_follow/source/dir/in_dir_link.txt" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::File)
+                assert_eq!(entry.header().data_kind(), pna::DataKind::FILE)
             }
             "symlink_follow/source/link_dir" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::Directory)
+                assert_eq!(entry.header().data_kind(), pna::DataKind::DIRECTORY)
             }
             "symlink_follow/source/link_dir/in_dir_link.txt" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::File)
+                assert_eq!(entry.header().data_kind(), pna::DataKind::FILE)
             }
             "symlink_follow/source/link_dir/in_dir_text.txt" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::File)
+                assert_eq!(entry.header().data_kind(), pna::DataKind::FILE)
             }
             "symlink_follow/source/link.txt" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::File)
+                assert_eq!(entry.header().data_kind(), pna::DataKind::FILE)
             }
             path => unreachable!("unexpected entry found: {path}"),
         }
@@ -240,14 +240,14 @@ fn broken_symlink_no_follow() {
         "broken_symlink_no_follow/broken_symlink_no_follow.pna",
         |entry| match entry.header().path().as_str() {
             "broken_symlink_no_follow/source" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::Directory)
+                assert_eq!(entry.header().data_kind(), pna::DataKind::DIRECTORY)
             }
             "broken_symlink_no_follow/source/broken.txt" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::SymbolicLink);
+                assert_eq!(entry.header().data_kind(), pna::DataKind::SYMBOLIC_LINK);
                 assert_eq!(archive::read_symlink_target(&entry), "missing.txt");
             }
             "broken_symlink_no_follow/source/broken_link" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::SymbolicLink);
+                assert_eq!(entry.header().data_kind(), pna::DataKind::SYMBOLIC_LINK);
                 assert_eq!(archive::read_symlink_target(&entry), "missing_target");
             }
             path => unreachable!("unexpected entry found: {path}"),
@@ -312,14 +312,14 @@ fn broken_symlink_follow() {
         "broken_symlink_follow/broken_symlink_follow.pna",
         |entry| match entry.header().path().as_str() {
             "broken_symlink_follow/source" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::Directory)
+                assert_eq!(entry.header().data_kind(), pna::DataKind::DIRECTORY)
             }
             "broken_symlink_follow/source/broken.txt" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::SymbolicLink);
+                assert_eq!(entry.header().data_kind(), pna::DataKind::SYMBOLIC_LINK);
                 assert_eq!(archive::read_symlink_target(&entry), "missing.txt");
             }
             "broken_symlink_follow/source/broken_link" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::SymbolicLink);
+                assert_eq!(entry.header().data_kind(), pna::DataKind::SYMBOLIC_LINK);
                 assert_eq!(archive::read_symlink_target(&entry), "missing_target");
             }
             path => unreachable!("unexpected entry found: {path}"),
@@ -389,7 +389,7 @@ fn symlink_depth0_no_follow_file() {
         "symlink_depth0_no_follow_file/symlink_depth0_no_follow_file.pna",
         |entry| match entry.header().path().as_str() {
             "symlink_depth0_no_follow_file/link.txt" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::SymbolicLink);
+                assert_eq!(entry.header().data_kind(), pna::DataKind::SYMBOLIC_LINK);
                 assert_eq!(archive::read_symlink_target(&entry), "target.txt");
             }
             path => unreachable!("unexpected entry found: {path}"),
@@ -456,7 +456,7 @@ fn symlink_depth0_no_follow_dir() {
         "symlink_depth0_no_follow_dir/symlink_depth0_no_follow_dir.pna",
         |entry| match entry.header().path().as_str() {
             "symlink_depth0_no_follow_dir/link_dir" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::SymbolicLink);
+                assert_eq!(entry.header().data_kind(), pna::DataKind::SYMBOLIC_LINK);
                 assert_eq!(archive::read_symlink_target(&entry), "dir");
             }
             path => unreachable!("unexpected entry found: {path}"),
@@ -516,30 +516,30 @@ fn symlink_follow_command_line_partial() {
     archive::for_each_entry("symlink_follow_partial/partial.pna", |entry| {
         match entry.header().path().as_str() {
             "symlink_follow_partial/source/dir" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::Directory);
+                assert_eq!(entry.header().data_kind(), pna::DataKind::DIRECTORY);
             }
             "symlink_follow_partial/source/dir/in_dir_link.txt" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::SymbolicLink);
+                assert_eq!(entry.header().data_kind(), pna::DataKind::SYMBOLIC_LINK);
                 assert_eq!(archive::read_symlink_target(&entry), "in_dir_text.txt");
             }
             "symlink_follow_partial/source/dir/in_dir_text.txt" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::File);
+                assert_eq!(entry.header().data_kind(), pna::DataKind::FILE);
             }
             "symlink_follow_partial/source/link_dir" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::Directory);
+                assert_eq!(entry.header().data_kind(), pna::DataKind::DIRECTORY);
             }
             "symlink_follow_partial/source/link_dir/in_dir_link.txt" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::SymbolicLink);
+                assert_eq!(entry.header().data_kind(), pna::DataKind::SYMBOLIC_LINK);
                 assert_eq!(archive::read_symlink_target(&entry), "in_dir_text.txt");
             }
             "symlink_follow_partial/source/link_dir/in_dir_text.txt" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::File);
+                assert_eq!(entry.header().data_kind(), pna::DataKind::FILE);
             }
             "symlink_follow_partial/source/link.txt" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::File);
+                assert_eq!(entry.header().data_kind(), pna::DataKind::FILE);
             }
             "symlink_follow_partial/source/text.txt" => {
-                assert_eq!(entry.header().data_kind(), pna::DataKind::File);
+                assert_eq!(entry.header().data_kind(), pna::DataKind::FILE);
             }
             path => unreachable!("unexpected entry found: {path}"),
         }

--- a/cli/tests/cli/create/symlink_metadata.rs
+++ b/cli/tests/cli/create/symlink_metadata.rs
@@ -51,7 +51,7 @@ fn create_symlink_stores_own_permissions() {
 
     let mut found_symlink = false;
     archive::for_each_entry(format!("{base}/{base}.pna"), |entry| {
-        if entry.header().data_kind() == pna::DataKind::SymbolicLink {
+        if entry.header().data_kind() == pna::DataKind::SYMBOLIC_LINK {
             let pm = entry
                 .metadata()
                 .permission_mode()
@@ -107,7 +107,7 @@ fn create_symlink_stores_own_timestamps() {
 
     let mut found_symlink = false;
     archive::for_each_entry(format!("{base}/{base}.pna"), |entry| {
-        if entry.header().data_kind() == pna::DataKind::SymbolicLink {
+        if entry.header().data_kind() == pna::DataKind::SYMBOLIC_LINK {
             let archived_mtime = entry
                 .metadata()
                 .modified()
@@ -154,7 +154,7 @@ fn create_broken_symlink_stores_metadata() {
 
     let mut found_broken = false;
     archive::for_each_entry(format!("{base}/{base}.pna"), |entry| {
-        if entry.header().data_kind() == pna::DataKind::SymbolicLink {
+        if entry.header().data_kind() == pna::DataKind::SYMBOLIC_LINK {
             assert_eq!(archive::read_symlink_target(&entry), "nonexistent");
             // wasi has no POSIX mode; permission is never populated there.
             #[cfg(not(target_os = "wasi"))]
@@ -224,7 +224,7 @@ fn create_follow_links_stores_target_metadata() {
 
     assert_eq!(
         link_entry_kind,
-        Some(pna::DataKind::File),
+        Some(pna::DataKind::FILE),
         "with --follow-links, symlink should be archived as File"
     );
     assert_eq!(
@@ -281,7 +281,7 @@ fn create_follow_links_stores_target_timestamps() {
 
     assert_eq!(
         link_entry_kind,
-        Some(pna::DataKind::File),
+        Some(pna::DataKind::FILE),
         "with --follow-links, symlink should be archived as File"
     );
     let archived_secs = link_entry_mtime.expect("should have mtime");
@@ -335,7 +335,7 @@ fn create_symlink_does_not_store_target_permissions() {
         if entry.header().path().as_str().ends_with("target.txt") {
             target_perm = entry.metadata().permission_mode().map(|v| v.get() & 0o777);
         }
-        if entry.header().data_kind() == pna::DataKind::SymbolicLink {
+        if entry.header().data_kind() == pna::DataKind::SYMBOLIC_LINK {
             symlink_perm = entry.metadata().permission_mode().map(|v| v.get() & 0o777);
         }
     })
@@ -380,7 +380,7 @@ fn roundtrip_symlink_metadata_preserved() {
     // Verify the archive has a symlink entry with metadata
     let mut has_symlink_with_perm = false;
     archive::for_each_entry(format!("{base}/{base}.pna"), |entry| {
-        if entry.header().data_kind() == pna::DataKind::SymbolicLink {
+        if entry.header().data_kind() == pna::DataKind::SYMBOLIC_LINK {
             // wasi has no POSIX mode; permission is never populated there.
             #[cfg(not(target_os = "wasi"))]
             {
@@ -454,7 +454,7 @@ fn roundtrip_broken_symlink_metadata_preserved() {
     // Verify archive content
     let mut has_broken_symlink = false;
     archive::for_each_entry(format!("{base}/{base}.pna"), |entry| {
-        if entry.header().data_kind() == pna::DataKind::SymbolicLink {
+        if entry.header().data_kind() == pna::DataKind::SYMBOLIC_LINK {
             assert_eq!(archive::read_symlink_target(&entry), "nonexistent");
             // wasi has no POSIX mode; permission is never populated there.
             #[cfg(not(target_os = "wasi"))]

--- a/cli/tests/cli/delete/directory_entry.rs
+++ b/cli/tests/cli/delete/directory_entry.rs
@@ -44,11 +44,11 @@ fn delete_directory_entry() {
     })
     .unwrap();
     assert!(
-        before.contains(&(format!("{base}/in"), pna::DataKind::Directory)),
+        before.contains(&(format!("{base}/in"), pna::DataKind::DIRECTORY)),
         "archive should contain directory entry before deletion"
     );
     assert!(
-        before.contains(&(format!("{base}/in/subdir"), pna::DataKind::Directory)),
+        before.contains(&(format!("{base}/in/subdir"), pna::DataKind::DIRECTORY)),
         "archive should contain subdir entry before deletion"
     );
 

--- a/cli/tests/cli/delete/symlink_entry.rs
+++ b/cli/tests/cli/delete/symlink_entry.rs
@@ -38,7 +38,7 @@ fn delete_symlink_entry() {
         if entry.header().path().as_str() == "delete_symlink_entry/in/link.txt" {
             assert_eq!(
                 entry.header().data_kind(),
-                pna::DataKind::SymbolicLink,
+                pna::DataKind::SYMBOLIC_LINK,
                 "link.txt should be a symlink entry"
             );
             has_symlink = true;
@@ -133,7 +133,7 @@ fn delete_symlink_target_keeps_symlink() {
         if path == "delete_symlink_target/in/link.txt" {
             assert_eq!(
                 entry.header().data_kind(),
-                pna::DataKind::SymbolicLink,
+                pna::DataKind::SYMBOLIC_LINK,
                 "link.txt should still be a symlink"
             );
             seen_symlink = true;

--- a/cli/tests/cli/extract/option_keep_permission.rs
+++ b/cli/tests/cli/extract/option_keep_permission.rs
@@ -501,7 +501,7 @@ fn extract_preserves_directory_permission() {
     archive::for_each_entry("extract_dir_perm/archive.pna", |entry| {
         if entry.header().path().as_str().ends_with("raw/images") {
             found = true;
-            assert_eq!(entry.header().data_kind(), pna::DataKind::Directory);
+            assert_eq!(entry.header().data_kind(), pna::DataKind::DIRECTORY);
             let mode = entry.metadata().permission_mode().unwrap();
             assert_eq!(mode.get() & 0o777, 0o750);
         }

--- a/cli/tests/cli/update/symlink_entry.rs
+++ b/cli/tests/cli/update/symlink_entry.rs
@@ -58,7 +58,7 @@ fn update_keeps_symlink_entry() {
     let mut symlink_kind = false;
     archive::for_each_entry("update_keeps_symlink/archive.pna", |entry| {
         if entry.header().path().as_str() == "update_keeps_symlink/in/link.txt" {
-            symlink_kind = entry.header().data_kind() == pna::DataKind::SymbolicLink;
+            symlink_kind = entry.header().data_kind() == pna::DataKind::SYMBOLIC_LINK;
         }
         seen.insert(entry.header().path().to_string());
     })

--- a/cli/tests/cli/utils/archive.rs
+++ b/cli/tests/cli/utils/archive.rs
@@ -88,7 +88,7 @@ pub fn create_encrypted_archive_with_permissions(
 
     let write_options = pna::WriteOptions::builder()
         .password(Some(password))
-        .encryption(pna::Encryption::Aes)
+        .encryption(pna::Encryption::AES)
         .cipher_mode(pna::CipherMode::CTR)
         .build();
 

--- a/fuzz/fuzz_targets/aes_cbc.rs
+++ b/fuzz/fuzz_targets/aes_cbc.rs
@@ -7,7 +7,7 @@ use std::io::prelude::*;
 fuzz_target!(|data: &[u8]| {
     let write_option = WriteOptions::builder()
         .password(Some("password"))
-        .encryption(Encryption::Aes)
+        .encryption(Encryption::AES)
         .cipher_mode(CipherMode::CBC)
         .compression(Compression::NO)
         .build();

--- a/fuzz/fuzz_targets/aes_cbc.rs
+++ b/fuzz/fuzz_targets/aes_cbc.rs
@@ -9,7 +9,7 @@ fuzz_target!(|data: &[u8]| {
         .password(Some("password"))
         .encryption(Encryption::Aes)
         .cipher_mode(CipherMode::CBC)
-        .compression(Compression::No)
+        .compression(Compression::NO)
         .build();
     let mut builder = EntryBuilder::new_file("fuzz".into(), write_option).unwrap();
     builder.write_all(data).unwrap();

--- a/fuzz/fuzz_targets/aes_ctr.rs
+++ b/fuzz/fuzz_targets/aes_ctr.rs
@@ -9,7 +9,7 @@ fuzz_target!(|data: &[u8]| {
         .password(Some("password"))
         .encryption(Encryption::Aes)
         .cipher_mode(CipherMode::CTR)
-        .compression(Compression::No)
+        .compression(Compression::NO)
         .build();
     let mut builder = EntryBuilder::new_file("fuzz".into(), write_option).unwrap();
     builder.write_all(data).unwrap();

--- a/fuzz/fuzz_targets/aes_ctr.rs
+++ b/fuzz/fuzz_targets/aes_ctr.rs
@@ -7,7 +7,7 @@ use std::io::prelude::*;
 fuzz_target!(|data: &[u8]| {
     let write_option = WriteOptions::builder()
         .password(Some("password"))
-        .encryption(Encryption::Aes)
+        .encryption(Encryption::AES)
         .cipher_mode(CipherMode::CTR)
         .compression(Compression::NO)
         .build();

--- a/fuzz/fuzz_targets/camellia_cbc.rs
+++ b/fuzz/fuzz_targets/camellia_cbc.rs
@@ -9,7 +9,7 @@ fuzz_target!(|data: &[u8]| {
         .password(Some("password"))
         .encryption(Encryption::Camellia)
         .cipher_mode(CipherMode::CBC)
-        .compression(Compression::No)
+        .compression(Compression::NO)
         .build();
     let mut builder = EntryBuilder::new_file("fuzz".into(), write_option).unwrap();
     builder.write_all(data).unwrap();

--- a/fuzz/fuzz_targets/camellia_cbc.rs
+++ b/fuzz/fuzz_targets/camellia_cbc.rs
@@ -7,7 +7,7 @@ use std::io::prelude::*;
 fuzz_target!(|data: &[u8]| {
     let write_option = WriteOptions::builder()
         .password(Some("password"))
-        .encryption(Encryption::Camellia)
+        .encryption(Encryption::CAMELLIA)
         .cipher_mode(CipherMode::CBC)
         .compression(Compression::NO)
         .build();

--- a/fuzz/fuzz_targets/camellia_ctr.rs
+++ b/fuzz/fuzz_targets/camellia_ctr.rs
@@ -7,7 +7,7 @@ use std::io::prelude::*;
 fuzz_target!(|data: &[u8]| {
     let write_option = WriteOptions::builder()
         .password(Some("password"))
-        .encryption(Encryption::Camellia)
+        .encryption(Encryption::CAMELLIA)
         .cipher_mode(CipherMode::CTR)
         .compression(Compression::NO)
         .build();

--- a/fuzz/fuzz_targets/camellia_ctr.rs
+++ b/fuzz/fuzz_targets/camellia_ctr.rs
@@ -9,7 +9,7 @@ fuzz_target!(|data: &[u8]| {
         .password(Some("password"))
         .encryption(Encryption::Camellia)
         .cipher_mode(CipherMode::CTR)
-        .compression(Compression::No)
+        .compression(Compression::NO)
         .build();
     let mut builder = EntryBuilder::new_file("fuzz".into(), write_option).unwrap();
     builder.write_all(data).unwrap();

--- a/fuzz/fuzz_targets/split_archive.rs
+++ b/fuzz/fuzz_targets/split_archive.rs
@@ -6,7 +6,7 @@ use std::io::prelude::*;
 
 fuzz_target!(|data: (&[u8], usize)| {
     let (data, split_size) = data;
-    let write_option = WriteOptions::builder().compression(Compression::No).build();
+    let write_option = WriteOptions::builder().compression(Compression::NO).build();
     let mut builder = EntryBuilder::new_file("fuzz".into(), write_option).unwrap();
     builder.write_all(data).unwrap();
     let entry = builder.build().unwrap();

--- a/lib/benches/create_extract.rs
+++ b/lib/benches/create_extract.rs
@@ -105,7 +105,7 @@ fn bench_write_zstd_archive(c: &mut Criterion) {
     c.bench_function("write_zstd_archive", |b| {
         bench_write_archive(b, {
             let mut builder = WriteOptions::builder();
-            builder.compression(Compression::ZStandard);
+            builder.compression(Compression::ZSTANDARD);
             builder
         });
     });
@@ -115,7 +115,7 @@ fn bench_read_zstd_archive(c: &mut Criterion) {
     c.bench_function("read_zstd_archive", |b| {
         bench_read_archive(b, {
             let mut builder = WriteOptions::builder();
-            builder.compression(Compression::ZStandard);
+            builder.compression(Compression::ZSTANDARD);
             builder
         });
     });
@@ -125,7 +125,7 @@ fn bench_read_zstd_archive_from_slice(c: &mut Criterion) {
     c.bench_function("read_zstd_archive_from_slice", |b| {
         bench_read_archive_from_slice(b, {
             let mut builder = WriteOptions::builder();
-            builder.compression(Compression::ZStandard);
+            builder.compression(Compression::ZSTANDARD);
             builder
         });
     });
@@ -135,7 +135,7 @@ fn bench_write_deflate_archive(c: &mut Criterion) {
     c.bench_function("write_deflate_archive", |b| {
         bench_write_archive(b, {
             let mut builder = WriteOptions::builder();
-            builder.compression(Compression::Deflate);
+            builder.compression(Compression::DEFLATE);
             builder
         });
     });
@@ -145,7 +145,7 @@ fn bench_read_deflate_archive(c: &mut Criterion) {
     c.bench_function("read_deflate_archive", |b| {
         bench_read_archive(b, {
             let mut builder = WriteOptions::builder();
-            builder.compression(Compression::Deflate);
+            builder.compression(Compression::DEFLATE);
             builder
         });
     });
@@ -155,7 +155,7 @@ fn bench_read_deflate_archive_from_slice(c: &mut Criterion) {
     c.bench_function("read_deflate_archive_from_slice", |b| {
         bench_read_archive_from_slice(b, {
             let mut builder = WriteOptions::builder();
-            builder.compression(Compression::Deflate);
+            builder.compression(Compression::DEFLATE);
             builder
         });
     });

--- a/lib/benches/create_extract.rs
+++ b/lib/benches/create_extract.rs
@@ -196,7 +196,7 @@ fn bench_write_aes_ctr_archive(c: &mut Criterion) {
         bench_write_archive(b, {
             let mut builder = WriteOptions::builder();
             builder
-                .encryption(Encryption::Aes)
+                .encryption(Encryption::AES)
                 .cipher_mode(CipherMode::CTR);
             builder
         });
@@ -208,7 +208,7 @@ fn bench_read_aes_ctr_archive(c: &mut Criterion) {
         bench_read_archive(b, {
             let mut builder = WriteOptions::builder();
             builder
-                .encryption(Encryption::Aes)
+                .encryption(Encryption::AES)
                 .cipher_mode(CipherMode::CTR);
             builder
         });
@@ -220,7 +220,7 @@ fn bench_write_aes_cbc_archive(c: &mut Criterion) {
         bench_write_archive(b, {
             let mut builder = WriteOptions::builder();
             builder
-                .encryption(Encryption::Aes)
+                .encryption(Encryption::AES)
                 .cipher_mode(CipherMode::CBC);
             builder
         });
@@ -232,7 +232,7 @@ fn bench_read_aes_cbc_archive(c: &mut Criterion) {
         bench_read_archive(b, {
             let mut builder = WriteOptions::builder();
             builder
-                .encryption(Encryption::Aes)
+                .encryption(Encryption::AES)
                 .cipher_mode(CipherMode::CBC);
             builder
         });
@@ -244,7 +244,7 @@ fn bench_write_camellia_ctr_archive(c: &mut Criterion) {
         bench_write_archive(b, {
             let mut builder = WriteOptions::builder();
             builder
-                .encryption(Encryption::Camellia)
+                .encryption(Encryption::CAMELLIA)
                 .cipher_mode(CipherMode::CTR);
             builder
         });
@@ -256,7 +256,7 @@ fn bench_read_camellia_ctr_archive(c: &mut Criterion) {
         bench_read_archive(b, {
             let mut builder = WriteOptions::builder();
             builder
-                .encryption(Encryption::Camellia)
+                .encryption(Encryption::CAMELLIA)
                 .cipher_mode(CipherMode::CTR);
             builder
         });
@@ -268,7 +268,7 @@ fn bench_write_camellia_cbc_archive(c: &mut Criterion) {
         bench_write_archive(b, {
             let mut builder = WriteOptions::builder();
             builder
-                .encryption(Encryption::Camellia)
+                .encryption(Encryption::CAMELLIA)
                 .cipher_mode(CipherMode::CBC);
             builder
         });
@@ -280,7 +280,7 @@ fn bench_read_camellia_cbc_archive(c: &mut Criterion) {
         bench_read_archive(b, {
             let mut builder = WriteOptions::builder();
             builder
-                .encryption(Encryption::Camellia)
+                .encryption(Encryption::CAMELLIA)
                 .cipher_mode(CipherMode::CBC);
             builder
         });

--- a/lib/examples/change_compression_method.rs
+++ b/lib/examples/change_compression_method.rs
@@ -29,6 +29,6 @@ fn main() -> io::Result<()> {
     change_compression_method(
         include_bytes!("../../resources/test/deflate.pna").as_slice(),
         &mut dist,
-        Compression::Deflate,
+        Compression::DEFLATE,
     )
 }

--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -209,7 +209,7 @@ mod tests {
     fn store_archive() {
         archive(
             b"src data bytes",
-            WriteOptions::builder().compression(Compression::No).build(),
+            WriteOptions::builder().compression(Compression::NO).build(),
         )
         .unwrap()
     }
@@ -219,7 +219,7 @@ mod tests {
         archive(
             b"src data bytes",
             WriteOptions::builder()
-                .compression(Compression::Deflate)
+                .compression(Compression::DEFLATE)
                 .build(),
         )
         .unwrap()
@@ -230,7 +230,7 @@ mod tests {
         archive(
             b"src data bytes",
             WriteOptions::builder()
-                .compression(Compression::ZStandard)
+                .compression(Compression::ZSTANDARD)
                 .build(),
         )
         .unwrap()
@@ -250,7 +250,7 @@ mod tests {
         archive(
             b"plain text",
             WriteOptions::builder()
-                .compression(Compression::No)
+                .compression(Compression::NO)
                 .encryption(Encryption::Aes)
                 .cipher_mode(CipherMode::CBC)
                 .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
@@ -265,7 +265,7 @@ mod tests {
         archive(
             b"plain text",
             WriteOptions::builder()
-                .compression(Compression::ZStandard)
+                .compression(Compression::ZSTANDARD)
                 .encryption(Encryption::Aes)
                 .cipher_mode(CipherMode::CTR)
                 .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
@@ -280,7 +280,7 @@ mod tests {
         archive(
             b"plain text",
             WriteOptions::builder()
-                .compression(Compression::ZStandard)
+                .compression(Compression::ZSTANDARD)
                 .encryption(Encryption::Aes)
                 .cipher_mode(CipherMode::CBC)
                 .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
@@ -295,7 +295,7 @@ mod tests {
         archive(
             b"plain text",
             WriteOptions::builder()
-                .compression(Compression::ZStandard)
+                .compression(Compression::ZSTANDARD)
                 .encryption(Encryption::Camellia)
                 .cipher_mode(CipherMode::CTR)
                 .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
@@ -310,7 +310,7 @@ mod tests {
         archive(
             b"plain text",
             WriteOptions::builder()
-                .compression(Compression::ZStandard)
+                .compression(Compression::ZSTANDARD)
                 .encryption(Encryption::Camellia)
                 .cipher_mode(CipherMode::CBC)
                 .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
@@ -592,7 +592,7 @@ mod tests {
     fn solid_store_camellia_cbc() {
         solid_archive(
             WriteOptions::builder()
-                .compression(Compression::No)
+                .compression(Compression::NO)
                 .encryption(Encryption::Camellia)
                 .cipher_mode(CipherMode::CBC)
                 .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))

--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -251,7 +251,7 @@ mod tests {
             b"plain text",
             WriteOptions::builder()
                 .compression(Compression::NO)
-                .encryption(Encryption::Aes)
+                .encryption(Encryption::AES)
                 .cipher_mode(CipherMode::CBC)
                 .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
                 .password(Some("password"))
@@ -266,7 +266,7 @@ mod tests {
             b"plain text",
             WriteOptions::builder()
                 .compression(Compression::ZSTANDARD)
-                .encryption(Encryption::Aes)
+                .encryption(Encryption::AES)
                 .cipher_mode(CipherMode::CTR)
                 .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
                 .password(Some("password"))
@@ -281,7 +281,7 @@ mod tests {
             b"plain text",
             WriteOptions::builder()
                 .compression(Compression::ZSTANDARD)
-                .encryption(Encryption::Aes)
+                .encryption(Encryption::AES)
                 .cipher_mode(CipherMode::CBC)
                 .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
                 .password(Some("password"))
@@ -296,7 +296,7 @@ mod tests {
             b"plain text",
             WriteOptions::builder()
                 .compression(Compression::ZSTANDARD)
-                .encryption(Encryption::Camellia)
+                .encryption(Encryption::CAMELLIA)
                 .cipher_mode(CipherMode::CTR)
                 .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
                 .password(Some("password"))
@@ -311,7 +311,7 @@ mod tests {
             b"plain text",
             WriteOptions::builder()
                 .compression(Compression::ZSTANDARD)
-                .encryption(Encryption::Camellia)
+                .encryption(Encryption::CAMELLIA)
                 .cipher_mode(CipherMode::CBC)
                 .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
                 .password(Some("password"))
@@ -326,7 +326,7 @@ mod tests {
             b"plain text",
             WriteOptions::builder()
                 .compression(Compression::XZ)
-                .encryption(Encryption::Aes)
+                .encryption(Encryption::AES)
                 .cipher_mode(CipherMode::CBC)
                 .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
                 .password(Some("password"))
@@ -341,7 +341,7 @@ mod tests {
             b"plain text",
             WriteOptions::builder()
                 .compression(Compression::XZ)
-                .encryption(Encryption::Camellia)
+                .encryption(Encryption::CAMELLIA)
                 .cipher_mode(CipherMode::CBC)
                 .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
                 .password(Some("password"))
@@ -357,7 +357,7 @@ mod tests {
     #[test]
     fn entries_share_derived_key_with_unique_iv() {
         let options = WriteOptions::builder()
-            .encryption(Encryption::Aes)
+            .encryption(Encryption::AES)
             .password(Some("password"))
             .build();
         let mut writer = Archive::write_header(Vec::new()).unwrap();
@@ -400,7 +400,7 @@ mod tests {
     #[test]
     fn read_options_derives_key_once_per_archive() {
         let options = WriteOptions::builder()
-            .encryption(Encryption::Aes)
+            .encryption(Encryption::AES)
             .password(Some("password"))
             .try_build()
             .unwrap();
@@ -443,7 +443,7 @@ mod tests {
     fn read_options_cache_handles_distinct_phsf_entries() {
         let mut options_builder = WriteOptions::builder();
         options_builder
-            .encryption(Encryption::Aes)
+            .encryption(Encryption::AES)
             .password(Some("password"));
         let mut writer = Archive::write_header(Vec::new()).unwrap();
         for name in ["test/first", "test/second"] {
@@ -482,7 +482,7 @@ mod tests {
     #[test]
     fn read_options_cache_is_reused_across_solid_blocks() {
         let write_options = WriteOptions::builder()
-            .encryption(Encryption::Aes)
+            .encryption(Encryption::AES)
             .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
             .password(Some("password"))
             .try_build()
@@ -521,7 +521,7 @@ mod tests {
     #[test]
     fn write_options_reusable_across_archives() {
         let options = WriteOptions::builder()
-            .encryption(Encryption::Aes)
+            .encryption(Encryption::AES)
             .password(Some("password"))
             .build();
         for _ in 0..2 {
@@ -593,7 +593,7 @@ mod tests {
         solid_archive(
             WriteOptions::builder()
                 .compression(Compression::NO)
-                .encryption(Encryption::Camellia)
+                .encryption(Encryption::CAMELLIA)
                 .cipher_mode(CipherMode::CBC)
                 .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
                 .password(Some("PASSWORD"))

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -1551,7 +1551,7 @@ mod tests {
         let mut builder = EntryBuilder::new_file(
             "encoded".into(),
             WriteOptions::builder()
-                .compression(Compression::Deflate)
+                .compression(Compression::DEFLATE)
                 .build(),
         )
         .unwrap();
@@ -1575,7 +1575,7 @@ mod tests {
     #[test]
     fn solid_entry_encoded_reader_concatenates_sdat_bodies() {
         let solid = SolidEntry {
-            header: SolidHeader::new(Compression::No, Encryption::No, CipherMode::CBC),
+            header: SolidHeader::new(Compression::NO, Encryption::No, CipherMode::CBC),
             phsf: None,
             data: vec![b"abc".to_vec(), b"def".to_vec()],
             extra: Vec::new(),

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -1575,7 +1575,7 @@ mod tests {
     #[test]
     fn solid_entry_encoded_reader_concatenates_sdat_bodies() {
         let solid = SolidEntry {
-            header: SolidHeader::new(Compression::NO, Encryption::No, CipherMode::CBC),
+            header: SolidHeader::new(Compression::NO, Encryption::NO, CipherMode::CBC),
             phsf: None,
             data: vec![b"abc".to_vec(), b"def".to_vec()],
             extra: Vec::new(),

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -451,7 +451,7 @@ impl EntryBuilder {
         }
         let metadata = Metadata {
             raw_file_size: match (self.store_file_size, self.header.data_kind) {
-                (true, DataKind::File) => Some(self.file_size),
+                (true, DataKind::FILE) => Some(self.file_size),
                 _ => None,
             },
             compressed_size: data.iter().map(|d| d.len()).sum(),

--- a/lib/src/entry/content.rs
+++ b/lib/src/entry/content.rs
@@ -94,17 +94,15 @@ impl<T: AsRef<[u8]>> NormalEntry<T> {
     #[inline]
     pub fn content(&self, option: impl ReadOption) -> io::Result<EntryContent<'_>> {
         match self.header.data_kind {
-            DataKind::File => Ok(EntryContent::File(self.reader(option)?)),
-            DataKind::Directory => Ok(EntryContent::Directory),
-            DataKind::SymbolicLink => Ok(EntryContent::SymbolicLink(read_reference(
+            DataKind::FILE => Ok(EntryContent::File(self.reader(option)?)),
+            DataKind::DIRECTORY => Ok(EntryContent::Directory),
+            DataKind::SYMBOLIC_LINK => Ok(EntryContent::SymbolicLink(read_reference(
                 self.reader(option)?,
             )?)),
-            DataKind::HardLink => Ok(EntryContent::HardLink(read_reference(
+            DataKind::HARD_LINK => Ok(EntryContent::HardLink(read_reference(
                 self.reader(option)?,
             )?)),
-            kind @ (DataKind::Reserved(_) | DataKind::Private(_)) => {
-                Ok(EntryContent::Unknown(kind, self.reader(option)?))
-            }
+            kind => Ok(EntryContent::Unknown(kind, self.reader(option)?)),
         }
     }
 }
@@ -248,11 +246,11 @@ mod tests {
         let mut builder = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
         builder.write_all(b"raw").unwrap();
         let mut entry = builder.build().unwrap();
-        entry.header.data_kind = DataKind::Reserved(42);
+        entry.header.data_kind = DataKind::from_byte(42);
         let EntryContent::Unknown(kind, reader) = entry.content(read_options()).unwrap() else {
             panic!("expected Unknown");
         };
-        assert_eq!(DataKind::Reserved(42), kind);
+        assert_eq!(DataKind::from_byte(42), kind);
         assert_eq!("raw", io::read_to_string(reader).unwrap());
     }
 
@@ -261,11 +259,11 @@ mod tests {
         let mut builder = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
         builder.write_all(b"raw").unwrap();
         let mut entry = builder.build().unwrap();
-        entry.header.data_kind = DataKind::Private(200);
+        entry.header.data_kind = DataKind::from_byte(200);
         let EntryContent::Unknown(kind, reader) = entry.content(read_options()).unwrap() else {
             panic!("expected Unknown");
         };
-        assert_eq!(DataKind::Private(200), kind);
+        assert_eq!(DataKind::from_byte(200), kind);
         assert_eq!("raw", io::read_to_string(reader).unwrap());
     }
 

--- a/lib/src/entry/content.rs
+++ b/lib/src/entry/content.rs
@@ -272,7 +272,7 @@ mod tests {
     /// same way `EntryBuilder::build` does.
     fn encrypted_symlink_entry(target: &str, password: &str) -> NormalEntry {
         let options = WriteOptions::builder()
-            .encryption(Encryption::Aes)
+            .encryption(Encryption::AES)
             .password(Some(password))
             .try_build()
             .unwrap();
@@ -325,7 +325,7 @@ mod tests {
     #[test]
     fn encrypted_directory_decodes_without_password() {
         let mut entry = EntryBuilder::new_dir("d".into()).build().unwrap();
-        entry.header.encryption = Encryption::Aes;
+        entry.header.encryption = Encryption::AES;
         entry.header.cipher_mode = CipherMode::CTR;
         assert!(matches!(
             entry.content(read_options()).unwrap(),

--- a/lib/src/entry/header.rs
+++ b/lib/src/entry/header.rs
@@ -44,7 +44,7 @@ impl EntryHeader {
     pub(crate) const fn new(data_kind: DataKind, path: EntryName) -> Self {
         Self::new_with_options(
             data_kind,
-            Compression::No,
+            Compression::NO,
             Encryption::No,
             CipherMode::CBC,
             path,
@@ -146,8 +146,7 @@ impl EntryHeader {
             major: bytes[0],
             minor: bytes[1],
             data_kind: DataKind::from_byte(bytes[2]),
-            compression: Compression::try_from(bytes[3])
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
+            compression: Compression::from_byte(bytes[3]),
             encryption: Encryption::try_from(bytes[4])
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
             cipher_mode: CipherMode::try_from(bytes[5])
@@ -284,8 +283,7 @@ impl SolidHeader {
         Ok(Self {
             major: bytes[0],
             minor: bytes[1],
-            compression: Compression::try_from(bytes[2])
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
+            compression: Compression::from_byte(bytes[2]),
             encryption: Encryption::try_from(bytes[3])
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
             cipher_mode: CipherMode::try_from(bytes[4])
@@ -317,7 +315,7 @@ mod tests {
     #[test]
     fn entry_header_to_from_bytes() {
         let header = EntryHeader::for_file(
-            Compression::ZStandard,
+            Compression::ZSTANDARD,
             Encryption::Camellia,
             CipherMode::CTR,
             "file".into(),
@@ -336,7 +334,7 @@ mod tests {
 
     #[test]
     fn solid_header_to_from_bytes() {
-        let header = SolidHeader::new(Compression::ZStandard, Encryption::Aes, CipherMode::CBC);
+        let header = SolidHeader::new(Compression::ZSTANDARD, Encryption::Aes, CipherMode::CBC);
         assert_eq!(
             header,
             SolidHeader::try_from_bytes(&header.to_bytes()).unwrap(),

--- a/lib/src/entry/header.rs
+++ b/lib/src/entry/header.rs
@@ -45,7 +45,7 @@ impl EntryHeader {
         Self::new_with_options(
             data_kind,
             Compression::NO,
-            Encryption::No,
+            Encryption::NO,
             CipherMode::CBC,
             path,
         )
@@ -147,8 +147,7 @@ impl EntryHeader {
             minor: bytes[1],
             data_kind: DataKind::from_byte(bytes[2]),
             compression: Compression::from_byte(bytes[3]),
-            encryption: Encryption::try_from(bytes[4])
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
+            encryption: Encryption::from_byte(bytes[4]),
             cipher_mode: CipherMode::try_from(bytes[5])
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
             sanitized_path: OnceLock::new(),
@@ -284,8 +283,7 @@ impl SolidHeader {
             major: bytes[0],
             minor: bytes[1],
             compression: Compression::from_byte(bytes[2]),
-            encryption: Encryption::try_from(bytes[3])
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
+            encryption: Encryption::from_byte(bytes[3]),
             cipher_mode: CipherMode::try_from(bytes[4])
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
         })
@@ -316,7 +314,7 @@ mod tests {
     fn entry_header_to_from_bytes() {
         let header = EntryHeader::for_file(
             Compression::ZSTANDARD,
-            Encryption::Camellia,
+            Encryption::CAMELLIA,
             CipherMode::CTR,
             "file".into(),
         );
@@ -334,7 +332,7 @@ mod tests {
 
     #[test]
     fn solid_header_to_from_bytes() {
-        let header = SolidHeader::new(Compression::ZSTANDARD, Encryption::Aes, CipherMode::CBC);
+        let header = SolidHeader::new(Compression::ZSTANDARD, Encryption::AES, CipherMode::CBC);
         assert_eq!(
             header,
             SolidHeader::try_from_bytes(&header.to_bytes()).unwrap(),

--- a/lib/src/entry/header.rs
+++ b/lib/src/entry/header.rs
@@ -148,8 +148,7 @@ impl EntryHeader {
             data_kind: DataKind::from_byte(bytes[2]),
             compression: Compression::from_byte(bytes[3]),
             encryption: Encryption::from_byte(bytes[4]),
-            cipher_mode: CipherMode::try_from(bytes[5])
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
+            cipher_mode: CipherMode::from_byte(bytes[5]),
             sanitized_path: OnceLock::new(),
             name: path,
         };
@@ -284,8 +283,7 @@ impl SolidHeader {
             minor: bytes[1],
             compression: Compression::from_byte(bytes[2]),
             encryption: Encryption::from_byte(bytes[3]),
-            cipher_mode: CipherMode::try_from(bytes[4])
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
+            cipher_mode: CipherMode::from_byte(bytes[4]),
         })
     }
 }

--- a/lib/src/entry/header.rs
+++ b/lib/src/entry/header.rs
@@ -58,23 +58,23 @@ impl EntryHeader {
         cipher_mode: CipherMode,
         path: EntryName,
     ) -> Self {
-        Self::new_with_options(DataKind::File, compression, encryption, cipher_mode, path)
+        Self::new_with_options(DataKind::FILE, compression, encryption, cipher_mode, path)
     }
 
     #[inline]
     pub(crate) const fn for_dir(path: EntryName) -> Self {
-        Self::new(DataKind::Directory, path)
+        Self::new(DataKind::DIRECTORY, path)
     }
 
     /// Creates a header for a symbolic link (symlink).
     #[inline]
     pub(crate) const fn for_symlink(path: EntryName) -> Self {
-        Self::new(DataKind::SymbolicLink, path)
+        Self::new(DataKind::SYMBOLIC_LINK, path)
     }
 
     #[inline]
     pub(crate) const fn for_hard_link(path: EntryName) -> Self {
-        Self::new(DataKind::HardLink, path)
+        Self::new(DataKind::HARD_LINK, path)
     }
 
     /// Creates a new EntryHeader with a different name, resetting the sanitized path cache.
@@ -145,8 +145,7 @@ impl EntryHeader {
         let header = Self {
             major: bytes[0],
             minor: bytes[1],
-            data_kind: DataKind::try_from(bytes[2])
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
+            data_kind: DataKind::from_byte(bytes[2]),
             compression: Compression::try_from(bytes[3])
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
             encryption: Encryption::try_from(bytes[4])

--- a/lib/src/entry/options.rs
+++ b/lib/src/entry/options.rs
@@ -138,9 +138,9 @@ mod private {
         #[inline]
         fn encryption(&self) -> Encryption {
             self.cipher()
-                .map_or(Encryption::No, |it| match it.cipher_algorithm {
-                    CipherAlgorithm::Aes => Encryption::Aes,
-                    CipherAlgorithm::Camellia => Encryption::Camellia,
+                .map_or(Encryption::NO, |it| match it.cipher_algorithm {
+                    CipherAlgorithm::Aes => Encryption::AES,
+                    CipherAlgorithm::Camellia => Encryption::CAMELLIA,
                 })
         }
 
@@ -466,57 +466,115 @@ impl<T: AsRef<[u8]>> From<T> for Password {
 }
 
 /// Encryption algorithm.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub enum Encryption {
-    /// Do not apply any encryption.
-    No,
-    /// Aes algorithm.
-    Aes,
-    /// Camellia algorithm.
-    Camellia,
-    /// Value reserved for future PNA specification (raw value < 128).
-    Reserved(u8),
-    /// Application-specific private value (raw value >= 128).
-    Private(u8),
-}
+///
+/// Values without an associated constant are either reserved for future
+/// PNA specification (raw value < 128) or application-specific private
+/// values (raw value >= 128).
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Encryption(u8);
 
 impl Encryption {
-    /// Serialize this encryption method to its u8 representation.
+    /// Do not apply any encryption.
+    pub const NO: Self = Self(0);
+    /// Aes algorithm.
+    pub const AES: Self = Self(1);
+    /// Camellia algorithm.
+    pub const CAMELLIA: Self = Self(2);
+
+    /// Deprecated alias of [`Encryption::NO`].
+    #[deprecated(since = "0.36.0", note = "renamed to `Encryption::NO`")]
+    #[allow(non_upper_case_globals)]
+    pub const No: Self = Self::NO;
+    /// Deprecated alias of [`Encryption::AES`].
+    #[deprecated(since = "0.36.0", note = "renamed to `Encryption::AES`")]
+    #[allow(non_upper_case_globals)]
+    pub const Aes: Self = Self::AES;
+    /// Deprecated alias of [`Encryption::CAMELLIA`].
+    #[deprecated(since = "0.36.0", note = "renamed to `Encryption::CAMELLIA`")]
+    #[allow(non_upper_case_globals)]
+    pub const Camellia: Self = Self::CAMELLIA;
+
+    /// Deserializes an encryption algorithm from its u8 representation.
+    ///
+    /// Every byte value is a valid encryption algorithm value, so this
+    /// conversion never fails.
+    #[inline]
+    pub const fn from_byte(value: u8) -> Self {
+        Self(value)
+    }
+
+    /// Serializes this encryption algorithm to its u8 representation.
     #[inline]
     pub const fn to_byte(self) -> u8 {
-        match self {
-            Self::No => 0,
-            Self::Aes => 1,
-            Self::Camellia => 2,
-            Self::Reserved(v) | Self::Private(v) => v,
+        self.0
+    }
+
+    /// Creates an application-specific private value.
+    ///
+    /// Returns `Some` if `value` is in the private range (`128..=255`),
+    /// otherwise `None`.
+    #[inline]
+    pub const fn new_private(value: u8) -> Option<Self> {
+        if value >= 128 {
+            Some(Self(value))
+        } else {
+            None
         }
     }
 
-    /// Returns `true` if this is a reserved value.
+    /// Converts a `u8` into an [`Encryption`]. Never fails.
+    ///
+    /// Shadows `<Encryption as TryFrom<u8>>::try_from` so existing
+    /// `Encryption::try_from(..)` call sites receive a deprecation warning;
+    /// both will be removed together in a future release.
+    ///
+    /// # Errors
+    ///
+    /// Never returns `Err`; every byte value is a valid encryption algorithm.
+    #[deprecated(since = "0.36.0", note = "use `Encryption::from_byte`")]
+    #[allow(clippy::should_implement_trait)]
     #[inline]
-    pub const fn is_reserved(self) -> bool {
-        matches!(self, Self::Reserved(_))
+    pub const fn try_from(value: u8) -> Result<Self, UnknownValueError> {
+        Ok(Self::from_byte(value))
     }
 
-    /// Returns `true` if this is a private value.
+    /// Returns `true` if this value is reserved for future PNA specification
+    /// (unassigned and raw value < 128).
+    #[inline]
+    pub const fn is_reserved(self) -> bool {
+        !matches!(self.0, 0..=2) && self.0 < 128
+    }
+
+    /// Returns `true` if this is an application-specific private value
+    /// (raw value >= 128).
     #[inline]
     pub const fn is_private(self) -> bool {
-        matches!(self, Self::Private(_))
+        self.0 >= 128
     }
 }
 
+impl fmt::Debug for Encryption {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::NO => f.write_str("No"),
+            Self::AES => f.write_str("Aes"),
+            Self::CAMELLIA => f.write_str("Camellia"),
+            Self(v) if v < 128 => f.debug_tuple("Reserved").field(&v).finish(),
+            Self(v) => f.debug_tuple("Private").field(&v).finish(),
+        }
+    }
+}
+
+/// Infallible; kept for backward compatibility with the former enum-based
+/// API and scheduled for removal in a future release. Use
+/// [`Encryption::from_byte`] instead.
 impl TryFrom<u8> for Encryption {
     type Error = UnknownValueError;
 
     #[inline]
     fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
-            0 => Ok(Self::No),
-            1 => Ok(Self::Aes),
-            2 => Ok(Self::Camellia),
-            v if v < 128 => Ok(Self::Reserved(v)),
-            v => Ok(Self::Private(v)),
-        }
+        Ok(Self::from_byte(value))
     }
 }
 
@@ -606,7 +664,7 @@ impl HashAlgorithm {
     /// use libpna::{WriteOptions, Encryption, HashAlgorithm};
     ///
     /// let opts = WriteOptions::builder()
-    ///     .encryption(Encryption::Aes)
+    ///     .encryption(Encryption::AES)
     ///     .hash_algorithm(HashAlgorithm::pbkdf2_sha256())
     ///     .password(Some("password"))
     ///     .build();
@@ -629,7 +687,7 @@ impl HashAlgorithm {
     /// use libpna::{WriteOptions, Encryption, HashAlgorithm};
     ///
     /// let opts = WriteOptions::builder()
-    ///     .encryption(Encryption::Aes)
+    ///     .encryption(Encryption::AES)
     ///     .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(100_000)))
     ///     .password(Some("password"))
     ///     .build();
@@ -650,7 +708,7 @@ impl HashAlgorithm {
     /// use libpna::{WriteOptions, Encryption, HashAlgorithm};
     ///
     /// let opts = WriteOptions::builder()
-    ///     .encryption(Encryption::Aes)
+    ///     .encryption(Encryption::AES)
     ///     .hash_algorithm(HashAlgorithm::argon2id())
     ///     .password(Some("secure_password"))
     ///     .build();
@@ -677,7 +735,7 @@ impl HashAlgorithm {
     ///
     /// // Custom Argon2id with higher security parameters
     /// let opts = WriteOptions::builder()
-    ///     .encryption(Encryption::Aes)
+    ///     .encryption(Encryption::AES)
     ///     .hash_algorithm(HashAlgorithm::argon2id_with(
     ///         Some(4),       // time_cost: 4 iterations
     ///         Some(65536),   // memory_cost: 64 MiB
@@ -877,7 +935,7 @@ impl TryFrom<u8> for DataKind {
 /// use libpna::{WriteOptions, Encryption, CipherMode, HashAlgorithm};
 ///
 /// let opts = WriteOptions::builder()
-///     .encryption(Encryption::Aes)
+///     .encryption(Encryption::AES)
 ///     .cipher_mode(CipherMode::CTR)
 ///     .hash_algorithm(HashAlgorithm::argon2id())
 ///     .password(Some("secure_password"))
@@ -890,7 +948,7 @@ impl TryFrom<u8> for DataKind {
 ///
 /// let opts = WriteOptions::builder()
 ///     .compression(Compression::ZSTANDARD)
-///     .encryption(Encryption::Aes)
+///     .encryption(Encryption::AES)
 ///     .cipher_mode(CipherMode::CTR)
 ///     .hash_algorithm(HashAlgorithm::argon2id())
 ///     .password(Some("secure_password"))
@@ -1000,7 +1058,7 @@ impl WriteOptionsBuilder {
         Self {
             compression: Compression::NO,
             compression_level: CompressionLevel::DEFAULT,
-            encryption: Encryption::No,
+            encryption: Encryption::NO,
             cipher_mode: CipherMode::CTR,
             hash_algorithm: HashAlgorithm::argon2id(),
             password: None,
@@ -1083,7 +1141,7 @@ impl WriteOptionsBuilder {
     ///
     /// # fn main() -> std::io::Result<()> {
     /// let opts = WriteOptions::builder()
-    ///     .encryption(Encryption::Aes)
+    ///     .encryption(Encryption::AES)
     ///     .password(Some("password"))
     ///     .try_build()?;
     /// # Ok(())
@@ -1092,10 +1150,10 @@ impl WriteOptionsBuilder {
     #[inline]
     #[must_use = "building options without using them is wasteful"]
     pub fn try_build(&self) -> io::Result<WriteOptions> {
-        let cipher = if self.encryption != Encryption::No {
+        let cipher = if self.encryption != Encryption::NO {
             let cipher_algorithm = match self.encryption {
-                Encryption::Aes => CipherAlgorithm::Aes,
-                Encryption::Camellia => CipherAlgorithm::Camellia,
+                Encryption::AES => CipherAlgorithm::Aes,
+                Encryption::CAMELLIA => CipherAlgorithm::Camellia,
                 other => {
                     return Err(io::Error::new(
                         io::ErrorKind::Unsupported,
@@ -1147,8 +1205,8 @@ impl WriteOptionsBuilder {
     ///
     /// # Panics
     ///
-    /// Panics if [`encryption()`](Self::encryption) was set to [`Encryption::Aes`] or
-    /// [`Encryption::Camellia`] but [`password()`](Self::password) was not called with
+    /// Panics if [`encryption()`](Self::encryption) was set to [`Encryption::AES`] or
+    /// [`Encryption::CAMELLIA`] but [`password()`](Self::password) was not called with
     /// a password, or if key derivation fails (see [`try_build()`](Self::try_build) for
     /// the fallible variant).
     ///
@@ -1157,7 +1215,7 @@ impl WriteOptionsBuilder {
     /// use libpna::{WriteOptions, Encryption};
     ///
     /// let opts = WriteOptions::builder()
-    ///     .encryption(Encryption::Aes)
+    ///     .encryption(Encryption::AES)
     ///     .build();  // PANICS: "Password was not provided."
     /// ```
     ///
@@ -1166,7 +1224,7 @@ impl WriteOptionsBuilder {
     /// use libpna::{WriteOptions, Encryption};
     ///
     /// let opts = WriteOptions::builder()
-    ///     .encryption(Encryption::Aes)
+    ///     .encryption(Encryption::AES)
     ///     .password(Some("secure_password"))
     ///     .build();  // OK
     /// ```
@@ -1291,7 +1349,7 @@ mod tests {
     #[test]
     fn try_build_derives_key_at_build() {
         let options = WriteOptions::builder()
-            .encryption(Encryption::Aes)
+            .encryption(Encryption::AES)
             .password(Some("password"))
             .try_build()
             .unwrap();
@@ -1304,7 +1362,7 @@ mod tests {
     fn each_build_generates_fresh_salt() {
         let mut builder = WriteOptions::builder();
         builder
-            .encryption(Encryption::Aes)
+            .encryption(Encryption::AES)
             .password(Some("password"));
         let first = builder.try_build().unwrap();
         let second = builder.try_build().unwrap();
@@ -1317,7 +1375,7 @@ mod tests {
     #[test]
     fn try_build_without_password_returns_error() {
         let err = WriteOptions::builder()
-            .encryption(Encryption::Aes)
+            .encryption(Encryption::AES)
             .try_build()
             .unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
@@ -1326,7 +1384,7 @@ mod tests {
     #[test]
     fn try_build_with_invalid_kdf_params_returns_error() {
         let result = WriteOptions::builder()
-            .encryption(Encryption::Aes)
+            .encryption(Encryption::AES)
             .hash_algorithm(HashAlgorithm::argon2id_with(Some(0), None, None))
             .password(Some("password"))
             .try_build();
@@ -1336,7 +1394,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Password was not provided.")]
     fn build_without_password_panics() {
-        let _ = WriteOptions::builder().encryption(Encryption::Aes).build();
+        let _ = WriteOptions::builder().encryption(Encryption::AES).build();
     }
 
     fn test_output(byte: u8) -> Output {
@@ -1523,6 +1581,86 @@ mod tests {
     fn try_build_with_unknown_compression_returns_unsupported() {
         let err = WriteOptions::builder()
             .compression(Compression::from_byte(5))
+            .try_build()
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    }
+
+    #[test]
+    fn encryption_round_trips_all_byte_values() {
+        for v in 0..=u8::MAX {
+            assert_eq!(Encryption::from_byte(v).to_byte(), v);
+        }
+    }
+
+    #[test]
+    fn encryption_known_constants_map_to_spec_bytes() {
+        assert_eq!(Encryption::NO.to_byte(), 0);
+        assert_eq!(Encryption::AES.to_byte(), 1);
+        assert_eq!(Encryption::CAMELLIA.to_byte(), 2);
+    }
+
+    #[test]
+    fn encryption_new_private_boundary() {
+        assert_eq!(Encryption::new_private(0), None);
+        assert_eq!(Encryption::new_private(127), None);
+        assert_eq!(
+            Encryption::new_private(128),
+            Some(Encryption::from_byte(128))
+        );
+        assert_eq!(
+            Encryption::new_private(255),
+            Some(Encryption::from_byte(255))
+        );
+    }
+
+    #[test]
+    fn encryption_predicates() {
+        assert!(!Encryption::NO.is_reserved());
+        assert!(!Encryption::CAMELLIA.is_reserved());
+        assert!(!Encryption::CAMELLIA.is_private());
+        assert!(Encryption::from_byte(3).is_reserved());
+        assert!(Encryption::from_byte(127).is_reserved());
+        assert!(!Encryption::from_byte(127).is_private());
+        assert!(!Encryption::from_byte(128).is_reserved());
+        assert!(Encryption::from_byte(128).is_private());
+        assert!(Encryption::from_byte(255).is_private());
+    }
+
+    #[test]
+    fn encryption_debug_matches_former_enum_output() {
+        assert_eq!(format!("{:?}", Encryption::NO), "No");
+        assert_eq!(format!("{:?}", Encryption::AES), "Aes");
+        assert_eq!(format!("{:?}", Encryption::CAMELLIA), "Camellia");
+        assert_eq!(format!("{:?}", Encryption::from_byte(3)), "Reserved(3)");
+        assert_eq!(format!("{:?}", Encryption::from_byte(200)), "Private(200)");
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn encryption_deprecated_aliases_equal_new_constants() {
+        assert_eq!(Encryption::No, Encryption::NO);
+        assert_eq!(Encryption::Aes, Encryption::AES);
+        assert_eq!(Encryption::Camellia, Encryption::CAMELLIA);
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn encryption_try_from_is_infallible_and_matches_from_byte() {
+        for v in 0..=u8::MAX {
+            assert_eq!(Encryption::try_from(v).unwrap(), Encryption::from_byte(v));
+            assert_eq!(
+                <Encryption as TryFrom<u8>>::try_from(v).unwrap(),
+                Encryption::from_byte(v)
+            );
+        }
+    }
+
+    #[test]
+    fn try_build_with_unknown_encryption_returns_unsupported() {
+        let err = WriteOptions::builder()
+            .encryption(Encryption::from_byte(5))
+            .password(Some("password"))
             .try_build()
             .unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::Unsupported);

--- a/lib/src/entry/options.rs
+++ b/lib/src/entry/options.rs
@@ -128,9 +128,9 @@ mod private {
         #[inline]
         fn compression(&self) -> Compression {
             match self.compress() {
-                Compress::No => Compression::No,
-                Compress::Deflate(_) => Compression::Deflate,
-                Compress::ZStandard(_) => Compression::ZStandard,
+                Compress::No => Compression::NO,
+                Compress::Deflate(_) => Compression::DEFLATE,
+                Compress::ZStandard(_) => Compression::ZSTANDARD,
                 Compress::XZ(_) => Compression::XZ,
             }
         }
@@ -220,61 +220,118 @@ mod private {
 }
 
 /// Compression method.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub enum Compression {
-    /// Do not apply any compression.
-    No,
-    /// Zlib format.
-    Deflate,
-    /// ZStandard format.
-    ZStandard,
-    /// Xz format.
-    XZ,
-    /// Value reserved for future PNA specification (raw value < 128).
-    Reserved(u8),
-    /// Application-specific private value (raw value >= 128).
-    Private(u8),
-}
+///
+/// Values without an associated constant are either reserved for future
+/// PNA specification (raw value < 128) or application-specific private
+/// values (raw value >= 128).
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Compression(u8);
 
 impl Compression {
-    /// Serialize this compression method to its u8 representation.
+    /// Do not apply any compression.
+    pub const NO: Self = Self(0);
+    /// Zlib format.
+    pub const DEFLATE: Self = Self(1);
+    /// ZStandard format.
+    pub const ZSTANDARD: Self = Self(2);
+    /// Xz format.
+    pub const XZ: Self = Self(4);
+
+    /// Deprecated alias of [`Compression::NO`].
+    #[deprecated(since = "0.36.0", note = "renamed to `Compression::NO`")]
+    #[allow(non_upper_case_globals)]
+    pub const No: Self = Self::NO;
+    /// Deprecated alias of [`Compression::DEFLATE`].
+    #[deprecated(since = "0.36.0", note = "renamed to `Compression::DEFLATE`")]
+    #[allow(non_upper_case_globals)]
+    pub const Deflate: Self = Self::DEFLATE;
+    /// Deprecated alias of [`Compression::ZSTANDARD`].
+    #[deprecated(since = "0.36.0", note = "renamed to `Compression::ZSTANDARD`")]
+    #[allow(non_upper_case_globals)]
+    pub const ZStandard: Self = Self::ZSTANDARD;
+
+    /// Deserializes a compression method from its u8 representation.
+    ///
+    /// Every byte value is a valid compression method, so this conversion
+    /// never fails.
+    #[inline]
+    pub const fn from_byte(value: u8) -> Self {
+        Self(value)
+    }
+
+    /// Serializes this compression method to its u8 representation.
     #[inline]
     pub const fn to_byte(self) -> u8 {
-        match self {
-            Self::No => 0,
-            Self::Deflate => 1,
-            Self::ZStandard => 2,
-            Self::XZ => 4,
-            Self::Reserved(v) | Self::Private(v) => v,
+        self.0
+    }
+
+    /// Creates an application-specific private value.
+    ///
+    /// Returns `Some` if `value` is in the private range (`128..=255`),
+    /// otherwise `None`.
+    #[inline]
+    pub const fn new_private(value: u8) -> Option<Self> {
+        if value >= 128 {
+            Some(Self(value))
+        } else {
+            None
         }
     }
 
-    /// Returns `true` if this is a reserved value.
+    /// Converts a `u8` into a [`Compression`]. Never fails.
+    ///
+    /// Shadows `<Compression as TryFrom<u8>>::try_from` so existing
+    /// `Compression::try_from(..)` call sites receive a deprecation warning;
+    /// both will be removed together in a future release.
+    ///
+    /// # Errors
+    ///
+    /// Never returns `Err`; every byte value is a valid compression method.
+    #[deprecated(since = "0.36.0", note = "use `Compression::from_byte`")]
+    #[allow(clippy::should_implement_trait)]
     #[inline]
-    pub const fn is_reserved(self) -> bool {
-        matches!(self, Self::Reserved(_))
+    pub const fn try_from(value: u8) -> Result<Self, UnknownValueError> {
+        Ok(Self::from_byte(value))
     }
 
-    /// Returns `true` if this is a private value.
+    /// Returns `true` if this value is reserved for future PNA specification
+    /// (unassigned and raw value < 128).
+    #[inline]
+    pub const fn is_reserved(self) -> bool {
+        !matches!(self.0, 0..=2 | 4) && self.0 < 128
+    }
+
+    /// Returns `true` if this is an application-specific private value
+    /// (raw value >= 128).
     #[inline]
     pub const fn is_private(self) -> bool {
-        matches!(self, Self::Private(_))
+        self.0 >= 128
     }
 }
 
+impl fmt::Debug for Compression {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::NO => f.write_str("No"),
+            Self::DEFLATE => f.write_str("Deflate"),
+            Self::ZSTANDARD => f.write_str("ZStandard"),
+            Self::XZ => f.write_str("XZ"),
+            Self(v) if v < 128 => f.debug_tuple("Reserved").field(&v).finish(),
+            Self(v) => f.debug_tuple("Private").field(&v).finish(),
+        }
+    }
+}
+
+/// Infallible; kept for backward compatibility with the former enum-based
+/// API and scheduled for removal in a future release. Use
+/// [`Compression::from_byte`] instead.
 impl TryFrom<u8> for Compression {
     type Error = UnknownValueError;
 
     #[inline]
     fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
-            0 => Ok(Self::No),
-            1 => Ok(Self::Deflate),
-            2 => Ok(Self::ZStandard),
-            4 => Ok(Self::XZ),
-            v if v < 128 => Ok(Self::Reserved(v)),
-            v => Ok(Self::Private(v)),
-        }
+        Ok(Self::from_byte(value))
     }
 }
 
@@ -810,7 +867,7 @@ impl TryFrom<u8> for DataKind {
 /// use libpna::{WriteOptions, Compression, CompressionLevel};
 ///
 /// let opts = WriteOptions::builder()
-///     .compression(Compression::ZStandard)
+///     .compression(Compression::ZSTANDARD)
 ///     .compression_level(CompressionLevel::max())
 ///     .build();
 /// ```
@@ -832,7 +889,7 @@ impl TryFrom<u8> for DataKind {
 /// use libpna::{WriteOptions, Compression, Encryption, CipherMode, HashAlgorithm};
 ///
 /// let opts = WriteOptions::builder()
-///     .compression(Compression::ZStandard)
+///     .compression(Compression::ZSTANDARD)
 ///     .encryption(Encryption::Aes)
 ///     .cipher_mode(CipherMode::CTR)
 ///     .hash_algorithm(HashAlgorithm::argon2id())
@@ -922,9 +979,9 @@ impl From<WriteOptions> for WriteOptionsBuilder {
     #[inline]
     fn from(value: WriteOptions) -> Self {
         let (compression, compression_level) = match value.compress {
-            Compress::No => (Compression::No, CompressionLevel::DEFAULT),
-            Compress::Deflate(level) => (Compression::Deflate, level.into()),
-            Compress::ZStandard(level) => (Compression::ZStandard, level.into()),
+            Compress::No => (Compression::NO, CompressionLevel::DEFAULT),
+            Compress::Deflate(level) => (Compression::DEFLATE, level.into()),
+            Compress::ZStandard(level) => (Compression::ZSTANDARD, level.into()),
             Compress::XZ(level) => (Compression::XZ, level.into()),
         };
         Self {
@@ -941,7 +998,7 @@ impl From<WriteOptions> for WriteOptionsBuilder {
 impl WriteOptionsBuilder {
     const fn new() -> Self {
         Self {
-            compression: Compression::No,
+            compression: Compression::NO,
             compression_level: CompressionLevel::DEFAULT,
             encryption: Encryption::No,
             cipher_mode: CipherMode::CTR,
@@ -1065,9 +1122,9 @@ impl WriteOptionsBuilder {
         };
         Ok(WriteOptions {
             compress: match self.compression {
-                Compression::No => Compress::No,
-                Compression::Deflate => Compress::Deflate(self.compression_level.into()),
-                Compression::ZStandard => Compress::ZStandard(self.compression_level.into()),
+                Compression::NO => Compress::No,
+                Compression::DEFLATE => Compress::Deflate(self.compression_level.into()),
+                Compression::ZSTANDARD => Compress::ZStandard(self.compression_level.into()),
                 Compression::XZ => Compress::XZ(self.compression_level.into()),
                 other => {
                     return Err(io::Error::new(
@@ -1388,5 +1445,86 @@ mod tests {
                 DataKind::from_byte(v)
             );
         }
+    }
+
+    #[test]
+    fn compression_round_trips_all_byte_values() {
+        for v in 0..=u8::MAX {
+            assert_eq!(Compression::from_byte(v).to_byte(), v);
+        }
+    }
+
+    #[test]
+    fn compression_known_constants_map_to_spec_bytes() {
+        assert_eq!(Compression::NO.to_byte(), 0);
+        assert_eq!(Compression::DEFLATE.to_byte(), 1);
+        assert_eq!(Compression::ZSTANDARD.to_byte(), 2);
+        assert_eq!(Compression::XZ.to_byte(), 4);
+    }
+
+    #[test]
+    fn compression_new_private_boundary() {
+        assert_eq!(Compression::new_private(0), None);
+        assert_eq!(Compression::new_private(127), None);
+        assert_eq!(
+            Compression::new_private(128),
+            Some(Compression::from_byte(128))
+        );
+        assert_eq!(
+            Compression::new_private(255),
+            Some(Compression::from_byte(255))
+        );
+    }
+
+    #[test]
+    fn compression_predicates() {
+        assert!(!Compression::NO.is_reserved());
+        assert!(!Compression::XZ.is_reserved());
+        assert!(!Compression::XZ.is_private());
+        assert!(Compression::from_byte(3).is_reserved());
+        assert!(Compression::from_byte(127).is_reserved());
+        assert!(!Compression::from_byte(127).is_private());
+        assert!(!Compression::from_byte(128).is_reserved());
+        assert!(Compression::from_byte(128).is_private());
+        assert!(Compression::from_byte(255).is_private());
+    }
+
+    #[test]
+    fn compression_debug_matches_former_enum_output() {
+        assert_eq!(format!("{:?}", Compression::NO), "No");
+        assert_eq!(format!("{:?}", Compression::DEFLATE), "Deflate");
+        assert_eq!(format!("{:?}", Compression::ZSTANDARD), "ZStandard");
+        assert_eq!(format!("{:?}", Compression::XZ), "XZ");
+        assert_eq!(format!("{:?}", Compression::from_byte(3)), "Reserved(3)");
+        assert_eq!(format!("{:?}", Compression::from_byte(200)), "Private(200)");
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn compression_deprecated_aliases_equal_new_constants() {
+        assert_eq!(Compression::No, Compression::NO);
+        assert_eq!(Compression::Deflate, Compression::DEFLATE);
+        assert_eq!(Compression::ZStandard, Compression::ZSTANDARD);
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn compression_try_from_is_infallible_and_matches_from_byte() {
+        for v in 0..=u8::MAX {
+            assert_eq!(Compression::try_from(v).unwrap(), Compression::from_byte(v));
+            assert_eq!(
+                <Compression as TryFrom<u8>>::try_from(v).unwrap(),
+                Compression::from_byte(v)
+            );
+        }
+    }
+
+    #[test]
+    fn try_build_with_unknown_compression_returns_unsupported() {
+        let err = WriteOptions::builder()
+            .compression(Compression::from_byte(5))
+            .try_build()
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Unsupported);
     }
 }

--- a/lib/src/entry/options.rs
+++ b/lib/src/entry/options.rs
@@ -645,64 +645,123 @@ impl HashAlgorithm {
 
 /// Type of filesystem object represented by an entry.
 ///
-/// Each variant determines how the entry's data should be interpreted
-/// and how the entry should be extracted to the filesystem.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub enum DataKind {
-    /// Regular file. Entry data contains the file contents.
-    File,
-    /// Directory. Entry has no data content.
-    Directory,
-    /// Symbolic link. Entry data contains the UTF-8 encoded link target path.
-    SymbolicLink,
-    /// Hard link. Entry data contains the UTF-8 encoded path of the target entry
-    /// within the same archive.
-    HardLink,
-    /// Value reserved for future PNA specification (raw value < 128).
-    Reserved(u8),
-    /// Application-specific private value (raw value >= 128).
-    Private(u8),
-}
+/// Each value determines how the entry's data should be interpreted
+/// and how the entry should be extracted to the filesystem. Values
+/// without an associated constant are either reserved for future PNA
+/// specification (raw value < 128) or application-specific private
+/// values (raw value >= 128).
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct DataKind(u8);
 
 impl DataKind {
-    /// Serialize this data kind to its u8 representation.
+    /// Regular file. Entry data contains the file contents.
+    pub const FILE: Self = Self(0);
+    /// Directory. Entry has no data content.
+    pub const DIRECTORY: Self = Self(1);
+    /// Symbolic link. Entry data contains the UTF-8 encoded link target path.
+    pub const SYMBOLIC_LINK: Self = Self(2);
+    /// Hard link. Entry data contains the UTF-8 encoded path of the target
+    /// entry within the same archive.
+    pub const HARD_LINK: Self = Self(3);
+
+    /// Deprecated alias of [`DataKind::FILE`].
+    #[deprecated(since = "0.36.0", note = "renamed to `DataKind::FILE`")]
+    #[allow(non_upper_case_globals)]
+    pub const File: Self = Self::FILE;
+    /// Deprecated alias of [`DataKind::DIRECTORY`].
+    #[deprecated(since = "0.36.0", note = "renamed to `DataKind::DIRECTORY`")]
+    #[allow(non_upper_case_globals)]
+    pub const Directory: Self = Self::DIRECTORY;
+    /// Deprecated alias of [`DataKind::SYMBOLIC_LINK`].
+    #[deprecated(since = "0.36.0", note = "renamed to `DataKind::SYMBOLIC_LINK`")]
+    #[allow(non_upper_case_globals)]
+    pub const SymbolicLink: Self = Self::SYMBOLIC_LINK;
+    /// Deprecated alias of [`DataKind::HARD_LINK`].
+    #[deprecated(since = "0.36.0", note = "renamed to `DataKind::HARD_LINK`")]
+    #[allow(non_upper_case_globals)]
+    pub const HardLink: Self = Self::HARD_LINK;
+
+    /// Deserializes a data kind from its u8 representation.
+    ///
+    /// Every byte value is a valid data kind, so this conversion never fails.
+    #[inline]
+    pub const fn from_byte(value: u8) -> Self {
+        Self(value)
+    }
+
+    /// Serializes this data kind to its u8 representation.
     #[inline]
     pub const fn to_byte(self) -> u8 {
-        match self {
-            Self::File => 0,
-            Self::Directory => 1,
-            Self::SymbolicLink => 2,
-            Self::HardLink => 3,
-            Self::Reserved(v) | Self::Private(v) => v,
+        self.0
+    }
+
+    /// Creates an application-specific private value.
+    ///
+    /// Returns `Some` if `value` is in the private range (`128..=255`),
+    /// otherwise `None`.
+    #[inline]
+    pub const fn new_private(value: u8) -> Option<Self> {
+        if value >= 128 {
+            Some(Self(value))
+        } else {
+            None
         }
     }
 
-    /// Returns `true` if this is a reserved value.
+    /// Converts a `u8` into a [`DataKind`]. Never fails.
+    ///
+    /// Shadows `<DataKind as TryFrom<u8>>::try_from` so existing
+    /// `DataKind::try_from(..)` call sites receive a deprecation warning;
+    /// both will be removed together in a future release.
+    ///
+    /// # Errors
+    ///
+    /// Never returns `Err`; every byte value is a valid data kind.
+    #[deprecated(since = "0.36.0", note = "use `DataKind::from_byte`")]
+    #[allow(clippy::should_implement_trait)]
     #[inline]
-    pub const fn is_reserved(self) -> bool {
-        matches!(self, Self::Reserved(_))
+    pub const fn try_from(value: u8) -> Result<Self, UnknownValueError> {
+        Ok(Self::from_byte(value))
     }
 
-    /// Returns `true` if this is a private value.
+    /// Returns `true` if this value is reserved for future PNA specification
+    /// (unassigned and raw value < 128).
+    #[inline]
+    pub const fn is_reserved(self) -> bool {
+        !matches!(self.0, 0..=3) && self.0 < 128
+    }
+
+    /// Returns `true` if this is an application-specific private value
+    /// (raw value >= 128).
     #[inline]
     pub const fn is_private(self) -> bool {
-        matches!(self, Self::Private(_))
+        self.0 >= 128
     }
 }
 
+impl fmt::Debug for DataKind {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::FILE => f.write_str("File"),
+            Self::DIRECTORY => f.write_str("Directory"),
+            Self::SYMBOLIC_LINK => f.write_str("SymbolicLink"),
+            Self::HARD_LINK => f.write_str("HardLink"),
+            Self(v) if v < 128 => f.debug_tuple("Reserved").field(&v).finish(),
+            Self(v) => f.debug_tuple("Private").field(&v).finish(),
+        }
+    }
+}
+
+/// Infallible; kept for backward compatibility with the former enum-based
+/// API and scheduled for removal in a future release. Use
+/// [`DataKind::from_byte`] instead.
 impl TryFrom<u8> for DataKind {
     type Error = UnknownValueError;
 
     #[inline]
     fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
-            0 => Ok(Self::File),
-            1 => Ok(Self::Directory),
-            2 => Ok(Self::SymbolicLink),
-            3 => Ok(Self::HardLink),
-            v if v < 128 => Ok(Self::Reserved(v)),
-            v => Ok(Self::Private(v)),
-        }
+        Ok(Self::from_byte(value))
     }
 }
 
@@ -1262,5 +1321,72 @@ mod tests {
         options.key_cache.insert("phsf-a", test_output(1));
         let rebuilt = options.clone().into_builder().build();
         assert_eq!(rebuilt.cached_key_count(), 0);
+    }
+
+    #[test]
+    fn data_kind_round_trips_all_byte_values() {
+        for v in 0..=u8::MAX {
+            assert_eq!(DataKind::from_byte(v).to_byte(), v);
+        }
+    }
+
+    #[test]
+    fn data_kind_known_constants_map_to_spec_bytes() {
+        assert_eq!(DataKind::FILE.to_byte(), 0);
+        assert_eq!(DataKind::DIRECTORY.to_byte(), 1);
+        assert_eq!(DataKind::SYMBOLIC_LINK.to_byte(), 2);
+        assert_eq!(DataKind::HARD_LINK.to_byte(), 3);
+    }
+
+    #[test]
+    fn data_kind_new_private_boundary() {
+        assert_eq!(DataKind::new_private(0), None);
+        assert_eq!(DataKind::new_private(127), None);
+        assert_eq!(DataKind::new_private(128), Some(DataKind::from_byte(128)));
+        assert_eq!(DataKind::new_private(255), Some(DataKind::from_byte(255)));
+    }
+
+    #[test]
+    fn data_kind_predicates() {
+        assert!(!DataKind::FILE.is_reserved());
+        assert!(!DataKind::FILE.is_private());
+        assert!(!DataKind::HARD_LINK.is_reserved());
+        assert!(DataKind::from_byte(4).is_reserved());
+        assert!(DataKind::from_byte(127).is_reserved());
+        assert!(!DataKind::from_byte(127).is_private());
+        assert!(!DataKind::from_byte(128).is_reserved());
+        assert!(DataKind::from_byte(128).is_private());
+        assert!(DataKind::from_byte(255).is_private());
+    }
+
+    #[test]
+    fn data_kind_debug_matches_former_enum_output() {
+        assert_eq!(format!("{:?}", DataKind::FILE), "File");
+        assert_eq!(format!("{:?}", DataKind::DIRECTORY), "Directory");
+        assert_eq!(format!("{:?}", DataKind::SYMBOLIC_LINK), "SymbolicLink");
+        assert_eq!(format!("{:?}", DataKind::HARD_LINK), "HardLink");
+        assert_eq!(format!("{:?}", DataKind::from_byte(5)), "Reserved(5)");
+        assert_eq!(format!("{:?}", DataKind::from_byte(200)), "Private(200)");
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn data_kind_deprecated_aliases_equal_new_constants() {
+        assert_eq!(DataKind::File, DataKind::FILE);
+        assert_eq!(DataKind::Directory, DataKind::DIRECTORY);
+        assert_eq!(DataKind::SymbolicLink, DataKind::SYMBOLIC_LINK);
+        assert_eq!(DataKind::HardLink, DataKind::HARD_LINK);
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn data_kind_try_from_is_infallible_and_matches_from_byte() {
+        for v in 0..=u8::MAX {
+            assert_eq!(DataKind::try_from(v).unwrap(), DataKind::from_byte(v));
+            assert_eq!(
+                <DataKind as TryFrom<u8>>::try_from(v).unwrap(),
+                DataKind::from_byte(v)
+            );
+        }
     }
 }

--- a/lib/src/entry/options.rs
+++ b/lib/src/entry/options.rs
@@ -579,53 +579,99 @@ impl TryFrom<u8> for Encryption {
 }
 
 /// Cipher mode of encryption algorithm.
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub enum CipherMode {
-    /// Cipher Block Chaining mode.
-    CBC,
-    /// Counter mode.
-    CTR,
-    /// Value reserved for future PNA specification (raw value < 128).
-    Reserved(u8),
-    /// Application-specific private value (raw value >= 128).
-    Private(u8),
-}
+///
+/// Values without an associated constant are either reserved for future
+/// PNA specification (raw value < 128) or application-specific private
+/// values (raw value >= 128).
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct CipherMode(u8);
 
 impl CipherMode {
-    /// Serialize this cipher mode to its u8 representation.
+    /// Cipher Block Chaining mode.
+    pub const CBC: Self = Self(0);
+    /// Counter mode.
+    pub const CTR: Self = Self(1);
+
+    /// Deserializes a cipher mode from its u8 representation.
+    ///
+    /// Every byte value is a valid cipher mode value, so this conversion
+    /// never fails.
+    #[inline]
+    pub const fn from_byte(value: u8) -> Self {
+        Self(value)
+    }
+
+    /// Serializes this cipher mode to its u8 representation.
     #[inline]
     pub const fn to_byte(self) -> u8 {
-        match self {
-            Self::CBC => 0,
-            Self::CTR => 1,
-            Self::Reserved(v) | Self::Private(v) => v,
+        self.0
+    }
+
+    /// Creates an application-specific private value.
+    ///
+    /// Returns `Some` if `value` is in the private range (`128..=255`),
+    /// otherwise `None`.
+    #[inline]
+    pub const fn new_private(value: u8) -> Option<Self> {
+        if value >= 128 {
+            Some(Self(value))
+        } else {
+            None
         }
     }
 
-    /// Returns `true` if this is a reserved value.
+    /// Converts a `u8` into a [`CipherMode`]. Never fails.
+    ///
+    /// Shadows `<CipherMode as TryFrom<u8>>::try_from` so existing
+    /// `CipherMode::try_from(..)` call sites receive a deprecation warning;
+    /// both will be removed together in a future release.
+    ///
+    /// # Errors
+    ///
+    /// Never returns `Err`; every byte value is a valid cipher mode.
+    #[deprecated(since = "0.36.0", note = "use `CipherMode::from_byte`")]
+    #[allow(clippy::should_implement_trait)]
     #[inline]
-    pub const fn is_reserved(self) -> bool {
-        matches!(self, Self::Reserved(_))
+    pub const fn try_from(value: u8) -> Result<Self, UnknownValueError> {
+        Ok(Self::from_byte(value))
     }
 
-    /// Returns `true` if this is a private value.
+    /// Returns `true` if this value is reserved for future PNA specification
+    /// (unassigned and raw value < 128).
+    #[inline]
+    pub const fn is_reserved(self) -> bool {
+        !matches!(self.0, 0..=1) && self.0 < 128
+    }
+
+    /// Returns `true` if this is an application-specific private value
+    /// (raw value >= 128).
     #[inline]
     pub const fn is_private(self) -> bool {
-        matches!(self, Self::Private(_))
+        self.0 >= 128
     }
 }
 
+impl fmt::Debug for CipherMode {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::CBC => f.write_str("CBC"),
+            Self::CTR => f.write_str("CTR"),
+            Self(v) if v < 128 => f.debug_tuple("Reserved").field(&v).finish(),
+            Self(v) => f.debug_tuple("Private").field(&v).finish(),
+        }
+    }
+}
+
+/// Infallible; kept for backward compatibility with the former enum-based
+/// API and scheduled for removal in a future release. Use
+/// [`CipherMode::from_byte`] instead.
 impl TryFrom<u8> for CipherMode {
     type Error = UnknownValueError;
 
     #[inline]
     fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
-            0 => Ok(Self::CBC),
-            1 => Ok(Self::CTR),
-            v if v < 128 => Ok(Self::Reserved(v)),
-            v => Ok(Self::Private(v)),
-        }
+        Ok(Self::from_byte(value))
     }
 }
 
@@ -1664,5 +1710,65 @@ mod tests {
             .try_build()
             .unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::Unsupported);
+    }
+
+    #[test]
+    fn cipher_mode_round_trips_all_byte_values() {
+        for v in 0..=u8::MAX {
+            assert_eq!(CipherMode::from_byte(v).to_byte(), v);
+        }
+    }
+
+    #[test]
+    fn cipher_mode_known_constants_map_to_spec_bytes() {
+        assert_eq!(CipherMode::CBC.to_byte(), 0);
+        assert_eq!(CipherMode::CTR.to_byte(), 1);
+    }
+
+    #[test]
+    fn cipher_mode_new_private_boundary() {
+        assert_eq!(CipherMode::new_private(0), None);
+        assert_eq!(CipherMode::new_private(127), None);
+        assert_eq!(
+            CipherMode::new_private(128),
+            Some(CipherMode::from_byte(128))
+        );
+        assert_eq!(
+            CipherMode::new_private(255),
+            Some(CipherMode::from_byte(255))
+        );
+    }
+
+    #[test]
+    fn cipher_mode_predicates() {
+        assert!(!CipherMode::CBC.is_reserved());
+        assert!(!CipherMode::CTR.is_reserved());
+        assert!(!CipherMode::CTR.is_private());
+        assert!(CipherMode::from_byte(2).is_reserved());
+        assert!(CipherMode::from_byte(127).is_reserved());
+        assert!(!CipherMode::from_byte(127).is_private());
+        assert!(!CipherMode::from_byte(128).is_reserved());
+        assert!(CipherMode::from_byte(128).is_private());
+        assert!(CipherMode::from_byte(255).is_private());
+    }
+
+    #[test]
+    fn cipher_mode_debug_matches_former_enum_output() {
+        assert_eq!(format!("{:?}", CipherMode::CBC), "CBC");
+        assert_eq!(format!("{:?}", CipherMode::CTR), "CTR");
+        assert_eq!(format!("{:?}", CipherMode::from_byte(2)), "Reserved(2)");
+        assert_eq!(format!("{:?}", CipherMode::from_byte(200)), "Private(200)");
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn cipher_mode_try_from_is_infallible_and_matches_from_byte() {
+        for v in 0..=u8::MAX {
+            assert_eq!(CipherMode::try_from(v).unwrap(), CipherMode::from_byte(v));
+            assert_eq!(
+                <CipherMode as TryFrom<u8>>::try_from(v).unwrap(),
+                CipherMode::from_byte(v)
+            );
+        }
     }
 }

--- a/lib/src/entry/read.rs
+++ b/lib/src/entry/read.rs
@@ -45,8 +45,8 @@ pub(crate) fn decrypt_reader<R: Read>(
     key_cache: Option<&KeyCache>,
 ) -> io::Result<DecryptReader<R>> {
     Ok(match encryption {
-        Encryption::No => DecryptReader::No(reader),
-        encryption @ (Encryption::Aes | Encryption::Camellia) => {
+        Encryption::NO => DecryptReader::No(reader),
+        encryption @ (Encryption::AES | Encryption::CAMELLIA) => {
             let s = phsf.ok_or_else(|| {
                 io::Error::new(io::ErrorKind::InvalidData, "`PHSF` chunk not found")
             })?;
@@ -56,22 +56,22 @@ pub(crate) fn decrypt_reader<R: Read>(
             let hash = resolve_key(s, password, key_cache)?;
             let key = hash.as_bytes();
             match (encryption, cipher_mode) {
-                (Encryption::Aes, CipherMode::CBC) => {
+                (Encryption::AES, CipherMode::CBC) => {
                     let mut iv = vec![0; Aes256::block_size()];
                     reader.read_exact(&mut iv)?;
                     DecryptReader::CbcAes(DecryptCbcAes256Reader::new(reader, key, &iv)?)
                 }
-                (Encryption::Aes, CipherMode::CTR) => {
+                (Encryption::AES, CipherMode::CTR) => {
                     let mut iv = vec![0u8; Aes256::block_size()];
                     reader.read_exact(&mut iv)?;
                     DecryptReader::CtrAes(Ctr128BEReader::new(reader, key, &iv)?)
                 }
-                (Encryption::Camellia, CipherMode::CBC) => {
+                (Encryption::CAMELLIA, CipherMode::CBC) => {
                     let mut iv = vec![0; Camellia256::block_size()];
                     reader.read_exact(&mut iv)?;
                     DecryptReader::CbcCamellia(DecryptCbcCamellia256Reader::new(reader, key, &iv)?)
                 }
-                (Encryption::Camellia, CipherMode::CTR) => {
+                (Encryption::CAMELLIA, CipherMode::CTR) => {
                     let mut iv = vec![0u8; Camellia256::block_size()];
                     reader.read_exact(&mut iv)?;
                     DecryptReader::CtrCamellia(Ctr128BEReader::new(reader, key, &iv)?)
@@ -137,7 +137,7 @@ mod tests {
         let phsf = "$argon2id$v=19$m=8,t=1,p=1$c29tZXNhbHQ";
         let result = decrypt_reader(
             io::Cursor::new(Vec::<u8>::new()),
-            Encryption::Camellia,
+            Encryption::CAMELLIA,
             CipherMode::Reserved(3),
             Some(phsf),
             Some(b"password"),

--- a/lib/src/entry/read.rs
+++ b/lib/src/entry/read.rs
@@ -102,11 +102,11 @@ pub(crate) fn decompress_reader<R: Read>(
 ) -> io::Result<DecompressReader<R>> {
     let reader = io::BufReader::with_capacity(DECOMPRESS_BUFFER_SIZE, reader);
     Ok(match compression {
-        Compression::No => DecompressReader::No(reader),
-        Compression::Deflate => {
+        Compression::NO => DecompressReader::No(reader),
+        Compression::DEFLATE => {
             DecompressReader::Deflate(flate2::bufread::ZlibDecoder::new(reader))
         }
-        Compression::ZStandard => DecompressReader::ZStd(zstd::Decoder::with_buffer(reader)?),
+        Compression::ZSTANDARD => DecompressReader::ZStd(zstd::Decoder::with_buffer(reader)?),
         Compression::XZ => DecompressReader::Xz(liblzma::bufread::XzDecoder::new(reader)),
         _ => {
             return Err(io::Error::new(

--- a/lib/src/entry/read.rs
+++ b/lib/src/entry/read.rs
@@ -138,7 +138,7 @@ mod tests {
         let result = decrypt_reader(
             io::Cursor::new(Vec::<u8>::new()),
             Encryption::CAMELLIA,
-            CipherMode::Reserved(3),
+            CipherMode::from_byte(3),
             Some(phsf),
             Some(b"password"),
             None,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -68,12 +68,12 @@
 //!
 //! // Compressed entry (Zstandard)
 //! let compressed = WriteOptions::builder()
-//!     .compression(Compression::ZStandard)
+//!     .compression(Compression::ZSTANDARD)
 //!     .build();
 //!
 //! // Encrypted entry (AES-256-CTR with Argon2id key derivation)
 //! let encrypted = WriteOptions::builder()
-//!     .compression(Compression::ZStandard)
+//!     .compression(Compression::ZSTANDARD)
 //!     .encryption(Encryption::Aes)
 //!     .cipher_mode(CipherMode::CTR)
 //!     .hash_algorithm(HashAlgorithm::argon2id())

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -74,7 +74,7 @@
 //! // Encrypted entry (AES-256-CTR with Argon2id key derivation)
 //! let encrypted = WriteOptions::builder()
 //!     .compression(Compression::ZSTANDARD)
-//!     .encryption(Encryption::Aes)
+//!     .encryption(Encryption::AES)
 //!     .cipher_mode(CipherMode::CTR)
 //!     .hash_algorithm(HashAlgorithm::argon2id())
 //!     .password(Some("secure_password"))

--- a/lib/tests/extract_compatibility.rs
+++ b/lib/tests/extract_compatibility.rs
@@ -5,7 +5,7 @@ fn extract_all(bytes: &[u8], password: Option<&[u8]>) {
     let mut archive_reader = Archive::read_header(bytes).unwrap();
     for entry in archive_reader.entries().skip_solid() {
         let item = entry.unwrap();
-        if item.header().data_kind() == DataKind::Directory {
+        if item.header().data_kind() == DataKind::DIRECTORY {
             continue;
         }
         let path = item.header().path().as_str();

--- a/lib/tests/extract_multipart_compatibility.rs
+++ b/lib/tests/extract_multipart_compatibility.rs
@@ -8,7 +8,7 @@ fn extract_all(follows: &[&[u8]], password: Option<&str>) {
         idx += 1;
         for entry in archive_reader.entries().skip_solid() {
             let item = entry.unwrap();
-            if item.header().data_kind() == DataKind::Directory {
+            if item.header().data_kind() == DataKind::DIRECTORY {
                 continue;
             }
             let path = item.header().path().to_string();

--- a/lib/tests/extract_solid_compatibility.rs
+++ b/lib/tests/extract_solid_compatibility.rs
@@ -53,7 +53,7 @@ fn extract_all(bytes: &[u8], password: Option<&[u8]>) {
     let read_options = ReadOptions::with_password(password);
     for entry in archive_reader.entries_with_options(&read_options) {
         let item = entry.unwrap();
-        if item.header().data_kind() == DataKind::Directory {
+        if item.header().data_kind() == DataKind::DIRECTORY {
             continue;
         }
         n += 1;
@@ -69,7 +69,7 @@ fn extract_all(bytes: &[u8], password: Option<&[u8]>) {
             ReadEntry::Solid(item) => {
                 for item in item.entries(&read_options).unwrap() {
                     let item = item.unwrap();
-                    if item.header().data_kind() == DataKind::Directory {
+                    if item.header().data_kind() == DataKind::DIRECTORY {
                         continue;
                     }
                     n += 1;
@@ -77,7 +77,7 @@ fn extract_all(bytes: &[u8], password: Option<&[u8]>) {
                 }
             }
             ReadEntry::Normal(item) => {
-                if item.header().data_kind() == DataKind::Directory {
+                if item.header().data_kind() == DataKind::DIRECTORY {
                     continue;
                 }
                 n += 1;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -268,7 +268,7 @@ fn build_write_options(method: CompressionMethod, password: Option<&str>) -> lib
     if let Some(pw) = password {
         libpna::WriteOptions::builder()
             .compression(compression)
-            .encryption(libpna::Encryption::Aes)
+            .encryption(libpna::Encryption::AES)
             .cipher_mode(libpna::CipherMode::CTR)
             .password(Some(pw))
             .build()

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -260,9 +260,9 @@ fn tar_stem(path: &Path) -> String {
 
 fn build_write_options(method: CompressionMethod, password: Option<&str>) -> libpna::WriteOptions {
     let compression = match method {
-        CompressionMethod::None | CompressionMethod::Store => libpna::Compression::No,
-        CompressionMethod::Zlib => libpna::Compression::Deflate,
-        CompressionMethod::Zstd => libpna::Compression::ZStandard,
+        CompressionMethod::None | CompressionMethod::Store => libpna::Compression::NO,
+        CompressionMethod::Zlib => libpna::Compression::DEFLATE,
+        CompressionMethod::Zstd => libpna::Compression::ZSTANDARD,
         CompressionMethod::Xz => libpna::Compression::XZ,
     };
     if let Some(pw) = password {
@@ -272,7 +272,7 @@ fn build_write_options(method: CompressionMethod, password: Option<&str>) -> lib
             .cipher_mode(libpna::CipherMode::CTR)
             .password(Some(pw))
             .build()
-    } else if matches!(compression, libpna::Compression::No) {
+    } else if matches!(compression, libpna::Compression::NO) {
         libpna::WriteOptions::store()
     } else {
         libpna::WriteOptions::builder()


### PR DESCRIPTION
## Summary
Replace the `DataKind`, `Compression`, `Encryption`, and `CipherMode` enums with byte-backed newtypes (`pub struct X(u8)` + associated constants). The open-enum shape allowed constructing aliased values such as `DataKind::Reserved(0)` (same wire byte as `File` but unequal), and assigning a new known value would silently change the meaning of existing `Reserved(n)` matches; with the newtype every byte value has a single canonical representation and future assignments are non-breaking.

## Notes
- Canonical constants are SCREAMING_SNAKE (`DataKind::FILE`, …). Old variant spellings remain available as `#[deprecated]` constants where the spelling changed; `CipherMode::CBC`/`CTR` and `Compression::XZ` are unchanged.
- `TryFrom<u8>` is kept (behavior unchanged, still infallible) and shadowed by a deprecated inherent `try_from`, so `X::try_from(b)` call sites get a deprecation warning; both will be removed together in a future release. `from_byte` is the successor.
- `Reserved(v)`/`Private(v)` pattern matches no longer compile; use a wildcard arm with `is_reserved()`/`is_private()`.
- `Debug` output is unchanged. `Ord` now follows the byte value; the only observable difference is `Compression`'s unassigned byte 3 now ordering before `XZ` (4).
- Considered and rejected constructors: `new_reserved` (with "unassigned → Some" semantics its result would silently change across versions once a value is assigned; with "any value < 128 → Some" semantics `new_reserved(0)` would return `FILE` — the reserved range is the specification's namespace) and `unsafe new_unchecked` (every byte is a valid canonical value, so there is no safety invariant for `unsafe` to guard; unchecked total construction is exactly `from_byte`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized archive metadata handling for compression, encryption, cipher modes, and entry types.
  * Added support for constructing and inspecting custom and unknown metadata values.

* **Bug Fixes**
  * Improved archive header validation and handling of unsupported metadata values.
  * Preserved existing compression, encryption, extraction, comparison, and verification behavior across CLI and library workflows.

* **Documentation**
  * Updated examples and API documentation to reflect the standardized metadata options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->