### PR TITLE
:bug: Reject solid entries with unsupported version

### DIFF
--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -601,6 +601,15 @@ where
                 format!("`{}` chunk not found", ChunkType::SHED),
             ));
         };
+        if header.major != 0 || header.minor != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!(
+                    "solid entry version {}.{} is not supported",
+                    header.major, header.minor
+                ),
+            ));
+        }
         let mut extra = vec![];
         let mut data = vec![];
         let mut phsf = None;
@@ -1624,6 +1633,28 @@ mod tests {
         let err = result.unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
         assert!(err.to_string().contains("critical"));
+    }
+
+    #[test]
+    fn reject_solid_entry_with_unsupported_major_version() {
+        let shed = RawChunk::from_data(ChunkType::SHED, vec![1, 0, 0, 0, 0]);
+        let send = RawChunk::from_data(ChunkType::SEND, vec![]);
+
+        let raw_entry = RawEntry(vec![shed, send]);
+        let result = SolidEntry::try_from(raw_entry);
+
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::Unsupported);
+    }
+
+    #[test]
+    fn reject_solid_entry_with_unsupported_minor_version() {
+        let shed = RawChunk::from_data(ChunkType::SHED, vec![0, 1, 0, 0, 0]);
+        let send = RawChunk::from_data(ChunkType::SEND, vec![]);
+
+        let raw_entry = RawEntry(vec![shed, send]);
+        let result = SolidEntry::try_from(raw_entry);
+
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::Unsupported);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Reading a SolidEntry did not validate the SHED header's major/minor version, so older implementations would silently misread archives with a future solid format. Like NormalEntry, versions other than 0.0 are now rejected with `io::ErrorKind::Unsupported`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Solid entries with unsupported major or minor `SHED` versions are now rejected with a clear unsupported-version error.
* **Tests**
  * Added coverage for solid entries using unsupported major and minor versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->