### PR TITLE
Remove deprecated bsdtar compression level flags

### DIFF
--- a/cli/src/command/bsdtar.rs
+++ b/cli/src/command/bsdtar.rs
@@ -1,7 +1,7 @@
 use crate::{
     cli::{
-        CipherAlgorithmArgs, ColorChoice, DateTime, DeflateLevel, GlobalContext, HashAlgorithmArgs,
-        MissingTimePolicy, NameIdPair, PasswordArgs, XzLevel, ZstdLevel,
+        CipherAlgorithmArgs, ColorChoice, DateTime, GlobalContext, HashAlgorithmArgs,
+        MissingTimePolicy, NameIdPair, PasswordArgs,
     },
     command::{
         Command,
@@ -41,26 +41,12 @@ use std::{
 struct CompressionAlgorithmArgs {
     #[arg(long, help = "No compression")]
     store: bool,
-    #[arg(
-        long,
-        visible_alias = "zlib",
-        value_name = "level",
-        help = "Use deflate for compression [possible level: 1-9, min, max]"
-    )]
-    deflate: Option<Option<DeflateLevel>>,
-    #[arg(
-        long,
-        value_name = "level",
-        help = "Use zstd for compression [possible level: 1-21, min, max]"
-    )]
-    zstd: Option<Option<ZstdLevel>>,
-    #[arg(
-        short = 'J',
-        long,
-        value_name = "level",
-        help = "Use xz for compression [possible level: 0-9, min, max]"
-    )]
-    xz: Option<Option<XzLevel>>,
+    #[arg(long, visible_alias = "zlib", help = "Use deflate for compression")]
+    deflate: bool,
+    #[arg(long, help = "Use zstd for compression")]
+    zstd: bool,
+    #[arg(short = 'J', long, help = "Use xz for compression")]
+    xz: bool,
 }
 
 impl CompressionAlgorithmArgs {
@@ -68,38 +54,29 @@ impl CompressionAlgorithmArgs {
         &self,
         options: Option<&crate::cli::ArchiveOptions>,
     ) -> (pna::Compression, Option<pna::CompressionLevel>) {
-        let (compression, flag_level, module_level) = if self.store {
-            (pna::Compression::No, None, None)
-        } else if let Some(level) = self.xz {
+        let (compression, module_level) = if self.store {
+            (pna::Compression::No, None)
+        } else if self.xz {
             (
                 pna::Compression::XZ,
-                level.map(Into::into),
                 options.and_then(|o| o.xz_compression_level.map(Into::into)),
             )
-        } else if let Some(level) = self.zstd {
+        } else if self.zstd {
             (
                 pna::Compression::ZStandard,
-                level.map(Into::into),
                 options.and_then(|o| o.zstd_compression_level.map(Into::into)),
             )
-        } else if let Some(level) = self.deflate {
+        } else if self.deflate {
             (
                 pna::Compression::Deflate,
-                level.map(Into::into),
                 options.and_then(|o| o.deflate_compression_level.map(Into::into)),
             )
         } else {
-            (pna::Compression::ZStandard, None, None)
+            (pna::Compression::ZStandard, None)
         };
 
-        if flag_level.is_some() {
-            log::warn!(
-                "compression level in flags is deprecated, use `--options='compression-level=N'` instead"
-            );
-        }
-
         let global_level = options.and_then(|o| o.compression_level);
-        let level = module_level.or(global_level).or(flag_level);
+        let level = module_level.or(global_level);
 
         (compression, level)
     }

--- a/cli/tests/cli/combination.rs
+++ b/cli/tests/cli/combination.rs
@@ -14,6 +14,15 @@ const COMPRESSION_OPTIONS: &[Option<&[&str]>] = &[
     Some(&["--xz", "1"]),
 ];
 
+// bsdtar's compression flags select an algorithm only; the level is set via
+// `--options='compression-level=N'`, not a value on the flag itself.
+const BSDTAR_COMPRESSION_OPTIONS: &[Option<&[&str]>] = &[
+    Some(&["--store"]),
+    Some(&["--deflate"]),
+    Some(&["--zstd"]),
+    Some(&["--xz"]),
+];
+
 const ENCRYPTION_OPTIONS: &[Option<[&str; 2]>] = &[
     None,
     Some(["--aes", "ctr"]),
@@ -144,7 +153,7 @@ fn combination_stdio() {
         );
     }
     for keep in STDIO_KEEP_OPTIONS {
-        for compress in COMPRESSION_OPTIONS {
+        for compress in BSDTAR_COMPRESSION_OPTIONS {
             for encrypt in ENCRYPTION_OPTIONS {
                 for solid in SOLID_OPTIONS {
                     let mut options = [*keep, *solid]

--- a/cli/tests/cli/stdio/option_options.rs
+++ b/cli/tests/cli/stdio/option_options.rs
@@ -1,7 +1,7 @@
 #![cfg(not(target_family = "wasm"))]
 use crate::utils::setup;
 use assert_cmd::cargo::cargo_bin_cmd;
-use predicates::prelude::{PredicateBooleanExt, predicate};
+use predicates::prelude::predicate;
 use std::fs;
 
 /// --options with global compression-level creates archive successfully.
@@ -40,47 +40,6 @@ fn stdio_options_module_compression_level() {
         .arg(file)
         .assert()
         .success();
-}
-
-/// Flag-level compression (--zstd=N) shows deprecation warning.
-#[test]
-fn stdio_flag_level_shows_deprecation_warning() {
-    setup();
-    let file = "stdio_flag_level_deprecated.txt";
-    fs::write(file, "test content").unwrap();
-
-    let mut cmd = cargo_bin_cmd!("pna");
-    cmd.arg("experimental")
-        .arg("stdio")
-        .arg("-c")
-        .arg("--zstd=15")
-        .arg("--")
-        .arg(file)
-        .assert()
-        .success()
-        .stderr(predicate::str::contains(
-            "compression level in flags is deprecated",
-        ));
-}
-
-/// --options without flag-level does not show deprecation warning.
-#[test]
-fn stdio_options_no_deprecation_warning() {
-    setup();
-    let file = "stdio_options_no_deprecation.txt";
-    fs::write(file, "test content").unwrap();
-
-    let mut cmd = cargo_bin_cmd!("pna");
-    cmd.arg("experimental")
-        .arg("stdio")
-        .arg("-c")
-        .arg("--zstd")
-        .arg("--options=compression-level=15")
-        .arg("--")
-        .arg(file)
-        .assert()
-        .success()
-        .stderr(predicate::str::contains("deprecated").not());
 }
 
 /// Invalid --options value shows error with context.


### PR DESCRIPTION
## Summary
Removes flag-level compression-level acceptance (e.g. `--zstd=15`) from `compat bsdtar`, deprecated since `0.30.2` and past the four-minor-version removal window (grace period ended at `0.34.0`; current version `0.35.1`). This was a PNA extension, not real bsdtar behavior; `--options='compression-level=N'` is the bsdtar-compatible way to set it and remains unaffected. The compression method flags themselves (`--store`/`--deflate`/`--zstd`/`--xz`) are unchanged.

## Notes
`--zstd=15`-style old syntax now fails with a clap parse error instead of a deprecation warning + success.

Closes #3214