### PR TITLE
:bug: Skip entries with unknown data kind on extract

### DIFF
--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -1312,10 +1312,12 @@ where
     pna::RawChunk<T>: Chunk,
 {
     if item.header().data_kind() != DataKind::FILE {
-        unreachable!(
-            "extract_file_entry called with {:?}",
-            item.header().data_kind()
+        log::warn!(
+            "Skipped extracting an entry with unsupported data kind {:?}: {}",
+            item.header().data_kind(),
+            item_path
         );
+        return Ok(());
     }
     let Some((path, remove_existing)) = prepare_extraction(
         &item,

--- a/cli/tests/cli/extract.rs
+++ b/cli/tests/cli/extract.rs
@@ -19,5 +19,6 @@ mod sanitize_parent_components;
 #[cfg(windows)]
 mod symlink_link_target_type;
 mod symlink_metadata;
+mod unknown_data_kind;
 #[cfg(windows)]
 mod verbatim_out_dir;

--- a/cli/tests/cli/extract/unknown_data_kind.rs
+++ b/cli/tests/cli/extract/unknown_data_kind.rs
@@ -1,0 +1,49 @@
+use crate::utils::setup;
+use clap::Parser;
+use portable_network_archive::cli;
+use std::{fs, io::Write, path::Path};
+
+/// Precondition: an archive contains an entry with a data-kind byte
+/// unassigned by the specification, alongside a regular file entry.
+/// Action: extract the archive.
+/// Expectation: extraction succeeds, the unknown-kind entry is skipped
+/// (no file created for it), and the regular file is extracted with its
+/// contents intact.
+#[test]
+fn extract_skips_unknown_data_kind() {
+    setup();
+    let archive_path = "extract_unknown_data_kind/archive.pna";
+    fs::create_dir_all(Path::new(archive_path).parent().unwrap()).unwrap();
+    let mut archive = pna::Archive::write_header(fs::File::create(archive_path).unwrap()).unwrap();
+
+    let mut unknown_builder =
+        pna::OpaqueEntryBuilder::new("unknown.bin".into(), pna::DataKind::from_byte(42)).unwrap();
+    unknown_builder.write_all(b"will be reinterpreted").unwrap();
+    archive.add_entry(unknown_builder.build().unwrap()).unwrap();
+
+    let mut known_builder = pna::FileEntryBuilder::new("known.txt".into()).unwrap();
+    known_builder.write_all(b"regular file contents").unwrap();
+    archive.add_entry(known_builder.build().unwrap()).unwrap();
+
+    archive.finalize().unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        "-f",
+        "extract_unknown_data_kind/archive.pna",
+        "--overwrite",
+        "--out-dir",
+        "extract_unknown_data_kind/dist",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    assert!(!Path::new("extract_unknown_data_kind/dist/unknown.bin").exists());
+    assert_eq!(
+        "regular file contents",
+        fs::read_to_string("extract_unknown_data_kind/dist/known.txt").unwrap()
+    );
+}


### PR DESCRIPTION
## Summary
Extracting a crafted archive whose entry carries an unassigned data-kind byte panicked via `unreachable!` in `extract_file_entry`, because the extraction dispatch routes everything that is not a link or directory there. Such entries are now skipped with a warning and extraction continues (follow-up to the review on #3218).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Archive extraction now skips unsupported entry types instead of failing unexpectedly.
  * Supported files continue to extract successfully, while unsupported entries are reported with a warning and omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->