### PR TITLE
:recycle: Move entry xattrs into Metadata

### DIFF
--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -2115,6 +2115,7 @@ fn transform_normal_entry(
                 .with_modified(metadata.modified())
                 .with_accessed(metadata.accessed())
                 .with_link_target_type(metadata.link_target_type())
+                .with_xattrs(metadata.xattrs().to_vec())
                 .with_owner_uid(new_uid.map(pna::OwnerUid::from))
                 .with_owner_gid(new_gid.map(pna::OwnerGid::from))
                 .with_owner_user_name(crate::command::core::permission::owner_name_opt(&new_uname))

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -1607,7 +1607,7 @@ where
 
     #[cfg(unix)]
     if !skip_xattr_acl && matches!(keep_options.xattr_strategy, XattrStrategy::Always) {
-        match utils::os::unix::fs::xattrs::set_xattrs(path, item.xattrs()) {
+        match utils::os::unix::fs::xattrs::set_xattrs(path, item.metadata().xattrs()) {
             Ok(()) => {}
             Err(e) if e.kind() == io::ErrorKind::Unsupported => {
                 log::warn!(

--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -446,7 +446,7 @@ impl TableRow {
             },
             // Only collect xattrs if needed
             xattrs: if collect.xattrs {
-                entry.xattrs().to_vec()
+                entry.metadata().xattrs().to_vec()
             } else {
                 Vec::new()
             },

--- a/cli/src/command/migrate.rs
+++ b/cli/src/command/migrate.rs
@@ -101,6 +101,7 @@ where
         .with_modified(modified)
         .with_accessed(accessed)
         .with_link_target_type(link_target_type)
+        .with_xattrs(src.xattrs().to_vec())
         .with_owner_uid(own.uid.map(pna::OwnerUid::from))
         .with_owner_gid(own.gid.map(pna::OwnerGid::from))
         .with_owner_user_name(

--- a/cli/src/command/strip.rs
+++ b/cli/src/command/strip.rs
@@ -132,10 +132,10 @@ where
         metadata = metadata.with_created(entry.metadata().created());
         metadata = metadata.with_modified(entry.metadata().modified());
     }
-    entry = entry.with_metadata(metadata);
-    if !options.keep_xattr {
-        entry = entry.with_xattrs(&[]);
+    if options.keep_xattr {
+        metadata = metadata.with_xattrs(entry.metadata().xattrs().to_vec());
     }
+    entry = entry.with_metadata(metadata);
     let keep_private_all = options
         .keep_private
         .as_ref()

--- a/cli/src/command/xattr.rs
+++ b/cli/src/command/xattr.rs
@@ -207,6 +207,7 @@ fn archive_get_xattr(args: GetXattrCommand) -> anyhow::Result<()> {
             if globs.matches_any(name) {
                 println!("# file: {name}");
                 for attr in entry
+                    .metadata()
                     .xattrs()
                     .iter()
                     .filter(|a| dump_option.is_match(a.name()))
@@ -301,6 +302,7 @@ impl SetAttrStrategy<'_> {
             SetAttrStrategy::Restore(restore) => {
                 if let Some(attrs) = restore.get(entry.name().as_str()) {
                     let xattrs = entry
+                        .metadata()
                         .xattrs()
                         .iter()
                         .map(|it| (it.name(), it.value()))
@@ -319,7 +321,8 @@ impl SetAttrStrategy<'_> {
                             Ok(pna::ExtendedAttribute::new(name, value))
                         })
                         .collect::<io::Result<Vec<_>>>()?;
-                    Ok(entry.with_xattrs(xattrs))
+                    let metadata = entry.metadata().clone().with_xattrs(xattrs);
+                    Ok(entry.with_metadata(metadata))
                 } else {
                     Ok(entry)
                 }
@@ -372,8 +375,9 @@ fn transform_entry<T>(
     value: &[u8],
     remove: Option<&str>,
 ) -> io::Result<NormalEntry<T>> {
-    let xattrs = transform_xattr(entry.xattrs(), name, value, remove)?;
-    Ok(entry.with_xattrs(xattrs))
+    let xattrs = transform_xattr(entry.metadata().xattrs(), name, value, remove)?;
+    let metadata = entry.metadata().clone().with_xattrs(xattrs);
+    Ok(entry.with_metadata(metadata))
 }
 
 #[inline]

--- a/cli/tests/cli/bsdtar/option_same_permissions.rs
+++ b/cli/tests/cli/bsdtar/option_same_permissions.rs
@@ -1103,7 +1103,7 @@ fn bsdtar_extract_with_p_restores_xattr() {
     // Verify archive has xattr stored
     let mut has_xattr = false;
     archive::for_each_entry(&archive_path, |entry| {
-        if entry.header().path().as_str() == "test.txt" && !entry.xattrs().is_empty() {
+        if entry.header().path().as_str() == "test.txt" && !entry.metadata().xattrs().is_empty() {
             has_xattr = true;
         }
     })

--- a/cli/tests/cli/xattr/get/option_match_encoding.rs
+++ b/cli/tests/cli/xattr/get/option_match_encoding.rs
@@ -68,13 +68,13 @@ fn xattr_get_name_match_encoding() {
     for_each_entry("xattr_get_opts/archive.pna", |entry| {
         match entry.header().path().as_str() {
             "xattr_get_opts/in/raw/empty.txt" => {
-                assert_eq!(entry.xattrs(), &[xattr("user.name", b"pna")]);
+                assert_eq!(entry.metadata().xattrs(), &[xattr("user.name", b"pna")]);
             }
             "xattr_get_opts/in/raw/text.txt" => {
-                assert_eq!(entry.xattrs(), &[xattr("user.value", b"data")]);
+                assert_eq!(entry.metadata().xattrs(), &[xattr("user.value", b"data")]);
             }
             _ => {
-                assert!(entry.xattrs().is_empty());
+                assert!(entry.metadata().xattrs().is_empty());
             }
         }
     })

--- a/cli/tests/cli/xattr/set/basic.rs
+++ b/cli/tests/cli/xattr/set/basic.rs
@@ -30,16 +30,16 @@ fn archive_xattr_set() {
     archive::for_each_entry("xattr_set/zstd.pna", |entry| {
         if entry.name() == "raw/empty.txt" {
             assert_eq!(
-                entry.xattrs(),
+                entry.metadata().xattrs(),
                 &[archive::xattr("user.name", b"pna developers!")]
             );
         } else {
             // Non-target entries should remain unaffected (no xattrs)
             assert!(
-                entry.xattrs().is_empty(),
+                entry.metadata().xattrs().is_empty(),
                 "Entry {} should have no xattrs but has {:?}",
                 entry.name(),
-                entry.xattrs()
+                entry.metadata().xattrs()
             );
         }
     })
@@ -92,7 +92,7 @@ fn xattr_long_key_value() {
     archive::for_each_entry("xattr_long/zstd.pna", |entry| {
         if entry.name() == "raw/empty.txt" {
             assert_eq!(
-                entry.xattrs(),
+                entry.metadata().xattrs(),
                 &[
                     archive::xattr(long_name.as_str(), long_value.as_bytes()),
                     archive::xattr("user.special", "\0\n\r\x7f\u{1F600}".as_bytes()),
@@ -101,10 +101,10 @@ fn xattr_long_key_value() {
         } else {
             // Non-target entries should remain unaffected (no xattrs)
             assert!(
-                entry.xattrs().is_empty(),
+                entry.metadata().xattrs().is_empty(),
                 "Entry {} should have no xattrs but has {:?}",
                 entry.name(),
-                entry.xattrs()
+                entry.metadata().xattrs()
             );
         }
     })
@@ -138,14 +138,14 @@ fn xattr_empty_key() {
 
     archive::for_each_entry("xattr_empty_key/zstd.pna", |entry| {
         if entry.name() == "raw/empty.txt" {
-            assert_eq!(entry.xattrs(), &[archive::xattr("", b"value")]);
+            assert_eq!(entry.metadata().xattrs(), &[archive::xattr("", b"value")]);
         } else {
             // Non-target entries should remain unaffected (no xattrs)
             assert!(
-                entry.xattrs().is_empty(),
+                entry.metadata().xattrs().is_empty(),
                 "Entry {} should have no xattrs but has {:?}",
                 entry.name(),
-                entry.xattrs()
+                entry.metadata().xattrs()
             );
         }
     })
@@ -179,14 +179,17 @@ fn xattr_empty_value() {
 
     archive::for_each_entry("xattr_empty_value/zstd.pna", |entry| {
         if entry.name() == "raw/empty.txt" {
-            assert_eq!(entry.xattrs(), &[archive::xattr("user.empty", b"")]);
+            assert_eq!(
+                entry.metadata().xattrs(),
+                &[archive::xattr("user.empty", b"")]
+            );
         } else {
             // Non-target entries should remain unaffected (no xattrs)
             assert!(
-                entry.xattrs().is_empty(),
+                entry.metadata().xattrs().is_empty(),
                 "Entry {} should have no xattrs but has {:?}",
                 entry.name(),
-                entry.xattrs()
+                entry.metadata().xattrs()
             );
         }
     })
@@ -223,7 +226,7 @@ fn xattr_set_preserved_in_archive() {
         if entry.name() == "raw/empty.txt" {
             found = true;
             assert_eq!(
-                entry.xattrs(),
+                entry.metadata().xattrs(),
                 &[archive::xattr("user.roundtrip", b"preserved_value")]
             );
         }
@@ -308,10 +311,11 @@ fn xattr_round_trip_preservation() {
             found = true;
             assert!(
                 entry
+                    .metadata()
                     .xattrs()
                     .contains(&archive::xattr("user.roundtrip", b"preserved_value")),
                 "round-tripped entry is missing user.roundtrip xattr: {:?}",
-                entry.xattrs()
+                entry.metadata().xattrs()
             );
         }
     })

--- a/cli/tests/cli/xattr/set/multipart.rs
+++ b/cli/tests/cli/xattr/set/multipart.rs
@@ -62,7 +62,7 @@ fn xattr_set_on_multipart_archive() {
     // Verify xattr was applied in the consolidated output (archive.pna, not archive.part1.pna)
     archive::for_each_entry("xattr_multipart/split/archive.pna", |entry| {
         if entry.name() == "xattr_multipart/in/raw/empty.txt" {
-            let xattrs = entry.xattrs();
+            let xattrs = entry.metadata().xattrs();
             assert_eq!(xattrs.len(), 1, "entry should have exactly one xattr");
             assert_eq!(xattrs[0].name(), "user.multipart");
             assert_eq!(xattrs[0].value(), b"from_split");
@@ -133,7 +133,7 @@ fn xattr_set_multiple_entries_multipart() {
         let path = entry.name();
         if path.as_str().ends_with(".txt") {
             txt_count += 1;
-            let xattrs = entry.xattrs();
+            let xattrs = entry.metadata().xattrs();
             assert_eq!(
                 xattrs.len(),
                 1,
@@ -143,7 +143,7 @@ fn xattr_set_multiple_entries_multipart() {
             assert_eq!(xattrs[0].value(), b"text");
         } else {
             assert!(
-                entry.xattrs().is_empty(),
+                entry.metadata().xattrs().is_empty(),
                 "non-txt file {path} should have no xattrs"
             );
         }

--- a/cli/tests/cli/xattr/set/option_base64.rs
+++ b/cli/tests/cli/xattr/set/option_base64.rs
@@ -32,16 +32,16 @@ fn xattr_set_base64() {
     archive::for_each_entry("xattr_set_base64/zstd.pna", |entry| {
         if entry.name() == "raw/empty.txt" {
             assert_eq!(
-                entry.xattrs(),
+                entry.metadata().xattrs(),
                 &[archive::xattr("user.base64", b"Hello World")]
             );
         } else {
             // Non-target entries should remain unaffected (no xattrs)
             assert!(
-                entry.xattrs().is_empty(),
+                entry.metadata().xattrs().is_empty(),
                 "Entry {} should have no xattrs but has {:?}",
                 entry.name(),
-                entry.xattrs()
+                entry.metadata().xattrs()
             );
         }
     })

--- a/cli/tests/cli/xattr/set/option_hex.rs
+++ b/cli/tests/cli/xattr/set/option_hex.rs
@@ -32,16 +32,16 @@ fn xattr_set_hex() {
     archive::for_each_entry("xattr_set_hex/zstd.pna", |entry| {
         if entry.name() == "raw/empty.txt" {
             assert_eq!(
-                entry.xattrs(),
+                entry.metadata().xattrs(),
                 &[archive::xattr("user.hex", b"Hello World")]
             );
         } else {
             // Non-target entries should remain unaffected (no xattrs)
             assert!(
-                entry.xattrs().is_empty(),
+                entry.metadata().xattrs().is_empty(),
                 "Entry {} should have no xattrs but has {:?}",
                 entry.name(),
-                entry.xattrs()
+                entry.metadata().xattrs()
             );
         }
     })

--- a/cli/tests/cli/xattr/set/option_keep_solid.rs
+++ b/cli/tests/cli/xattr/set/option_keep_solid.rs
@@ -58,7 +58,7 @@ fn xattr_set_keep_solid() {
     // Verify xattr was applied
     archive::for_each_entry("xattr_keep_solid/archive.pna", |entry| {
         if entry.name() == "xattr_keep_solid/in/raw/empty.txt" {
-            let xattrs = entry.xattrs();
+            let xattrs = entry.metadata().xattrs();
             assert_eq!(xattrs.len(), 1, "entry should have exactly one xattr");
             assert_eq!(xattrs[0].name(), "user.author");
             assert_eq!(xattrs[0].value(), b"pna developers");
@@ -127,7 +127,7 @@ fn xattr_set_keep_solid_preserves_existing() {
     // Verify both xattrs exist
     archive::for_each_entry("xattr_keep_solid_existing/archive.pna", |entry| {
         if entry.name() == "xattr_keep_solid_existing/in/raw/empty.txt" {
-            let xattrs = entry.xattrs();
+            let xattrs = entry.metadata().xattrs();
             assert_eq!(xattrs.len(), 2, "entry should have two xattrs");
             assert!(
                 xattrs

--- a/cli/tests/cli/xattr/set/option_password.rs
+++ b/cli/tests/cli/xattr/set/option_password.rs
@@ -32,17 +32,17 @@ fn xattr_set_with_password() {
 
     archive::for_each_entry_with_password("xattr_password/zstd_aes_ctr.pna", "password", |entry| {
         if entry.name() == "raw/empty.txt" {
-            let xattrs = entry.xattrs();
+            let xattrs = entry.metadata().xattrs();
             assert_eq!(xattrs.len(), 1, "entry should have exactly one xattr");
             assert_eq!(xattrs[0].name(), "user.author");
             assert_eq!(xattrs[0].value(), b"pna developers");
         } else {
             // Non-target entries should remain unaffected (no xattrs)
             assert!(
-                entry.xattrs().is_empty(),
+                entry.metadata().xattrs().is_empty(),
                 "Entry {} should have no xattrs but has {:?}",
                 entry.name(),
-                entry.xattrs()
+                entry.metadata().xattrs()
             );
         }
     })
@@ -85,17 +85,17 @@ fn xattr_set_with_password_file() {
         password,
         |entry| {
             if entry.name() == "raw/empty.txt" {
-                let xattrs = entry.xattrs();
+                let xattrs = entry.metadata().xattrs();
                 assert_eq!(xattrs.len(), 1, "entry should have exactly one xattr");
                 assert_eq!(xattrs[0].name(), "user.version");
                 assert_eq!(xattrs[0].value(), b"1.0.0");
             } else {
                 // Non-target entries should remain unaffected (no xattrs)
                 assert!(
-                    entry.xattrs().is_empty(),
+                    entry.metadata().xattrs().is_empty(),
                     "Entry {} should have no xattrs but has {:?}",
                     entry.name(),
-                    entry.xattrs()
+                    entry.metadata().xattrs()
                 );
             }
         },
@@ -158,7 +158,7 @@ fn xattr_set_wrong_password_no_effect() {
         "password",
         |entry| {
             if entry.name() == "raw/empty.txt" {
-                let xattrs = entry.xattrs();
+                let xattrs = entry.metadata().xattrs();
                 // Original xattr should exist
                 assert!(
                     xattrs
@@ -169,10 +169,10 @@ fn xattr_set_wrong_password_no_effect() {
             } else {
                 // Non-target entries should remain unaffected (no xattrs)
                 assert!(
-                    entry.xattrs().is_empty(),
+                    entry.metadata().xattrs().is_empty(),
                     "Entry {} should have no xattrs but has {:?}",
                     entry.name(),
-                    entry.xattrs()
+                    entry.metadata().xattrs()
                 );
             }
         },

--- a/cli/tests/cli/xattr/set/option_remove.rs
+++ b/cli/tests/cli/xattr/set/option_remove.rs
@@ -44,14 +44,17 @@ fn archive_xattr_remove() {
 
     for_each_entry("xattr_remove/xattr_remove.pna", |entry| {
         if entry.name() == "xattr_remove/in/raw/empty.txt" {
-            assert_eq!(entry.xattrs(), &[xattr("user.name", b"pna developers!")],);
+            assert_eq!(
+                entry.metadata().xattrs(),
+                &[xattr("user.name", b"pna developers!")],
+            );
         } else {
             // Non-target entries should have no xattrs
             assert!(
-                entry.xattrs().is_empty(),
+                entry.metadata().xattrs().is_empty(),
                 "Entry {} should have no xattrs but has {:?}",
                 entry.name(),
-                entry.xattrs()
+                entry.metadata().xattrs()
             );
         }
     })
@@ -75,10 +78,10 @@ fn archive_xattr_remove() {
     for_each_entry("xattr_remove/xattr_remove.pna", |entry| {
         // After removal, all entries should have no xattrs
         assert!(
-            entry.xattrs().is_empty(),
+            entry.metadata().xattrs().is_empty(),
             "Entry {} should have no xattrs after removal but has {:?}",
             entry.name(),
-            entry.xattrs()
+            entry.metadata().xattrs()
         );
     })
     .unwrap();

--- a/cli/tests/cli/xattr/set/option_restore_from_file.rs
+++ b/cli/tests/cli/xattr/set/option_restore_from_file.rs
@@ -57,7 +57,7 @@ fn xattr_restore_from_file() {
     archive::for_each_entry("xattr_restore_file/archive.pna", |entry| {
         match entry.name().as_str() {
             "xattr_restore_file/in/raw/empty.txt" => {
-                let xattrs = entry.xattrs();
+                let xattrs = entry.metadata().xattrs();
                 assert_eq!(xattrs.len(), 2);
                 assert!(
                     xattrs
@@ -71,13 +71,13 @@ fn xattr_restore_from_file() {
                 );
             }
             "xattr_restore_file/in/raw/text.txt" => {
-                let xattrs = entry.xattrs();
+                let xattrs = entry.metadata().xattrs();
                 assert_eq!(xattrs.len(), 1);
                 assert_eq!(xattrs[0].name(), "user.description");
                 assert_eq!(xattrs[0].value(), b"sample text file");
             }
             _ => {
-                assert!(entry.xattrs().is_empty());
+                assert!(entry.metadata().xattrs().is_empty());
             }
         }
     })
@@ -133,7 +133,7 @@ fn xattr_restore_from_file_with_encodings() {
 
     archive::for_each_entry("xattr_restore_enc/archive.pna", |entry| {
         if entry.name() == "xattr_restore_enc/in/raw/empty.txt" {
-            let xattrs = entry.xattrs();
+            let xattrs = entry.metadata().xattrs();
             assert_eq!(xattrs.len(), 3);
             assert!(
                 xattrs
@@ -226,7 +226,7 @@ fn xattr_restore_from_file_merge() {
 
     archive::for_each_entry("xattr_restore_merge/archive.pna", |entry| {
         if entry.name() == "xattr_restore_merge/in/raw/empty.txt" {
-            let xattrs = entry.xattrs();
+            let xattrs = entry.metadata().xattrs();
             assert_eq!(xattrs.len(), 3, "should have 3 xattrs after merge");
             assert!(
                 xattrs

--- a/cli/tests/cli/xattr/set/option_unsolid.rs
+++ b/cli/tests/cli/xattr/set/option_unsolid.rs
@@ -58,7 +58,7 @@ fn xattr_set_unsolid() {
     // Verify xattr was applied
     archive::for_each_entry("xattr_unsolid/archive.pna", |entry| {
         if entry.name() == "xattr_unsolid/in/raw/empty.txt" {
-            let xattrs = entry.xattrs();
+            let xattrs = entry.metadata().xattrs();
             assert_eq!(xattrs.len(), 1, "entry should have exactly one xattr");
             assert_eq!(xattrs[0].name(), "user.author");
             assert_eq!(xattrs[0].value(), b"pna developers");
@@ -123,12 +123,12 @@ fn xattr_set_unsolid_multiple_entries() {
     archive::for_each_entry("xattr_unsolid_multi/archive.pna", |entry| {
         entry_count += 1;
         if entry.name() == "xattr_unsolid_multi/in/raw/empty.txt" {
-            let xattrs = entry.xattrs();
+            let xattrs = entry.metadata().xattrs();
             assert_eq!(xattrs.len(), 1, "target entry should have xattr");
             assert_eq!(xattrs[0].name(), "user.marker");
         } else {
             assert!(
-                entry.xattrs().is_empty(),
+                entry.metadata().xattrs().is_empty(),
                 "other entries should have no xattrs"
             );
         }

--- a/cli/tests/cli/xattr/set/overwrite.rs
+++ b/cli/tests/cli/xattr/set/overwrite.rs
@@ -45,14 +45,17 @@ fn xattr_overwrite() {
 
     archive::for_each_entry("xattr_overwrite/zstd.pna", |entry| {
         if entry.name() == "raw/empty.txt" {
-            assert_eq!(entry.xattrs(), &[archive::xattr("user.name", b"second")]);
+            assert_eq!(
+                entry.metadata().xattrs(),
+                &[archive::xattr("user.name", b"second")]
+            );
         } else {
             // Non-target entries should remain unaffected (no xattrs)
             assert!(
-                entry.xattrs().is_empty(),
+                entry.metadata().xattrs().is_empty(),
                 "Entry {} should have no xattrs but has {:?}",
                 entry.name(),
-                entry.xattrs()
+                entry.metadata().xattrs()
             );
         }
     })

--- a/cli/tests/cli/xattr/set/set_and_remove.rs
+++ b/cli/tests/cli/xattr/set/set_and_remove.rs
@@ -62,14 +62,14 @@ fn xattr_multiple_set_and_remove() {
 
     archive::for_each_entry("xattr_multi/zstd.pna", |entry| {
         if entry.name() == "raw/empty.txt" {
-            assert_eq!(entry.xattrs(), &[archive::xattr("user.b", b"B")]);
+            assert_eq!(entry.metadata().xattrs(), &[archive::xattr("user.b", b"B")]);
         } else {
             // Non-target entries should remain unaffected (no xattrs)
             assert!(
-                entry.xattrs().is_empty(),
+                entry.metadata().xattrs().is_empty(),
                 "Entry {} should have no xattrs but has {:?}",
                 entry.name(),
-                entry.xattrs()
+                entry.metadata().xattrs()
             );
         }
     })

--- a/lib/src/archive/write.rs
+++ b/lib/src/archive/write.rs
@@ -602,6 +602,9 @@ where
         writer.flush()?;
         writer.try_into_inner()?.try_into_inner()?.into_inner()
     };
+    for xattr in metadata.xattrs {
+        (ChunkType::xATR, xattr.to_bytes()).write_chunk_in(inner)?;
+    }
     (ChunkType::FEND, Vec::<u8>::new()).write_chunk_in(inner)?;
     Ok(())
 }

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -646,7 +646,6 @@ pub struct NormalEntry<T = Vec<u8>> {
     pub(crate) extra: Vec<RawChunk<T>>,
     pub(crate) data: Vec<T>,
     pub(crate) metadata: Metadata,
-    pub(crate) xattrs: Vec<ExtendedAttribute>,
 }
 
 impl<T> TryFrom<RawEntry<T>> for NormalEntry<T>
@@ -784,9 +783,9 @@ where
                 owner_user_sid,
                 owner_group_sid,
                 permission_mode,
+                xattrs,
             },
             data,
-            xattrs,
         })
     }
 }
@@ -816,6 +815,7 @@ where
             owner_user_sid,
             owner_group_sid,
             permission_mode,
+            xattrs,
         } = &self.metadata;
 
         total += (ChunkType::FHED, self.header.to_bytes()).write_chunk_in(writer)?;
@@ -884,7 +884,7 @@ where
         if let Some(ltp) = link_target_type {
             total += (ChunkType::fLTP, ltp.to_bytes()).write_chunk_in(writer)?;
         }
-        for xattr in &self.xattrs {
+        for xattr in xattrs {
             total += (ChunkType::xATR, xattr.to_bytes()).write_chunk_in(writer)?;
         }
         total += (ChunkType::FEND, []).write_chunk_in(writer)?;
@@ -914,6 +914,7 @@ where
             owner_user_sid,
             owner_group_sid,
             permission_mode,
+            xattrs,
         } = self.metadata;
         let mut vec = Vec::new();
         vec.push(RawChunk::from_data(ChunkType::FHED, self.header.to_bytes()));
@@ -994,7 +995,7 @@ where
         if let Some(ltp) = link_target_type {
             vec.push(RawChunk::from_data(ChunkType::fLTP, ltp.to_bytes()));
         }
-        for xattr in self.xattrs {
+        for xattr in xattrs {
             vec.push(RawChunk::from_data(ChunkType::xATR, xattr.to_bytes()));
         }
         vec.push(RawChunk::from_data(ChunkType::FEND, Vec::new()));
@@ -1059,9 +1060,13 @@ impl<T> NormalEntry<T> {
     }
 
     /// Returns the extended attributes of this entry.
+    #[deprecated(
+        since = "0.36.0",
+        note = "xattrs are now a Metadata facet; use NormalEntry::metadata().xattrs()"
+    )]
     #[inline]
     pub fn xattrs(&self) -> &[ExtendedAttribute] {
-        &self.xattrs
+        self.metadata.xattrs()
     }
 
     /// Returns the extra chunks of this entry.
@@ -1092,24 +1097,13 @@ impl<T> NormalEntry<T> {
     }
 
     /// Applies extended attributes to the entry.
-    ///
-    /// # Examples
-    /// ```rust
-    /// # use std::io;
-    /// use libpna::{EntryBuilder, ExtendedAttribute, XattrName, XattrValue};
-    ///
-    /// # fn main() -> io::Result<()> {
-    /// let mut entry = EntryBuilder::new_dir("dir_entry".into()).build()?;
-    /// entry.with_xattrs(&[ExtendedAttribute::new(
-    ///     XattrName::try_from("key").unwrap(),
-    ///     XattrValue::try_from(b"value".as_slice()).unwrap(),
-    /// )]);
-    /// # Ok(())
-    /// # }
-    /// ```
+    #[deprecated(
+        since = "0.36.0",
+        note = "xattrs are now a Metadata facet; set them via Metadata::with_xattrs and NormalEntry::with_metadata"
+    )]
     #[inline]
     pub fn with_xattrs(mut self, xattrs: impl Into<Vec<ExtendedAttribute>>) -> Self {
-        self.xattrs = xattrs.into();
+        self.metadata.xattrs = xattrs.into();
         self
     }
 
@@ -1221,7 +1215,6 @@ impl<'a> From<NormalEntry<Cow<'a, [u8]>>> for NormalEntry<Vec<u8>> {
             extra: value.extra.into_iter().map(Into::into).collect(),
             data: value.data.into_iter().map(Into::into).collect(),
             metadata: value.metadata,
-            xattrs: value.xattrs,
         }
     }
 }
@@ -1235,7 +1228,6 @@ impl<'a> From<NormalEntry<&'a [u8]>> for NormalEntry<Vec<u8>> {
             extra: value.extra.into_iter().map(Into::into).collect(),
             data: value.data.into_iter().map(Into::into).collect(),
             metadata: value.metadata,
-            xattrs: value.xattrs,
         }
     }
 }
@@ -1249,7 +1241,6 @@ impl From<NormalEntry<Vec<u8>>> for NormalEntry<Cow<'_, [u8]>> {
             extra: value.extra.into_iter().map(Into::into).collect(),
             data: value.data.into_iter().map(Into::into).collect(),
             metadata: value.metadata,
-            xattrs: value.xattrs,
         }
     }
 }
@@ -1263,7 +1254,6 @@ impl<'a> From<NormalEntry<&'a [u8]>> for NormalEntry<Cow<'a, [u8]>> {
             extra: value.extra.into_iter().map(Into::into).collect(),
             data: value.data.into_iter().map(Into::into).collect(),
             metadata: value.metadata,
-            xattrs: value.xattrs,
         }
     }
 }
@@ -1681,5 +1671,41 @@ mod tests {
         assert!(result.is_ok());
         let entry = result.unwrap();
         assert_eq!(entry.extra.len(), 0);
+    }
+
+    fn sample_xattr() -> ExtendedAttribute {
+        ExtendedAttribute::new(
+            XattrName::try_from("user.k").unwrap(),
+            XattrValue::try_from(b"v".as_slice()).unwrap(),
+        )
+    }
+
+    #[test]
+    fn xattrs_round_trip_through_metadata() {
+        let xattr = sample_xattr();
+        let mut builder = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
+        builder.add_xattr(xattr.clone());
+        let entry = builder.build().unwrap();
+        let restored = NormalEntry::try_from(RawEntry(entry.into_chunks())).unwrap();
+        assert_eq!(restored.metadata().xattrs(), &[xattr]);
+    }
+
+    #[test]
+    fn empty_xattrs_emit_no_xatr_chunk() {
+        let entry = EntryBuilder::new_file("f".into(), WriteOptions::store())
+            .unwrap()
+            .build()
+            .unwrap();
+        assert!(entry.into_chunks().iter().all(|c| c.ty != ChunkType::xATR));
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn deprecated_xattrs_accessor_delegates_to_metadata() {
+        let mut builder = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
+        builder.add_xattr(sample_xattr());
+        let entry = builder.build().unwrap();
+        assert_eq!(entry.xattrs(), entry.metadata().xattrs());
+        assert!(!entry.xattrs().is_empty());
     }
 }

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -467,6 +467,7 @@ impl EntryBuilder {
             owner_user_sid: self.owner_user_sid,
             owner_group_sid: self.owner_group_sid,
             permission_mode: self.permission_mode,
+            xattrs: self.xattrs,
         };
         Ok(NormalEntry {
             header: self.header,
@@ -474,7 +475,6 @@ impl EntryBuilder {
             extra: self.extra_chunks,
             data,
             metadata,
-            xattrs: self.xattrs,
         })
     }
 }
@@ -852,6 +852,27 @@ mod tests {
         reader.read_to_end(&mut buf).unwrap();
 
         assert_eq!("テストデータ".as_bytes(), &buf[..]);
+    }
+
+    #[test]
+    fn solid_write_file_with_xattrs_metadata_round_trips() {
+        use crate::entry::{XattrName, XattrValue};
+        let xattr = ExtendedAttribute::new(
+            XattrName::try_from("user.k").unwrap(),
+            XattrValue::try_from(b"v".as_slice()).unwrap(),
+        );
+        let mut builder = SolidEntryBuilder::new(WriteOptions::store()).unwrap();
+        builder
+            .write_file(
+                "entry".into(),
+                Metadata::new().with_xattrs(vec![xattr.clone()]),
+                |w| w.write_all(b"data"),
+            )
+            .unwrap();
+        let solid_entry = builder.build_as_entry().unwrap();
+        let mut entries = solid_entry.entries(ReadOptions::builder().build()).unwrap();
+        let entry = entries.next().unwrap().unwrap();
+        assert_eq!(entry.metadata().xattrs(), &[xattr]);
     }
 
     #[test]

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -1,5 +1,6 @@
 //! Metadata and permission types for archive entries.
 
+use crate::entry::ExtendedAttribute;
 use crate::util::bounded::{LengthExceeded, str::BoundedString};
 use crate::{Duration, UnknownValueError};
 use std::io::{self, Read};
@@ -38,6 +39,7 @@ pub struct Metadata {
     pub(crate) owner_user_sid: Option<OwnerUserSid>,
     pub(crate) owner_group_sid: Option<OwnerGroupSid>,
     pub(crate) permission_mode: Option<PermissionMode>,
+    pub(crate) xattrs: Vec<ExtendedAttribute>,
 }
 
 impl Metadata {
@@ -59,6 +61,7 @@ impl Metadata {
             owner_user_sid: None,
             owner_group_sid: None,
             permission_mode: None,
+            xattrs: Vec::new(),
         }
     }
 
@@ -182,6 +185,16 @@ impl Metadata {
         self
     }
 
+    /// Sets the extended attributes facet (`xATR`).
+    ///
+    /// Each attribute is serialized as one `xATR` chunk. Passing an empty
+    /// collection records no attributes and emits no `xATR` chunks.
+    #[inline]
+    pub fn with_xattrs(mut self, xattrs: impl Into<Vec<ExtendedAttribute>>) -> Self {
+        self.xattrs = xattrs.into();
+        self
+    }
+
     /// Returns the raw file size of this entry's data in bytes.
     #[inline]
     pub const fn raw_file_size(&self) -> Option<u128> {
@@ -261,6 +274,12 @@ impl Metadata {
     #[inline]
     pub const fn link_target_type(&self) -> Option<LinkTargetType> {
         self.link_target_type
+    }
+
+    /// Returns the extended attributes (`xATR`) recorded for this entry.
+    #[inline]
+    pub fn xattrs(&self) -> &[ExtendedAttribute] {
+        &self.xattrs
     }
 }
 


### PR DESCRIPTION
## Summary
xattr is wire-level ancillary metadata (`xATR`) on par with `cTIM`/`fPRM`, so move it into `Metadata`. `NormalEntry::xattrs()`/`with_xattrs()` are kept as deprecated delegates to `Metadata`.

## Notes
- `Metadata`'s `Eq`/`Ord`/`Hash` now include xattrs
- Write paths that take `Metadata` (e.g. `SolidEntryBuilder::write_file`) can now write xattrs (previously there was no way to do so)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended attributes are now stored and accessed as part of entry metadata.
  * Archive creation and conversion now preserve extended attributes.
  * Extended attributes are correctly written to and restored from archives.

* **Bug Fixes**
  * Fixed loss of extended attributes during metadata updates, ownership changes, and migration.
  * Improved consistency across extended-attribute commands and metadata restoration.

* **Refactor**
  * Consolidated extended-attribute handling through the metadata interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->