### PR TITLE
:bug: Write ancillary chunks before FDAT

### DIFF
--- a/lib/src/archive/write.rs
+++ b/lib/src/archive/write.rs
@@ -590,6 +590,9 @@ where
     if let Some(v) = metadata.permission_mode {
         (ChunkType::fMOd, v.to_bytes()).write_chunk_in(inner)?;
     }
+    for xattr in metadata.xattrs {
+        (ChunkType::xATR, xattr.to_bytes()).write_chunk_in(inner)?;
+    }
     let context = get_writer_context(option)?;
     if let Some(WriteCipher { context: c, .. }) = &context.cipher {
         (ChunkType::PHSF, c.phsf.as_bytes()).write_chunk_in(inner)?;
@@ -602,9 +605,6 @@ where
         writer.flush()?;
         writer.try_into_inner()?.try_into_inner()?.into_inner()
     };
-    for xattr in metadata.xattrs {
-        (ChunkType::xATR, xattr.to_bytes()).write_chunk_in(inner)?;
-    }
     (ChunkType::FEND, Vec::<u8>::new()).write_chunk_in(inner)?;
     Ok(())
 }

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -839,12 +839,6 @@ where
                 .write_chunk_in(writer)?;
         }
 
-        if let Some(p) = &self.phsf {
-            total += (ChunkType::PHSF, p.as_bytes()).write_chunk_in(writer)?;
-        }
-        for data_chunk in &self.data {
-            total += (ChunkType::FDAT, data_chunk).write_chunk_in(writer)?;
-        }
         if let Some(c) = created {
             total += (ChunkType::cTIM, c.whole_seconds().to_be_bytes()).write_chunk_in(writer)?;
             if c.subsec_nanoseconds() != 0 {
@@ -896,6 +890,12 @@ where
         for xattr in xattrs {
             total += (ChunkType::xATR, xattr.to_bytes()).write_chunk_in(writer)?;
         }
+        if let Some(p) = &self.phsf {
+            total += (ChunkType::PHSF, p.as_bytes()).write_chunk_in(writer)?;
+        }
+        for data_chunk in &self.data {
+            total += (ChunkType::FDAT, data_chunk).write_chunk_in(writer)?;
+        }
         total += (ChunkType::FEND, []).write_chunk_in(writer)?;
         Ok(total)
     }
@@ -935,12 +935,6 @@ where
             ));
         }
 
-        if let Some(p) = self.phsf {
-            vec.push(RawChunk::from_data(ChunkType::PHSF, p.into_bytes()));
-        }
-        for data_chunk in self.data {
-            vec.push(RawChunk::from((ChunkType::FDAT, data_chunk)).into());
-        }
         if let Some(c) = created {
             vec.push(RawChunk::from_data(
                 ChunkType::cTIM,
@@ -1006,6 +1000,12 @@ where
         }
         for xattr in xattrs {
             vec.push(RawChunk::from_data(ChunkType::xATR, xattr.to_bytes()));
+        }
+        if let Some(p) = self.phsf {
+            vec.push(RawChunk::from_data(ChunkType::PHSF, p.into_bytes()));
+        }
+        for data_chunk in self.data {
+            vec.push(RawChunk::from((ChunkType::FDAT, data_chunk)).into());
         }
         vec.push(RawChunk::from_data(ChunkType::FEND, Vec::new()));
         vec
@@ -1738,5 +1738,23 @@ mod tests {
         let entry = builder.build().unwrap();
         assert_eq!(entry.xattrs(), entry.metadata().xattrs());
         assert!(!entry.xattrs().is_empty());
+    }
+
+    #[test]
+    fn ancillary_chunks_are_written_before_fdat() {
+        let mut builder = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
+        builder
+            .created(Duration::seconds(1))
+            .permission_mode(PermissionMode::from(0o755))
+            .add_xattr(sample_xattr());
+        builder.write_all(b"data").unwrap();
+        let entry = builder.build().unwrap();
+        let chunks = entry.into_chunks();
+
+        let fdat_pos = chunks.iter().position(|c| c.ty == ChunkType::FDAT).unwrap();
+        for ty in [ChunkType::cTIM, ChunkType::fMOd, ChunkType::xATR] {
+            let pos = chunks.iter().position(|c| c.ty == ty).unwrap();
+            assert!(pos < fdat_pos, "{ty:?} must appear before FDAT");
+        }
     }
 }


### PR DESCRIPTION
## Summary
Follow-up to #3238: `xATR` (and, for `NormalEntry::write_in`/`into_chunks`, all other ancillary chunks — timestamps, permission, owner info, `fLTP`) is now written before `FDAT` instead of after, matching the entry layout `[ FHED | Ancillary* | FDAT* | FEND ]`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected archive entry serialization order for extended attributes, timestamps, modification metadata, and file data.
  * Improved compatibility by ensuring metadata appears before file content in generated archives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->