### PR TITLE
:construction_worker: Install dist via cargo-install action on riscv runner and allow manual dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,14 +134,22 @@ jobs:
           key: ${{ join(matrix.targets, '-') }}
           cache-provider: ${{ matrix.cache_provider }}
       - name: Cache dist binary
+        if: ${{ !contains(matrix.targets, 'riscv64gc-unknown-linux-gnu') }}
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cargo/bin/dist
           key: dist-${{ runner.os }}-${{ runner.arch }}-v0.31.0
       - name: Install dist
+        if: ${{ !contains(matrix.targets, 'riscv64gc-unknown-linux-gnu') }}
         shell: bash
         run: |
           dist --version 2>/dev/null | grep -q "0.31.0" || (${{ matrix.install_dist.run }} || cargo install --locked --version 0.31.0 cargo-dist)
+      - name: Install dist from crates.io
+        if: ${{ contains(matrix.targets, 'riscv64gc-unknown-linux-gnu') }}
+        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0
+        with:
+          crate: cargo-dist
+          version: "0.31.0"
       # Get the dist-manifest
       - name: Fetch local artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ permissions:
 # will be marked as a prerelease.
 on:
   pull_request:
+  workflow_dispatch:
   push:
     tags:
       - 'portable-network-archive-[0-9]+.[0-9]+.[0-9]+*'
@@ -51,9 +52,9 @@ jobs:
     timeout-minutes: 60
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
-      tag: ${{ !github.event.pull_request && github.ref_name || '' }}
-      tag-flag: ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }}
-      publishing: ${{ !github.event.pull_request }}
+      tag: ${{ github.event_name == 'push' && github.ref_name || '' }}
+      tag-flag: ${{ github.event_name == 'push' && format('--tag={0}', github.ref_name) || '' }}
+      publishing: ${{ github.event_name == 'push' }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -78,7 +79,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
+          dist ${{ (github.event_name == 'push' && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
           echo "dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Install `dist` on the riscv64 runner via `baptiste0928/cargo-install` (with binary caching) instead of falling back to a plain `cargo install`.
- Add a `workflow_dispatch` trigger to the release workflow. Release detection now checks `github.event_name == 'push'` (which only fires on tags), so manual runs build artifacts without publishing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Release workflows can now be started manually when needed.
  - Improved release planning for tag-based builds.
  - Updated local artifact generation to support RISC-V targets more reliably.
  - Streamlined tooling installation during release builds for more consistent artifact production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->