### PR TITLE
:bug: Require BSDTAR_REFERENCE=1 exactly to enable bsdtar reference mode

### DIFF
--- a/cli/tests/cli/bsdtar/option_update_strip_components.rs
+++ b/cli/tests/cli/bsdtar/option_update_strip_components.rs
@@ -36,7 +36,7 @@ const MTIME_2020: i64 = 1_577_836_800; // 2020-01-01T00:00:00Z
 const MTIME_2026: i64 = 1_767_225_600; // 2026-01-01T00:00:00Z
 
 fn is_bsdtar_reference() -> bool {
-    std::env::var_os("BSDTAR_REFERENCE").is_some()
+    std::env::var("BSDTAR_REFERENCE").is_ok_and(|value| value == "1")
 }
 
 fn bsdtar_binary() -> String {


### PR DESCRIPTION
## Summary
`is_bsdtar_reference()` only checked whether `BSDTAR_REFERENCE` was set at all, so values like `0` or `false` also enabled reference mode, contradicting the module's own doc comment which documents `BSDTAR_REFERENCE=1` as the toggle.