### PR TITLE
Verify ACL contents and re-encoding in 0.19.1 migration tests

### DIFF
--- a/cli/tests/cli/migrate/acl_0_19_1.rs
+++ b/cli/tests/cli/migrate/acl_0_19_1.rs
@@ -7,6 +7,7 @@
 //! dump and separately assert the chunk-level re-encoding actually happened.
 
 use crate::utils::{EmbedExt, TestResources, archive, setup};
+#[cfg(not(target_family = "wasm"))]
 use assert_cmd::cargo::cargo_bin_cmd;
 use clap::Parser;
 use pna::prelude::*;
@@ -27,6 +28,7 @@ struct MigrateAclCase {
     acl_entries: &'static [&'static str],
 }
 
+#[cfg(not(target_family = "wasm"))]
 fn expected_acl_dump(case: &MigrateAclCase) -> String {
     format!(
         "# file: {}\n# owner: \n# group: \n# platform: {}\n{}\n\n",
@@ -54,6 +56,9 @@ fn assert_migrated_acl(case: &MigrateAclCase) {
     .unwrap();
 
     // The migrated archive must dump exactly the ACL recorded in the 0.19.1 fixture.
+    // Subprocess spawning is unavailable on wasm; the chunk-level assertions below
+    // still run there.
+    #[cfg(not(target_family = "wasm"))]
     cargo_bin_cmd!("pna")
         .args([
             "--quiet",

--- a/cli/tests/cli/migrate/acl_0_19_1.rs
+++ b/cli/tests/cli/migrate/acl_0_19_1.rs
@@ -1,19 +1,43 @@
 //! Tests for migrating archives with ACL data from 0.19.1 format to latest format.
 //!
-//! The 0.19.1 format stored ACL metadata differently. These tests verify that
-//! migration correctly transforms the ACL data while preserving its semantics.
+//! The 0.19.1 format stored each ACL entry as a self-describing `faCe` chunk with
+//! an embedded platform prefix. Migration re-encodes them as one `faCl` platform
+//! chunk followed by platform-less `faCe` chunks. `acl get` renders both formats
+//! identically, so these tests pin the migrated ACL contents against a hardcoded
+//! dump and separately assert the chunk-level re-encoding actually happened.
 
 use crate::utils::{EmbedExt, TestResources, archive, setup};
+use assert_cmd::cargo::cargo_bin_cmd;
 use clap::Parser;
+use pna::prelude::*;
 use portable_network_archive::cli;
 
-/// Precondition: A 0.19.1 format archive with Linux ACL data exists.
-/// Action: Run `pna experimental migrate` to convert to latest format.
-/// Expectation: Migration succeeds and output archive is readable with preserved ACL data.
-#[test]
-fn migrate_linux_acl() {
-    setup();
-    TestResources::extract_in("0.19.1/linux_acl.pna", ".").unwrap();
+const POSIX_ACL_ENTRIES: &[&str] = &[":u::allow:r|w|x", ":g::allow:r|w", ":o::allow:r"];
+const MACOS_ACL_ENTRIES: &[&str] = &[":g:everyone:allow:r|w|x|delete|append|chown"];
+const WINDOWS_ACL_ENTRIES: &[&str] = &[concat!(
+    ":g:everyone:allow:r|w|x|delete|append|delete_child|readattr|writeattr|",
+    "readextattr|writeextattr|readsecurity|writesecurity|chown|sync|read_data|write_data"
+)];
+
+struct MigrateAclCase {
+    archive: &'static str,
+    migrated: &'static str,
+    entry: &'static str,
+    platform: &'static str,
+    acl_entries: &'static [&'static str],
+}
+
+fn expected_acl_dump(case: &MigrateAclCase) -> String {
+    format!(
+        "# file: {}\n# owner: \n# group: \n# platform: {}\n{}\n\n",
+        case.entry,
+        case.platform,
+        case.acl_entries.join("\n")
+    )
+}
+
+fn assert_migrated_acl(case: &MigrateAclCase) {
+    TestResources::extract_in(case.archive, ".").unwrap();
 
     cli::Cli::try_parse_from([
         "pna",
@@ -21,112 +45,119 @@ fn migrate_linux_acl() {
         "experimental",
         "migrate",
         "-f",
-        "0.19.1/linux_acl.pna",
+        case.archive,
         "--output",
-        "migrate_linux_acl/migrated.pna",
+        case.migrated,
     ])
     .unwrap()
     .execute()
     .unwrap();
 
-    // Verify output archive is readable
-    let mut count = 0;
-    archive::for_each_entry("migrate_linux_acl/migrated.pna", |_entry| {
-        count += 1;
+    // The migrated archive must dump exactly the ACL recorded in the 0.19.1 fixture.
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "acl",
+            "get",
+            "-f",
+            case.migrated,
+            case.entry,
+        ])
+        .assert()
+        .success()
+        .stdout(expected_acl_dump(case));
+
+    // `acl get` reads the 0.19.1 format as well, so the dump alone cannot tell a
+    // conversion from a pass-through. The re-encoded form is one `faCl` platform
+    // chunk plus one `faCe` chunk per ACL entry.
+    let facl = pna::ChunkType::private(*b"faCl").unwrap();
+    let face = pna::ChunkType::private(*b"faCe").unwrap();
+    let mut entries = 0;
+    archive::for_each_entry(case.migrated, |entry| {
+        let platform_chunks: Vec<_> = entry
+            .extra_chunks()
+            .iter()
+            .filter(|c| c.ty() == facl)
+            .collect();
+        assert_eq!(
+            platform_chunks.len(),
+            1,
+            "migrated entry should have exactly one faCl platform chunk"
+        );
+        assert_eq!(platform_chunks[0].data(), case.platform.as_bytes());
+        let ace_count = entry
+            .extra_chunks()
+            .iter()
+            .filter(|c| c.ty() == face)
+            .count();
+        assert_eq!(ace_count, case.acl_entries.len());
+        entries += 1;
     })
     .unwrap();
-    assert!(count > 0, "Migrated archive should contain entries");
+    assert_eq!(entries, 1);
+}
+
+/// Precondition: A 0.19.1 format archive with Linux ACL data exists.
+/// Action: Run `pna experimental migrate` to convert to latest format.
+/// Expectation: The migrated archive dumps the original ACL entries and stores
+/// them re-encoded as faCl/faCe chunks.
+#[test]
+fn migrate_linux_acl() {
+    setup();
+    assert_migrated_acl(&MigrateAclCase {
+        archive: "0.19.1/linux_acl.pna",
+        migrated: "migrate_linux_acl/migrated.pna",
+        entry: "linux_acl.txt",
+        platform: "linux",
+        acl_entries: POSIX_ACL_ENTRIES,
+    });
 }
 
 /// Precondition: A 0.19.1 format archive with macOS ACL data exists.
 /// Action: Run `pna experimental migrate` to convert to latest format.
-/// Expectation: Migration succeeds and output archive is readable with preserved ACL data.
+/// Expectation: The migrated archive dumps the original ACL entries and stores
+/// them re-encoded as faCl/faCe chunks.
 #[test]
 fn migrate_macos_acl() {
     setup();
-    TestResources::extract_in("0.19.1/macos_acl.pna", ".").unwrap();
-
-    cli::Cli::try_parse_from([
-        "pna",
-        "--quiet",
-        "experimental",
-        "migrate",
-        "-f",
-        "0.19.1/macos_acl.pna",
-        "--output",
-        "migrate_macos_acl/migrated.pna",
-    ])
-    .unwrap()
-    .execute()
-    .unwrap();
-
-    // Verify output archive is readable
-    let mut count = 0;
-    archive::for_each_entry("migrate_macos_acl/migrated.pna", |_entry| {
-        count += 1;
-    })
-    .unwrap();
-    assert!(count > 0, "Migrated archive should contain entries");
+    assert_migrated_acl(&MigrateAclCase {
+        archive: "0.19.1/macos_acl.pna",
+        migrated: "migrate_macos_acl/migrated.pna",
+        entry: "macos_acl.txt",
+        platform: "macos",
+        acl_entries: MACOS_ACL_ENTRIES,
+    });
 }
 
 /// Precondition: A 0.19.1 format archive with FreeBSD ACL data exists.
 /// Action: Run `pna experimental migrate` to convert to latest format.
-/// Expectation: Migration succeeds and output archive is readable with preserved ACL data.
+/// Expectation: The migrated archive dumps the original ACL entries and stores
+/// them re-encoded as faCl/faCe chunks.
 #[test]
 fn migrate_freebsd_acl() {
     setup();
-    TestResources::extract_in("0.19.1/freebsd_acl.pna", ".").unwrap();
-
-    cli::Cli::try_parse_from([
-        "pna",
-        "--quiet",
-        "experimental",
-        "migrate",
-        "-f",
-        "0.19.1/freebsd_acl.pna",
-        "--output",
-        "migrate_freebsd_acl/migrated.pna",
-    ])
-    .unwrap()
-    .execute()
-    .unwrap();
-
-    // Verify output archive is readable
-    let mut count = 0;
-    archive::for_each_entry("migrate_freebsd_acl/migrated.pna", |_entry| {
-        count += 1;
-    })
-    .unwrap();
-    assert!(count > 0, "Migrated archive should contain entries");
+    assert_migrated_acl(&MigrateAclCase {
+        archive: "0.19.1/freebsd_acl.pna",
+        migrated: "migrate_freebsd_acl/migrated.pna",
+        entry: "freebsd_acl.txt",
+        platform: "freebsd",
+        acl_entries: POSIX_ACL_ENTRIES,
+    });
 }
 
 /// Precondition: A 0.19.1 format archive with Windows ACL data exists.
 /// Action: Run `pna experimental migrate` to convert to latest format.
-/// Expectation: Migration succeeds and output archive is readable with preserved ACL data.
+/// Expectation: The migrated archive dumps the original ACL entries and stores
+/// them re-encoded as faCl/faCe chunks.
 #[test]
 fn migrate_windows_acl() {
     setup();
-    TestResources::extract_in("0.19.1/windows_acl.pna", ".").unwrap();
-
-    cli::Cli::try_parse_from([
-        "pna",
-        "--quiet",
-        "experimental",
-        "migrate",
-        "-f",
-        "0.19.1/windows_acl.pna",
-        "--output",
-        "migrate_windows_acl/migrated.pna",
-    ])
-    .unwrap()
-    .execute()
-    .unwrap();
-
-    // Verify output archive is readable
-    let mut count = 0;
-    archive::for_each_entry("migrate_windows_acl/migrated.pna", |_entry| {
-        count += 1;
-    })
-    .unwrap();
-    assert!(count > 0, "Migrated archive should contain entries");
+    assert_migrated_acl(&MigrateAclCase {
+        archive: "0.19.1/windows_acl.pna",
+        migrated: "migrate_windows_acl/migrated.pna",
+        entry: "windows_acl.txt",
+        platform: "windows",
+        acl_entries: WINDOWS_ACL_ENTRIES,
+    });
 }

--- a/cli/tests/cli/migrate/acl_0_19_1.rs
+++ b/cli/tests/cli/migrate/acl_0_19_1.rs
@@ -1,128 +1,90 @@
 //! Tests for migrating archives with ACL data from 0.19.1 format to latest format.
 //!
-//! The 0.19.1 format stored ACL metadata differently. These tests verify that
-//! migration correctly transforms the ACL data while preserving its semantics.
+//! The 0.19.1 format stored each ACL entry as a self-describing `faCe` chunk with
+//! an embedded platform prefix. Migration re-encodes them as one `faCl` platform
+//! chunk followed by platform-less `faCe` chunks.
 
 use crate::utils::{EmbedExt, TestResources, archive, setup};
 use clap::Parser;
+use pna::Chunk;
 use portable_network_archive::cli;
 
-/// Precondition: A 0.19.1 format archive with Linux ACL data exists.
-/// Action: Run `pna migrate` to convert to latest format.
-/// Expectation: Migration succeeds and output archive is readable with preserved ACL data.
-#[test]
-fn migrate_linux_acl() {
-    setup();
-    TestResources::extract_in("0.19.1/linux_acl.pna", ".").unwrap();
+const POSIX_ACL_ENTRIES: &[&str] = &[":u::allow:r|w|x", ":g::allow:r|w", ":o::allow:r"];
+const MACOS_ACL_ENTRIES: &[&str] = &[":g:everyone:allow:r|w|x|delete|append|chown"];
+const WINDOWS_ACL_ENTRIES: &[&str] = &[concat!(
+    ":g:everyone:allow:r|w|x|delete|append|delete_child|readattr|writeattr|",
+    "readextattr|writeextattr|readsecurity|writesecurity|chown|sync|read_data|write_data"
+)];
+
+fn assert_migrated_acl(platform: &str, acl_entries: &[&str]) {
+    let source = format!("0.19.1/{platform}_acl.pna");
+    let migrated = format!("migrate_{platform}_acl/migrated.pna");
+    TestResources::extract_in(&source, ".").unwrap();
 
     cli::Cli::try_parse_from([
-        "pna",
-        "--quiet",
-        "migrate",
-        "-f",
-        "0.19.1/linux_acl.pna",
-        "--output",
-        "migrate_linux_acl/migrated.pna",
+        "pna", "--quiet", "migrate", "-f", &source, "--output", &migrated,
     ])
     .unwrap()
     .execute()
     .unwrap();
 
-    // Verify output archive is readable
-    let mut count = 0;
-    archive::for_each_entry("migrate_linux_acl/migrated.pna", |_entry| {
-        count += 1;
+    // `acl get` renders the 0.19.1 format identically, so only the chunk bytes
+    // can tell a conversion from a pass-through.
+    let facl = pna::ChunkType::private(*b"faCl").unwrap();
+    let face = pna::ChunkType::private(*b"faCe").unwrap();
+    let mut expected = vec![(facl, platform.as_bytes())];
+    expected.extend(acl_entries.iter().map(|ace| (face, ace.as_bytes())));
+    let mut entries = 0;
+    archive::for_each_entry(&migrated, |entry| {
+        let acl_chunks: Vec<_> = entry
+            .extra_chunks()
+            .iter()
+            .filter(|c| c.ty() == facl || c.ty() == face)
+            .map(|c| (c.ty(), c.data()))
+            .collect();
+        assert_eq!(acl_chunks, expected);
+        entries += 1;
     })
     .unwrap();
-    assert!(count > 0, "Migrated archive should contain entries");
+    assert_eq!(entries, 1);
+}
+
+/// Precondition: A 0.19.1 format archive with Linux ACL data exists.
+/// Action: Run `pna migrate` to convert to latest format.
+/// Expectation: The migrated entry stores the original ACL entries as one faCl
+/// platform chunk followed by platform-less faCe chunks.
+#[test]
+fn migrate_linux_acl() {
+    setup();
+    assert_migrated_acl("linux", POSIX_ACL_ENTRIES);
 }
 
 /// Precondition: A 0.19.1 format archive with macOS ACL data exists.
 /// Action: Run `pna migrate` to convert to latest format.
-/// Expectation: Migration succeeds and output archive is readable with preserved ACL data.
+/// Expectation: The migrated entry stores the original ACL entries as one faCl
+/// platform chunk followed by platform-less faCe chunks.
 #[test]
 fn migrate_macos_acl() {
     setup();
-    TestResources::extract_in("0.19.1/macos_acl.pna", ".").unwrap();
-
-    cli::Cli::try_parse_from([
-        "pna",
-        "--quiet",
-        "migrate",
-        "-f",
-        "0.19.1/macos_acl.pna",
-        "--output",
-        "migrate_macos_acl/migrated.pna",
-    ])
-    .unwrap()
-    .execute()
-    .unwrap();
-
-    // Verify output archive is readable
-    let mut count = 0;
-    archive::for_each_entry("migrate_macos_acl/migrated.pna", |_entry| {
-        count += 1;
-    })
-    .unwrap();
-    assert!(count > 0, "Migrated archive should contain entries");
+    assert_migrated_acl("macos", MACOS_ACL_ENTRIES);
 }
 
 /// Precondition: A 0.19.1 format archive with FreeBSD ACL data exists.
 /// Action: Run `pna migrate` to convert to latest format.
-/// Expectation: Migration succeeds and output archive is readable with preserved ACL data.
+/// Expectation: The migrated entry stores the original ACL entries as one faCl
+/// platform chunk followed by platform-less faCe chunks.
 #[test]
 fn migrate_freebsd_acl() {
     setup();
-    TestResources::extract_in("0.19.1/freebsd_acl.pna", ".").unwrap();
-
-    cli::Cli::try_parse_from([
-        "pna",
-        "--quiet",
-        "migrate",
-        "-f",
-        "0.19.1/freebsd_acl.pna",
-        "--output",
-        "migrate_freebsd_acl/migrated.pna",
-    ])
-    .unwrap()
-    .execute()
-    .unwrap();
-
-    // Verify output archive is readable
-    let mut count = 0;
-    archive::for_each_entry("migrate_freebsd_acl/migrated.pna", |_entry| {
-        count += 1;
-    })
-    .unwrap();
-    assert!(count > 0, "Migrated archive should contain entries");
+    assert_migrated_acl("freebsd", POSIX_ACL_ENTRIES);
 }
 
 /// Precondition: A 0.19.1 format archive with Windows ACL data exists.
 /// Action: Run `pna migrate` to convert to latest format.
-/// Expectation: Migration succeeds and output archive is readable with preserved ACL data.
+/// Expectation: The migrated entry stores the original ACL entries as one faCl
+/// platform chunk followed by platform-less faCe chunks.
 #[test]
 fn migrate_windows_acl() {
     setup();
-    TestResources::extract_in("0.19.1/windows_acl.pna", ".").unwrap();
-
-    cli::Cli::try_parse_from([
-        "pna",
-        "--quiet",
-        "migrate",
-        "-f",
-        "0.19.1/windows_acl.pna",
-        "--output",
-        "migrate_windows_acl/migrated.pna",
-    ])
-    .unwrap()
-    .execute()
-    .unwrap();
-
-    // Verify output archive is readable
-    let mut count = 0;
-    archive::for_each_entry("migrate_windows_acl/migrated.pna", |_entry| {
-        count += 1;
-    })
-    .unwrap();
-    assert!(count > 0, "Migrated archive should contain entries");
+    assert_migrated_acl("windows", WINDOWS_ACL_ENTRIES);
 }


### PR DESCRIPTION
## Summary
Strengthen the 0.19.1 ACL migration tests to check the migrated ACL contents against hardcoded `acl get` dumps and to assert the faCl/faCe chunk re-encoding, replacing the previous entry-count-only assertions.

## Notes
`acl get` renders the 0.19.1 format identically to the current format, so the dump alone cannot distinguish a real conversion from a pass-through; the chunk-level assertion covers that case.

## Verification
Mutation checks (not run in CI): silently dropping one ACL entry in the migration fails the dump assertion; passing the old chunks through unconverted fails the faCl assertion. Both mutations were reverted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded ACL migration coverage across Linux, macOS, FreeBSD, and Windows.
  - Added stricter validation that migrated archives contain correctly ordered and encoded ACL metadata.
  - Consolidated platform-specific migration checks into shared, consistent assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->