### PR TITLE
:sparkles: Add kind-specific entry builders

### DIFF
--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -27,8 +27,9 @@ pub(crate) use path_filter::PathFilter;
 use path_slash::*;
 pub(crate) use path_transformer::PathTransformers;
 use pna::{
-    Archive, EntryBuilder, EntryPart, LinkTargetType, MIN_CHUNK_BYTES_SIZE, NormalEntry,
-    PNA_HEADER, ReadEntry, ReadOptions, SolidEntryBuilder, WriteOptions, prelude::*,
+    Archive, DirEntryBuilder, EntryPart, FileEntryBuilder, HardLinkEntryBuilder, LinkTargetType,
+    MIN_CHUNK_BYTES_SIZE, Metadata, NormalEntry, PNA_HEADER, ReadEntry, ReadOptions,
+    SolidEntryBuilder, SymlinkEntryBuilder, WriteOptions, prelude::*,
 };
 use std::{
     borrow::Cow,
@@ -961,24 +962,42 @@ pub(crate) fn create_entry(
                 log::debug!("Skip: {}", path.display());
                 return Ok(None);
             };
-            let entry = EntryBuilder::new_hard_link(entry_name, reference)?;
-            apply_metadata(entry, path, keep_options, metadata)?.build()
+            let mut entry = HardLinkEntryBuilder::new(entry_name, reference)?;
+            entry.metadata(build_entry_metadata(path, keep_options, metadata)?);
+            for chunk in collect_extra_chunks(path, keep_options, metadata)? {
+                entry.add_extra_chunk(chunk);
+            }
+            entry.build()
         }
         StoreAs::Symlink(link_target_type) => {
             let source = fs::read_link(path)?;
             let reference = pathname_editor.edit_symlink(&source);
-            let mut entry = EntryBuilder::new_symlink(entry_name, reference)?;
-            entry.link_target_type(*link_target_type);
-            apply_metadata(entry, path, keep_options, metadata)?.build()
+            let mut entry = SymlinkEntryBuilder::new(entry_name, reference)?;
+            entry.metadata(
+                build_entry_metadata(path, keep_options, metadata)?
+                    .with_link_target_type(Some(*link_target_type)),
+            );
+            for chunk in collect_extra_chunks(path, keep_options, metadata)? {
+                entry.add_extra_chunk(chunk);
+            }
+            entry.build()
         }
         StoreAs::File => {
-            let mut entry = EntryBuilder::new_file(entry_name, option)?;
+            let mut entry = FileEntryBuilder::new_with_options(entry_name, option)?;
             write_from_path(&mut entry, path)?;
-            apply_metadata(entry, path, keep_options, metadata)?.build()
+            entry.metadata(build_entry_metadata(path, keep_options, metadata)?);
+            for chunk in collect_extra_chunks(path, keep_options, metadata)? {
+                entry.add_extra_chunk(chunk);
+            }
+            entry.build()
         }
         StoreAs::Dir => {
-            let entry = EntryBuilder::new_dir(entry_name);
-            apply_metadata(entry, path, keep_options, metadata)?.build()
+            let mut entry = DirEntryBuilder::new(entry_name);
+            entry.metadata(build_entry_metadata(path, keep_options, metadata)?);
+            for chunk in collect_extra_chunks(path, keep_options, metadata)? {
+                entry.add_extra_chunk(chunk);
+            }
+            entry.build()
         }
     }
     .map(Some)
@@ -1006,13 +1025,19 @@ pub(crate) fn entry_option(
     option_builder.build()
 }
 
+/// Builds the [`Metadata`] for an entry from filesystem metadata, according to `keep_options`.
+///
+/// This covers the metadata facets that are representable in [`Metadata`] itself
+/// (timestamps, owner, permission mode, extended attributes). ACL, file flags, and
+/// macOS AppleDouble data are not part of `Metadata` and are collected separately by
+/// [`collect_extra_chunks`].
 #[cfg_attr(target_os = "wasi", allow(unused_variables))]
-pub(crate) fn apply_metadata(
-    mut entry: EntryBuilder,
+pub(crate) fn build_entry_metadata(
     path: &Path,
     keep_options: &KeepOptions,
     meta: &fs::Metadata,
-) -> io::Result<EntryBuilder> {
+) -> io::Result<Metadata> {
+    let mut metadata = Metadata::new();
     if let TimestampStrategy::Preserve {
         mtime,
         ctime,
@@ -1020,13 +1045,13 @@ pub(crate) fn apply_metadata(
     } = keep_options.timestamp_strategy
     {
         if let Some(c) = ctime.resolve(meta.created().ok()) {
-            entry.created_time(c);
+            metadata = metadata.with_created_time(c);
         }
         if let Some(m) = mtime.resolve(meta.modified().ok()) {
-            entry.modified_time(m);
+            metadata = metadata.with_modified_time(m);
         }
         if let Some(a) = atime.resolve(meta.accessed().ok()) {
-            entry.accessed_time(a);
+            metadata = metadata.with_accessed_time(a);
         }
     }
     #[cfg(unix)]
@@ -1052,13 +1077,14 @@ pub(crate) fn apply_metadata(
                 .into(),
             Some(gname) => gname.clone(),
         };
-        entry.owner_uid(pna::OwnerUid::from(u64::from(uid)));
-        entry.owner_gid(pna::OwnerGid::from(u64::from(gid)));
-        entry.owner_user_name(crate::command::core::permission::owner_name_opt(&uname));
-        entry.owner_group_name(crate::command::core::permission::owner_group_name_opt(
-            &gname,
-        ));
-        entry.permission_mode(pna::PermissionMode::from(mode));
+        metadata = metadata
+            .with_owner_uid(Some(pna::OwnerUid::from(u64::from(uid))))
+            .with_owner_gid(Some(pna::OwnerGid::from(u64::from(gid))))
+            .with_owner_user_name(crate::command::core::permission::owner_name_opt(&uname))
+            .with_owner_group_name(crate::command::core::permission::owner_group_name_opt(
+                &gname,
+            ))
+            .with_permission_mode(Some(pna::PermissionMode::from(mode)));
     }
     #[cfg(windows)]
     if let OwnerStrategy::Preserve { options } = &keep_options.owner_strategy {
@@ -1078,13 +1104,14 @@ pub(crate) fn apply_metadata(
         let gid = options.gid.map_or(u64::MAX, Into::into);
         let uname = options.uname.clone().unwrap_or(user.name);
         let gname = options.gname.clone().unwrap_or(group.name);
-        entry.owner_uid(pna::OwnerUid::from(uid));
-        entry.owner_gid(pna::OwnerGid::from(gid));
-        entry.owner_user_name(crate::command::core::permission::owner_name_opt(&uname));
-        entry.owner_group_name(crate::command::core::permission::owner_group_name_opt(
-            &gname,
-        ));
-        entry.permission_mode(pna::PermissionMode::from(mode));
+        metadata = metadata
+            .with_owner_uid(Some(pna::OwnerUid::from(uid)))
+            .with_owner_gid(Some(pna::OwnerGid::from(gid)))
+            .with_owner_user_name(crate::command::core::permission::owner_name_opt(&uname))
+            .with_owner_group_name(crate::command::core::permission::owner_group_name_opt(
+                &gname,
+            ))
+            .with_permission_mode(Some(pna::PermissionMode::from(mode)));
     }
     // On macOS, when mac_metadata_strategy is Always, AppleDouble packing via copyfile()
     // already includes xattrs and ACLs. Skip separate handling to avoid duplication.
@@ -1096,8 +1123,58 @@ pub(crate) fn apply_metadata(
     #[cfg(not(target_os = "macos"))]
     let skip_xattr_acl = false;
 
+    #[cfg(unix)]
+    if !skip_xattr_acl && matches!(keep_options.xattr_strategy, XattrStrategy::Always) {
+        match utils::os::unix::fs::xattrs::get_xattrs(path) {
+            Ok(xattrs) => {
+                metadata = metadata.with_xattrs(xattrs);
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::Unsupported => {
+                log::warn!(
+                    "Extended attributes are not supported on filesystem for '{}': {}",
+                    path.display(),
+                    e
+                );
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    #[cfg(not(unix))]
+    if let XattrStrategy::Always = keep_options.xattr_strategy {
+        log::warn!("Currently extended attribute is not supported on this platform.");
+    }
+    Ok(metadata)
+}
+
+/// Collects the extra chunks (ACL, file flags, macOS AppleDouble metadata) for an
+/// entry, according to `keep_options`.
+///
+/// These facets are not representable in [`Metadata`] and must be attached to the
+/// entry builder directly via `add_extra_chunk`.
+#[cfg_attr(target_os = "wasi", allow(unused_variables))]
+#[cfg_attr(not(feature = "acl"), allow(unused_variables))]
+pub(crate) fn collect_extra_chunks(
+    path: &Path,
+    keep_options: &KeepOptions,
+    meta: &fs::Metadata,
+) -> io::Result<Vec<pna::RawChunk>> {
+    #[cfg_attr(not(any(feature = "acl", target_os = "macos")), allow(unused_imports))]
+    use pna::RawChunk;
+
+    let mut chunks = Vec::new();
+
+    // On macOS, when mac_metadata_strategy is Always, AppleDouble packing via copyfile()
+    // already includes xattrs and ACLs. Skip separate handling to avoid duplication.
+    #[cfg(target_os = "macos")]
+    let skip_acl = matches!(
+        keep_options.mac_metadata_strategy,
+        MacMetadataStrategy::Always
+    );
+    #[cfg(not(target_os = "macos"))]
+    let skip_acl = false;
+
     #[cfg(feature = "acl")]
-    if !skip_xattr_acl {
+    if !skip_acl {
         #[cfg(any(
             target_os = "linux",
             target_os = "freebsd",
@@ -1106,15 +1183,13 @@ pub(crate) fn apply_metadata(
         ))]
         if let AclStrategy::Always = keep_options.acl_strategy {
             use crate::chunk;
-            use pna::RawChunk;
             let follow_links = !meta.file_type().is_symlink();
             let acl_result = utils::acl::get_facl(path, follow_links);
             match acl_result {
                 Ok(acl) => {
-                    entry
-                        .add_extra_chunk(RawChunk::from_data(chunk::faCl, acl.platform.to_bytes()));
+                    chunks.push(RawChunk::from_data(chunk::faCl, acl.platform.to_bytes()));
                     for ace in acl.entries {
-                        entry.add_extra_chunk(RawChunk::from_data(chunk::faCe, ace.to_bytes()));
+                        chunks.push(RawChunk::from_data(chunk::faCe, ace.to_bytes()));
                     }
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::Unsupported => {
@@ -1141,33 +1216,11 @@ pub(crate) fn apply_metadata(
     if let AclStrategy::Always = keep_options.acl_strategy {
         log::warn!("Please enable `acl` feature and rebuild and install pna.");
     }
-    #[cfg(unix)]
-    if !skip_xattr_acl && matches!(keep_options.xattr_strategy, XattrStrategy::Always) {
-        match utils::os::unix::fs::xattrs::get_xattrs(path) {
-            Ok(xattrs) => {
-                for attr in xattrs {
-                    entry.add_xattr(attr);
-                }
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::Unsupported => {
-                log::warn!(
-                    "Extended attributes are not supported on filesystem for '{}': {}",
-                    path.display(),
-                    e
-                );
-            }
-            Err(e) => return Err(e),
-        }
-    }
-    #[cfg(not(unix))]
-    if let XattrStrategy::Always = keep_options.xattr_strategy {
-        log::warn!("Currently extended attribute is not supported on this platform.");
-    }
     if let FflagsStrategy::Always = keep_options.fflags_strategy {
         match utils::fs::get_flags(path) {
             Ok(flags) => {
                 for flag in flags {
-                    entry.add_extra_chunk(crate::chunk::fflag_chunk(&flag));
+                    chunks.push(crate::chunk::fflag_chunk(&flag));
                 }
             }
             Err(e) if e.kind() == std::io::ErrorKind::Unsupported => {
@@ -1183,15 +1236,11 @@ pub(crate) fn apply_metadata(
     // macOS metadata (AppleDouble) - packs xattrs, ACLs, resource forks via copyfile()
     #[cfg(target_os = "macos")]
     if let MacMetadataStrategy::Always = keep_options.mac_metadata_strategy {
-        use pna::RawChunk;
         match utils::os::unix::fs::copyfile::pack_apple_double(path) {
             Ok(apple_double_data) => {
                 if !apple_double_data.is_empty() {
                     let len = apple_double_data.len();
-                    entry.add_extra_chunk(RawChunk::from_data(
-                        crate::chunk::maMd,
-                        apple_double_data,
-                    ));
+                    chunks.push(RawChunk::from_data(crate::chunk::maMd, apple_double_data));
                     log::debug!(
                         "Packed macOS metadata for '{}' ({len} bytes)",
                         path.display(),
@@ -1214,7 +1263,7 @@ pub(crate) fn apply_metadata(
     if let MacMetadataStrategy::Always = keep_options.mac_metadata_strategy {
         log::warn!("macOS metadata (--mac-metadata) is only supported on macOS.");
     }
-    Ok(entry)
+    Ok(chunks)
 }
 
 pub(crate) fn split_to_parts(

--- a/cli/src/command/core/mtree.rs
+++ b/cli/src/command/core/mtree.rs
@@ -8,10 +8,12 @@ use super::{
     TimestampStrategy,
 };
 use mtree2::{Entry as MtreeEntry, FileType as MtreeFileType, MTree};
-use pna::prelude::EntryBuilderExt;
-use pna::{EntryBuilder, NormalEntry, WriteOptions};
+use pna::prelude::*;
+use pna::{
+    DirEntryBuilder, FileEntryBuilder, Metadata, NormalEntry, SymlinkEntryBuilder, WriteOptions,
+};
 use std::{
-    fs::{self, Metadata},
+    fs,
     io::{self, BufRead, Read},
     path::{Path, PathBuf},
 };
@@ -335,7 +337,7 @@ fn create_entry_from_mtree(
 }
 
 /// Fetches metadata for a path, formatting errors with the path for context.
-fn get_metadata(path: &Path) -> io::Result<Metadata> {
+fn get_metadata(path: &Path) -> io::Result<fs::Metadata> {
     fs::metadata(path).map_err(|e| io::Error::new(e.kind(), format!("{}: {}", path.display(), e)))
 }
 
@@ -357,19 +359,18 @@ fn create_file_entry(
     entry_name: pna::EntryName,
     source_path: &Path,
     mtree_entry: &MtreeEntry,
-    metadata: &Metadata,
+    metadata: &fs::Metadata,
     option: &WriteOptions,
     keep_options: &KeepOptions,
 ) -> io::Result<Option<NormalEntry>> {
-    let mut entry = EntryBuilder::new_file(entry_name, option)?;
+    let mut entry = FileEntryBuilder::new_with_options(entry_name, option)?;
 
     let file = fs::File::open(source_path)?;
     let mut reader = io::BufReader::with_capacity(64 * 1024, file);
     io::copy(&mut reader, &mut entry)?;
 
-    apply_mtree_metadata(entry, mtree_entry, metadata, keep_options)?
-        .build()
-        .map(Some)
+    entry.metadata(build_mtree_metadata(mtree_entry, metadata, keep_options)?);
+    entry.build().map(Some)
 }
 
 /// Creates a directory entry from mtree specification.
@@ -379,21 +380,19 @@ fn create_dir_entry(
     mtree_entry: &MtreeEntry,
     keep_options: &KeepOptions,
 ) -> io::Result<Option<NormalEntry>> {
-    let entry = EntryBuilder::new_dir(entry_name);
+    let mut entry = DirEntryBuilder::new(entry_name);
 
     let metadata = match fs::metadata(source_path) {
         Ok(meta) => meta,
         Err(e) if e.kind() == io::ErrorKind::NotFound => {
-            return apply_mtree_metadata_without_fs(entry, mtree_entry, keep_options)?
-                .build()
-                .map(Some);
+            entry.metadata(build_mtree_metadata_without_fs(mtree_entry, keep_options)?);
+            return entry.build().map(Some);
         }
         Err(e) => return Err(e),
     };
 
-    apply_mtree_metadata(entry, mtree_entry, &metadata, keep_options)?
-        .build()
-        .map(Some)
+    entry.metadata(build_mtree_metadata(mtree_entry, &metadata, keep_options)?);
+    entry.build().map(Some)
 }
 
 /// Creates a symlink entry from mtree specification.
@@ -402,7 +401,7 @@ fn create_symlink_entry(
     source_path: &Path,
     mtree_entry: &MtreeEntry,
     pathname_editor: &PathnameEditor,
-    metadata: &Metadata,
+    metadata: &fs::Metadata,
     keep_options: &KeepOptions,
 ) -> io::Result<Option<NormalEntry>> {
     let link_target = if let Some(link) = mtree_entry.link() {
@@ -411,22 +410,21 @@ fn create_symlink_entry(
         pathname_editor.edit_symlink(&fs::read_link(source_path)?)
     };
 
-    let entry = EntryBuilder::new_symlink(entry_name, link_target)?;
+    let mut entry = SymlinkEntryBuilder::new(entry_name, link_target)?;
 
-    apply_mtree_metadata(entry, mtree_entry, metadata, keep_options)?
-        .build()
-        .map(Some)
+    entry.metadata(build_mtree_metadata(mtree_entry, metadata, keep_options)?);
+    entry.build().map(Some)
 }
 
-/// Applies metadata from mtree entry, with filesystem metadata as fallback.
+/// Builds metadata from mtree entry, with filesystem metadata as fallback.
 /// When `nochange` keyword is set, always uses filesystem metadata (bsdtar behavior).
 /// Reference: libarchive's parse_file() in archive_read_support_format_mtree.c
-fn apply_mtree_metadata(
-    mut entry: EntryBuilder,
+fn build_mtree_metadata(
     mtree_entry: &MtreeEntry,
-    fs_metadata: &Metadata,
+    fs_metadata: &fs::Metadata,
     keep_options: &KeepOptions,
-) -> io::Result<EntryBuilder> {
+) -> io::Result<Metadata> {
+    let mut metadata = Metadata::new();
     let nochange = mtree_entry.no_change();
 
     if let TimestampStrategy::Preserve {
@@ -437,13 +435,13 @@ fn apply_mtree_metadata(
     {
         let mtree_time = if nochange { None } else { mtree_entry.time() };
         if let Some(m) = mtime.resolve(mtree_time.or_else(|| fs_metadata.modified().ok())) {
-            entry.modified_time(m);
+            metadata = metadata.with_modified_time(m);
         }
         if let Some(c) = ctime.resolve(fs_metadata.created().ok()) {
-            entry.created_time(c);
+            metadata = metadata.with_created_time(c);
         }
         if let Some(a) = atime.resolve(fs_metadata.accessed().ok()) {
-            entry.accessed_time(a);
+            metadata = metadata.with_accessed_time(a);
         }
     }
 
@@ -482,16 +480,17 @@ fn apply_mtree_metadata(
             },
         );
 
-        entry.owner_uid(pna::OwnerUid::from(u64::from(uid)));
-        entry.owner_gid(pna::OwnerGid::from(u64::from(gid)));
-        entry.owner_user_name(crate::command::core::permission::owner_name_opt(&uname));
-        entry.owner_group_name(crate::command::core::permission::owner_group_name_opt(
-            &gname,
-        ));
-        entry.permission_mode(pna::PermissionMode::from(mode));
+        metadata = metadata
+            .with_owner_uid(Some(pna::OwnerUid::from(u64::from(uid))))
+            .with_owner_gid(Some(pna::OwnerGid::from(u64::from(gid))))
+            .with_owner_user_name(crate::command::core::permission::owner_name_opt(&uname))
+            .with_owner_group_name(crate::command::core::permission::owner_group_name_opt(
+                &gname,
+            ))
+            .with_permission_mode(Some(pna::PermissionMode::from(mode)));
     }
 
-    Ok(entry)
+    Ok(metadata)
 }
 
 /// Resolves a numeric ID (uid or gid) with nochange and override handling.
@@ -524,16 +523,17 @@ where
     lookup_from_id().unwrap_or_default()
 }
 
-/// Applies metadata from mtree entry only (no filesystem metadata available).
-fn apply_mtree_metadata_without_fs(
-    mut entry: EntryBuilder,
+/// Builds metadata from mtree entry only (no filesystem metadata available).
+fn build_mtree_metadata_without_fs(
     mtree_entry: &MtreeEntry,
     keep_options: &KeepOptions,
-) -> io::Result<EntryBuilder> {
+) -> io::Result<Metadata> {
+    let mut metadata = Metadata::new();
+
     if let TimestampStrategy::Preserve { mtime, .. } = keep_options.timestamp_strategy
         && let Some(m) = mtime.resolve(mtree_entry.time())
     {
-        entry.modified_time(m);
+        metadata = metadata.with_modified_time(m);
     }
 
     #[cfg(unix)]
@@ -548,16 +548,17 @@ fn apply_mtree_metadata_without_fs(
         let uname = resolve_name(false, options.uname.as_ref(), mtree_entry.uname(), || None);
         let gname = resolve_name(false, options.gname.as_ref(), mtree_entry.gname(), || None);
 
-        entry.owner_uid(pna::OwnerUid::from(u64::from(uid)));
-        entry.owner_gid(pna::OwnerGid::from(u64::from(gid)));
-        entry.owner_user_name(crate::command::core::permission::owner_name_opt(&uname));
-        entry.owner_group_name(crate::command::core::permission::owner_group_name_opt(
-            &gname,
-        ));
-        entry.permission_mode(pna::PermissionMode::from(mode));
+        metadata = metadata
+            .with_owner_uid(Some(pna::OwnerUid::from(u64::from(uid))))
+            .with_owner_gid(Some(pna::OwnerGid::from(u64::from(gid))))
+            .with_owner_user_name(crate::command::core::permission::owner_name_opt(&uname))
+            .with_owner_group_name(crate::command::core::permission::owner_group_name_opt(
+                &gname,
+            ))
+            .with_permission_mode(Some(pna::PermissionMode::from(mode)));
     }
 
-    Ok(entry)
+    Ok(metadata)
 }
 
 #[cfg(test)]

--- a/cli/tests/cli/bsdtar/list_line_ending.rs
+++ b/cli/tests/cli/bsdtar/list_line_ending.rs
@@ -2,17 +2,17 @@
 
 use crate::utils::setup;
 use assert_cmd::cargo::cargo_bin_cmd;
-use pna::{Archive, EntryBuilder, WriteOptions};
+use pna::{Archive, FileEntryBuilder};
 use std::io::Write;
 
 fn build_two_entry_archive() -> Vec<u8> {
     let mut archive = Archive::write_header(Vec::new()).unwrap();
 
-    let mut a = EntryBuilder::new_file("a.txt".into(), WriteOptions::store()).unwrap();
+    let mut a = FileEntryBuilder::new("a.txt".into()).unwrap();
     a.write_all(b"alpha").unwrap();
     archive.add_entry(a.build().unwrap()).unwrap();
 
-    let mut b = EntryBuilder::new_file("b.txt".into(), WriteOptions::store()).unwrap();
+    let mut b = FileEntryBuilder::new("b.txt".into()).unwrap();
     b.write_all(b"beta").unwrap();
     archive.add_entry(b.build().unwrap()).unwrap();
 

--- a/cli/tests/cli/bsdtar/option_fast_read.rs
+++ b/cli/tests/cli/bsdtar/option_fast_read.rs
@@ -1,6 +1,6 @@
 use crate::utils::{list_lines, setup};
 use assert_cmd::cargo::cargo_bin_cmd;
-use pna::{Archive, EntryBuilder, WriteOptions};
+use pna::{Archive, FileEntryBuilder};
 use std::{
     fs,
     io::Write,
@@ -21,7 +21,7 @@ fn build_duplicate_archive(path: impl AsRef<Path>) -> Vec<u8> {
         ("b.txt", b"first-b"),
         ("b.txt", b"second-b"),
     ] {
-        let mut builder = EntryBuilder::new_file(name.into(), WriteOptions::store()).unwrap();
+        let mut builder = FileEntryBuilder::new(name.into()).unwrap();
         builder.write_all(content).unwrap();
         archive.add_entry(builder.build().unwrap()).unwrap();
     }

--- a/cli/tests/cli/bsdtar/option_ignore_zeros.rs
+++ b/cli/tests/cli/bsdtar/option_ignore_zeros.rs
@@ -1,6 +1,6 @@
 use crate::utils::{list_lines, setup};
 use assert_cmd::cargo::cargo_bin_cmd;
-use pna::{Archive, EntryBuilder, ReadOptions, WriteOptions};
+use pna::{Archive, FileEntryBuilder, ReadOptions};
 use std::{
     fs,
     io::{Cursor, Read, Write},
@@ -10,7 +10,7 @@ use std::{
 fn build_archive(entries: &[(&str, &[u8])]) -> Vec<u8> {
     let mut archive = Archive::write_header(Vec::new()).unwrap();
     for (name, content) in entries {
-        let mut builder = EntryBuilder::new_file((*name).into(), WriteOptions::store()).unwrap();
+        let mut builder = FileEntryBuilder::new((*name).into()).unwrap();
         builder.write_all(content).unwrap();
         archive.add_entry(builder.build().unwrap()).unwrap();
     }

--- a/cli/tests/cli/bsdtar/option_to_stdout.rs
+++ b/cli/tests/cli/bsdtar/option_to_stdout.rs
@@ -2,7 +2,7 @@
 
 use crate::utils::setup;
 use assert_cmd::cargo::{CommandCargoExt, cargo_bin_cmd};
-use pna::{Archive, EntryBuilder, WriteOptions};
+use pna::{Archive, DirEntryBuilder, FileEntryBuilder, HardLinkEntryBuilder, SymlinkEntryBuilder};
 use std::{
     io::{Read, Write},
     process::{Command, Stdio},
@@ -11,26 +11,26 @@ use std::{
 fn build_mixed_kind_archive() -> Vec<u8> {
     let mut archive = Archive::write_header(Vec::new()).unwrap();
 
-    let mut a = EntryBuilder::new_file("a.txt".into(), WriteOptions::store()).unwrap();
+    let mut a = FileEntryBuilder::new("a.txt".into()).unwrap();
     a.write_all(b"alpha").unwrap();
     archive.add_entry(a.build().unwrap()).unwrap();
 
-    let dir = EntryBuilder::new_dir("dir/".into()).build().unwrap();
+    let dir = DirEntryBuilder::new("dir/".into()).build().unwrap();
     archive.add_entry(dir).unwrap();
 
-    let symlink = EntryBuilder::new_symlink("link.txt".into(), "a.txt".into())
+    let symlink = SymlinkEntryBuilder::new("link.txt".into(), "a.txt".into())
         .unwrap()
         .build()
         .unwrap();
     archive.add_entry(symlink).unwrap();
 
-    let hardlink = EntryBuilder::new_hard_link("hard.txt".into(), "a.txt".into())
+    let hardlink = HardLinkEntryBuilder::new("hard.txt".into(), "a.txt".into())
         .unwrap()
         .build()
         .unwrap();
     archive.add_entry(hardlink).unwrap();
 
-    let mut b = EntryBuilder::new_file("b.txt".into(), WriteOptions::store()).unwrap();
+    let mut b = FileEntryBuilder::new("b.txt".into()).unwrap();
     b.write_all(b"beta").unwrap();
     archive.add_entry(b.build().unwrap()).unwrap();
 
@@ -40,7 +40,7 @@ fn build_mixed_kind_archive() -> Vec<u8> {
 fn build_large_archive(content_size: usize) -> Vec<u8> {
     let mut archive = Archive::write_header(Vec::new()).unwrap();
 
-    let mut builder = EntryBuilder::new_file("big.bin".into(), WriteOptions::store()).unwrap();
+    let mut builder = FileEntryBuilder::new("big.bin".into()).unwrap();
     let chunk = vec![0u8; 4096];
     let mut remaining = content_size;
     while remaining > 0 {

--- a/cli/tests/cli/bsdtar/path_traversal.rs
+++ b/cli/tests/cli/bsdtar/path_traversal.rs
@@ -1,6 +1,9 @@
 use crate::utils::setup;
 use assert_cmd::cargo::cargo_bin_cmd;
-use pna::{Archive, EntryBuilder, EntryName, EntryReference, WriteOptions};
+use pna::{
+    Archive, EntryName, EntryReference, FileEntryBuilder, HardLinkEntryBuilder,
+    SymlinkEntryBuilder, WriteOptions,
+};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -23,7 +26,7 @@ fn build_archive_with_file(archive_path: &Path, file_name: &str, file_content: &
 
     writer
         .add_entry({
-            let mut builder = EntryBuilder::new_file(
+            let mut builder = FileEntryBuilder::new_with_options(
                 EntryName::from_utf8_preserve_root(file_name),
                 WriteOptions::builder().build(),
             )
@@ -51,7 +54,7 @@ fn build_archive_with_file_and_symlink(
 
     writer
         .add_entry({
-            let mut builder = EntryBuilder::new_file(
+            let mut builder = FileEntryBuilder::new_with_options(
                 EntryName::from_utf8_preserve_root(file_name),
                 WriteOptions::builder().build(),
             )
@@ -63,7 +66,7 @@ fn build_archive_with_file_and_symlink(
 
     writer
         .add_entry({
-            EntryBuilder::new_symlink(
+            SymlinkEntryBuilder::new(
                 EntryName::from_utf8_preserve_root(symlink_name),
                 EntryReference::from_utf8_preserve_root(symlink_target),
             )
@@ -91,7 +94,7 @@ fn build_archive_with_file_and_hardlink(
 
     writer
         .add_entry({
-            let mut builder = EntryBuilder::new_file(
+            let mut builder = FileEntryBuilder::new_with_options(
                 EntryName::from_utf8_preserve_root(file_name),
                 WriteOptions::builder().build(),
             )
@@ -103,7 +106,7 @@ fn build_archive_with_file_and_hardlink(
 
     writer
         .add_entry({
-            EntryBuilder::new_hard_link(
+            HardLinkEntryBuilder::new(
                 EntryName::from_utf8_preserve_root(hardlink_name),
                 EntryReference::from_utf8_preserve_root(hardlink_target),
             )

--- a/cli/tests/cli/bsdtar/unlink_first.rs
+++ b/cli/tests/cli/bsdtar/unlink_first.rs
@@ -1,6 +1,8 @@
 use crate::utils::setup;
 use assert_cmd::cargo::cargo_bin_cmd;
-use pna::{Archive, Duration, EntryBuilder, WriteOptions, fs as pna_fs};
+use pna::{
+    Archive, DirEntryBuilder, Duration, FileEntryBuilder, Metadata, WriteOptions, fs as pna_fs,
+};
 use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
@@ -15,8 +17,9 @@ fn build_archive_with_mtime(path: &PathBuf, name: &str, contents: &str, mtime: D
     writer
         .add_entry({
             let mut builder =
-                EntryBuilder::new_file(name.into(), WriteOptions::builder().build()).unwrap();
-            builder.modified(mtime);
+                FileEntryBuilder::new_with_options(name.into(), WriteOptions::builder().build())
+                    .unwrap();
+            builder.metadata(Metadata::new().with_modified(Some(mtime)));
             builder.write_all(contents.as_bytes()).unwrap();
             builder.build().unwrap()
         })
@@ -33,7 +36,8 @@ fn build_single_file_archive(path: &PathBuf, name: &str, contents: &str) {
     writer
         .add_entry({
             let mut builder =
-                EntryBuilder::new_file(name.into(), WriteOptions::builder().build()).unwrap();
+                FileEntryBuilder::new_with_options(name.into(), WriteOptions::builder().build())
+                    .unwrap();
             builder.write_all(contents.as_bytes()).unwrap();
             builder.build().unwrap()
         })
@@ -279,13 +283,15 @@ fn unlink_first_with_follow_symlinks_preserves_symlinked_directory() {
         let file = fs::File::create(&archive_path).unwrap();
         let mut writer = Archive::write_header(file).unwrap();
         writer
-            .add_entry(EntryBuilder::new_dir("dir".into()).build().unwrap())
+            .add_entry(DirEntryBuilder::new("dir".into()).build().unwrap())
             .unwrap();
         writer
             .add_entry({
-                let mut builder =
-                    EntryBuilder::new_file("dir/file.txt".into(), WriteOptions::builder().build())
-                        .unwrap();
+                let mut builder = FileEntryBuilder::new_with_options(
+                    "dir/file.txt".into(),
+                    WriteOptions::builder().build(),
+                )
+                .unwrap();
                 builder.write_all(b"payload").unwrap();
                 builder.build().unwrap()
             })

--- a/cli/tests/cli/chmod.rs
+++ b/cli/tests/cli/chmod.rs
@@ -17,7 +17,10 @@ use crate::utils::{archive, archive::FileEntryDef, setup};
 use clap::Parser;
 #[allow(deprecated)]
 use pna::Permission;
-use pna::{Archive, EntryBuilder, EntryName, WriteOptions};
+use pna::{
+    Archive, DirEntryBuilder, EntryName, FileEntryBuilder, HardLinkEntryBuilder, Metadata,
+    SymlinkEntryBuilder,
+};
 use portable_network_archive::cli;
 use std::fs::File;
 use std::io::Write;
@@ -80,18 +83,15 @@ fn archive_chmod_drops_legacy_fprm() {
     let path = "chmod_legacy_fprm.pna";
     {
         let mut archive = Archive::write_header(File::create(path).unwrap()).unwrap();
-        let mut builder = EntryBuilder::new_file(
-            EntryName::from_utf8_preserve_root(ENTRY_PATH),
-            WriteOptions::store(),
-        )
-        .unwrap();
-        builder.permission(Permission::new(
+        let mut builder =
+            FileEntryBuilder::new(EntryName::from_utf8_preserve_root(ENTRY_PATH)).unwrap();
+        builder.metadata(Metadata::new().with_permission(Some(Permission::new(
             1000,
             "user".to_string(),
             1000,
             "group".to_string(),
             0o777,
-        ));
+        ))));
         builder.write_all(ENTRY_CONTENT).unwrap();
         archive.add_entry(builder.build().unwrap()).unwrap();
         archive.finalize().unwrap();
@@ -131,11 +131,8 @@ fn archive_chmod_numeric_sets_missing_permission_mode() {
     let path = "chmod_missing_mode_numeric.pna";
     {
         let mut archive = Archive::write_header(File::create(path).unwrap()).unwrap();
-        let mut builder = EntryBuilder::new_file(
-            EntryName::from_utf8_preserve_root(ENTRY_PATH),
-            WriteOptions::store(),
-        )
-        .unwrap();
+        let mut builder =
+            FileEntryBuilder::new(EntryName::from_utf8_preserve_root(ENTRY_PATH)).unwrap();
         builder.write_all(ENTRY_CONTENT).unwrap();
         archive.add_entry(builder.build().unwrap()).unwrap();
         archive.finalize().unwrap();
@@ -176,17 +173,17 @@ fn archive_chmod_symbolic_uses_default_mode_for_missing_permission() {
     {
         let mut archive = Archive::write_header(File::create(path).unwrap()).unwrap();
 
-        let mut file = EntryBuilder::new_file("file.txt".into(), WriteOptions::store()).unwrap();
+        let mut file = FileEntryBuilder::new("file.txt".into()).unwrap();
         file.write_all(b"file").unwrap();
         archive.add_entry(file.build().unwrap()).unwrap();
 
         archive
-            .add_entry(EntryBuilder::new_dir("dir".into()).build().unwrap())
+            .add_entry(DirEntryBuilder::new("dir".into()).build().unwrap())
             .unwrap();
 
         archive
             .add_entry(
-                EntryBuilder::new_symlink("link.txt".into(), "file.txt".into())
+                SymlinkEntryBuilder::new("link.txt".into(), "file.txt".into())
                     .unwrap()
                     .build()
                     .unwrap(),
@@ -195,7 +192,7 @@ fn archive_chmod_symbolic_uses_default_mode_for_missing_permission() {
 
         archive
             .add_entry(
-                EntryBuilder::new_hard_link("hard.txt".into(), "file.txt".into())
+                HardLinkEntryBuilder::new("hard.txt".into(), "file.txt".into())
                     .unwrap()
                     .build()
                     .unwrap(),

--- a/cli/tests/cli/chown/preserve_owner_absence.rs
+++ b/cli/tests/cli/chown/preserve_owner_absence.rs
@@ -1,6 +1,6 @@
 use crate::utils::{archive, setup};
 use clap::Parser;
-use pna::{Archive, EntryBuilder, EntryName, WriteOptions};
+use pna::{Archive, EntryName, FileEntryBuilder, Metadata};
 use portable_network_archive::cli;
 use std::fs::File;
 use std::io::Write;
@@ -17,19 +17,13 @@ fn chown_user_only_preserves_missing_gid() {
     let path = "chown_preserve_absence.pna";
     {
         let mut a = Archive::write_header(File::create(path).unwrap()).unwrap();
-        let mut mo = EntryBuilder::new_file(
-            EntryName::from_utf8_preserve_root("mode_only.txt"),
-            WriteOptions::store(),
-        )
-        .unwrap();
-        mo.permission_mode(pna::PermissionMode::from(0o644));
+        let mut mo =
+            FileEntryBuilder::new(EntryName::from_utf8_preserve_root("mode_only.txt")).unwrap();
+        mo.metadata(Metadata::new().with_permission_mode(Some(pna::PermissionMode::from(0o644))));
         mo.write_all(b"m").unwrap();
         a.add_entry(mo.build().unwrap()).unwrap();
-        let mut bare = EntryBuilder::new_file(
-            EntryName::from_utf8_preserve_root("bare.txt"),
-            WriteOptions::store(),
-        )
-        .unwrap();
+        let mut bare =
+            FileEntryBuilder::new(EntryName::from_utf8_preserve_root("bare.txt")).unwrap();
         bare.write_all(b"x").unwrap();
         a.add_entry(bare.build().unwrap()).unwrap();
         a.finalize().unwrap();
@@ -93,19 +87,13 @@ fn chown_group_only_preserves_missing_uid() {
     let path = "chown_preserve_absence_group.pna";
     {
         let mut a = Archive::write_header(File::create(path).unwrap()).unwrap();
-        let mut mo = EntryBuilder::new_file(
-            EntryName::from_utf8_preserve_root("mode_only.txt"),
-            WriteOptions::store(),
-        )
-        .unwrap();
-        mo.permission_mode(pna::PermissionMode::from(0o600));
+        let mut mo =
+            FileEntryBuilder::new(EntryName::from_utf8_preserve_root("mode_only.txt")).unwrap();
+        mo.metadata(Metadata::new().with_permission_mode(Some(pna::PermissionMode::from(0o600))));
         mo.write_all(b"m").unwrap();
         a.add_entry(mo.build().unwrap()).unwrap();
-        let mut bare = EntryBuilder::new_file(
-            EntryName::from_utf8_preserve_root("bare.txt"),
-            WriteOptions::store(),
-        )
-        .unwrap();
+        let mut bare =
+            FileEntryBuilder::new(EntryName::from_utf8_preserve_root("bare.txt")).unwrap();
         bare.write_all(b"x").unwrap();
         a.add_entry(bare.build().unwrap()).unwrap();
         a.finalize().unwrap();

--- a/cli/tests/cli/chown/user_only.rs
+++ b/cli/tests/cli/chown/user_only.rs
@@ -2,7 +2,7 @@ use crate::utils::{archive, archive::FileEntryDef, setup};
 use clap::Parser;
 #[allow(deprecated)]
 use pna::Permission;
-use pna::{Archive, EntryBuilder, EntryName, WriteOptions};
+use pna::{Archive, EntryName, FileEntryBuilder, Metadata};
 use portable_network_archive::cli;
 use std::fs::File;
 use std::io::Write;
@@ -93,18 +93,15 @@ fn chown_user_only_drops_legacy_fprm() {
     let path = "chown_legacy_fprm.pna";
     {
         let mut archive = Archive::write_header(File::create(path).unwrap()).unwrap();
-        let mut builder = EntryBuilder::new_file(
-            EntryName::from_utf8_preserve_root("target.txt"),
-            WriteOptions::store(),
-        )
-        .unwrap();
-        builder.permission(Permission::new(
+        let mut builder =
+            FileEntryBuilder::new(EntryName::from_utf8_preserve_root("target.txt")).unwrap();
+        builder.metadata(Metadata::new().with_permission(Some(Permission::new(
             1000,
             "user".to_string(),
             1000,
             "group".to_string(),
             0o644,
-        ));
+        ))));
         builder.write_all(b"target").unwrap();
         archive.add_entry(builder.build().unwrap()).unwrap();
         archive.finalize().unwrap();

--- a/cli/tests/cli/extract/hardlink.rs
+++ b/cli/tests/cli/extract/hardlink.rs
@@ -1,6 +1,6 @@
 use crate::utils::setup;
 use clap::Parser;
-use pna::{Archive, EntryBuilder, WriteOptions};
+use pna::{Archive, FileEntryBuilder, HardLinkEntryBuilder, WriteOptions};
 use portable_network_archive::cli;
 use std::{fs, io::Write, path::Path};
 
@@ -14,9 +14,11 @@ fn init_resource<P: AsRef<Path>>(path: P) {
 
     writer
         .add_entry({
-            let mut builder =
-                EntryBuilder::new_file("origin1.txt".into(), WriteOptions::builder().build())
-                    .unwrap();
+            let mut builder = FileEntryBuilder::new_with_options(
+                "origin1.txt".into(),
+                WriteOptions::builder().build(),
+            )
+            .unwrap();
             builder.write_all(b"original text\n").unwrap();
             builder.build().unwrap()
         })
@@ -24,24 +26,25 @@ fn init_resource<P: AsRef<Path>>(path: P) {
     writer
         .add_entry({
             let builder =
-                EntryBuilder::new_hard_link("linked1.txt".into(), "origin1.txt".into()).unwrap();
+                HardLinkEntryBuilder::new("linked1.txt".into(), "origin1.txt".into()).unwrap();
             builder.build().unwrap()
         })
         .unwrap();
     writer
         .add_entry({
             let builder =
-                EntryBuilder::new_hard_link("dir/linked1.txt".into(), "origin1.txt".into())
-                    .unwrap();
+                HardLinkEntryBuilder::new("dir/linked1.txt".into(), "origin1.txt".into()).unwrap();
             builder.build().unwrap()
         })
         .unwrap();
 
     writer
         .add_entry({
-            let mut builder =
-                EntryBuilder::new_file("dir/origin2.txt".into(), WriteOptions::builder().build())
-                    .unwrap();
+            let mut builder = FileEntryBuilder::new_with_options(
+                "dir/origin2.txt".into(),
+                WriteOptions::builder().build(),
+            )
+            .unwrap();
             builder.write_all(b"original text text\n").unwrap();
             builder.build().unwrap()
         })
@@ -49,7 +52,7 @@ fn init_resource<P: AsRef<Path>>(path: P) {
     writer
         .add_entry({
             let builder =
-                EntryBuilder::new_hard_link("dir/linked2.txt".into(), "dir/origin2.txt".into())
+                HardLinkEntryBuilder::new("dir/linked2.txt".into(), "dir/origin2.txt".into())
                     .unwrap();
             builder.build().unwrap()
         })
@@ -57,8 +60,7 @@ fn init_resource<P: AsRef<Path>>(path: P) {
     writer
         .add_entry({
             let builder =
-                EntryBuilder::new_hard_link("linked2.txt".into(), "dir/origin2.txt".into())
-                    .unwrap();
+                HardLinkEntryBuilder::new("linked2.txt".into(), "dir/origin2.txt".into()).unwrap();
             builder.build().unwrap()
         })
         .unwrap();

--- a/cli/tests/cli/extract/option_keep_newer_files.rs
+++ b/cli/tests/cli/extract/option_keep_newer_files.rs
@@ -1,6 +1,6 @@
 use crate::utils::setup;
 use clap::Parser;
-use pna::{Archive, Duration, EntryBuilder, WriteOptions};
+use pna::{Archive, Duration, FileEntryBuilder, Metadata, WriteOptions};
 use portable_network_archive::cli;
 use std::{
     fs,
@@ -18,9 +18,10 @@ fn init_file_archive<P: AsRef<Path>>(path: P, modified: Option<Duration>) {
     let file = fs::File::create(path).unwrap();
     let mut archive = Archive::write_header(file).unwrap();
     let mut builder =
-        EntryBuilder::new_file("file.txt".into(), WriteOptions::builder().build()).unwrap();
+        FileEntryBuilder::new_with_options("file.txt".into(), WriteOptions::builder().build())
+            .unwrap();
     if let Some(mtime) = modified {
-        builder.modified(mtime);
+        builder.metadata(Metadata::new().with_modified(Some(mtime)));
     }
     builder.write_all(b"from archive").unwrap();
     let entry = builder.build().unwrap();

--- a/cli/tests/cli/extract/option_keep_old_files.rs
+++ b/cli/tests/cli/extract/option_keep_old_files.rs
@@ -1,6 +1,6 @@
 use crate::utils::setup;
 use clap::Parser;
-use pna::{Archive, Duration, EntryBuilder, WriteOptions};
+use pna::{Archive, Duration, FileEntryBuilder, Metadata, WriteOptions};
 use portable_network_archive::cli;
 use std::{
     fs,
@@ -17,9 +17,10 @@ fn init_file_archive<P: AsRef<Path>>(path: P, modified: Option<Duration>) {
     let file = fs::File::create(path).unwrap();
     let mut archive = Archive::write_header(file).unwrap();
     let mut builder =
-        EntryBuilder::new_file("file.txt".into(), WriteOptions::builder().build()).unwrap();
+        FileEntryBuilder::new_with_options("file.txt".into(), WriteOptions::builder().build())
+            .unwrap();
     if let Some(mtime) = modified {
-        builder.modified(mtime);
+        builder.metadata(Metadata::new().with_modified(Some(mtime)));
     }
     builder.write_all(b"from archive").unwrap();
     let entry = builder.build().unwrap();

--- a/cli/tests/cli/extract/option_keep_timestamp.rs
+++ b/cli/tests/cli/extract/option_keep_timestamp.rs
@@ -108,13 +108,15 @@ fn extract_keep_timestamp_restores_directory_times() {
     // Build archive programmatically with a directory entry having explicit timestamps
     let file = fs::File::create(&archive_path).unwrap();
     let mut archive = pna::Archive::write_header(file).unwrap();
-    let mut dir_builder = pna::EntryBuilder::new_dir("mydir".into());
-    dir_builder.modified(mtime_epoch);
-    dir_builder.accessed(atime_epoch);
+    let mut dir_builder = pna::DirEntryBuilder::new("mydir".into());
+    dir_builder.metadata(
+        pna::Metadata::new()
+            .with_modified(Some(mtime_epoch))
+            .with_accessed(Some(atime_epoch)),
+    );
     archive.add_entry(dir_builder.build().unwrap()).unwrap();
     // Add a file inside the directory so extraction creates the directory
-    let mut file_builder =
-        pna::EntryBuilder::new_file("mydir/file.txt".into(), pna::WriteOptions::store()).unwrap();
+    let mut file_builder = pna::FileEntryBuilder::new("mydir/file.txt".into()).unwrap();
     file_builder.write_all(b"content").unwrap();
     archive.add_entry(file_builder.build().unwrap()).unwrap();
     archive.finalize().unwrap();
@@ -167,23 +169,31 @@ fn extract_with_keep_timestamp_restores_nested_directory_times() {
     let file = fs::File::create(&archive_path).unwrap();
     let mut archive = pna::Archive::write_header(file).unwrap();
 
-    let mut dir_a = pna::EntryBuilder::new_dir("a".into());
-    dir_a.modified(a_mtime_epoch);
-    dir_a.accessed(a_atime_epoch);
+    let mut dir_a = pna::DirEntryBuilder::new("a".into());
+    dir_a.metadata(
+        pna::Metadata::new()
+            .with_modified(Some(a_mtime_epoch))
+            .with_accessed(Some(a_atime_epoch)),
+    );
     archive.add_entry(dir_a.build().unwrap()).unwrap();
 
-    let mut dir_b = pna::EntryBuilder::new_dir("a/b".into());
-    dir_b.modified(b_mtime_epoch);
-    dir_b.accessed(b_atime_epoch);
+    let mut dir_b = pna::DirEntryBuilder::new("a/b".into());
+    dir_b.metadata(
+        pna::Metadata::new()
+            .with_modified(Some(b_mtime_epoch))
+            .with_accessed(Some(b_atime_epoch)),
+    );
     archive.add_entry(dir_b.build().unwrap()).unwrap();
 
-    let mut dir_c = pna::EntryBuilder::new_dir("a/b/c".into());
-    dir_c.modified(c_mtime_epoch);
-    dir_c.accessed(c_atime_epoch);
+    let mut dir_c = pna::DirEntryBuilder::new("a/b/c".into());
+    dir_c.metadata(
+        pna::Metadata::new()
+            .with_modified(Some(c_mtime_epoch))
+            .with_accessed(Some(c_atime_epoch)),
+    );
     archive.add_entry(dir_c.build().unwrap()).unwrap();
 
-    let mut file_builder =
-        pna::EntryBuilder::new_file("a/b/c/file.txt".into(), pna::WriteOptions::store()).unwrap();
+    let mut file_builder = pna::FileEntryBuilder::new("a/b/c/file.txt".into()).unwrap();
     file_builder.write_all(b"content").unwrap();
     archive.add_entry(file_builder.build().unwrap()).unwrap();
     archive.finalize().unwrap();
@@ -244,17 +254,22 @@ fn extract_keep_timestamp_restores_hardlink_times() {
     let file = fs::File::create(&archive_path).unwrap();
     let mut archive = pna::Archive::write_header(file).unwrap();
 
-    let mut file_builder =
-        pna::EntryBuilder::new_file("original.txt".into(), pna::WriteOptions::store()).unwrap();
-    file_builder.modified(mtime_epoch);
-    file_builder.accessed(atime_epoch);
+    let mut file_builder = pna::FileEntryBuilder::new("original.txt".into()).unwrap();
+    file_builder.metadata(
+        pna::Metadata::new()
+            .with_modified(Some(mtime_epoch))
+            .with_accessed(Some(atime_epoch)),
+    );
     file_builder.write_all(b"shared content").unwrap();
     archive.add_entry(file_builder.build().unwrap()).unwrap();
 
     let mut link_builder =
-        pna::EntryBuilder::new_hard_link("link.txt".into(), "original.txt".into()).unwrap();
-    link_builder.modified(mtime_epoch);
-    link_builder.accessed(atime_epoch);
+        pna::HardLinkEntryBuilder::new("link.txt".into(), "original.txt".into()).unwrap();
+    link_builder.metadata(
+        pna::Metadata::new()
+            .with_modified(Some(mtime_epoch))
+            .with_accessed(Some(atime_epoch)),
+    );
     archive.add_entry(link_builder.build().unwrap()).unwrap();
 
     archive.finalize().unwrap();

--- a/cli/tests/cli/extract/option_safe_writes.rs
+++ b/cli/tests/cli/extract/option_safe_writes.rs
@@ -1,6 +1,9 @@
 use crate::utils::setup;
 use clap::Parser;
-use pna::{Archive, EntryBuilder, WriteOptions};
+use pna::{
+    Archive, DirEntryBuilder, FileEntryBuilder, HardLinkEntryBuilder, SymlinkEntryBuilder,
+    WriteOptions,
+};
 use portable_network_archive::cli;
 use std::{
     fs,
@@ -15,7 +18,8 @@ fn create_file_archive(archive_path: &Path, file_name: &str, content: &[u8]) {
     let file = fs::File::create(archive_path).unwrap();
     let mut archive = Archive::write_header(file).unwrap();
     let mut builder =
-        EntryBuilder::new_file(file_name.into(), WriteOptions::builder().build()).unwrap();
+        FileEntryBuilder::new_with_options(file_name.into(), WriteOptions::builder().build())
+            .unwrap();
     builder.write_all(content).unwrap();
     archive.add_entry(builder.build().unwrap()).unwrap();
     archive.finalize().unwrap();
@@ -247,12 +251,13 @@ fn extract_with_safe_writes_creates_symlink() {
 
     // Add target file first
     let mut builder =
-        EntryBuilder::new_file("target.txt".into(), WriteOptions::builder().build()).unwrap();
+        FileEntryBuilder::new_with_options("target.txt".into(), WriteOptions::builder().build())
+            .unwrap();
     builder.write_all(b"target content").unwrap();
     archive.add_entry(builder.build().unwrap()).unwrap();
 
     // Add symlink pointing to target
-    let builder = EntryBuilder::new_symlink("link.txt".into(), "target.txt".into()).unwrap();
+    let builder = SymlinkEntryBuilder::new("link.txt".into(), "target.txt".into()).unwrap();
     archive.add_entry(builder.build().unwrap()).unwrap();
 
     archive.finalize().unwrap();
@@ -319,13 +324,13 @@ fn extract_with_safe_writes_creates_hardlink() {
 
     // Add original file
     let mut builder =
-        EntryBuilder::new_file("original.txt".into(), WriteOptions::builder().build()).unwrap();
+        FileEntryBuilder::new_with_options("original.txt".into(), WriteOptions::builder().build())
+            .unwrap();
     builder.write_all(b"shared content").unwrap();
     archive.add_entry(builder.build().unwrap()).unwrap();
 
     // Add hardlink to original
-    let builder =
-        EntryBuilder::new_hard_link("hardlink.txt".into(), "original.txt".into()).unwrap();
+    let builder = HardLinkEntryBuilder::new("hardlink.txt".into(), "original.txt".into()).unwrap();
     archive.add_entry(builder.build().unwrap()).unwrap();
 
     archive.finalize().unwrap();
@@ -455,7 +460,7 @@ fn extract_with_safe_writes_creates_directory() {
     let file = fs::File::create(&archive_path).unwrap();
     let mut archive = Archive::write_header(file).unwrap();
 
-    let builder = EntryBuilder::new_dir("subdir".into());
+    let builder = DirEntryBuilder::new("subdir".into());
     archive.add_entry(builder.build().unwrap()).unwrap();
 
     archive.finalize().unwrap();
@@ -504,12 +509,13 @@ fn extract_with_safe_writes_replaces_file_with_symlink() {
 
     // Add target file
     let mut builder =
-        EntryBuilder::new_file("target.txt".into(), WriteOptions::builder().build()).unwrap();
+        FileEntryBuilder::new_with_options("target.txt".into(), WriteOptions::builder().build())
+            .unwrap();
     builder.write_all(b"target content").unwrap();
     archive.add_entry(builder.build().unwrap()).unwrap();
 
     // Add symlink
-    let builder = EntryBuilder::new_symlink("link.txt".into(), "target.txt".into()).unwrap();
+    let builder = SymlinkEntryBuilder::new("link.txt".into(), "target.txt".into()).unwrap();
     archive.add_entry(builder.build().unwrap()).unwrap();
 
     archive.finalize().unwrap();
@@ -579,13 +585,13 @@ fn extract_with_safe_writes_replaces_file_with_hardlink() {
 
     // Add original file
     let mut builder =
-        EntryBuilder::new_file("original.txt".into(), WriteOptions::builder().build()).unwrap();
+        FileEntryBuilder::new_with_options("original.txt".into(), WriteOptions::builder().build())
+            .unwrap();
     builder.write_all(b"shared content").unwrap();
     archive.add_entry(builder.build().unwrap()).unwrap();
 
     // Add hardlink
-    let builder =
-        EntryBuilder::new_hard_link("hardlink.txt".into(), "original.txt".into()).unwrap();
+    let builder = HardLinkEntryBuilder::new("hardlink.txt".into(), "original.txt".into()).unwrap();
     archive.add_entry(builder.build().unwrap()).unwrap();
 
     archive.finalize().unwrap();
@@ -708,7 +714,7 @@ fn extract_with_safe_writes_replaces_symlink_with_symlink() {
     let file = fs::File::create(&archive_path).unwrap();
     let mut archive = Archive::write_header(file).unwrap();
 
-    let builder = EntryBuilder::new_symlink("link.txt".into(), "new_target.txt".into()).unwrap();
+    let builder = SymlinkEntryBuilder::new("link.txt".into(), "new_target.txt".into()).unwrap();
     archive.add_entry(builder.build().unwrap()).unwrap();
 
     archive.finalize().unwrap();
@@ -774,12 +780,13 @@ fn extract_with_safe_writes_replaces_symlink_with_hardlink() {
 
     // Add original file
     let mut builder =
-        EntryBuilder::new_file("original.txt".into(), WriteOptions::builder().build()).unwrap();
+        FileEntryBuilder::new_with_options("original.txt".into(), WriteOptions::builder().build())
+            .unwrap();
     builder.write_all(b"shared content").unwrap();
     archive.add_entry(builder.build().unwrap()).unwrap();
 
     // Add hardlink
-    let builder = EntryBuilder::new_hard_link("link.txt".into(), "original.txt".into()).unwrap();
+    let builder = HardLinkEntryBuilder::new("link.txt".into(), "original.txt".into()).unwrap();
     archive.add_entry(builder.build().unwrap()).unwrap();
 
     archive.finalize().unwrap();

--- a/cli/tests/cli/extract/overwrite_order.rs
+++ b/cli/tests/cli/extract/overwrite_order.rs
@@ -17,8 +17,7 @@ fn extract_duplicate_entries_last_wins() {
     let mut archive = pna::Archive::write_header(file).unwrap();
 
     for content in [b"aaa", b"bbb", b"ccc"] {
-        let mut builder =
-            pna::EntryBuilder::new_file("file.txt".into(), pna::WriteOptions::store()).unwrap();
+        let mut builder = pna::FileEntryBuilder::new("file.txt".into()).unwrap();
         builder.write_all(content).unwrap();
         archive.add_entry(builder.build().unwrap()).unwrap();
     }

--- a/cli/tests/cli/extract/overwrite_symlink.rs
+++ b/cli/tests/cli/extract/overwrite_symlink.rs
@@ -1,6 +1,6 @@
 use crate::utils::setup;
 use clap::Parser;
-use pna::{Archive, EntryBuilder, WriteOptions, fs as pna_fs};
+use pna::{Archive, FileEntryBuilder, SymlinkEntryBuilder, WriteOptions, fs as pna_fs};
 use portable_network_archive::cli;
 use std::{
     fs,
@@ -19,17 +19,18 @@ fn init_symlink_archive<P: AsRef<Path>>(path: P) {
 
     writer
         .add_entry({
-            let builder =
-                EntryBuilder::new_symlink("link".into(), "new_target.txt".into()).unwrap();
+            let builder = SymlinkEntryBuilder::new("link".into(), "new_target.txt".into()).unwrap();
             builder.build().unwrap()
         })
         .unwrap();
 
     writer
         .add_entry({
-            let mut builder =
-                EntryBuilder::new_file("new_target.txt".into(), WriteOptions::builder().build())
-                    .unwrap();
+            let mut builder = FileEntryBuilder::new_with_options(
+                "new_target.txt".into(),
+                WriteOptions::builder().build(),
+            )
+            .unwrap();
             builder.write_all(b"updated").unwrap();
             builder.build().unwrap()
         })

--- a/cli/tests/cli/extract/sanitize_parent_components.rs
+++ b/cli/tests/cli/extract/sanitize_parent_components.rs
@@ -16,7 +16,7 @@ fn extract_command_sanitizes_parent_components_in_entry_names() {
     let mut archive = pna::Archive::write_header(archive_file).unwrap();
 
     let raw_name = pna::EntryName::from_utf8_preserve_root("../escape.txt");
-    let mut builder = pna::EntryBuilder::new_file(raw_name, pna::WriteOptions::store()).unwrap();
+    let mut builder = pna::FileEntryBuilder::new(raw_name).unwrap();
     builder.write_all(b"payload").unwrap();
     let entry = builder.build().unwrap();
     archive.add_entry(entry).unwrap();

--- a/cli/tests/cli/list/owner_facet_mode_only.rs
+++ b/cli/tests/cli/list/owner_facet_mode_only.rs
@@ -1,6 +1,6 @@
 use crate::utils::setup;
 use assert_cmd::cargo::cargo_bin_cmd;
-use pna::{Archive, Duration, EntryBuilder, EntryName, WriteOptions};
+use pna::{Archive, Duration, EntryName, FileEntryBuilder, Metadata};
 use std::io::Write;
 
 fn build_archive(path: &str) {
@@ -10,27 +10,27 @@ fn build_archive(path: &str) {
     // Jan 26 2025 00:00:00 UTC — deterministic timestamp for exact output matching
     let mtime = Duration::new(1737849600, 0);
 
-    let mut mode_only = EntryBuilder::new_file(
-        EntryName::from_utf8_preserve_root("mode_only.txt"),
-        WriteOptions::store(),
-    )
-    .unwrap();
-    mode_only.modified(mtime);
-    mode_only.permission_mode(pna::PermissionMode::from(0o644));
+    let mut mode_only =
+        FileEntryBuilder::new(EntryName::from_utf8_preserve_root("mode_only.txt")).unwrap();
+    mode_only.metadata(
+        Metadata::new()
+            .with_modified(Some(mtime))
+            .with_permission_mode(Some(pna::PermissionMode::from(0o644))),
+    );
     mode_only.write_all(b"a").unwrap();
     archive.add_entry(mode_only.build().unwrap()).unwrap();
 
-    let mut full_owner = EntryBuilder::new_file(
-        EntryName::from_utf8_preserve_root("full_owner.txt"),
-        WriteOptions::store(),
-    )
-    .unwrap();
-    full_owner.modified(mtime);
-    full_owner.owner_uid(pna::OwnerUid::from(1000));
-    full_owner.owner_gid(pna::OwnerGid::from(1000));
-    full_owner.owner_user_name(pna::OwnerUserName::new("alice").unwrap());
-    full_owner.owner_group_name(pna::OwnerGroupName::new("devs").unwrap());
-    full_owner.permission_mode(pna::PermissionMode::from(0o600));
+    let mut full_owner =
+        FileEntryBuilder::new(EntryName::from_utf8_preserve_root("full_owner.txt")).unwrap();
+    full_owner.metadata(
+        Metadata::new()
+            .with_modified(Some(mtime))
+            .with_owner_uid(Some(pna::OwnerUid::from(1000)))
+            .with_owner_gid(Some(pna::OwnerGid::from(1000)))
+            .with_owner_user_name(Some(pna::OwnerUserName::new("alice").unwrap()))
+            .with_owner_group_name(Some(pna::OwnerGroupName::new("devs").unwrap()))
+            .with_permission_mode(Some(pna::PermissionMode::from(0o600))),
+    );
     full_owner.write_all(b"b").unwrap();
     archive.add_entry(full_owner.build().unwrap()).unwrap();
 

--- a/cli/tests/cli/list/trailing_slash.rs
+++ b/cli/tests/cli/list/trailing_slash.rs
@@ -1,6 +1,6 @@
 use crate::utils::setup;
 use assert_cmd::cargo::cargo_bin_cmd;
-use pna::{Archive, Duration, EntryBuilder, EntryName, WriteOptions};
+use pna::{Archive, DirEntryBuilder, Duration, EntryName, FileEntryBuilder, Metadata};
 use std::{fs, io::Write, path::Path};
 
 fn create_archive_with_trailing_slash_dir(path: &str) {
@@ -11,26 +11,29 @@ fn create_archive_with_trailing_slash_dir(path: &str) {
     // Jan 26 2025 00:00:00 UTC — deterministic timestamp for exact output matching
     let mtime = Duration::new(1737849600, 0);
 
-    let mut dir_builder = EntryBuilder::new_dir(EntryName::from_utf8_preserve_root("dir/"));
-    dir_builder.modified(mtime);
-    dir_builder.owner_uid(pna::OwnerUid::from(0));
-    dir_builder.owner_gid(pna::OwnerGid::from(0));
-    dir_builder.owner_user_name(pna::OwnerUserName::new("root").unwrap());
-    dir_builder.owner_group_name(pna::OwnerGroupName::new("root").unwrap());
-    dir_builder.permission_mode(pna::PermissionMode::from(0o755));
+    let mut dir_builder = DirEntryBuilder::new(EntryName::from_utf8_preserve_root("dir/"));
+    dir_builder.metadata(
+        Metadata::new()
+            .with_modified(Some(mtime))
+            .with_owner_uid(Some(pna::OwnerUid::from(0)))
+            .with_owner_gid(Some(pna::OwnerGid::from(0)))
+            .with_owner_user_name(Some(pna::OwnerUserName::new("root").unwrap()))
+            .with_owner_group_name(Some(pna::OwnerGroupName::new("root").unwrap()))
+            .with_permission_mode(Some(pna::PermissionMode::from(0o755))),
+    );
     archive.add_entry(dir_builder.build().unwrap()).unwrap();
 
-    let mut file_builder = EntryBuilder::new_file(
-        EntryName::from_utf8_preserve_root("dir/file.txt"),
-        WriteOptions::store(),
-    )
-    .unwrap();
-    file_builder.modified(mtime);
-    file_builder.owner_uid(pna::OwnerUid::from(0));
-    file_builder.owner_gid(pna::OwnerGid::from(0));
-    file_builder.owner_user_name(pna::OwnerUserName::new("root").unwrap());
-    file_builder.owner_group_name(pna::OwnerGroupName::new("root").unwrap());
-    file_builder.permission_mode(pna::PermissionMode::from(0o644));
+    let mut file_builder =
+        FileEntryBuilder::new(EntryName::from_utf8_preserve_root("dir/file.txt")).unwrap();
+    file_builder.metadata(
+        Metadata::new()
+            .with_modified(Some(mtime))
+            .with_owner_uid(Some(pna::OwnerUid::from(0)))
+            .with_owner_gid(Some(pna::OwnerGid::from(0)))
+            .with_owner_user_name(Some(pna::OwnerUserName::new("root").unwrap()))
+            .with_owner_group_name(Some(pna::OwnerGroupName::new("root").unwrap()))
+            .with_permission_mode(Some(pna::PermissionMode::from(0o644))),
+    );
     file_builder.write_all(b"hello").unwrap();
     archive.add_entry(file_builder.build().unwrap()).unwrap();
 

--- a/cli/tests/cli/sort/by_atime.rs
+++ b/cli/tests/cli/sort/by_atime.rs
@@ -1,6 +1,6 @@
 use crate::utils::{archive::for_each_entry, setup};
 use clap::Parser;
-use pna::{Archive, Duration, EntryBuilder, WriteOptions};
+use pna::{Archive, Duration, FileEntryBuilder, Metadata};
 use portable_network_archive::cli;
 use std::fs;
 
@@ -14,18 +14,18 @@ fn sort_by_atime() {
     let file = fs::File::create("sort_by_atime/unsorted.pna").unwrap();
     let mut archive = Archive::write_header(file).unwrap();
     let entry1 = {
-        let mut b = EntryBuilder::new_file("c.txt".into(), WriteOptions::store()).unwrap();
-        b.accessed(Duration::seconds(3000));
+        let mut b = FileEntryBuilder::new("c.txt".into()).unwrap();
+        b.metadata(Metadata::new().with_accessed(Some(Duration::seconds(3000))));
         b.build().unwrap()
     };
     let entry2 = {
-        let mut b = EntryBuilder::new_file("a.txt".into(), WriteOptions::store()).unwrap();
-        b.accessed(Duration::seconds(1000));
+        let mut b = FileEntryBuilder::new("a.txt".into()).unwrap();
+        b.metadata(Metadata::new().with_accessed(Some(Duration::seconds(1000))));
         b.build().unwrap()
     };
     let entry3 = {
-        let mut b = EntryBuilder::new_file("b.txt".into(), WriteOptions::store()).unwrap();
-        b.accessed(Duration::seconds(2000));
+        let mut b = FileEntryBuilder::new("b.txt".into()).unwrap();
+        b.metadata(Metadata::new().with_accessed(Some(Duration::seconds(2000))));
         b.build().unwrap()
     };
     archive.add_entry(entry1).unwrap();

--- a/cli/tests/cli/sort/by_ctime.rs
+++ b/cli/tests/cli/sort/by_ctime.rs
@@ -1,6 +1,6 @@
 use crate::utils::{archive::for_each_entry, setup};
 use clap::Parser;
-use pna::{Archive, Duration, EntryBuilder, WriteOptions};
+use pna::{Archive, Duration, FileEntryBuilder, Metadata};
 use portable_network_archive::cli;
 use std::fs;
 
@@ -14,18 +14,18 @@ fn sort_by_ctime() {
     let file = fs::File::create("sort_by_ctime/unsorted.pna").unwrap();
     let mut archive = Archive::write_header(file).unwrap();
     let entry1 = {
-        let mut b = EntryBuilder::new_file("c.txt".into(), WriteOptions::store()).unwrap();
-        b.created(Duration::seconds(3000));
+        let mut b = FileEntryBuilder::new("c.txt".into()).unwrap();
+        b.metadata(Metadata::new().with_created(Some(Duration::seconds(3000))));
         b.build().unwrap()
     };
     let entry2 = {
-        let mut b = EntryBuilder::new_file("a.txt".into(), WriteOptions::store()).unwrap();
-        b.created(Duration::seconds(1000));
+        let mut b = FileEntryBuilder::new("a.txt".into()).unwrap();
+        b.metadata(Metadata::new().with_created(Some(Duration::seconds(1000))));
         b.build().unwrap()
     };
     let entry3 = {
-        let mut b = EntryBuilder::new_file("b.txt".into(), WriteOptions::store()).unwrap();
-        b.created(Duration::seconds(2000));
+        let mut b = FileEntryBuilder::new("b.txt".into()).unwrap();
+        b.metadata(Metadata::new().with_created(Some(Duration::seconds(2000))));
         b.build().unwrap()
     };
     archive.add_entry(entry1).unwrap();

--- a/cli/tests/cli/sort/by_mtime.rs
+++ b/cli/tests/cli/sort/by_mtime.rs
@@ -1,6 +1,6 @@
 use crate::utils::{archive::for_each_entry, setup};
 use clap::Parser;
-use pna::{Archive, Duration, EntryBuilder, WriteOptions};
+use pna::{Archive, Duration, FileEntryBuilder, Metadata};
 use portable_network_archive::cli;
 use std::fs;
 
@@ -14,18 +14,18 @@ fn sort_by_mtime() {
     let file = fs::File::create("sort_by_mtime/unsorted.pna").unwrap();
     let mut archive = Archive::write_header(file).unwrap();
     let entry1 = {
-        let mut b = EntryBuilder::new_file("c.txt".into(), WriteOptions::store()).unwrap();
-        b.modified(Duration::seconds(3000));
+        let mut b = FileEntryBuilder::new("c.txt".into()).unwrap();
+        b.metadata(Metadata::new().with_modified(Some(Duration::seconds(3000))));
         b.build().unwrap()
     };
     let entry2 = {
-        let mut b = EntryBuilder::new_file("a.txt".into(), WriteOptions::store()).unwrap();
-        b.modified(Duration::seconds(1000));
+        let mut b = FileEntryBuilder::new("a.txt".into()).unwrap();
+        b.metadata(Metadata::new().with_modified(Some(Duration::seconds(1000))));
         b.build().unwrap()
     };
     let entry3 = {
-        let mut b = EntryBuilder::new_file("b.txt".into(), WriteOptions::store()).unwrap();
-        b.modified(Duration::seconds(2000));
+        let mut b = FileEntryBuilder::new("b.txt".into()).unwrap();
+        b.metadata(Metadata::new().with_modified(Some(Duration::seconds(2000))));
         b.build().unwrap()
     };
     archive.add_entry(entry1).unwrap();

--- a/cli/tests/cli/sort/by_name.rs
+++ b/cli/tests/cli/sort/by_name.rs
@@ -1,6 +1,6 @@
 use crate::utils::{archive::for_each_entry, setup};
 use clap::Parser;
-use pna::{Archive, EntryBuilder, WriteOptions};
+use pna::{Archive, FileEntryBuilder};
 use portable_network_archive::cli;
 use std::fs;
 
@@ -13,9 +13,9 @@ fn sort_by_name() {
     fs::create_dir_all("sort_by_name").unwrap();
     let file = fs::File::create("sort_by_name/unsorted.pna").unwrap();
     let mut archive = Archive::write_header(file).unwrap();
-    let entry_b = EntryBuilder::new_file("b.txt".into(), WriteOptions::store()).unwrap();
+    let entry_b = FileEntryBuilder::new("b.txt".into()).unwrap();
     archive.add_entry(entry_b.build().unwrap()).unwrap();
-    let entry_a = EntryBuilder::new_file("a.txt".into(), WriteOptions::store()).unwrap();
+    let entry_a = FileEntryBuilder::new("a.txt".into()).unwrap();
     archive.add_entry(entry_a.build().unwrap()).unwrap();
     archive.finalize().unwrap();
 

--- a/cli/tests/cli/sort/by_name_desc.rs
+++ b/cli/tests/cli/sort/by_name_desc.rs
@@ -1,6 +1,6 @@
 use crate::utils::{archive::for_each_entry, setup};
 use clap::Parser;
-use pna::{Archive, EntryBuilder, WriteOptions};
+use pna::{Archive, FileEntryBuilder};
 use portable_network_archive::cli;
 use std::fs;
 
@@ -13,9 +13,9 @@ fn sort_by_name_desc() {
     fs::create_dir_all("sort_by_name_desc").unwrap();
     let file = fs::File::create("sort_by_name_desc/unsorted.pna").unwrap();
     let mut archive = Archive::write_header(file).unwrap();
-    let entry_a = EntryBuilder::new_file("a.txt".into(), WriteOptions::store()).unwrap();
+    let entry_a = FileEntryBuilder::new("a.txt".into()).unwrap();
     archive.add_entry(entry_a.build().unwrap()).unwrap();
-    let entry_b = EntryBuilder::new_file("b.txt".into(), WriteOptions::store()).unwrap();
+    let entry_b = FileEntryBuilder::new("b.txt".into()).unwrap();
     archive.add_entry(entry_b.build().unwrap()).unwrap();
     archive.finalize().unwrap();
 

--- a/cli/tests/cli/sort/multiple_keys.rs
+++ b/cli/tests/cli/sort/multiple_keys.rs
@@ -1,6 +1,6 @@
 use crate::utils::{archive::for_each_entry, setup};
 use clap::Parser;
-use pna::{Archive, Duration, EntryBuilder, WriteOptions};
+use pna::{Archive, Duration, FileEntryBuilder, Metadata};
 use portable_network_archive::cli;
 use std::fs;
 
@@ -15,23 +15,32 @@ fn sort_by_multiple_keys() {
     let mut archive = Archive::write_header(file).unwrap();
     // a.txt: ctime=1000, mtime=3000
     let entry1 = {
-        let mut b = EntryBuilder::new_file("a.txt".into(), WriteOptions::store()).unwrap();
-        b.created(Duration::seconds(1000));
-        b.modified(Duration::seconds(3000));
+        let mut b = FileEntryBuilder::new("a.txt".into()).unwrap();
+        b.metadata(
+            Metadata::new()
+                .with_created(Some(Duration::seconds(1000)))
+                .with_modified(Some(Duration::seconds(3000))),
+        );
         b.build().unwrap()
     };
     // b.txt: ctime=1000, mtime=2000
     let entry2 = {
-        let mut b = EntryBuilder::new_file("b.txt".into(), WriteOptions::store()).unwrap();
-        b.created(Duration::seconds(1000));
-        b.modified(Duration::seconds(2000));
+        let mut b = FileEntryBuilder::new("b.txt".into()).unwrap();
+        b.metadata(
+            Metadata::new()
+                .with_created(Some(Duration::seconds(1000)))
+                .with_modified(Some(Duration::seconds(2000))),
+        );
         b.build().unwrap()
     };
     // c.txt: ctime=2000, mtime=1000
     let entry3 = {
-        let mut b = EntryBuilder::new_file("c.txt".into(), WriteOptions::store()).unwrap();
-        b.created(Duration::seconds(2000));
-        b.modified(Duration::seconds(1000));
+        let mut b = FileEntryBuilder::new("c.txt".into()).unwrap();
+        b.metadata(
+            Metadata::new()
+                .with_created(Some(Duration::seconds(2000)))
+                .with_modified(Some(Duration::seconds(1000))),
+        );
         b.build().unwrap()
     };
     archive.add_entry(entry1).unwrap();

--- a/cli/tests/cli/sort/order_combination.rs
+++ b/cli/tests/cli/sort/order_combination.rs
@@ -1,6 +1,6 @@
 use crate::utils::{archive::for_each_entry, setup};
 use clap::Parser;
-use pna::{Archive, Duration, EntryBuilder, WriteOptions};
+use pna::{Archive, Duration, FileEntryBuilder, Metadata};
 use portable_network_archive::cli;
 use std::fs;
 
@@ -15,26 +15,35 @@ fn sort_by_all_keys() {
     let mut archive = Archive::write_header(file).unwrap();
     // a.txt: ctime=1000, mtime=3000, atime=2000
     let entry1 = {
-        let mut b = EntryBuilder::new_file("a.txt".into(), WriteOptions::store()).unwrap();
-        b.created(Duration::seconds(1000));
-        b.modified(Duration::seconds(3000));
-        b.accessed(Duration::seconds(2000));
+        let mut b = FileEntryBuilder::new("a.txt".into()).unwrap();
+        b.metadata(
+            Metadata::new()
+                .with_created(Some(Duration::seconds(1000)))
+                .with_modified(Some(Duration::seconds(3000)))
+                .with_accessed(Some(Duration::seconds(2000))),
+        );
         b.build().unwrap()
     };
     // b.txt: ctime=1000, mtime=2000, atime=3000
     let entry2 = {
-        let mut b = EntryBuilder::new_file("b.txt".into(), WriteOptions::store()).unwrap();
-        b.created(Duration::seconds(1000));
-        b.modified(Duration::seconds(2000));
-        b.accessed(Duration::seconds(3000));
+        let mut b = FileEntryBuilder::new("b.txt".into()).unwrap();
+        b.metadata(
+            Metadata::new()
+                .with_created(Some(Duration::seconds(1000)))
+                .with_modified(Some(Duration::seconds(2000)))
+                .with_accessed(Some(Duration::seconds(3000))),
+        );
         b.build().unwrap()
     };
     // c.txt: ctime=2000, mtime=1000, atime=1000
     let entry3 = {
-        let mut b = EntryBuilder::new_file("c.txt".into(), WriteOptions::store()).unwrap();
-        b.created(Duration::seconds(2000));
-        b.modified(Duration::seconds(1000));
-        b.accessed(Duration::seconds(1000));
+        let mut b = FileEntryBuilder::new("c.txt".into()).unwrap();
+        b.metadata(
+            Metadata::new()
+                .with_created(Some(Duration::seconds(2000)))
+                .with_modified(Some(Duration::seconds(1000)))
+                .with_accessed(Some(Duration::seconds(1000))),
+        );
         b.build().unwrap()
     };
     archive.add_entry(entry1).unwrap();

--- a/cli/tests/cli/utils/archive.rs
+++ b/cli/tests/cli/utils/archive.rs
@@ -33,13 +33,15 @@ pub fn create_archive_with_permissions(
     let mut archive = pna::Archive::write_header(file)?;
 
     for entry_def in entries {
-        let mut builder =
-            pna::EntryBuilder::new_file(entry_def.path.into(), pna::WriteOptions::store())?;
-        builder.owner_uid(pna::OwnerUid::from(1000));
-        builder.owner_gid(pna::OwnerGid::from(1000));
-        builder.owner_user_name(pna::OwnerUserName::new("user").unwrap());
-        builder.owner_group_name(pna::OwnerGroupName::new("group").unwrap());
-        builder.permission_mode(pna::PermissionMode::from(entry_def.permission));
+        let mut builder = pna::FileEntryBuilder::new(entry_def.path.into())?;
+        builder.metadata(
+            pna::Metadata::new()
+                .with_owner_uid(Some(pna::OwnerUid::from(1000)))
+                .with_owner_gid(Some(pna::OwnerGid::from(1000)))
+                .with_owner_user_name(Some(pna::OwnerUserName::new("user").unwrap()))
+                .with_owner_group_name(Some(pna::OwnerGroupName::new("group").unwrap()))
+                .with_permission_mode(Some(pna::PermissionMode::from(entry_def.permission))),
+        );
         builder.write_all(entry_def.content)?;
         let entry = builder.build()?;
         archive.add_entry(entry)?;
@@ -59,13 +61,15 @@ pub fn create_solid_archive_with_permissions(
 
     let mut solid_builder = pna::SolidEntryBuilder::new(pna::WriteOptions::store())?;
     for entry_def in entries {
-        let mut builder =
-            pna::EntryBuilder::new_file(entry_def.path.into(), pna::WriteOptions::store())?;
-        builder.owner_uid(pna::OwnerUid::from(1000));
-        builder.owner_gid(pna::OwnerGid::from(1000));
-        builder.owner_user_name(pna::OwnerUserName::new("user").unwrap());
-        builder.owner_group_name(pna::OwnerGroupName::new("group").unwrap());
-        builder.permission_mode(pna::PermissionMode::from(entry_def.permission));
+        let mut builder = pna::FileEntryBuilder::new(entry_def.path.into())?;
+        builder.metadata(
+            pna::Metadata::new()
+                .with_owner_uid(Some(pna::OwnerUid::from(1000)))
+                .with_owner_gid(Some(pna::OwnerGid::from(1000)))
+                .with_owner_user_name(Some(pna::OwnerUserName::new("user").unwrap()))
+                .with_owner_group_name(Some(pna::OwnerGroupName::new("group").unwrap()))
+                .with_permission_mode(Some(pna::PermissionMode::from(entry_def.permission))),
+        );
         builder.write_all(entry_def.content)?;
         let entry = builder.build()?;
         solid_builder.add_entry(entry)?;
@@ -94,12 +98,15 @@ pub fn create_encrypted_archive_with_permissions(
 
     for entry_def in entries {
         let mut builder =
-            pna::EntryBuilder::new_file(entry_def.path.into(), write_options.clone())?;
-        builder.owner_uid(pna::OwnerUid::from(1000));
-        builder.owner_gid(pna::OwnerGid::from(1000));
-        builder.owner_user_name(pna::OwnerUserName::new("user").unwrap());
-        builder.owner_group_name(pna::OwnerGroupName::new("group").unwrap());
-        builder.permission_mode(pna::PermissionMode::from(entry_def.permission));
+            pna::FileEntryBuilder::new_with_options(entry_def.path.into(), write_options.clone())?;
+        builder.metadata(
+            pna::Metadata::new()
+                .with_owner_uid(Some(pna::OwnerUid::from(1000)))
+                .with_owner_gid(Some(pna::OwnerGid::from(1000)))
+                .with_owner_user_name(Some(pna::OwnerUserName::new("user").unwrap()))
+                .with_owner_group_name(Some(pna::OwnerGroupName::new("group").unwrap()))
+                .with_permission_mode(Some(pna::PermissionMode::from(entry_def.permission))),
+        );
         builder.write_all(entry_def.content)?;
         let entry = builder.build()?;
         archive.add_entry(entry)?;
@@ -172,9 +179,7 @@ pub fn create_test_archive(path: impl AsRef<Path>, entries: &[(&str, &str)]) {
     for (name, contents) in entries {
         writer
             .add_entry({
-                let mut builder =
-                    pna::EntryBuilder::new_file((*name).into(), pna::WriteOptions::store())
-                        .unwrap();
+                let mut builder = pna::FileEntryBuilder::new((*name).into()).unwrap();
                 builder.write_all(contents.as_bytes()).unwrap();
                 builder.build().unwrap()
             })
@@ -205,13 +210,15 @@ pub fn create_archive_with_symlinks(
     let mut archive = pna::Archive::write_header(file)?;
 
     for entry_def in file_entries {
-        let mut builder =
-            pna::EntryBuilder::new_file(entry_def.path.into(), pna::WriteOptions::store())?;
-        builder.owner_uid(pna::OwnerUid::from(1000));
-        builder.owner_gid(pna::OwnerGid::from(1000));
-        builder.owner_user_name(pna::OwnerUserName::new("user").unwrap());
-        builder.owner_group_name(pna::OwnerGroupName::new("group").unwrap());
-        builder.permission_mode(pna::PermissionMode::from(entry_def.permission));
+        let mut builder = pna::FileEntryBuilder::new(entry_def.path.into())?;
+        builder.metadata(
+            pna::Metadata::new()
+                .with_owner_uid(Some(pna::OwnerUid::from(1000)))
+                .with_owner_gid(Some(pna::OwnerGid::from(1000)))
+                .with_owner_user_name(Some(pna::OwnerUserName::new("user").unwrap()))
+                .with_owner_group_name(Some(pna::OwnerGroupName::new("group").unwrap()))
+                .with_permission_mode(Some(pna::PermissionMode::from(entry_def.permission))),
+        );
         builder.write_all(entry_def.content)?;
         let entry = builder.build()?;
         archive.add_entry(entry)?;
@@ -219,24 +226,26 @@ pub fn create_archive_with_symlinks(
 
     for symlink_def in symlink_entries {
         let mut builder =
-            pna::EntryBuilder::new_symlink(symlink_def.path.into(), symlink_def.target.into())?;
-        builder.link_target_type(symlink_def.link_target_type);
+            pna::SymlinkEntryBuilder::new(symlink_def.path.into(), symlink_def.target.into())?;
+        let mut metadata = pna::Metadata::new().with_link_target_type(symlink_def.link_target_type);
         if let Some(mode) = symlink_def.permission {
-            builder.owner_uid(pna::OwnerUid::from(1000));
-            builder.owner_gid(pna::OwnerGid::from(1000));
-            builder.owner_user_name(pna::OwnerUserName::new("user").unwrap());
-            builder.owner_group_name(pna::OwnerGroupName::new("group").unwrap());
-            builder.permission_mode(pna::PermissionMode::from(mode));
+            metadata = metadata
+                .with_owner_uid(Some(pna::OwnerUid::from(1000)))
+                .with_owner_gid(Some(pna::OwnerGid::from(1000)))
+                .with_owner_user_name(Some(pna::OwnerUserName::new("user").unwrap()))
+                .with_owner_group_name(Some(pna::OwnerGroupName::new("group").unwrap()))
+                .with_permission_mode(Some(pna::PermissionMode::from(mode)));
         }
         if let Some(m) = symlink_def.modified {
-            builder.modified(m);
+            metadata = metadata.with_modified(Some(m));
         }
         if let Some(a) = symlink_def.accessed {
-            builder.accessed(a);
+            metadata = metadata.with_accessed(Some(a));
         }
         if let Some(c) = symlink_def.created {
-            builder.created(c);
+            metadata = metadata.with_created(Some(c));
         }
+        builder.metadata(metadata);
         let entry = builder.build()?;
         archive.add_entry(entry)?;
     }

--- a/fuzz/fuzz_targets/aes_cbc.rs
+++ b/fuzz/fuzz_targets/aes_cbc.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use libpna::{CipherMode, Compression, Encryption, EntryBuilder, ReadOptions, WriteOptions};
+use libpna::{CipherMode, Compression, Encryption, FileEntryBuilder, ReadOptions, WriteOptions};
 use std::io::prelude::*;
 
 fuzz_target!(|data: &[u8]| {
@@ -11,7 +11,7 @@ fuzz_target!(|data: &[u8]| {
         .cipher_mode(CipherMode::CBC)
         .compression(Compression::NO)
         .build();
-    let mut builder = EntryBuilder::new_file("fuzz".into(), write_option).unwrap();
+    let mut builder = FileEntryBuilder::new_with_options("fuzz".into(), write_option).unwrap();
     builder.write_all(data).unwrap();
     let entry = builder.build().unwrap();
     let read_option = ReadOptions::with_password(Some("password"));

--- a/fuzz/fuzz_targets/aes_ctr.rs
+++ b/fuzz/fuzz_targets/aes_ctr.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use libpna::{CipherMode, Compression, Encryption, EntryBuilder, ReadOptions, WriteOptions};
+use libpna::{CipherMode, Compression, Encryption, FileEntryBuilder, ReadOptions, WriteOptions};
 use std::io::prelude::*;
 
 fuzz_target!(|data: &[u8]| {
@@ -11,7 +11,7 @@ fuzz_target!(|data: &[u8]| {
         .cipher_mode(CipherMode::CTR)
         .compression(Compression::NO)
         .build();
-    let mut builder = EntryBuilder::new_file("fuzz".into(), write_option).unwrap();
+    let mut builder = FileEntryBuilder::new_with_options("fuzz".into(), write_option).unwrap();
     builder.write_all(data).unwrap();
     let entry = builder.build().unwrap();
     let read_option = ReadOptions::with_password(Some("password"));

--- a/fuzz/fuzz_targets/camellia_cbc.rs
+++ b/fuzz/fuzz_targets/camellia_cbc.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use libpna::{CipherMode, Compression, Encryption, EntryBuilder, ReadOptions, WriteOptions};
+use libpna::{CipherMode, Compression, Encryption, FileEntryBuilder, ReadOptions, WriteOptions};
 use std::io::prelude::*;
 
 fuzz_target!(|data: &[u8]| {
@@ -11,7 +11,7 @@ fuzz_target!(|data: &[u8]| {
         .cipher_mode(CipherMode::CBC)
         .compression(Compression::NO)
         .build();
-    let mut builder = EntryBuilder::new_file("fuzz".into(), write_option).unwrap();
+    let mut builder = FileEntryBuilder::new_with_options("fuzz".into(), write_option).unwrap();
     builder.write_all(data).unwrap();
     let entry = builder.build().unwrap();
     let read_option = ReadOptions::with_password(Some("password"));

--- a/fuzz/fuzz_targets/camellia_ctr.rs
+++ b/fuzz/fuzz_targets/camellia_ctr.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use libpna::{CipherMode, Compression, Encryption, EntryBuilder, ReadOptions, WriteOptions};
+use libpna::{CipherMode, Compression, Encryption, FileEntryBuilder, ReadOptions, WriteOptions};
 use std::io::prelude::*;
 
 fuzz_target!(|data: &[u8]| {
@@ -11,7 +11,7 @@ fuzz_target!(|data: &[u8]| {
         .cipher_mode(CipherMode::CTR)
         .compression(Compression::NO)
         .build();
-    let mut builder = EntryBuilder::new_file("fuzz".into(), write_option).unwrap();
+    let mut builder = FileEntryBuilder::new_with_options("fuzz".into(), write_option).unwrap();
     builder.write_all(data).unwrap();
     let entry = builder.build().unwrap();
     let read_option = ReadOptions::with_password(Some("password"));

--- a/fuzz/fuzz_targets/split_archive.rs
+++ b/fuzz/fuzz_targets/split_archive.rs
@@ -1,13 +1,13 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use libpna::{Archive, Compression, EntryBuilder, EntryPart, ReadOptions, WriteOptions};
+use libpna::{Archive, Compression, EntryPart, FileEntryBuilder, ReadOptions, WriteOptions};
 use std::io::prelude::*;
 
 fuzz_target!(|data: (&[u8], usize)| {
     let (data, split_size) = data;
     let write_option = WriteOptions::builder().compression(Compression::NO).build();
-    let mut builder = EntryBuilder::new_file("fuzz".into(), write_option).unwrap();
+    let mut builder = FileEntryBuilder::new_with_options("fuzz".into(), write_option).unwrap();
     builder.write_all(data).unwrap();
     let entry = builder.build().unwrap();
     let entry_part = EntryPart::from(entry);

--- a/lib/README.md
+++ b/lib/README.md
@@ -37,17 +37,15 @@ fn main() -> io::Result<()> {
 ## Writing an archive
 
 ```rust
-use libpna::{Archive, EntryBuilder, WriteOptions};
+use libpna::{Archive, FileEntryBuilder, WriteOptions};
 use std::fs::File;
 use std::io::{self, prelude::*};
 
 fn main() -> io::Result<()> {
     let file = File::create("foo.pna")?;
     let mut archive = Archive::write_header(file)?;
-    let mut entry_builder = EntryBuilder::new_file(
-        "bar.txt".into(),
-        WriteOptions::builder().build(),
-    )?;
+    let mut entry_builder =
+        FileEntryBuilder::new_with_options("bar.txt".into(), WriteOptions::builder().build())?;
     entry_builder.write(b"content")?;
     let entry = entry_builder.build()?;
     archive.add_entry(entry)?;

--- a/lib/benches/create_extract.rs
+++ b/lib/benches/create_extract.rs
@@ -1,6 +1,6 @@
 use criterion::{Bencher, Criterion, criterion_group, criterion_main};
 use libpna::{
-    Archive, CipherMode, Compression, Encryption, EntryBuilder, ReadEntry, ReadOptions,
+    Archive, CipherMode, Compression, Encryption, FileEntryBuilder, ReadEntry, ReadOptions,
     WriteOptions, WriteOptionsBuilder,
 };
 use std::io::{self, prelude::*};
@@ -12,7 +12,7 @@ fn bench_write_archive(b: &mut Bencher, mut options: WriteOptionsBuilder) {
         let mut writer = Archive::write_header(&mut vec).unwrap();
         writer
             .add_entry({
-                let mut builder = EntryBuilder::new_file(
+                let mut builder = FileEntryBuilder::new_with_options(
                     "bench".into(),
                     options.password(Some("password")).build(),
                 )
@@ -30,9 +30,11 @@ fn bench_read_archive(b: &mut Bencher, mut options: WriteOptionsBuilder) {
     let mut writer = Archive::write_header(Vec::with_capacity(10000)).unwrap();
     writer
         .add_entry({
-            let mut builder =
-                EntryBuilder::new_file("bench".into(), options.password(Some("password")).build())
-                    .unwrap();
+            let mut builder = FileEntryBuilder::new_with_options(
+                "bench".into(),
+                options.password(Some("password")).build(),
+            )
+            .unwrap();
             builder.write_all(&buf).unwrap();
             builder.build().unwrap()
         })
@@ -57,9 +59,11 @@ fn bench_read_archive_from_slice(b: &mut Bencher, mut options: WriteOptionsBuild
     let mut writer = Archive::write_header(Vec::with_capacity(10000)).unwrap();
     writer
         .add_entry({
-            let mut builder =
-                EntryBuilder::new_file("bench".into(), options.password(Some("password")).build())
-                    .unwrap();
+            let mut builder = FileEntryBuilder::new_with_options(
+                "bench".into(),
+                options.password(Some("password")).build(),
+            )
+            .unwrap();
             builder.write_all(&buf).unwrap();
             builder.build().unwrap()
         })

--- a/lib/examples/async_io.rs
+++ b/lib/examples/async_io.rs
@@ -1,5 +1,5 @@
 #![cfg(not(target_family = "wasm"))]
-use libpna::{Archive, EntryBuilder, ReadEntry, ReadOptions, WriteOptions};
+use libpna::{Archive, FileEntryBuilder, ReadEntry, ReadOptions, WriteOptions};
 use std::io;
 use tokio_util::compat::{
     FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt, TokioAsyncReadCompatExt,
@@ -22,7 +22,7 @@ async fn create(path: String, file_names: &[String]) -> io::Result<()> {
     for file_name in file_names {
         let mut file = tokio::fs::File::open(file_name).await?;
         let mut entry_builder =
-            EntryBuilder::new_file(file_name.into(), WriteOptions::builder().build())?
+            FileEntryBuilder::new_with_options(file_name.into(), WriteOptions::builder().build())?
                 .compat_write();
         tokio::io::copy(&mut file, &mut entry_builder).await?;
         let entry = entry_builder.into_inner().build()?;

--- a/lib/examples/change_compression_method.rs
+++ b/lib/examples/change_compression_method.rs
@@ -1,4 +1,4 @@
-use libpna::{Archive, Compression, EntryBuilder, ReadOptions, WriteOptions};
+use libpna::{Archive, Compression, FileEntryBuilder, ReadOptions, WriteOptions};
 use std::io::{self, Read, Write};
 
 /// Change the entries compression method
@@ -12,7 +12,7 @@ fn change_compression_method<R: Read, W: Write>(
     for entry in reader.entries().skip_solid() {
         let entry = entry?;
         let header = entry.header();
-        let mut builder = EntryBuilder::new_file(
+        let mut builder = FileEntryBuilder::new_with_options(
             header.path().clone(),
             WriteOptions::builder().compression(compression).build(),
         )?;

--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -101,7 +101,7 @@ impl<T> Archive<T> {
     /// **Note**: This setting only affects the streaming write path
     /// ([`write_file()`](Archive::write_file)). Pre-built entries added via
     /// [`add_entry()`](Archive::add_entry) use their own chunk size configured
-    /// through [`EntryBuilder::max_chunk_size()`](crate::EntryBuilder::max_chunk_size).
+    /// through [`FileEntryBuilder::max_chunk_size()`](crate::FileEntryBuilder::max_chunk_size).
     ///
     #[inline]
     pub fn set_max_chunk_size(&mut self, size: NonZeroU32) {

--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -31,7 +31,7 @@ pub(crate) use {read::*, write::*};
 /// # Examples
 /// Creates a new PNA file and adds an entry to it.
 /// ```no_run
-/// # use libpna::{Archive, EntryBuilder, WriteOptions};
+/// # use libpna::{Archive, FileEntryBuilder, WriteOptions};
 /// # use std::fs::File;
 /// # use std::io::{self, prelude::*};
 ///
@@ -39,7 +39,7 @@ pub(crate) use {read::*, write::*};
 /// let file = File::create("foo.pna")?;
 /// let mut archive = Archive::write_header(file)?;
 /// let mut entry_builder =
-///     EntryBuilder::new_file("bar.txt".into(), WriteOptions::builder().build())?;
+///     FileEntryBuilder::new_with_options("bar.txt".into(), WriteOptions::builder().build())?;
 /// entry_builder.write_all(b"content")?;
 /// let entry = entry_builder.build()?;
 /// archive.add_entry(entry)?;
@@ -175,7 +175,7 @@ impl<T> Archive<T> {
 /// # Examples
 /// Creates a new solid mode PNA file and adds an entry to it.
 /// ```no_run
-/// use libpna::{Archive, EntryBuilder, WriteOptions};
+/// use libpna::{Archive, FileEntryBuilder, WriteOptions};
 /// use std::fs::File;
 /// # use std::io::{self, prelude::*};
 ///
@@ -183,7 +183,7 @@ impl<T> Archive<T> {
 /// let option = WriteOptions::builder().build();
 /// let file = File::create("foo.pna")?;
 /// let mut archive = Archive::write_solid_header(file, option)?;
-/// let mut entry_builder = EntryBuilder::new_file("bar.txt".into(), WriteOptions::store())?;
+/// let mut entry_builder = FileEntryBuilder::new("bar.txt".into())?;
 /// entry_builder.write_all(b"content")?;
 /// let entry = entry_builder.build()?;
 /// archive.add_entry(entry)?;
@@ -364,7 +364,8 @@ mod tests {
         for name in ["test/first", "test/second"] {
             writer
                 .add_entry({
-                    let mut builder = EntryBuilder::new_file(name.into(), &options).unwrap();
+                    let mut builder =
+                        FileEntryBuilder::new_with_options(name.into(), &options).unwrap();
                     builder.write_all(b"same plaintext").unwrap();
                     builder.build().unwrap()
                 })
@@ -408,7 +409,8 @@ mod tests {
         for name in ["test/first", "test/second", "test/third"] {
             writer
                 .add_entry({
-                    let mut builder = EntryBuilder::new_file(name.into(), &options).unwrap();
+                    let mut builder =
+                        FileEntryBuilder::new_with_options(name.into(), &options).unwrap();
                     builder.write_all(b"some text").unwrap();
                     builder.build().unwrap()
                 })
@@ -450,7 +452,8 @@ mod tests {
             let options = options_builder.try_build().unwrap();
             writer
                 .add_entry({
-                    let mut builder = EntryBuilder::new_file(name.into(), &options).unwrap();
+                    let mut builder =
+                        FileEntryBuilder::new_with_options(name.into(), &options).unwrap();
                     builder.write_all(b"some text").unwrap();
                     builder.build().unwrap()
                 })
@@ -532,7 +535,7 @@ mod tests {
     fn create_archive(src: &[u8], options: WriteOptions) -> io::Result<Vec<u8>> {
         let mut writer = Archive::write_header(Vec::with_capacity(src.len()))?;
         writer.add_entry({
-            let mut builder = EntryBuilder::new_file("test/text".into(), options)?;
+            let mut builder = FileEntryBuilder::new_with_options("test/text".into(), options)?;
             builder.write_all(src)?;
             builder.build()?
         })?;
@@ -557,11 +560,8 @@ mod tests {
         for i in 0..200 {
             archive
                 .add_entry({
-                    let mut builder = EntryBuilder::new_file(
-                        format!("test/text{i}").into(),
-                        WriteOptions::store(),
-                    )
-                    .unwrap();
+                    let mut builder =
+                        FileEntryBuilder::new(format!("test/text{i}").into()).unwrap();
                     builder
                         .write_all(format!("text{i}").repeat(i).as_bytes())
                         .unwrap();
@@ -606,12 +606,13 @@ mod tests {
         let archive = {
             let mut writer = Archive::write_header(Vec::new()).unwrap();
             let dir_entry = {
-                let builder = EntryBuilder::new_dir("test".into());
+                let builder = DirEntryBuilder::new("test".into());
                 builder.build().unwrap()
             };
             let file_entry = {
                 let options = WriteOptions::store();
-                let mut builder = EntryBuilder::new_file("test/text".into(), options).unwrap();
+                let mut builder =
+                    FileEntryBuilder::new_with_options("test/text".into(), options).unwrap();
                 builder.write_all(b"text").unwrap();
                 builder.build().unwrap()
             };
@@ -659,9 +660,11 @@ mod tests {
         let mut writer = Archive::write_header(Vec::new()).unwrap();
         writer
             .add_entry({
-                let builder =
-                    EntryBuilder::new_file("text1.txt".into(), WriteOptions::builder().build())
-                        .unwrap();
+                let builder = FileEntryBuilder::new_with_options(
+                    "text1.txt".into(),
+                    WriteOptions::builder().build(),
+                )
+                .unwrap();
                 builder.build().unwrap()
             })
             .unwrap();
@@ -671,9 +674,11 @@ mod tests {
         appender.seek_to_end().unwrap();
         appender
             .add_entry({
-                let builder =
-                    EntryBuilder::new_file("text2.txt".into(), WriteOptions::builder().build())
-                        .unwrap();
+                let builder = FileEntryBuilder::new_with_options(
+                    "text2.txt".into(),
+                    WriteOptions::builder().build(),
+                )
+                .unwrap();
                 builder.build().unwrap()
             })
             .unwrap();
@@ -692,11 +697,21 @@ mod tests {
     fn metadata() {
         let original_entry = {
             let mut builder =
-                EntryBuilder::new_file("name".into(), WriteOptions::builder().build()).unwrap();
-            builder.created(Duration::seconds(31));
-            builder.modified(Duration::seconds(32));
-            builder.accessed(Duration::seconds(33));
-            builder.permission(Permission::new(1, "uname".into(), 2, "gname".into(), 0o775));
+                FileEntryBuilder::new_with_options("name".into(), WriteOptions::builder().build())
+                    .unwrap();
+            builder.metadata(
+                Metadata::new()
+                    .with_created(Some(Duration::seconds(31)))
+                    .with_modified(Some(Duration::seconds(32)))
+                    .with_accessed(Some(Duration::seconds(33)))
+                    .with_permission(Some(Permission::new(
+                        1,
+                        "uname".into(),
+                        2,
+                        "gname".into(),
+                        0o775,
+                    ))),
+            );
             builder.write_all(b"entry data").unwrap();
             builder.build().unwrap()
         };

--- a/lib/src/archive/read.rs
+++ b/lib/src/archive/read.rs
@@ -428,7 +428,7 @@ impl<R: Read + Seek> Archive<R> {
     /// let mut archive = Archive::read_header(file)?;
     /// archive.seek_to_end()?;
     /// archive.add_entry({
-    ///     let entry = EntryBuilder::new_dir("dir_entry".into());
+    ///     let entry = DirEntryBuilder::new("dir_entry".into());
     ///     entry.build()?
     /// })?;
     /// archive.finalize()?;

--- a/lib/src/archive/write.rs
+++ b/lib/src/archive/write.rs
@@ -154,7 +154,7 @@ impl<W: Write> Archive<W> {
     /// # Examples
     ///
     /// ```no_run
-    /// use libpna::{Archive, EntryBuilder, WriteOptions};
+    /// use libpna::{Archive, FileEntryBuilder, WriteOptions};
     /// use std::fs;
     /// # use std::io;
     ///
@@ -162,7 +162,8 @@ impl<W: Write> Archive<W> {
     /// let file = fs::File::create("example.pna")?;
     /// let mut archive = Archive::write_header(file)?;
     /// archive.add_entry(
-    ///     EntryBuilder::new_file("example.txt".into(), WriteOptions::builder().build())?.build()?,
+    ///     FileEntryBuilder::new_with_options("example.txt".into(), WriteOptions::builder().build())?
+    ///         .build()?,
     /// )?;
     /// archive.finalize()?;
     /// #     Ok(())
@@ -182,7 +183,7 @@ impl<W: Write> Archive<W> {
     /// # Examples
     ///
     /// ```no_run
-    /// # use libpna::{Archive, EntryBuilder, EntryPart, WriteOptions};
+    /// # use libpna::{Archive, EntryPart, FileEntryBuilder, WriteOptions};
     /// # use std::fs::File;
     /// # use std::io;
     ///
@@ -190,7 +191,8 @@ impl<W: Write> Archive<W> {
     /// let part1_file = File::create("example.part1.pna")?;
     /// let mut archive_part1 = Archive::write_header(part1_file)?;
     /// let entry =
-    ///     EntryBuilder::new_file("example.txt".into(), WriteOptions::builder().build())?.build()?;
+    ///     FileEntryBuilder::new_with_options("example.txt".into(), WriteOptions::builder().build())?
+    ///         .build()?;
     /// archive_part1.add_entry_part(EntryPart::from(entry))?;
     ///
     /// let part2_file = File::create("example.part2.pna")?;
@@ -224,7 +226,7 @@ impl<W: Write> Archive<W> {
     ///
     /// # Examples
     /// ```no_run
-    /// # use libpna::{Archive, EntryBuilder, EntryPart, WriteOptions};
+    /// # use libpna::{Archive, EntryPart, FileEntryBuilder, WriteOptions};
     /// # use std::fs::File;
     /// # use std::io;
     ///
@@ -232,7 +234,8 @@ impl<W: Write> Archive<W> {
     /// let part1_file = File::create("example.part1.pna")?;
     /// let mut archive_part1 = Archive::write_header(part1_file)?;
     /// let entry =
-    ///     EntryBuilder::new_file("example.txt".into(), WriteOptions::builder().build())?.build()?;
+    ///     FileEntryBuilder::new_with_options("example.txt".into(), WriteOptions::builder().build())?
+    ///         .build()?;
     /// archive_part1.add_entry_part(EntryPart::from(entry))?;
     ///
     /// let part2_file = File::create("example.part2.pna")?;
@@ -406,7 +409,7 @@ impl<W: Write> SolidArchive<W> {
     /// # Examples
     ///
     /// ```no_run
-    /// use libpna::{Archive, EntryBuilder, WriteOptions};
+    /// use libpna::{Archive, FileEntryBuilder, WriteOptions};
     /// use std::fs::File;
     /// # use std::io;
     ///
@@ -414,8 +417,7 @@ impl<W: Write> SolidArchive<W> {
     /// let option = WriteOptions::builder().build();
     /// let file = File::create("example.pna")?;
     /// let mut archive = Archive::write_solid_header(file, option)?;
-    /// archive
-    ///     .add_entry(EntryBuilder::new_file("example.txt".into(), WriteOptions::store())?.build()?)?;
+    /// archive.add_entry(FileEntryBuilder::new("example.txt".into())?.build()?)?;
     /// archive.finalize()?;
     /// #     Ok(())
     /// # }

--- a/lib/src/archive/write.rs
+++ b/lib/src/archive/write.rs
@@ -484,7 +484,7 @@ impl<W: Write> SolidArchive<W> {
     /// [`write_solid_header()`](Archive::write_solid_header).
     ///
     /// Pre-built entries added via [`add_entry()`](SolidArchive::add_entry) use their own
-    /// chunk size configured through [`EntryBuilder::max_chunk_size()`](crate::EntryBuilder::max_chunk_size).
+    /// chunk size configured through [`FileEntryBuilder::max_chunk_size()`](crate::FileEntryBuilder::max_chunk_size).
     #[inline]
     pub fn set_max_file_chunk_size(&mut self, size: NonZeroU32) {
         self.max_chunk_size = Some(size);

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -14,8 +14,8 @@ mod write;
 pub use self::{
     attr::*,
     builder::{
-        DirEntryBuilder, EntryBuilder, FileEntryBuilder, HardLinkEntryBuilder, SolidEntryBuilder,
-        SymlinkEntryBuilder,
+        DirEntryBuilder, EntryBuilder, FileEntryBuilder, HardLinkEntryBuilder, OpaqueEntryBuilder,
+        SolidEntryBuilder, SymlinkEntryBuilder,
     },
     content::*,
     header::*,

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -11,6 +11,7 @@ mod read;
 mod reference;
 mod write;
 
+#[allow(deprecated)]
 pub use self::{
     attr::*,
     builder::{
@@ -1742,11 +1743,13 @@ mod tests {
 
     #[test]
     fn ancillary_chunks_are_written_before_fdat() {
-        let mut builder = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
-        builder
-            .created(Duration::seconds(1))
-            .permission_mode(PermissionMode::from(0o755))
-            .add_xattr(sample_xattr());
+        let mut builder = FileEntryBuilder::new("f".into()).unwrap();
+        builder.metadata(
+            Metadata::new()
+                .with_created(Some(Duration::seconds(1)))
+                .with_permission_mode(Some(PermissionMode::from(0o755)))
+                .with_xattrs(vec![sample_xattr()]),
+        );
         builder.write_all(b"data").unwrap();
         let entry = builder.build().unwrap();
         let chunks = entry.into_chunks();

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -1092,10 +1092,10 @@ impl<T> NormalEntry<T> {
     /// # Examples
     /// ```rust
     /// # use std::io;
-    /// use libpna::{EntryBuilder, Metadata};
+    /// use libpna::{DirEntryBuilder, Metadata};
     ///
     /// # fn main() -> io::Result<()> {
-    /// let mut entry = EntryBuilder::new_dir("dir_entry".into()).build()?;
+    /// let mut entry = DirEntryBuilder::new("dir_entry".into()).build()?;
     /// entry.with_metadata(Metadata::new());
     /// # Ok(())
     /// # }
@@ -1127,10 +1127,10 @@ impl<T> NormalEntry<T> {
     /// # Examples
     /// ```rust
     /// # use std::io;
-    /// use libpna::EntryBuilder;
+    /// use libpna::DirEntryBuilder;
     ///
     /// # fn main() -> io::Result<()> {
-    /// let entry = EntryBuilder::new_dir("original/path".into()).build()?;
+    /// let entry = DirEntryBuilder::new("original/path".into()).build()?;
     /// let renamed = entry.with_name("new/path".into());
     /// assert_eq!(renamed.header().path().as_str(), "new/path");
     /// # Ok(())
@@ -1149,10 +1149,10 @@ impl<T: Clone> NormalEntry<T> {
     /// # Examples
     /// ```rust
     /// # use std::io;
-    /// use libpna::{ChunkType, EntryBuilder, RawChunk};
+    /// use libpna::{ChunkType, DirEntryBuilder, RawChunk};
     ///
     /// # fn main() -> io::Result<()> {
-    /// let mut entry = EntryBuilder::new_dir("dir_entry".into()).build()?;
+    /// let mut entry = DirEntryBuilder::new("dir_entry".into()).build()?;
     /// entry.with_extra_chunks(&[RawChunk::from_data(
     ///     ChunkType::private(*b"myTy").unwrap(),
     ///     b"some data",
@@ -1540,7 +1540,7 @@ mod tests {
 
     #[test]
     fn normal_entry_with_name_updates_path() {
-        let entry = EntryBuilder::new_dir("original".into()).build().unwrap();
+        let entry = DirEntryBuilder::new("original".into()).build().unwrap();
         let _ = entry.header().path(); // Force cache population
         let renamed = entry.with_name("new".into());
         assert_eq!(renamed.header().path().as_str(), "new");
@@ -1550,7 +1550,7 @@ mod tests {
     #[test]
     fn normal_entry_encoded_reader_returns_encoded_fdat_body() {
         let data = b"plain data plain data plain data";
-        let mut builder = EntryBuilder::new_file(
+        let mut builder = FileEntryBuilder::new_with_options(
             "encoded".into(),
             WriteOptions::builder()
                 .compression(Compression::DEFLATE)
@@ -1717,8 +1717,8 @@ mod tests {
     #[test]
     fn xattrs_round_trip_through_metadata() {
         let xattr = sample_xattr();
-        let mut builder = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
-        builder.add_xattr(xattr.clone());
+        let mut builder = FileEntryBuilder::new("f".into()).unwrap();
+        builder.metadata(Metadata::new().with_xattrs(vec![xattr.clone()]));
         let entry = builder.build().unwrap();
         let restored = NormalEntry::try_from(RawEntry(entry.into_chunks())).unwrap();
         assert_eq!(restored.metadata().xattrs(), &[xattr]);
@@ -1726,18 +1726,15 @@ mod tests {
 
     #[test]
     fn empty_xattrs_emit_no_xatr_chunk() {
-        let entry = EntryBuilder::new_file("f".into(), WriteOptions::store())
-            .unwrap()
-            .build()
-            .unwrap();
+        let entry = FileEntryBuilder::new("f".into()).unwrap().build().unwrap();
         assert!(entry.into_chunks().iter().all(|c| c.ty != ChunkType::xATR));
     }
 
     #[allow(deprecated)]
     #[test]
     fn deprecated_xattrs_accessor_delegates_to_metadata() {
-        let mut builder = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
-        builder.add_xattr(sample_xattr());
+        let mut builder = FileEntryBuilder::new("f".into()).unwrap();
+        builder.metadata(Metadata::new().with_xattrs(vec![sample_xattr()]));
         let entry = builder.build().unwrap();
         assert_eq!(entry.xattrs(), entry.metadata().xattrs());
         assert!(!entry.xattrs().is_empty());

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -79,6 +79,10 @@ impl EntryBuilderCore {
         self.phsf = phsf;
     }
 
+    pub(crate) fn header(&self) -> &EntryHeader {
+        &self.header
+    }
+
     pub(crate) fn metadata(&mut self, metadata: Metadata) {
         self.metadata = metadata;
     }
@@ -220,61 +224,73 @@ impl EntryBuilderCore {
 /// # Ok(())
 /// # }
 /// ```
+///
+/// Prefer the kind-specific builders ([`FileEntryBuilder`], [`DirEntryBuilder`],
+/// [`SymlinkEntryBuilder`], [`HardLinkEntryBuilder`]) for new code; this type
+/// remains for constructing entries of arbitrary [`DataKind`]s.
 pub struct EntryBuilder {
-    header: EntryHeader,
-    phsf: Option<String>,
-    iv: Option<Vec<u8>>,
+    core: EntryBuilderCore,
     data: Option<CompressionWriter<CipherWriter<FlattenWriter>>>,
-    created: Option<Duration>,
-    last_modified: Option<Duration>,
-    accessed: Option<Duration>,
-    #[allow(deprecated)]
-    permission: Option<Permission>,
-    owner_uid: Option<OwnerUid>,
-    owner_gid: Option<OwnerGid>,
-    owner_user_name: Option<OwnerUserName>,
-    owner_group_name: Option<OwnerGroupName>,
-    owner_user_sid: Option<OwnerUserSid>,
-    owner_group_sid: Option<OwnerGroupSid>,
-    permission_mode: Option<PermissionMode>,
-    link_target_type: Option<LinkTargetType>,
     store_file_size: bool,
     file_size: u128,
-    xattrs: Vec<ExtendedAttribute>,
-    extra_chunks: Vec<RawChunk>,
 }
 
 impl EntryBuilder {
-    #[allow(deprecated)]
-    const fn new(header: EntryHeader) -> Self {
-        Self {
-            header,
-            phsf: None,
-            iv: None,
-            data: None,
-            created: None,
-            last_modified: None,
-            accessed: None,
-            permission: None,
-            owner_uid: None,
-            owner_gid: None,
-            owner_user_name: None,
-            owner_group_name: None,
-            owner_user_sid: None,
-            owner_group_sid: None,
-            permission_mode: None,
-            link_target_type: None,
+    /// Creates a builder for an entry of the given kind that stores its
+    /// data without compression or encryption.
+    ///
+    /// The entry data is written via the [`Write`] trait as an opaque byte
+    /// stream; its interpretation is left to the application. Prefer the
+    /// kind-specific builders for the kinds defined by the PNA
+    /// specification.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if initialization fails.
+    #[inline]
+    pub fn new(name: EntryName, kind: DataKind) -> io::Result<Self> {
+        Self::new_with_options(name, kind, WriteOptions::store())
+    }
+
+    /// Creates a builder for an entry of the given kind with the given
+    /// write options.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if initialization fails.
+    #[inline]
+    pub fn new_with_options(
+        name: EntryName,
+        kind: DataKind,
+        option: impl WriteOption,
+    ) -> io::Result<Self> {
+        let header = EntryHeader::new_with_options(
+            kind,
+            option.compression(),
+            option.encryption(),
+            option.cipher_mode(),
+            name,
+        );
+        let (writer, iv, phsf) = data_writer(option)?;
+        let mut core = EntryBuilderCore::new(header);
+        core.set_cipher(iv, phsf);
+        Ok(Self {
+            core,
+            data: Some(writer),
             store_file_size: true,
             file_size: 0,
-            xattrs: Vec::new(),
-            extra_chunks: Vec::new(),
-        }
+        })
     }
 
     /// Creates a new [`EntryBuilder`] for a directory entry.
     #[inline]
     pub const fn new_dir(name: EntryName) -> Self {
-        Self::new(EntryHeader::for_dir(name))
+        Self {
+            core: EntryBuilderCore::new(EntryHeader::for_dir(name)),
+            data: None,
+            store_file_size: true,
+            file_size: 0,
+        }
     }
 
     /// Creates a new [`EntryBuilder`] for a file entry with the given write options.
@@ -284,41 +300,21 @@ impl EntryBuilder {
     /// Returns an error if initialization fails.
     #[inline]
     pub fn new_file(name: EntryName, option: impl WriteOption) -> io::Result<Self> {
-        let header = EntryHeader::for_file(
-            option.compression(),
-            option.encryption(),
-            option.cipher_mode(),
-            name,
-        );
-        let context = get_writer_context(option)?;
-        let writer = get_writer(FlattenWriter::new(), &context)?;
-        let (iv, phsf) = match context.cipher {
-            None => (None, None),
-            Some(WriteCipher { context: c, .. }) => (Some(c.iv), Some(c.phsf)),
-        };
-        Ok(Self {
-            data: Some(writer),
-            iv,
-            phsf,
-            ..Self::new(header)
-        })
+        Self::new_with_options(name, DataKind::FILE, option)
     }
 
     /// Internal helper for creating link entries (symlink or hard link).
     fn new_link(header: EntryHeader, source: EntryReference) -> io::Result<Self> {
         let option = WriteOptions::store();
-        let context = get_writer_context(option)?;
-        let mut writer = get_writer(FlattenWriter::new(), &context)?;
+        let (mut writer, iv, phsf) = data_writer(option)?;
         writer.write_all(source.as_bytes())?;
-        let (iv, phsf) = match context.cipher {
-            None => (None, None),
-            Some(WriteCipher { context: c, .. }) => (Some(c.iv), Some(c.phsf)),
-        };
+        let mut core = EntryBuilderCore::new(header);
+        core.set_cipher(iv, phsf);
         Ok(Self {
+            core,
             data: Some(writer),
-            iv,
-            phsf,
-            ..Self::new(header)
+            store_file_size: true,
+            file_size: 0,
         })
     }
 
@@ -366,24 +362,34 @@ impl EntryBuilder {
         Self::new_link(EntryHeader::for_hard_link(name), source)
     }
 
+    /// Sets the metadata of the entry, replacing any previously set metadata.
+    ///
+    /// The raw file size and compressed size recorded in the given metadata
+    /// are ignored; [`build()`](Self::build) computes them.
+    #[inline]
+    pub fn metadata(&mut self, metadata: Metadata) -> &mut Self {
+        self.core.metadata(metadata);
+        self
+    }
+
     /// Sets the creation timestamp of the entry.
     #[inline]
     pub fn created(&mut self, since_unix_epoch: impl Into<Option<Duration>>) -> &mut Self {
-        self.created = since_unix_epoch.into();
+        self.core.metadata.created = since_unix_epoch.into();
         self
     }
 
     /// Sets the last modified timestamp of the entry.
     #[inline]
     pub fn modified(&mut self, since_unix_epoch: impl Into<Option<Duration>>) -> &mut Self {
-        self.last_modified = since_unix_epoch.into();
+        self.core.metadata.modified = since_unix_epoch.into();
         self
     }
 
     /// Sets the last accessed timestamp of the entry.
     #[inline]
     pub fn accessed(&mut self, since_unix_epoch: impl Into<Option<Duration>>) -> &mut Self {
-        self.accessed = since_unix_epoch.into();
+        self.core.metadata.accessed = since_unix_epoch.into();
         self
     }
 
@@ -395,50 +401,50 @@ impl EntryBuilder {
     #[allow(deprecated)]
     #[inline]
     pub fn permission(&mut self, permission: impl Into<Option<Permission>>) -> &mut Self {
-        self.permission = permission.into();
+        self.core.metadata.permission = permission.into();
         self
     }
 
     /// Sets the owner user id facet (`fUId`).
     #[inline]
     pub fn owner_uid(&mut self, value: impl Into<Option<OwnerUid>>) -> &mut Self {
-        self.owner_uid = value.into();
+        self.core.metadata.owner_uid = value.into();
         self
     }
     /// Sets the owner group id facet (`fGId`).
     #[inline]
     pub fn owner_gid(&mut self, value: impl Into<Option<OwnerGid>>) -> &mut Self {
-        self.owner_gid = value.into();
+        self.core.metadata.owner_gid = value.into();
         self
     }
     /// Sets the owner user name facet (`fONm`).
     #[inline]
     pub fn owner_user_name(&mut self, value: impl Into<Option<OwnerUserName>>) -> &mut Self {
-        self.owner_user_name = value.into();
+        self.core.metadata.owner_user_name = value.into();
         self
     }
     /// Sets the owner group name facet (`fGNm`).
     #[inline]
     pub fn owner_group_name(&mut self, value: impl Into<Option<OwnerGroupName>>) -> &mut Self {
-        self.owner_group_name = value.into();
+        self.core.metadata.owner_group_name = value.into();
         self
     }
     /// Sets the owner user SID facet (`fOSi`).
     #[inline]
     pub fn owner_user_sid(&mut self, value: impl Into<Option<OwnerUserSid>>) -> &mut Self {
-        self.owner_user_sid = value.into();
+        self.core.metadata.owner_user_sid = value.into();
         self
     }
     /// Sets the owner group SID facet (`fGSi`).
     #[inline]
     pub fn owner_group_sid(&mut self, value: impl Into<Option<OwnerGroupSid>>) -> &mut Self {
-        self.owner_group_sid = value.into();
+        self.core.metadata.owner_group_sid = value.into();
         self
     }
     /// Sets the POSIX permission mode facet (`fMOd`).
     #[inline]
     pub fn permission_mode(&mut self, value: impl Into<Option<PermissionMode>>) -> &mut Self {
-        self.permission_mode = value.into();
+        self.core.metadata.permission_mode = value.into();
         self
     }
 
@@ -454,7 +460,7 @@ impl EntryBuilder {
         &mut self,
         link_target_type: impl Into<Option<LinkTargetType>>,
     ) -> &mut Self {
-        self.link_target_type = link_target_type.into();
+        self.core.metadata.link_target_type = link_target_type.into();
         self
     }
 
@@ -467,17 +473,28 @@ impl EntryBuilder {
         self
     }
 
+    /// Sets whether to store the raw file size in the entry metadata.
+    ///
+    /// The size is recorded only for entries whose data kind is
+    /// [`DataKind::FILE`]. When `true` (the default), the raw file size is
+    /// recorded for such entries; when `false`, it is omitted.
+    #[inline]
+    pub fn store_file_size(&mut self, store: bool) -> &mut Self {
+        self.store_file_size = store;
+        self
+    }
+
     /// Adds an [`ExtendedAttribute`] to the entry.
     #[inline]
     pub fn add_xattr(&mut self, xattr: ExtendedAttribute) -> &mut Self {
-        self.xattrs.push(xattr);
+        self.core.metadata.xattrs.push(xattr);
         self
     }
 
     /// Adds extra chunk to the entry.
     #[inline]
     pub fn add_extra_chunk<T: Into<RawChunk>>(&mut self, chunk: T) -> &mut Self {
-        self.extra_chunks.push(chunk.into());
+        self.core.add_extra_chunk(chunk);
         self
     }
 
@@ -515,45 +532,18 @@ impl EntryBuilder {
     /// # Errors
     ///
     /// Returns an error if an I/O error occurs while building entry into buffer.
-    #[allow(deprecated)]
     #[inline]
     #[must_use = "building an entry without using it is wasteful"]
     pub fn build(self) -> io::Result<NormalEntry> {
-        let mut data = if let Some(data) = self.data {
+        let data = if let Some(data) = self.data {
             data.try_into_inner()?.try_into_inner()?.inner
         } else {
             Vec::new()
         };
-        if let Some(iv) = self.iv {
-            data.insert(0, iv);
-        }
-        let metadata = Metadata {
-            raw_file_size: match (self.store_file_size, self.header.data_kind) {
-                (true, DataKind::FILE) => Some(self.file_size),
-                _ => None,
-            },
-            compressed_size: data.iter().map(|d| d.len()).sum(),
-            created: self.created,
-            modified: self.last_modified,
-            accessed: self.accessed,
-            permission: self.permission,
-            link_target_type: self.link_target_type,
-            owner_uid: self.owner_uid,
-            owner_gid: self.owner_gid,
-            owner_user_name: self.owner_user_name,
-            owner_group_name: self.owner_group_name,
-            owner_user_sid: self.owner_user_sid,
-            owner_group_sid: self.owner_group_sid,
-            permission_mode: self.permission_mode,
-            xattrs: self.xattrs,
-        };
-        Ok(NormalEntry {
-            header: self.header,
-            phsf: self.phsf,
-            extra: self.extra_chunks,
-            data,
-            metadata,
-        })
+        let raw_file_size = (self.store_file_size
+            && self.core.header().data_kind() == DataKind::FILE)
+            .then_some(self.file_size);
+        Ok(self.core.build(data, raw_file_size))
     }
 }
 
@@ -847,5 +837,57 @@ mod tests {
             crate::EntryContent::HardLink(r) => assert_eq!(r.as_str(), "secret"),
             other => panic!("unexpected content: {other:?}"),
         }
+    }
+
+    #[test]
+    fn opaque_builder_round_trips_private_kind() {
+        let kind = crate::DataKind::new_private(200).unwrap();
+        let mut b = EntryBuilder::new("custom".into(), kind).unwrap();
+        b.write_all(b"opaque bytes").unwrap();
+        let entry = b.build().unwrap();
+        let raw = RawEntry(entry.into_chunks());
+        let restored = NormalEntry::try_from(raw).unwrap();
+        assert_eq!(restored.header().data_kind(), kind);
+        match restored.content(ReadOptions::builder().build()).unwrap() {
+            crate::EntryContent::Unknown(k, mut r) => {
+                assert_eq!(k, kind);
+                let mut buf = Vec::new();
+                r.read_to_end(&mut buf).unwrap();
+                assert_eq!(&buf[..], b"opaque bytes");
+            }
+            other => panic!("unexpected content: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn opaque_builder_with_file_kind_matches_file_entry_builder_wire() {
+        let mut a = EntryBuilder::new("f".into(), crate::DataKind::FILE).unwrap();
+        a.write_all(b"data").unwrap();
+        let mut b = FileEntryBuilder::new("f".into()).unwrap();
+        b.write_all(b"data").unwrap();
+        let ac: Vec<_> = a.build().unwrap().into_chunks();
+        let bc: Vec<_> = b.build().unwrap().into_chunks();
+        assert_eq!(ac, bc);
+    }
+
+    #[test]
+    fn opaque_builder_private_kind_omits_file_size() {
+        let kind = crate::DataKind::new_private(200).unwrap();
+        let mut b = EntryBuilder::new("custom".into(), kind).unwrap();
+        b.write_all(b"x").unwrap();
+        let entry = b.build().unwrap();
+        assert_eq!(entry.metadata().raw_file_size(), None);
+    }
+
+    #[test]
+    fn opaque_builder_metadata_replaces_previous() {
+        let mut b = EntryBuilder::new("f".into(), crate::DataKind::FILE).unwrap();
+        b.metadata(Metadata::new().with_modified(Some(crate::Duration::seconds(1))));
+        b.metadata(Metadata::new().with_modified(Some(crate::Duration::seconds(2))));
+        let entry = b.build().unwrap();
+        assert_eq!(
+            entry.metadata().modified(),
+            Some(crate::Duration::seconds(2))
+        );
     }
 }

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -54,6 +54,21 @@ pub(crate) fn data_writer(
     Ok((writer, iv, phsf))
 }
 
+/// Largest UTF-8 char-boundary prefix of `s` whose byte length is ≤ 255 —
+/// the `fONm`/`fGNm` owner-name wire bound (1-byte length prefix). Used to
+/// rescue a legacy fPRM name that exceeds the bounded owner-facet limit.
+fn owner_name_bounded(s: &str) -> &str {
+    const MAX: usize = u8::MAX as usize;
+    if s.len() <= MAX {
+        return s;
+    }
+    let mut end = MAX;
+    while !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
 /// Fields and logic shared by the kind-specific entry builders.
 pub(crate) struct EntryBuilderCore {
     header: EntryHeader,
@@ -83,8 +98,50 @@ impl EntryBuilderCore {
         &self.header
     }
 
+    /// Sets the metadata, rescuing deprecated `fPRM` permission data into
+    /// the owner-facet fields when no owner facet is set.
+    ///
+    /// If none of the owner-facet fields are populated, they are filled
+    /// from the `fPRM` data when present, and the `fPRM` data itself is
+    /// dropped from the stored metadata. Owner names longer than the
+    /// 255-byte wire bound of `fONm`/`fGNm` are truncated at a UTF-8
+    /// character boundary. If any owner-facet field is already populated,
+    /// the metadata is stored as-is (including `fPRM`, if set), preserving
+    /// the contract that `fPRM` and the owner facets are independent
+    /// chunks that may coexist.
+    ///
+    /// TODO: rescue unconditionally (dropping `fPRM` whenever it is
+    /// present, regardless of owner-facet fields) once the fPRM/owner-facet
+    /// coexistence contract is retired.
+    #[allow(deprecated)]
     pub(crate) fn metadata(&mut self, metadata: Metadata) {
-        self.metadata = metadata;
+        let has_owner_facet = metadata.owner_uid().is_some()
+            || metadata.owner_gid().is_some()
+            || metadata.owner_user_name().is_some()
+            || metadata.owner_group_name().is_some()
+            || metadata.owner_user_sid().is_some()
+            || metadata.owner_group_sid().is_some()
+            || metadata.permission_mode().is_some();
+        let Some(p) = (!has_owner_facet)
+            .then(|| metadata.permission().cloned())
+            .flatten()
+        else {
+            self.metadata = metadata;
+            return;
+        };
+        self.metadata = metadata
+            .with_owner_uid(Some(OwnerUid::from(p.uid())))
+            .with_owner_gid(Some(OwnerGid::from(p.gid())))
+            .with_owner_user_name(Some(
+                OwnerUserName::new(owner_name_bounded(p.uname()))
+                    .expect("owner_name_bounded guarantees <= 255 bytes"),
+            ))
+            .with_owner_group_name(Some(
+                OwnerGroupName::new(owner_name_bounded(p.gname()))
+                    .expect("owner_name_bounded guarantees <= 255 bytes"),
+            ))
+            .with_permission_mode(Some(PermissionMode::from(p.permissions())))
+            .with_permission(None);
     }
 
     pub(crate) fn add_extra_chunk(&mut self, chunk: impl Into<RawChunk>) {
@@ -889,5 +946,131 @@ mod tests {
             entry.metadata().modified(),
             Some(crate::Duration::seconds(2))
         );
+    }
+
+    #[test]
+    fn owner_name_bounded_passes_through_short_ascii() {
+        assert_eq!(owner_name_bounded(""), "");
+        assert_eq!(owner_name_bounded("alice"), "alice");
+        let exactly_255 = "a".repeat(255);
+        assert_eq!(owner_name_bounded(&exactly_255), exactly_255);
+    }
+
+    #[test]
+    fn owner_name_bounded_truncates_long_ascii_to_255() {
+        let s = "a".repeat(300);
+        let out = owner_name_bounded(&s);
+        assert_eq!(out.len(), 255);
+        assert!(out.bytes().all(|b| b == b'a'));
+        assert_eq!(owner_name_bounded(&"a".repeat(256)).len(), 255);
+    }
+
+    #[test]
+    fn owner_name_bounded_truncates_on_utf8_boundary() {
+        let two_byte_char = 'é';
+        assert_eq!(two_byte_char.len_utf8(), 2);
+        let s = String::from(two_byte_char).repeat(200); // 400 bytes
+        let out = owner_name_bounded(&s);
+        assert_eq!(out.len(), 254);
+        assert_eq!(out.chars().count(), 127);
+        assert!(out.chars().all(|c| c == two_byte_char));
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn metadata_preserves_all_owner_facets() {
+        let mut b = FileEntryBuilder::new("f".into()).unwrap();
+        b.metadata(
+            Metadata::new()
+                .with_owner_uid(Some(OwnerUid::from(1)))
+                .with_owner_gid(Some(OwnerGid::from(2)))
+                .with_owner_user_name(Some(OwnerUserName::new("u").unwrap()))
+                .with_owner_group_name(Some(OwnerGroupName::new("g").unwrap()))
+                .with_owner_user_sid(Some(OwnerUserSid::new("S-1-1").unwrap()))
+                .with_owner_group_sid(Some(OwnerGroupSid::new("S-1-2").unwrap()))
+                .with_permission_mode(Some(PermissionMode::from(0o644))),
+        );
+        let entry = b.build().unwrap();
+        let m = entry.metadata();
+        assert_eq!(m.owner_uid().map(|v| v.get()), Some(1));
+        assert_eq!(m.owner_gid().map(|v| v.get()), Some(2));
+        assert_eq!(m.owner_user_name().map(|v| v.as_str()), Some("u"));
+        assert_eq!(m.owner_group_name().map(|v| v.as_str()), Some("g"));
+        assert_eq!(m.owner_user_sid().map(|v| v.as_str()), Some("S-1-1"));
+        assert_eq!(m.owner_group_sid().map(|v| v.as_str()), Some("S-1-2"));
+        assert_eq!(m.permission_mode().map(|v| v.get()), Some(0o644));
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn metadata_rescues_fprm_only_source() {
+        let mut b = FileEntryBuilder::new("f".into()).unwrap();
+        b.metadata(Metadata::new().with_permission(Some(Permission::new(
+            7,
+            "legacy".to_string(),
+            8,
+            "grp".to_string(),
+            0o600,
+        ))));
+        let entry = b.build().unwrap();
+        let m = entry.metadata();
+        assert_eq!(m.owner_uid().map(|v| v.get()), Some(7));
+        assert_eq!(m.owner_gid().map(|v| v.get()), Some(8));
+        assert_eq!(m.owner_user_name().map(|v| v.as_str()), Some("legacy"));
+        assert_eq!(m.owner_group_name().map(|v| v.as_str()), Some("grp"));
+        assert_eq!(m.permission_mode().map(|v| v.get()), Some(0o600));
+        assert!(m.permission().is_none());
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn metadata_partial_owner_facet_skips_rescue() {
+        let mut b = FileEntryBuilder::new("f".into()).unwrap();
+        b.metadata(
+            Metadata::new()
+                .with_owner_uid(Some(OwnerUid::from(1)))
+                .with_owner_user_name(Some(OwnerUserName::new("new").unwrap()))
+                .with_permission(Some(Permission::new(
+                    7,
+                    "legacy".to_string(),
+                    8,
+                    "grp".to_string(),
+                    0o600,
+                ))),
+        );
+        let entry = b.build().unwrap();
+        let m = entry.metadata();
+        assert_eq!(m.owner_uid().map(|v| v.get()), Some(1));
+        assert_eq!(m.owner_user_name().map(|v| v.as_str()), Some("new"));
+        assert_eq!(m.owner_gid(), None);
+        assert_eq!(m.owner_group_name(), None);
+        assert_eq!(m.permission_mode(), None);
+        assert!(
+            m.permission().is_some(),
+            "fPRM must coexist with a partially set owner facet"
+        );
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn metadata_truncates_overlong_fprm_name() {
+        let big_char = 'é';
+        assert_eq!(big_char.len_utf8(), 2);
+        let big = String::from(big_char).repeat(200); // 400 bytes
+        let mut b = FileEntryBuilder::new("f".into()).unwrap();
+        b.metadata(Metadata::new().with_permission(Some(Permission::new(
+            7,
+            big,
+            8,
+            "grp".to_string(),
+            0o600,
+        ))));
+        let entry = b.build().unwrap();
+        let m = entry.metadata();
+        let uname = m.owner_user_name().unwrap().as_str();
+        assert_eq!(uname.len(), 254);
+        assert_eq!(uname.chars().count(), 127);
+        assert!(uname.chars().all(|c| c == big_char));
+        assert_eq!(m.owner_uid().map(|v| v.get()), Some(7));
     }
 }

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -241,6 +241,10 @@ pub struct OpaqueEntryBuilder {
 }
 
 /// Alias of [`OpaqueEntryBuilder`].
+#[deprecated(
+    since = "0.36.0",
+    note = "renamed to `OpaqueEntryBuilder`; prefer the kind-specific builders"
+)]
 pub type EntryBuilder = OpaqueEntryBuilder;
 
 impl OpaqueEntryBuilder {
@@ -291,6 +295,7 @@ impl OpaqueEntryBuilder {
     }
 
     /// Creates a new [`OpaqueEntryBuilder`] for a directory entry.
+    #[deprecated(since = "0.36.0", note = "use `DirEntryBuilder::new`")]
     #[inline]
     pub const fn new_dir(name: EntryName) -> Self {
         Self {
@@ -306,6 +311,7 @@ impl OpaqueEntryBuilder {
     /// # Errors
     ///
     /// Returns an error if initialization fails.
+    #[deprecated(since = "0.36.0", note = "use `FileEntryBuilder::new_with_options`")]
     #[inline]
     pub fn new_file(name: EntryName, option: impl WriteOption) -> io::Result<Self> {
         Self::new_with_options(name, DataKind::FILE, option)
@@ -334,15 +340,16 @@ impl OpaqueEntryBuilder {
     ///
     /// # Examples
     /// ```
-    /// use libpna::{OpaqueEntryBuilder, EntryName, EntryReference};
+    /// use libpna::{SymlinkEntryBuilder, EntryName, EntryReference};
     ///
-    /// let builder = OpaqueEntryBuilder::new_symlink(
+    /// let builder = SymlinkEntryBuilder::new(
     ///     EntryName::try_from("path/of/link").unwrap(),
     ///     EntryReference::try_from("path/of/target").unwrap(),
     /// )
     /// .unwrap();
     /// let entry = builder.build().unwrap();
     /// ```
+    #[deprecated(since = "0.36.0", note = "use `SymlinkEntryBuilder::new`")]
     #[inline]
     pub fn new_symlink(name: EntryName, source: EntryReference) -> io::Result<Self> {
         Self::new_link(EntryHeader::for_symlink(name), source)
@@ -356,15 +363,16 @@ impl OpaqueEntryBuilder {
     ///
     /// # Examples
     /// ```
-    /// use libpna::{OpaqueEntryBuilder, EntryName, EntryReference};
+    /// use libpna::{HardLinkEntryBuilder, EntryName, EntryReference};
     ///
-    /// let builder = OpaqueEntryBuilder::new_hard_link(
+    /// let builder = HardLinkEntryBuilder::new(
     ///     EntryName::try_from("path/of/link").unwrap(),
     ///     EntryReference::try_from("path/of/target").unwrap(),
     /// )
     /// .unwrap();
     /// let entry = builder.build().unwrap();
     /// ```
+    #[deprecated(since = "0.36.0", note = "use `HardLinkEntryBuilder::new`")]
     #[inline]
     pub fn new_hard_link(name: EntryName, source: EntryReference) -> io::Result<Self> {
         Self::new_link(EntryHeader::for_hard_link(name), source)
@@ -381,6 +389,10 @@ impl OpaqueEntryBuilder {
     }
 
     /// Sets the creation timestamp of the entry.
+    #[deprecated(
+        since = "0.36.0",
+        note = "use `OpaqueEntryBuilder::metadata` with `Metadata::with_*`"
+    )]
     #[inline]
     pub fn created(&mut self, since_unix_epoch: impl Into<Option<Duration>>) -> &mut Self {
         self.core.metadata.created = since_unix_epoch.into();
@@ -388,6 +400,10 @@ impl OpaqueEntryBuilder {
     }
 
     /// Sets the last modified timestamp of the entry.
+    #[deprecated(
+        since = "0.36.0",
+        note = "use `OpaqueEntryBuilder::metadata` with `Metadata::with_*`"
+    )]
     #[inline]
     pub fn modified(&mut self, since_unix_epoch: impl Into<Option<Duration>>) -> &mut Self {
         self.core.metadata.modified = since_unix_epoch.into();
@@ -395,6 +411,10 @@ impl OpaqueEntryBuilder {
     }
 
     /// Sets the last accessed timestamp of the entry.
+    #[deprecated(
+        since = "0.36.0",
+        note = "use `OpaqueEntryBuilder::metadata` with `Metadata::with_*`"
+    )]
     #[inline]
     pub fn accessed(&mut self, since_unix_epoch: impl Into<Option<Duration>>) -> &mut Self {
         self.core.metadata.accessed = since_unix_epoch.into();
@@ -404,7 +424,7 @@ impl OpaqueEntryBuilder {
     /// Sets the permission of the entry to the given owner, group, and permissions.
     #[deprecated(
         since = "0.34.0",
-        note = "the fPRM chunk is superseded by the owner facet chunks; use OpaqueEntryBuilder::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode"
+        note = "the fPRM chunk is superseded by the owner facet chunks; use `OpaqueEntryBuilder::metadata` with `Metadata::with_owner_uid`/`with_owner_gid`/`with_owner_user_name`/`with_owner_group_name`/`with_permission_mode`"
     )]
     #[allow(deprecated)]
     #[inline]
@@ -414,42 +434,70 @@ impl OpaqueEntryBuilder {
     }
 
     /// Sets the owner user id facet (`fUId`).
+    #[deprecated(
+        since = "0.36.0",
+        note = "use `OpaqueEntryBuilder::metadata` with `Metadata::with_*`"
+    )]
     #[inline]
     pub fn owner_uid(&mut self, value: impl Into<Option<OwnerUid>>) -> &mut Self {
         self.core.metadata.owner_uid = value.into();
         self
     }
     /// Sets the owner group id facet (`fGId`).
+    #[deprecated(
+        since = "0.36.0",
+        note = "use `OpaqueEntryBuilder::metadata` with `Metadata::with_*`"
+    )]
     #[inline]
     pub fn owner_gid(&mut self, value: impl Into<Option<OwnerGid>>) -> &mut Self {
         self.core.metadata.owner_gid = value.into();
         self
     }
     /// Sets the owner user name facet (`fONm`).
+    #[deprecated(
+        since = "0.36.0",
+        note = "use `OpaqueEntryBuilder::metadata` with `Metadata::with_*`"
+    )]
     #[inline]
     pub fn owner_user_name(&mut self, value: impl Into<Option<OwnerUserName>>) -> &mut Self {
         self.core.metadata.owner_user_name = value.into();
         self
     }
     /// Sets the owner group name facet (`fGNm`).
+    #[deprecated(
+        since = "0.36.0",
+        note = "use `OpaqueEntryBuilder::metadata` with `Metadata::with_*`"
+    )]
     #[inline]
     pub fn owner_group_name(&mut self, value: impl Into<Option<OwnerGroupName>>) -> &mut Self {
         self.core.metadata.owner_group_name = value.into();
         self
     }
     /// Sets the owner user SID facet (`fOSi`).
+    #[deprecated(
+        since = "0.36.0",
+        note = "use `OpaqueEntryBuilder::metadata` with `Metadata::with_*`"
+    )]
     #[inline]
     pub fn owner_user_sid(&mut self, value: impl Into<Option<OwnerUserSid>>) -> &mut Self {
         self.core.metadata.owner_user_sid = value.into();
         self
     }
     /// Sets the owner group SID facet (`fGSi`).
+    #[deprecated(
+        since = "0.36.0",
+        note = "use `OpaqueEntryBuilder::metadata` with `Metadata::with_*`"
+    )]
     #[inline]
     pub fn owner_group_sid(&mut self, value: impl Into<Option<OwnerGroupSid>>) -> &mut Self {
         self.core.metadata.owner_group_sid = value.into();
         self
     }
     /// Sets the POSIX permission mode facet (`fMOd`).
+    #[deprecated(
+        since = "0.36.0",
+        note = "use `OpaqueEntryBuilder::metadata` with `Metadata::with_*`"
+    )]
     #[inline]
     pub fn permission_mode(&mut self, value: impl Into<Option<PermissionMode>>) -> &mut Self {
         self.core.metadata.permission_mode = value.into();
@@ -463,6 +511,10 @@ impl OpaqueEntryBuilder {
     /// - `SymbolicLink` + `Directory` → directory symlink
     /// - `HardLink` + `File` → file hard link
     /// - `HardLink` + `Directory` → directory hard link
+    #[deprecated(
+        since = "0.36.0",
+        note = "use `OpaqueEntryBuilder::metadata` with `Metadata::with_*`"
+    )]
     #[inline]
     pub fn link_target_type(
         &mut self,
@@ -475,6 +527,7 @@ impl OpaqueEntryBuilder {
     /// Sets whether to store the raw file size in the entry metadata.
     ///
     /// When `true`, the raw file size is recorded; when `false`, it is omitted.
+    #[deprecated(since = "0.36.0", note = "renamed to `store_file_size`")]
     #[inline]
     pub fn file_size(&mut self, store: bool) -> &mut Self {
         self.store_file_size = store;
@@ -493,6 +546,10 @@ impl OpaqueEntryBuilder {
     }
 
     /// Adds an [`ExtendedAttribute`] to the entry.
+    #[deprecated(
+        since = "0.36.0",
+        note = "use `OpaqueEntryBuilder::metadata` with `Metadata::with_xattrs`"
+    )]
     #[inline]
     pub fn add_xattr(&mut self, xattr: ExtendedAttribute) -> &mut Self {
         self.core.metadata.xattrs.push(xattr);
@@ -515,10 +572,11 @@ impl OpaqueEntryBuilder {
     /// ```rust
     /// # use std::io::{self, Write};
     /// use std::num::NonZeroU32;
-    /// use libpna::{OpaqueEntryBuilder, WriteOptions};
+    /// use libpna::{OpaqueEntryBuilder, DataKind, WriteOptions};
     ///
     /// # fn main() -> io::Result<()> {
-    /// let mut builder = OpaqueEntryBuilder::new_file("data.bin".into(), WriteOptions::store())?;
+    /// let mut builder =
+    ///     OpaqueEntryBuilder::new_with_options("data.bin".into(), DataKind::FILE, WriteOptions::store())?;
     /// builder.max_chunk_size(NonZeroU32::new(1024 * 1024).unwrap()); // 1MB chunks
     /// builder.write_all(b"file content")?;
     /// let entry = builder.build()?;
@@ -611,7 +669,7 @@ mod tests {
 
     #[test]
     fn entry_extra_chunk() {
-        let mut builder = OpaqueEntryBuilder::new_dir("dir".into());
+        let mut builder = DirEntryBuilder::new("dir".into());
         builder.add_extra_chunk(RawChunk::from_data(
             ChunkType::private(*b"abCd").unwrap(),
             [],
@@ -627,8 +685,8 @@ mod tests {
     #[test]
     fn fltp_symlink_roundtrip() {
         let mut builder =
-            OpaqueEntryBuilder::new_symlink("link_name".into(), "target_dir".into()).unwrap();
-        builder.link_target_type(LinkTargetType::Directory);
+            SymlinkEntryBuilder::new("link_name".into(), "target_dir".into()).unwrap();
+        builder.metadata(Metadata::new().with_link_target_type(Some(LinkTargetType::Directory)));
         let entry = builder.build().unwrap();
         let chunks = entry.into_chunks();
         let raw = RawEntry(chunks);
@@ -642,8 +700,8 @@ mod tests {
     #[test]
     fn fltp_hardlink_roundtrip() {
         let mut builder =
-            OpaqueEntryBuilder::new_hard_link("dir_hardlink".into(), "target_dir".into()).unwrap();
-        builder.link_target_type(LinkTargetType::Directory);
+            HardLinkEntryBuilder::new("dir_hardlink".into(), "target_dir".into()).unwrap();
+        builder.metadata(Metadata::new().with_link_target_type(Some(LinkTargetType::Directory)));
         let entry = builder.build().unwrap();
         let chunks = entry.into_chunks();
         let raw = RawEntry(chunks);
@@ -656,7 +714,7 @@ mod tests {
 
     #[test]
     fn fltp_absent_returns_none() {
-        let builder = OpaqueEntryBuilder::new_symlink("link_name".into(), "target".into()).unwrap();
+        let builder = SymlinkEntryBuilder::new("link_name".into(), "target".into()).unwrap();
         let entry = builder.build().unwrap();
         let chunks = entry.into_chunks();
         let raw = RawEntry(chunks);
@@ -666,9 +724,8 @@ mod tests {
 
     #[test]
     fn fltp_on_regular_file_is_preserved() {
-        let mut builder =
-            OpaqueEntryBuilder::new_file("regular.txt".into(), WriteOptions::store()).unwrap();
-        builder.link_target_type(LinkTargetType::File);
+        let mut builder = FileEntryBuilder::new("regular.txt".into()).unwrap();
+        builder.metadata(Metadata::new().with_link_target_type(Some(LinkTargetType::File)));
         let entry = builder.build().unwrap();
         let chunks = entry.into_chunks();
         let raw = RawEntry(chunks);
@@ -1023,5 +1080,65 @@ mod tests {
         assert_eq!(uname.chars().count(), 127);
         assert!(uname.chars().all(|c| c == big_char));
         assert_eq!(m.owner_uid().map(|v| v.get()), Some(7));
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn deprecated_builder_paths_match_new_builders() {
+        let mut old = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
+        old.created(Some(crate::Duration::seconds(1)));
+        old.write_all(b"data").unwrap();
+        let old = old.build().unwrap();
+
+        let mut new = FileEntryBuilder::new("f".into()).unwrap();
+        new.metadata(Metadata::new().with_created(Some(crate::Duration::seconds(1))));
+        new.write_all(b"data").unwrap();
+        let new = new.build().unwrap();
+
+        assert_eq!(old.into_chunks(), new.into_chunks());
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn deprecated_new_symlink_matches_symlink_entry_builder_wire() {
+        let old = EntryBuilder::new_symlink("link".into(), "target".into())
+            .unwrap()
+            .build()
+            .unwrap();
+        let new = SymlinkEntryBuilder::new("link".into(), "target".into())
+            .unwrap()
+            .build()
+            .unwrap();
+        assert_eq!(old.into_chunks(), new.into_chunks());
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn deprecated_new_hard_link_matches_hard_link_entry_builder_wire() {
+        let old = EntryBuilder::new_hard_link("link".into(), "target".into())
+            .unwrap()
+            .build()
+            .unwrap();
+        let new = HardLinkEntryBuilder::new("link".into(), "target".into())
+            .unwrap()
+            .build()
+            .unwrap();
+        assert_eq!(old.into_chunks(), new.into_chunks());
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn deprecated_new_dir_matches_dir_entry_builder_wire() {
+        let mut old = EntryBuilder::new_dir("dir".into());
+        old.permission_mode(Some(crate::PermissionMode::from(0o755)));
+        let old = old.build().unwrap();
+
+        let mut new = DirEntryBuilder::new("dir".into());
+        new.metadata(
+            Metadata::new().with_permission_mode(Some(crate::PermissionMode::from(0o755))),
+        );
+        let new = new.build().unwrap();
+
+        assert_eq!(old.into_chunks(), new.into_chunks());
     }
 }

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -168,42 +168,55 @@ impl EntryBuilderCore {
     }
 }
 
-/// A builder for creating a [`NormalEntry`].
+/// A builder for creating a [`NormalEntry`] by writing an opaque byte
+/// stream tagged with a declared [`DataKind`].
 ///
-/// This builder provides a flexible way to construct entries for PNA archives by specifying
-/// the entry type (file, directory, symbolic link, hard link), content, and metadata.
-/// It handles compression and encryption transparently according to the provided [`WriteOptions`].
-///
-/// # Entry Types
-///
-/// - **Files**: Created with [`new_file()`](Self::new_file), supports data writing via the [`Write`] trait
-/// - **Directories**: Created with [`new_dir()`](Self::new_dir), have no data payload
-/// - **Symbolic links**: Created with [`new_symlink()`](Self::new_symlink), data is the link target path
-/// - **Hard links**: Created with [`new_hard_link()`](Self::new_hard_link), data is the link target path
+/// This is the escape hatch for [`DataKind`]s that have no dedicated
+/// builder: data written via the [`Write`] trait is compressed and
+/// encrypted according to the given [`WriteOptions`] and stored as-is, with
+/// no interpretation of its meaning. It also provides convenience
+/// constructors ([`new_dir()`](Self::new_dir), [`new_file()`](Self::new_file),
+/// [`new_symlink()`](Self::new_symlink), [`new_hard_link()`](Self::new_hard_link))
+/// for the kinds defined by the PNA specification, but for those kinds
+/// prefer the corresponding kind-specific builder instead
+/// ([`FileEntryBuilder`], [`DirEntryBuilder`], [`SymlinkEntryBuilder`],
+/// [`HardLinkEntryBuilder`]), which encode that kind's on-wire contract in
+/// the type itself. Reach for [`new()`](Self::new) or
+/// [`new_with_options()`](Self::new_with_options) directly only for kinds
+/// the specification does not define, such as private or experimental
+/// [`DataKind`]s.
 ///
 /// # Write Trait Behavior
 ///
-/// For **file entries**, the [`Write`] trait is fully functional. Data written via
-/// [`write_all()`](Write::write_all) or similar methods is automatically compressed and
-/// encrypted according to the [`WriteOptions`] provided at construction time. The original
-/// (uncompressed) file size is tracked separately.
+/// For entries constructed via [`new()`](Self::new) or
+/// [`new_with_options()`](Self::new_with_options) — writing the opaque byte
+/// stream for the declared [`DataKind`] — the [`Write`] trait is fully
+/// functional; the legacy [`new_file()`](Self::new_file) constructor (which
+/// delegates to [`new_with_options()`](Self::new_with_options) with
+/// [`DataKind::FILE`]) behaves the same way. Data written via
+/// [`write_all()`](Write::write_all) or similar methods is automatically
+/// compressed and encrypted according to the [`WriteOptions`] provided at
+/// construction time. The original (uncompressed) size is tracked
+/// separately.
 ///
-/// For **directory entries**, the [`Write`] trait is implemented but writing data has no effect.
-/// Directories do not store data payloads in PNA archives.
+/// For **directory entries** ([`new_dir()`](Self::new_dir)), the [`Write`]
+/// trait is implemented but writing data has no effect. Directories do not
+/// store data payloads in PNA archives.
 ///
-/// For **symbolic link and hard link entries**, do not use the [`Write`] trait. Instead, the
-/// link target is provided to the constructor ([`new_symlink()`](Self::new_symlink) or
-/// [`new_hard_link()`](Self::new_hard_link)).
+/// For **symbolic link and hard link entries**, do not use the [`Write`] trait.
+/// The link target is written internally when the entry is constructed via
+/// [`new_symlink()`](Self::new_symlink) or [`new_hard_link()`](Self::new_hard_link);
+/// writing further data onto the builder would corrupt it.
 ///
 /// # Metadata
 ///
 /// Metadata (timestamps, permissions, extended attributes) can be set at any time before
 /// calling [`build()`](Self::build). The order does not matter - you can set metadata before,
-/// during, or after writing data to file entries.
+/// during, or after writing data.
 ///
 /// # Compression and Encryption
 ///
-/// When data is written to a file entry:
+/// When data is written:
 /// 1. Data is compressed according to [`WriteOptions`] compression settings
 /// 2. Compressed data is encrypted according to [`WriteOptions`] encryption settings
 /// 3. Encrypted data is buffered into chunks
@@ -214,22 +227,23 @@ impl EntryBuilderCore {
 /// # Important Notes
 ///
 /// - Each builder can only be built **once** ([`build()`](Self::build) consumes `self`)
-/// - File entries with no data written will have **zero size**
+/// - Only entries with a [`DataKind::FILE`] kind record a raw file size; if no
+///   data is written, that size is recorded as **zero**. For all other kinds,
+///   the raw file size is omitted entirely
 /// - Compression and encryption are applied **during writes**, not at build time
 /// - The [`build()`](Self::build) method finalizes compression/encryption streams
 /// - Building a directory or file without calling write methods is valid
-///
-/// Prefer the kind-specific builders ([`FileEntryBuilder`], [`DirEntryBuilder`],
-/// [`SymlinkEntryBuilder`], [`HardLinkEntryBuilder`]) for new code; this type
-/// remains for constructing entries of arbitrary [`DataKind`]s.
-pub struct EntryBuilder {
+pub struct OpaqueEntryBuilder {
     core: EntryBuilderCore,
     data: Option<CompressionWriter<CipherWriter<FlattenWriter>>>,
     store_file_size: bool,
     file_size: u128,
 }
 
-impl EntryBuilder {
+/// Alias of [`OpaqueEntryBuilder`].
+pub type EntryBuilder = OpaqueEntryBuilder;
+
+impl OpaqueEntryBuilder {
     /// Creates a builder for an entry of the given kind that stores its
     /// data without compression or encryption.
     ///
@@ -276,7 +290,7 @@ impl EntryBuilder {
         })
     }
 
-    /// Creates a new [`EntryBuilder`] for a directory entry.
+    /// Creates a new [`OpaqueEntryBuilder`] for a directory entry.
     #[inline]
     pub const fn new_dir(name: EntryName) -> Self {
         Self {
@@ -287,7 +301,7 @@ impl EntryBuilder {
         }
     }
 
-    /// Creates a new [`EntryBuilder`] for a file entry with the given write options.
+    /// Creates a new [`OpaqueEntryBuilder`] for a file entry with the given write options.
     ///
     /// # Errors
     ///
@@ -312,7 +326,7 @@ impl EntryBuilder {
         })
     }
 
-    /// Creates a new [`EntryBuilder`] for a symbolic link entry pointing to the given source.
+    /// Creates a new [`OpaqueEntryBuilder`] for a symbolic link entry pointing to the given source.
     ///
     /// # Errors
     ///
@@ -320,9 +334,9 @@ impl EntryBuilder {
     ///
     /// # Examples
     /// ```
-    /// use libpna::{EntryBuilder, EntryName, EntryReference};
+    /// use libpna::{OpaqueEntryBuilder, EntryName, EntryReference};
     ///
-    /// let builder = EntryBuilder::new_symlink(
+    /// let builder = OpaqueEntryBuilder::new_symlink(
     ///     EntryName::try_from("path/of/link").unwrap(),
     ///     EntryReference::try_from("path/of/target").unwrap(),
     /// )
@@ -334,7 +348,7 @@ impl EntryBuilder {
         Self::new_link(EntryHeader::for_symlink(name), source)
     }
 
-    /// Creates a new [`EntryBuilder`] for a hard link entry pointing to the given source.
+    /// Creates a new [`OpaqueEntryBuilder`] for a hard link entry pointing to the given source.
     ///
     /// # Errors
     ///
@@ -342,9 +356,9 @@ impl EntryBuilder {
     ///
     /// # Examples
     /// ```
-    /// use libpna::{EntryBuilder, EntryName, EntryReference};
+    /// use libpna::{OpaqueEntryBuilder, EntryName, EntryReference};
     ///
-    /// let builder = EntryBuilder::new_hard_link(
+    /// let builder = OpaqueEntryBuilder::new_hard_link(
     ///     EntryName::try_from("path/of/link").unwrap(),
     ///     EntryReference::try_from("path/of/target").unwrap(),
     /// )
@@ -390,7 +404,7 @@ impl EntryBuilder {
     /// Sets the permission of the entry to the given owner, group, and permissions.
     #[deprecated(
         since = "0.34.0",
-        note = "the fPRM chunk is superseded by the owner facet chunks; use EntryBuilder::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode"
+        note = "the fPRM chunk is superseded by the owner facet chunks; use OpaqueEntryBuilder::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode"
     )]
     #[allow(deprecated)]
     #[inline]
@@ -501,10 +515,10 @@ impl EntryBuilder {
     /// ```rust
     /// # use std::io::{self, Write};
     /// use std::num::NonZeroU32;
-    /// use libpna::{EntryBuilder, WriteOptions};
+    /// use libpna::{OpaqueEntryBuilder, WriteOptions};
     ///
     /// # fn main() -> io::Result<()> {
-    /// let mut builder = EntryBuilder::new_file("data.bin".into(), WriteOptions::store())?;
+    /// let mut builder = OpaqueEntryBuilder::new_file("data.bin".into(), WriteOptions::store())?;
     /// builder.max_chunk_size(NonZeroU32::new(1024 * 1024).unwrap()); // 1MB chunks
     /// builder.write_all(b"file content")?;
     /// let entry = builder.build()?;
@@ -541,7 +555,7 @@ impl EntryBuilder {
     }
 }
 
-impl Write for EntryBuilder {
+impl Write for OpaqueEntryBuilder {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         if let Some(w) = &mut self.data {
@@ -560,7 +574,7 @@ impl Write for EntryBuilder {
 }
 
 #[cfg(feature = "unstable-async")]
-impl AsyncWrite for EntryBuilder {
+impl AsyncWrite for OpaqueEntryBuilder {
     #[inline]
     fn poll_write(
         self: Pin<&mut Self>,
@@ -597,7 +611,7 @@ mod tests {
 
     #[test]
     fn entry_extra_chunk() {
-        let mut builder = EntryBuilder::new_dir("dir".into());
+        let mut builder = OpaqueEntryBuilder::new_dir("dir".into());
         builder.add_extra_chunk(RawChunk::from_data(
             ChunkType::private(*b"abCd").unwrap(),
             [],
@@ -613,7 +627,7 @@ mod tests {
     #[test]
     fn fltp_symlink_roundtrip() {
         let mut builder =
-            EntryBuilder::new_symlink("link_name".into(), "target_dir".into()).unwrap();
+            OpaqueEntryBuilder::new_symlink("link_name".into(), "target_dir".into()).unwrap();
         builder.link_target_type(LinkTargetType::Directory);
         let entry = builder.build().unwrap();
         let chunks = entry.into_chunks();
@@ -628,7 +642,7 @@ mod tests {
     #[test]
     fn fltp_hardlink_roundtrip() {
         let mut builder =
-            EntryBuilder::new_hard_link("dir_hardlink".into(), "target_dir".into()).unwrap();
+            OpaqueEntryBuilder::new_hard_link("dir_hardlink".into(), "target_dir".into()).unwrap();
         builder.link_target_type(LinkTargetType::Directory);
         let entry = builder.build().unwrap();
         let chunks = entry.into_chunks();
@@ -642,7 +656,7 @@ mod tests {
 
     #[test]
     fn fltp_absent_returns_none() {
-        let builder = EntryBuilder::new_symlink("link_name".into(), "target".into()).unwrap();
+        let builder = OpaqueEntryBuilder::new_symlink("link_name".into(), "target".into()).unwrap();
         let entry = builder.build().unwrap();
         let chunks = entry.into_chunks();
         let raw = RawEntry(chunks);
@@ -653,7 +667,7 @@ mod tests {
     #[test]
     fn fltp_on_regular_file_is_preserved() {
         let mut builder =
-            EntryBuilder::new_file("regular.txt".into(), WriteOptions::store()).unwrap();
+            OpaqueEntryBuilder::new_file("regular.txt".into(), WriteOptions::store()).unwrap();
         builder.link_target_type(LinkTargetType::File);
         let entry = builder.build().unwrap();
         let chunks = entry.into_chunks();
@@ -836,7 +850,7 @@ mod tests {
     #[test]
     fn opaque_builder_round_trips_private_kind() {
         let kind = crate::DataKind::new_private(200).unwrap();
-        let mut b = EntryBuilder::new("custom".into(), kind).unwrap();
+        let mut b = OpaqueEntryBuilder::new("custom".into(), kind).unwrap();
         b.write_all(b"opaque bytes").unwrap();
         let entry = b.build().unwrap();
         let raw = RawEntry(entry.into_chunks());
@@ -855,7 +869,7 @@ mod tests {
 
     #[test]
     fn opaque_builder_with_file_kind_matches_file_entry_builder_wire() {
-        let mut a = EntryBuilder::new("f".into(), crate::DataKind::FILE).unwrap();
+        let mut a = OpaqueEntryBuilder::new("f".into(), crate::DataKind::FILE).unwrap();
         a.write_all(b"data").unwrap();
         let mut b = FileEntryBuilder::new("f".into()).unwrap();
         b.write_all(b"data").unwrap();
@@ -867,7 +881,7 @@ mod tests {
     #[test]
     fn opaque_builder_private_kind_omits_file_size() {
         let kind = crate::DataKind::new_private(200).unwrap();
-        let mut b = EntryBuilder::new("custom".into(), kind).unwrap();
+        let mut b = OpaqueEntryBuilder::new("custom".into(), kind).unwrap();
         b.write_all(b"x").unwrap();
         let entry = b.build().unwrap();
         assert_eq!(entry.metadata().raw_file_size(), None);
@@ -875,7 +889,7 @@ mod tests {
 
     #[test]
     fn opaque_builder_metadata_replaces_previous() {
-        let mut b = EntryBuilder::new("f".into(), crate::DataKind::FILE).unwrap();
+        let mut b = OpaqueEntryBuilder::new("f".into(), crate::DataKind::FILE).unwrap();
         b.metadata(Metadata::new().with_modified(Some(crate::Duration::seconds(1))));
         b.metadata(Metadata::new().with_modified(Some(crate::Duration::seconds(2))));
         let entry = b.build().unwrap();

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -713,7 +713,7 @@ mod tests {
     #[test]
     fn file_entry_builder_metadata_size_fields_are_overwritten() {
         let mut b = FileEntryBuilder::new("f".into()).unwrap();
-        b.metadata(Metadata::new()); // raw_file_size/compressed_size は builder が計算
+        b.metadata(Metadata::new());
         b.write_all(b"abc").unwrap();
         let entry = b.build().unwrap();
         assert_eq!(entry.metadata().raw_file_size(), Some(3));
@@ -769,7 +769,6 @@ mod tests {
         let b = SymlinkEntryBuilder::new_with_options("link".into(), "secret/target".into(), opt)
             .unwrap();
         let entry = b.build().unwrap();
-        // 平文でターゲットが漏れていないこと
         for chunk in entry.clone().into_chunks() {
             assert!(
                 !chunk
@@ -832,7 +831,6 @@ mod tests {
         let b =
             HardLinkEntryBuilder::new_with_options("link".into(), "secret".into(), opt).unwrap();
         let entry = b.build().unwrap();
-        // 平文でターゲットが漏れていないこと
         for chunk in entry.clone().into_chunks() {
             assert!(
                 !chunk

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -219,69 +219,6 @@ impl EntryBuilderCore {
 /// - The [`build()`](Self::build) method finalizes compression/encryption streams
 /// - Building a directory or file without calling write methods is valid
 ///
-/// # Examples
-///
-/// ## Creating a file entry
-///
-/// ```
-/// # use std::io::{self, Write};
-/// use libpna::{EntryBuilder, WriteOptions};
-///
-/// # fn main() -> io::Result<()> {
-/// let mut builder = EntryBuilder::new_file("my_file.txt".into(), WriteOptions::store())?;
-/// builder.write_all(b"This is the file content.")?;
-/// let entry = builder.build()?;
-/// # Ok(())
-/// # }
-/// ```
-///
-/// ## Creating a file entry with extended attributes
-///
-/// ```
-/// # use std::io::{self, Write};
-/// use libpna::{EntryBuilder, WriteOptions, ExtendedAttribute, XattrName, XattrValue};
-///
-/// # fn main() -> io::Result<()> {
-/// let mut builder = EntryBuilder::new_file("data.txt".into(), WriteOptions::store())?;
-/// builder.write_all(b"file content")?;
-/// builder.add_xattr(ExtendedAttribute::new(
-///     XattrName::try_from("user.comment").unwrap(),
-///     XattrValue::try_from(b"important".as_slice()).unwrap(),
-/// ));
-/// let entry = builder.build()?;
-/// # Ok(())
-/// # }
-/// ```
-///
-/// ## Creating a directory entry
-///
-/// ```
-/// # use std::io;
-/// use libpna::EntryBuilder;
-///
-/// # fn main() -> io::Result<()> {
-/// let builder = EntryBuilder::new_dir("my_dir/".into());
-/// let entry = builder.build()?;
-/// # Ok(())
-/// # }
-/// ```
-///
-/// ## Creating a symbolic link entry
-///
-/// ```
-/// # use std::io;
-/// use libpna::EntryBuilder;
-///
-/// # fn main() -> io::Result<()> {
-/// let builder = EntryBuilder::new_symlink(
-///     "link_name".into(),
-///     "target/file.txt".into()
-/// )?;
-/// let entry = builder.build()?;
-/// # Ok(())
-/// # }
-/// ```
-///
 /// Prefer the kind-specific builders ([`FileEntryBuilder`], [`DirEntryBuilder`],
 /// [`SymlinkEntryBuilder`], [`HardLinkEntryBuilder`]) for new code; this type
 /// remains for constructing entries of arbitrary [`DataKind`]s.

--- a/lib/src/entry/builder/solid.rs
+++ b/lib/src/entry/builder/solid.rs
@@ -45,17 +45,17 @@ impl Write for SolidEntryDataWriter<'_> {
 ///
 /// ```
 /// # use std::io::{self, Write};
-/// use libpna::{EntryBuilder, SolidEntryBuilder, WriteOptions};
+/// use libpna::{DirEntryBuilder, FileEntryBuilder, SolidEntryBuilder, WriteOptions};
 ///
 /// # fn main() -> io::Result<()> {
 /// let mut solid_builder = SolidEntryBuilder::new(WriteOptions::store())?;
 ///
 /// // Add a directory to the solid entry
-/// let dir_entry = EntryBuilder::new_dir("my_dir/".into()).build()?;
+/// let dir_entry = DirEntryBuilder::new("my_dir/".into()).build()?;
 /// solid_builder.add_entry(dir_entry)?;
 ///
 /// // Add a file to the solid entry
-/// let mut file_builder = EntryBuilder::new_file("my_dir/file.txt".into(), WriteOptions::store())?;
+/// let mut file_builder = FileEntryBuilder::new("my_dir/file.txt".into())?;
 /// file_builder.write_all(b"This is a file inside a solid entry.")?;
 /// solid_builder.add_entry(file_builder.build()?)?;
 ///
@@ -110,16 +110,15 @@ impl SolidEntryBuilder {
     /// # Examples
     ///
     /// ```no_run
-    /// use libpna::{EntryBuilder, SolidEntryBuilder, WriteOptions};
+    /// use libpna::{DirEntryBuilder, FileEntryBuilder, SolidEntryBuilder, WriteOptions};
     /// use std::io;
     /// use std::io::Write;
     ///
     /// # fn main() -> io::Result<()> {
     /// let mut builder = SolidEntryBuilder::new(WriteOptions::builder().build())?;
-    /// let dir_entry = EntryBuilder::new_dir("example".into()).build()?;
+    /// let dir_entry = DirEntryBuilder::new("example".into()).build()?;
     /// builder.add_entry(dir_entry)?;
-    /// let mut entry_builder =
-    ///     EntryBuilder::new_file("example/text.txt".into(), WriteOptions::store())?;
+    /// let mut entry_builder = FileEntryBuilder::new("example/text.txt".into())?;
     /// entry_builder.write_all(b"content")?;
     /// let file_entry = entry_builder.build()?;
     /// builder.add_entry(file_entry)?;
@@ -194,13 +193,13 @@ impl SolidEntryBuilder {
     /// ```rust
     /// # use std::io::{self, Write};
     /// use std::num::NonZeroU32;
-    /// use libpna::{EntryBuilder, SolidEntryBuilder, WriteOptions};
+    /// use libpna::{FileEntryBuilder, SolidEntryBuilder, WriteOptions};
     ///
     /// # fn main() -> io::Result<()> {
     /// let mut solid_builder = SolidEntryBuilder::new(WriteOptions::store())?;
     /// solid_builder.max_chunk_size(NonZeroU32::new(1024 * 1024).unwrap()); // 1MB chunks
     ///
-    /// let file_entry = EntryBuilder::new_file("file.txt".into(), WriteOptions::store())?;
+    /// let file_entry = FileEntryBuilder::new("file.txt".into())?;
     /// solid_builder.add_entry(file_entry.build()?)?;
     ///
     /// let solid_entry = solid_builder.build()?;

--- a/lib/src/entry/content.rs
+++ b/lib/src/entry/content.rs
@@ -12,11 +12,11 @@ use std::fmt;
 /// # Examples
 ///
 /// ```rust
-/// use libpna::{EntryBuilder, EntryContent, EntryName, ReadOptions, WriteOptions};
+/// use libpna::{EntryContent, EntryName, FileEntryBuilder, ReadOptions};
 /// use std::io::{self, Write};
 ///
 /// # fn main() -> io::Result<()> {
-/// let mut builder = EntryBuilder::new_file(EntryName::try_from("f.txt").unwrap(), WriteOptions::store())?;
+/// let mut builder = FileEntryBuilder::new(EntryName::try_from("f.txt").unwrap())?;
 /// builder.write_all(b"abc")?;
 /// let entry = builder.build()?;
 /// match entry.content(ReadOptions::builder().build())? {
@@ -76,10 +76,10 @@ impl<T: AsRef<[u8]>> NormalEntry<T> {
     /// # Examples
     ///
     /// ```rust
-    /// use libpna::{EntryBuilder, EntryContent, EntryName, EntryReference, ReadOptions};
+    /// use libpna::{EntryContent, EntryName, EntryReference, ReadOptions, SymlinkEntryBuilder};
     ///
     /// # fn main() -> std::io::Result<()> {
-    /// let entry = EntryBuilder::new_symlink(
+    /// let entry = SymlinkEntryBuilder::new(
     ///     EntryName::try_from("path/of/link").unwrap(),
     ///     EntryReference::try_from("path/of/target").unwrap(),
     /// )?
@@ -121,7 +121,7 @@ mod tests {
 
     #[test]
     fn file_reads_contents() {
-        let mut builder = EntryBuilder::new_file("f.txt".into(), WriteOptions::store()).unwrap();
+        let mut builder = FileEntryBuilder::new("f.txt".into()).unwrap();
         builder.write_all(b"abc").unwrap();
         let entry = builder.build().unwrap();
         let EntryContent::File(reader) = entry.content(read_options()).unwrap() else {
@@ -132,7 +132,7 @@ mod tests {
 
     #[test]
     fn empty_file_reads_empty() {
-        let builder = EntryBuilder::new_file("f.txt".into(), WriteOptions::store()).unwrap();
+        let builder = FileEntryBuilder::new("f.txt".into()).unwrap();
         let entry = builder.build().unwrap();
         let EntryContent::File(reader) = entry.content(read_options()).unwrap() else {
             panic!("expected File");
@@ -142,7 +142,7 @@ mod tests {
 
     #[test]
     fn directory_has_no_content() {
-        let entry = EntryBuilder::new_dir("d".into()).build().unwrap();
+        let entry = DirEntryBuilder::new("d".into()).build().unwrap();
         assert!(matches!(
             entry.content(read_options()).unwrap(),
             EntryContent::Directory
@@ -151,7 +151,7 @@ mod tests {
 
     #[test]
     fn symlink_target_roundtrips() {
-        let entry = EntryBuilder::new_symlink(
+        let entry = SymlinkEntryBuilder::new(
             "l".into(),
             EntryReference::from_utf8_preserve_root("target/path"),
         )
@@ -166,7 +166,7 @@ mod tests {
 
     #[test]
     fn absolute_symlink_target_is_preserved() {
-        let entry = EntryBuilder::new_symlink(
+        let entry = SymlinkEntryBuilder::new(
             "l".into(),
             EntryReference::from_utf8_preserve_root("/usr/bin/env"),
         )
@@ -182,7 +182,7 @@ mod tests {
     #[test]
     fn empty_symlink_target_roundtrips() {
         let entry =
-            EntryBuilder::new_symlink("l".into(), EntryReference::from_utf8_preserve_root(""))
+            SymlinkEntryBuilder::new("l".into(), EntryReference::from_utf8_preserve_root(""))
                 .unwrap()
                 .build()
                 .unwrap();
@@ -194,7 +194,7 @@ mod tests {
 
     #[test]
     fn hard_link_target_roundtrips() {
-        let entry = EntryBuilder::new_hard_link(
+        let entry = HardLinkEntryBuilder::new(
             "l".into(),
             EntryReference::from_utf8_preserve_root("target"),
         )
@@ -209,7 +209,7 @@ mod tests {
 
     #[test]
     fn directory_with_stray_data_is_still_directory() {
-        let mut entry = EntryBuilder::new_dir("d".into()).build().unwrap();
+        let mut entry = DirEntryBuilder::new("d".into()).build().unwrap();
         entry.data = vec![b"junk".to_vec()];
         assert!(matches!(
             entry.content(read_options()).unwrap(),
@@ -220,7 +220,7 @@ mod tests {
     #[test]
     fn non_utf8_symlink_target_is_invalid_data() {
         let mut entry =
-            EntryBuilder::new_symlink("l".into(), EntryReference::from_utf8_preserve_root("t"))
+            SymlinkEntryBuilder::new("l".into(), EntryReference::from_utf8_preserve_root("t"))
                 .unwrap()
                 .build()
                 .unwrap();
@@ -232,7 +232,7 @@ mod tests {
     #[test]
     fn non_utf8_hard_link_target_is_invalid_data() {
         let mut entry =
-            EntryBuilder::new_hard_link("l".into(), EntryReference::from_utf8_preserve_root("t"))
+            HardLinkEntryBuilder::new("l".into(), EntryReference::from_utf8_preserve_root("t"))
                 .unwrap()
                 .build()
                 .unwrap();
@@ -243,7 +243,7 @@ mod tests {
 
     #[test]
     fn reserved_kind_yields_unknown_with_raw_bytes() {
-        let mut builder = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
+        let mut builder = FileEntryBuilder::new("f".into()).unwrap();
         builder.write_all(b"raw").unwrap();
         let mut entry = builder.build().unwrap();
         entry.header.data_kind = DataKind::from_byte(42);
@@ -256,7 +256,7 @@ mod tests {
 
     #[test]
     fn private_kind_yields_unknown_with_raw_bytes() {
-        let mut builder = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
+        let mut builder = FileEntryBuilder::new("f".into()).unwrap();
         builder.write_all(b"raw").unwrap();
         let mut entry = builder.build().unwrap();
         entry.header.data_kind = DataKind::from_byte(200);
@@ -269,7 +269,7 @@ mod tests {
 
     /// Wire format allows encrypted link entries, but the public builder
     /// always writes links with store options; assemble one manually the
-    /// same way `EntryBuilder::build` does.
+    /// same way `SymlinkEntryBuilder::build` does.
     fn encrypted_symlink_entry(target: &str, password: &str) -> NormalEntry {
         let options = WriteOptions::builder()
             .encryption(Encryption::AES)
@@ -293,7 +293,7 @@ mod tests {
             data.insert(0, iv);
         }
         let mut entry =
-            EntryBuilder::new_symlink("l".into(), EntryReference::from_utf8_preserve_root(target))
+            SymlinkEntryBuilder::new("l".into(), EntryReference::from_utf8_preserve_root(target))
                 .unwrap()
                 .build()
                 .unwrap();
@@ -324,7 +324,7 @@ mod tests {
 
     #[test]
     fn encrypted_directory_decodes_without_password() {
-        let mut entry = EntryBuilder::new_dir("d".into()).build().unwrap();
+        let mut entry = DirEntryBuilder::new("d".into()).build().unwrap();
         entry.header.encryption = Encryption::AES;
         entry.header.cipher_mode = CipherMode::CTR;
         assert!(matches!(

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -990,13 +990,16 @@ mod tests {
     #[test]
     fn owner_id_facets_round_trip_via_entry() {
         use crate::entry::{OwnerGid, OwnerUid};
-        use crate::{Archive, EntryBuilder, WriteOptions};
+        use crate::{Archive, FileEntryBuilder};
         let mut buf = Vec::new();
         {
             let mut archive = Archive::write_header(&mut buf).unwrap();
-            let mut b = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
-            b.owner_uid(OwnerUid::from(1000));
-            b.owner_gid(OwnerGid::from(2000));
+            let mut b = FileEntryBuilder::new("f".into()).unwrap();
+            b.metadata(
+                Metadata::new()
+                    .with_owner_uid(Some(OwnerUid::from(1000)))
+                    .with_owner_gid(Some(OwnerGid::from(2000))),
+            );
             let entry = b.build().unwrap();
             archive.add_entry(entry).unwrap();
             archive.finalize().unwrap();
@@ -1011,13 +1014,16 @@ mod tests {
     #[test]
     fn owner_name_facets_round_trip_via_entry() {
         use crate::entry::{OwnerGroupName, OwnerUserName};
-        use crate::{Archive, EntryBuilder, WriteOptions};
+        use crate::{Archive, FileEntryBuilder};
         let mut buf = Vec::new();
         {
             let mut archive = Archive::write_header(&mut buf).unwrap();
-            let mut b = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
-            b.owner_user_name(OwnerUserName::new("alice").unwrap());
-            b.owner_group_name(OwnerGroupName::new("").unwrap());
+            let mut b = FileEntryBuilder::new("f".into()).unwrap();
+            b.metadata(
+                Metadata::new()
+                    .with_owner_user_name(Some(OwnerUserName::new("alice").unwrap()))
+                    .with_owner_group_name(Some(OwnerGroupName::new("").unwrap())),
+            );
             let entry = b.build().unwrap();
             archive.add_entry(entry).unwrap();
             archive.finalize().unwrap();
@@ -1032,13 +1038,16 @@ mod tests {
     #[test]
     fn owner_sid_facets_round_trip_via_entry() {
         use crate::entry::{OwnerGroupSid, OwnerUserSid};
-        use crate::{Archive, EntryBuilder, WriteOptions};
+        use crate::{Archive, FileEntryBuilder};
         let mut buf = Vec::new();
         {
             let mut archive = Archive::write_header(&mut buf).unwrap();
-            let mut b = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
-            b.owner_user_sid(OwnerUserSid::new("S-1-5-21-1-2-3-1001").unwrap());
-            b.owner_group_sid(OwnerGroupSid::new("S-1-5-32-544").unwrap());
+            let mut b = FileEntryBuilder::new("f".into()).unwrap();
+            b.metadata(
+                Metadata::new()
+                    .with_owner_user_sid(Some(OwnerUserSid::new("S-1-5-21-1-2-3-1001").unwrap()))
+                    .with_owner_group_sid(Some(OwnerGroupSid::new("S-1-5-32-544").unwrap())),
+            );
             let entry = b.build().unwrap();
             archive.add_entry(entry).unwrap();
             archive.finalize().unwrap();
@@ -1059,13 +1068,16 @@ mod tests {
     #[test]
     fn fosi_length_prefixed_round_trip_and_empty() {
         use crate::entry::{OwnerGroupSid, OwnerUserSid};
-        use crate::{Archive, EntryBuilder, WriteOptions};
+        use crate::{Archive, FileEntryBuilder};
         let mut buf = Vec::new();
         {
             let mut a = Archive::write_header(&mut buf).unwrap();
-            let mut b = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
-            b.owner_user_sid(OwnerUserSid::new("S-1-5-21-1-2-3-1001").unwrap());
-            b.owner_group_sid(OwnerGroupSid::new("").unwrap()); // empty -> [0] -> Some("")
+            let mut b = FileEntryBuilder::new("f".into()).unwrap();
+            b.metadata(
+                Metadata::new()
+                    .with_owner_user_sid(Some(OwnerUserSid::new("S-1-5-21-1-2-3-1001").unwrap()))
+                    .with_owner_group_sid(Some(OwnerGroupSid::new("").unwrap())), // empty -> [0] -> Some("")
+            );
             a.add_entry(b.build().unwrap()).unwrap();
             a.finalize().unwrap();
         }
@@ -1081,12 +1093,12 @@ mod tests {
     #[test]
     fn permission_mode_facet_round_trip_via_entry() {
         use crate::entry::PermissionMode;
-        use crate::{Archive, EntryBuilder, WriteOptions};
+        use crate::{Archive, FileEntryBuilder};
         let mut buf = Vec::new();
         {
             let mut archive = Archive::write_header(&mut buf).unwrap();
-            let mut b = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
-            b.permission_mode(PermissionMode::from(0o750));
+            let mut b = FileEntryBuilder::new("f".into()).unwrap();
+            b.metadata(Metadata::new().with_permission_mode(Some(PermissionMode::from(0o750))));
             let entry = b.build().unwrap();
             archive.add_entry(entry).unwrap();
             archive.finalize().unwrap();
@@ -1167,27 +1179,30 @@ mod tests {
             OwnerGid, OwnerGroupName, OwnerGroupSid, OwnerUid, OwnerUserName, OwnerUserSid,
             PermissionMode,
         };
-        use crate::{Archive, EntryBuilder, WriteOptions};
+        use crate::{Archive, FileEntryBuilder};
         let mut buf = Vec::new();
         {
             let mut archive = Archive::write_header(&mut buf).unwrap();
-            let mut b = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
-            // Legacy fPRM (Permission uses plain String uname/gname on this branch).
-            b.permission(Permission::new(
-                7,
-                "legacy".to_string(),
-                8,
-                "grp".to_string(),
-                0o600,
-            ));
-            // All 7 new owner facets.
-            b.owner_uid(OwnerUid::from(1));
-            b.owner_gid(OwnerGid::from(2));
-            b.owner_user_name(OwnerUserName::new("u").unwrap());
-            b.owner_group_name(OwnerGroupName::new("g").unwrap());
-            b.owner_user_sid(OwnerUserSid::new("S-1-1").unwrap());
-            b.owner_group_sid(OwnerGroupSid::new("S-1-2").unwrap());
-            b.permission_mode(PermissionMode::from(0o644));
+            let mut b = FileEntryBuilder::new("f".into()).unwrap();
+            b.metadata(
+                Metadata::new()
+                    // Legacy fPRM (Permission uses plain String uname/gname on this branch).
+                    .with_permission(Some(Permission::new(
+                        7,
+                        "legacy".to_string(),
+                        8,
+                        "grp".to_string(),
+                        0o600,
+                    )))
+                    // All 7 new owner facets.
+                    .with_owner_uid(Some(OwnerUid::from(1)))
+                    .with_owner_gid(Some(OwnerGid::from(2)))
+                    .with_owner_user_name(Some(OwnerUserName::new("u").unwrap()))
+                    .with_owner_group_name(Some(OwnerGroupName::new("g").unwrap()))
+                    .with_owner_user_sid(Some(OwnerUserSid::new("S-1-1").unwrap()))
+                    .with_owner_group_sid(Some(OwnerGroupSid::new("S-1-2").unwrap()))
+                    .with_permission_mode(Some(PermissionMode::from(0o644))),
+            );
             let entry = b.build().unwrap();
             archive.add_entry(entry).unwrap();
             archive.finalize().unwrap();
@@ -1216,11 +1231,11 @@ mod tests {
 
     #[test]
     fn fonm_trailing_bytes_after_length_are_ignored() {
-        use crate::{Archive, ChunkType, EntryBuilder, RawChunk, WriteOptions};
+        use crate::{Archive, ChunkType, FileEntryBuilder, RawChunk};
         let mut buf = Vec::new();
         {
             let mut a = Archive::write_header(&mut buf).unwrap();
-            let mut b = EntryBuilder::new_file("g".into(), WriteOptions::store()).unwrap();
+            let mut b = FileEntryBuilder::new("g".into()).unwrap();
             b.add_extra_chunk(RawChunk::from_data(
                 ChunkType::fONm,
                 vec![3, b'a', b'b', b'c', 0xFF],

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -293,7 +293,7 @@ impl Default for Metadata {
 /// Owner, group, and permission bits for an archive entry.
 #[deprecated(
     since = "0.34.0",
-    note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching EntryBuilder/with_* setters)"
+    note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching Metadata::with_* setters)"
 )]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Permission {
@@ -321,7 +321,7 @@ impl Permission {
     /// ```
     #[deprecated(
         since = "0.34.0",
-        note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching EntryBuilder/with_* setters)"
+        note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching Metadata::with_* setters)"
     )]
     #[inline]
     pub const fn new(uid: u64, uname: String, gid: u64, gname: String, permission: u16) -> Self {
@@ -346,7 +346,7 @@ impl Permission {
     /// ```
     #[deprecated(
         since = "0.34.0",
-        note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching EntryBuilder/with_* setters)"
+        note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching Metadata::with_* setters)"
     )]
     #[inline]
     pub const fn uid(&self) -> u64 {
@@ -366,7 +366,7 @@ impl Permission {
     /// ```
     #[deprecated(
         since = "0.34.0",
-        note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching EntryBuilder/with_* setters)"
+        note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching Metadata::with_* setters)"
     )]
     #[inline]
     pub fn uname(&self) -> &str {
@@ -386,7 +386,7 @@ impl Permission {
     /// ```
     #[deprecated(
         since = "0.34.0",
-        note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching EntryBuilder/with_* setters)"
+        note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching Metadata::with_* setters)"
     )]
     #[inline]
     pub const fn gid(&self) -> u64 {
@@ -406,7 +406,7 @@ impl Permission {
     /// ```
     #[deprecated(
         since = "0.34.0",
-        note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching EntryBuilder/with_* setters)"
+        note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching Metadata::with_* setters)"
     )]
     #[inline]
     pub fn gname(&self) -> &str {
@@ -426,7 +426,7 @@ impl Permission {
     /// ```
     #[deprecated(
         since = "0.34.0",
-        note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching EntryBuilder/with_* setters)"
+        note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching Metadata::with_* setters)"
     )]
     #[inline]
     pub const fn permissions(&self) -> u16 {

--- a/lib/src/entry/options.rs
+++ b/lib/src/entry/options.rs
@@ -1018,9 +1018,9 @@ impl WriteOptions {
     /// # Examples
     ///
     /// ```rust
-    /// use libpna::{EntryBuilder, WriteOptions};
+    /// use libpna::{FileEntryBuilder, WriteOptions};
     ///
-    /// EntryBuilder::new_file("example.txt".into(), WriteOptions::store()).unwrap();
+    /// FileEntryBuilder::new_with_options("example.txt".into(), WriteOptions::store()).unwrap();
     /// ```
     ///
     /// [Entry]: crate::Entry

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -10,7 +10,7 @@
 //! ## Creating an Archive
 //!
 //! ```no_run
-//! use libpna::{Archive, EntryBuilder, WriteOptions};
+//! use libpna::{Archive, DirEntryBuilder, FileEntryBuilder, WriteOptions};
 //! use std::fs::File;
 //! use std::io::{self, Write};
 //!
@@ -19,7 +19,7 @@
 //!     let mut archive = Archive::write_header(file)?;
 //!
 //!     // Add a file entry
-//!     let mut entry = EntryBuilder::new_file(
+//!     let mut entry = FileEntryBuilder::new_with_options(
 //!         "hello.txt".into(),
 //!         WriteOptions::builder().build(),
 //!     )?;
@@ -27,7 +27,7 @@
 //!     archive.add_entry(entry.build()?)?;
 //!
 //!     // Add a directory entry
-//!     let dir = EntryBuilder::new_dir("my_folder/".into());
+//!     let dir = DirEntryBuilder::new("my_folder/".into());
 //!     archive.add_entry(dir.build()?)?;
 //!
 //!     archive.finalize()?;
@@ -86,7 +86,7 @@
 //! Solid mode compresses multiple files together for better compression ratios:
 //!
 //! ```no_run
-//! use libpna::{Archive, EntryBuilder, SolidEntryBuilder, WriteOptions};
+//! use libpna::{Archive, FileEntryBuilder, SolidEntryBuilder, WriteOptions};
 //! use std::io::{self, Write};
 //!
 //! fn main() -> io::Result<()> {
@@ -95,11 +95,11 @@
 //!     // Create a solid entry containing multiple files
 //!     let mut solid = SolidEntryBuilder::new(WriteOptions::builder().build())?;
 //!
-//!     let mut file1 = EntryBuilder::new_file("file1.txt".into(), WriteOptions::store())?;
+//!     let mut file1 = FileEntryBuilder::new("file1.txt".into())?;
 //!     file1.write_all(b"Content 1")?;
 //!     solid.add_entry(file1.build()?)?;
 //!
-//!     let mut file2 = EntryBuilder::new_file("file2.txt".into(), WriteOptions::store())?;
+//!     let mut file2 = FileEntryBuilder::new("file2.txt".into())?;
 //!     file2.write_all(b"Content 2")?;
 //!     solid.add_entry(file2.build()?)?;
 //!

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -112,7 +112,8 @@
 //! # Key Types
 //!
 //! - [`Archive`] - Main entry point for reading and writing archives
-//! - [`EntryBuilder`] - Builder for creating file, directory, and link entries
+//! - [`FileEntryBuilder`] / [`DirEntryBuilder`] / [`SymlinkEntryBuilder`] / [`HardLinkEntryBuilder`] - Kind-specific entry builders
+//! - [`OpaqueEntryBuilder`] - Escape-hatch builder for entry kinds without a dedicated builder
 //! - [`SolidEntryBuilder`] - Builder for creating solid (multi-file) entries
 //! - [`WriteOptions`] - Configuration for compression and encryption when writing
 //! - [`ReadOptions`] - Configuration (password) for reading encrypted entries

--- a/pna/README.md
+++ b/pna/README.md
@@ -37,14 +37,14 @@ fn main() -> io::Result<()> {
 ## Writing an archive
 
 ```rust,no_run
-use pna::{Archive, EntryBuilder, WriteOptions};
+use pna::{Archive, FileEntryBuilder, WriteOptions};
 use std::fs::File;
 use std::io::{self, prelude::*};
 
 fn main() -> io::Result<()> {
     let file = File::create("foo.pna")?;
     let mut archive = Archive::write_header(file)?;
-    let mut entry_builder = EntryBuilder::new_file(
+    let mut entry_builder = FileEntryBuilder::new_with_options(
         "bar.txt".into(),
         WriteOptions::builder().build(),
     )?;

--- a/pna/src/ext.rs
+++ b/pna/src/ext.rs
@@ -24,7 +24,7 @@ mod time;
 pub use archive::*;
 pub use entry::*;
 pub use entry_builder::*;
-use libpna::{Archive, EntryBuilder, Metadata, NormalEntry};
+use libpna::{Archive, Metadata, NormalEntry, OpaqueEntryBuilder};
 pub use metadata::*;
 use std::fs;
 pub use time::*;
@@ -48,6 +48,6 @@ mod private {
     impl Sealed for Archive<fs::File> {}
     impl Sealed for Metadata {}
     impl Sealed for NormalEntry {}
-    impl Sealed for EntryBuilder {}
+    impl Sealed for OpaqueEntryBuilder {}
     impl Sealed for std::time::SystemTime {}
 }

--- a/pna/src/ext/entry.rs
+++ b/pna/src/ext/entry.rs
@@ -1,6 +1,8 @@
 //! Provides extension traits for [`NormalEntry`].
 use super::private;
-use libpna::{EntryBuilder, NormalEntry, WriteOptions};
+use libpna::{
+    DirEntryBuilder, FileEntryBuilder, Metadata, NormalEntry, SymlinkEntryBuilder, WriteOptions,
+};
 use std::{fs, io, path::Path};
 
 /// [`NormalEntry`] filesystem extension methods.
@@ -51,7 +53,7 @@ impl EntryFsExt for NormalEntry {
     /// `WriteOptions::builder().build()`). For directories, an empty directory
     /// entry is created. Symlinks are followed (uses [`std::fs::metadata`]). If
     /// the intention is to archive a symbolic link itself, use
-    /// [`EntryBuilder::new_symlink`].
+    /// [`SymlinkEntryBuilder::new`].
     ///
     /// # Examples
     ///
@@ -103,11 +105,11 @@ impl EntryFsExt for NormalEntry {
         let name = path.try_into().map_err(io::Error::other)?;
         if meta.is_file() {
             let mut file = fs::File::open(path)?;
-            let mut builder = EntryBuilder::new_file(name, options)?;
+            let mut builder = FileEntryBuilder::new_with_options(name, options)?;
             io::copy(&mut file, &mut builder)?;
             builder.build()
         } else {
-            let builder = EntryBuilder::new_dir(name);
+            let builder = DirEntryBuilder::new(name);
             builder.build()
         }
     }
@@ -117,7 +119,7 @@ impl EntryFsExt for NormalEntry {
     /// This behaves like [`EntryFsExt::from_path`], but uses
     /// [`std::fs::symlink_metadata`] to avoid following symbolic links.
     /// When `path` is a symbolic link, a symbolic-link entry is created using
-    /// [`EntryBuilder::new_symlink`], with the link target captured via
+    /// [`SymlinkEntryBuilder::new`], with the link target captured via
     /// [`std::fs::read_link`]. For regular files and directories, behavior is
     /// identical to [`EntryFsExt::from_path`].
     ///
@@ -176,7 +178,7 @@ impl EntryFsExt for NormalEntry {
         if meta.file_type().is_symlink() {
             let target = fs::read_link(path)?;
             let reference = target.as_path().try_into().map_err(io::Error::other)?;
-            let mut builder = EntryBuilder::new_symlink(name, reference)?;
+            let mut builder = SymlinkEntryBuilder::new(name, reference)?;
             #[cfg(windows)]
             let ltp = {
                 use std::os::windows::fs::FileTypeExt;
@@ -197,15 +199,15 @@ impl EntryFsExt for NormalEntry {
                 Err(e) if e.kind() == io::ErrorKind::NotFound => libpna::LinkTargetType::Unknown,
                 Err(e) => return Err(e),
             };
-            builder.link_target_type(ltp);
+            builder.metadata(Metadata::new().with_link_target_type(Some(ltp)));
             builder.build()
         } else if meta.is_file() {
             let mut file = fs::File::open(path)?;
-            let mut builder = EntryBuilder::new_file(name, options)?;
+            let mut builder = FileEntryBuilder::new_with_options(name, options)?;
             io::copy(&mut file, &mut builder)?;
             builder.build()
         } else {
-            let builder = EntryBuilder::new_dir(name);
+            let builder = DirEntryBuilder::new(name);
             builder.build()
         }
     }

--- a/pna/src/ext/entry_builder.rs
+++ b/pna/src/ext/entry_builder.rs
@@ -1,11 +1,11 @@
-//! Provides extension traits for [`EntryBuilder`].
+//! Provides extension traits for [`OpaqueEntryBuilder`].
 use crate::ext::{private, time::opt_system_time_to_duration};
 use libpna::{
-    EntryBuilder, Metadata, OwnerGid, OwnerGroupName, OwnerUid, OwnerUserName, PermissionMode,
+    Metadata, OpaqueEntryBuilder, OwnerGid, OwnerGroupName, OwnerUid, OwnerUserName, PermissionMode,
 };
 use std::time::SystemTime;
 
-/// [`EntryBuilder`] extension trait.
+/// [`OpaqueEntryBuilder`] extension trait.
 ///
 /// Provides convenience methods for setting entry metadata using [`SystemTime`]
 /// instead of the lower-level [`Duration`](libpna::Duration) representation.
@@ -51,7 +51,7 @@ fn owner_name_bounded(s: &str) -> &str {
     &s[..end]
 }
 
-impl EntryBuilderExt for EntryBuilder {
+impl EntryBuilderExt for OpaqueEntryBuilder {
     /// Sets metadata from a [`Metadata`] instance.
     ///
     /// # Examples
@@ -223,7 +223,7 @@ mod tests {
         let mut buf = Vec::new();
         {
             let mut a = Archive::write_header(&mut buf).unwrap();
-            let mut b = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
+            let mut b = OpaqueEntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
             b.permission(permission);
             b.add_metadata(src);
             a.add_entry(b.build().unwrap()).unwrap();

--- a/pna/src/ext/entry_builder.rs
+++ b/pna/src/ext/entry_builder.rs
@@ -9,6 +9,10 @@ use std::time::SystemTime;
 ///
 /// Provides convenience methods for setting entry metadata using [`SystemTime`]
 /// instead of the lower-level [`Duration`](libpna::Duration) representation.
+#[deprecated(
+    since = "0.36.0",
+    note = "use `Metadata` with `MetadataTimeExt::with_*_time`; the kind-specific builders' `metadata()` setter rescues deprecated `fPRM` permission data automatically"
+)]
 pub trait EntryBuilderExt: private::Sealed {
     /// Sets metadata from a [`Metadata`] instance.
     ///
@@ -51,21 +55,22 @@ fn owner_name_bounded(s: &str) -> &str {
     &s[..end]
 }
 
+#[allow(deprecated)]
 impl EntryBuilderExt for OpaqueEntryBuilder {
     /// Sets metadata from a [`Metadata`] instance.
     ///
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use pna::{EntryBuilder, Metadata, WriteOptions, prelude::*};
+    /// use pna::{FileEntryBuilder, Metadata, prelude::*};
     /// use std::fs;
     ///
     /// # fn main() -> std::io::Result<()> {
     /// let fs_meta = fs::metadata("some_file.txt")?;
     /// let metadata = Metadata::from_metadata(&fs_meta)?;
     ///
-    /// let mut builder = EntryBuilder::new_file("some_file.txt".try_into().unwrap(), WriteOptions::store())?;
-    /// builder.add_metadata(&metadata);
+    /// let mut builder = FileEntryBuilder::new("some_file.txt".try_into().unwrap())?;
+    /// builder.metadata(metadata);
     /// # Ok(())
     /// # }
     /// ```
@@ -115,15 +120,16 @@ impl EntryBuilderExt for OpaqueEntryBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use pna::{EntryBuilder, WriteOptions, prelude::*};
+    /// use pna::{FileEntryBuilder, Metadata, prelude::*};
     /// use std::time::SystemTime;
     ///
     /// # fn main() -> std::io::Result<()> {
-    /// let mut builder = EntryBuilder::new_file("file.txt".try_into().unwrap(), WriteOptions::store())?;
-    /// builder.created_time(SystemTime::now());
+    /// let mut builder = FileEntryBuilder::new("file.txt".try_into().unwrap())?;
+    /// builder.metadata(Metadata::new().with_created_time(Some(SystemTime::now())));
     /// # Ok(())
     /// # }
     /// ```
+    #[allow(deprecated)]
     #[inline]
     fn created_time(&mut self, time: impl Into<Option<SystemTime>>) -> &mut Self {
         self.created(opt_system_time_to_duration(time.into()))
@@ -134,15 +140,16 @@ impl EntryBuilderExt for OpaqueEntryBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use pna::{EntryBuilder, WriteOptions, prelude::*};
+    /// use pna::{FileEntryBuilder, Metadata, prelude::*};
     /// use std::time::SystemTime;
     ///
     /// # fn main() -> std::io::Result<()> {
-    /// let mut builder = EntryBuilder::new_file("file.txt".try_into().unwrap(), WriteOptions::store())?;
-    /// builder.modified_time(SystemTime::now());
+    /// let mut builder = FileEntryBuilder::new("file.txt".try_into().unwrap())?;
+    /// builder.metadata(Metadata::new().with_modified_time(Some(SystemTime::now())));
     /// # Ok(())
     /// # }
     /// ```
+    #[allow(deprecated)]
     #[inline]
     fn modified_time(&mut self, time: impl Into<Option<SystemTime>>) -> &mut Self {
         self.modified(opt_system_time_to_duration(time.into()))
@@ -153,15 +160,16 @@ impl EntryBuilderExt for OpaqueEntryBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use pna::{EntryBuilder, WriteOptions, prelude::*};
+    /// use pna::{FileEntryBuilder, Metadata, prelude::*};
     /// use std::time::SystemTime;
     ///
     /// # fn main() -> std::io::Result<()> {
-    /// let mut builder = EntryBuilder::new_file("file.txt".try_into().unwrap(), WriteOptions::store())?;
-    /// builder.accessed_time(SystemTime::now());
+    /// let mut builder = FileEntryBuilder::new("file.txt".try_into().unwrap())?;
+    /// builder.metadata(Metadata::new().with_accessed_time(Some(SystemTime::now())));
     /// # Ok(())
     /// # }
     /// ```
+    #[allow(deprecated)]
     #[inline]
     fn accessed_time(&mut self, time: impl Into<Option<SystemTime>>) -> &mut Self {
         self.accessed(opt_system_time_to_duration(time.into()))
@@ -204,11 +212,12 @@ mod tests {
     use libpna::Permission;
     use libpna::{Archive, OwnerGroupSid, OwnerUserSid, WriteOptions};
 
+    #[allow(deprecated)]
     fn roundtrip(src: &Metadata) -> Metadata {
         let mut buf = Vec::new();
         {
             let mut a = Archive::write_header(&mut buf).unwrap();
-            let mut b = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
+            let mut b = OpaqueEntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
             b.add_metadata(src);
             a.add_entry(b.build().unwrap()).unwrap();
             a.finalize().unwrap();

--- a/pna/src/prelude.rs
+++ b/pna/src/prelude.rs
@@ -7,6 +7,7 @@
 //! # #![allow(unused_imports)]
 //! use pna::prelude::*;
 //! ```
+#[allow(deprecated)]
 pub use crate::ext::{
     ArchiveFsExt, EntryBuilderExt, EntryFsExt, MetadataFsExt, MetadataPathExt, MetadataTimeExt,
     SystemTimeDurationExt, SystemTimeOutOfRange,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -298,9 +298,8 @@ fn convert_entry<R: Read, W: Write>(
     let entry_name = libpna::EntryName::from_utf8_preserve_root(&path);
 
     if entry_type.is_dir() {
-        let mut builder = libpna::EntryBuilder::new_dir(entry_name);
-        builder.modified(mtime_duration);
-        owner.apply(&mut builder);
+        let mut builder = libpna::DirEntryBuilder::new(entry_name);
+        builder.metadata(owner.metadata(mtime_duration));
         archive.add_entry(builder.build()?)?;
     } else if entry_type.is_symlink() {
         let link = entry
@@ -308,12 +307,11 @@ fn convert_entry<R: Read, W: Write>(
             .ok_or("symlink missing link name")?
             .to_string_lossy()
             .to_string();
-        let mut builder = libpna::EntryBuilder::new_symlink(
+        let mut builder = libpna::SymlinkEntryBuilder::new(
             entry_name,
             libpna::EntryReference::from_utf8_preserve_root(&link),
         )?;
-        builder.modified(mtime_duration);
-        owner.apply(&mut builder);
+        builder.metadata(owner.metadata(mtime_duration));
         archive.add_entry(builder.build()?)?;
     } else if entry_type.is_hard_link() {
         let link = entry
@@ -321,18 +319,16 @@ fn convert_entry<R: Read, W: Write>(
             .ok_or("hardlink missing link name")?
             .to_string_lossy()
             .to_string();
-        let mut builder = libpna::EntryBuilder::new_hard_link(
+        let mut builder = libpna::HardLinkEntryBuilder::new(
             entry_name,
             libpna::EntryReference::from_utf8_preserve_root(&link),
         )?;
-        builder.modified(mtime_duration);
-        owner.apply(&mut builder);
+        builder.metadata(owner.metadata(mtime_duration));
         archive.add_entry(builder.build()?)?;
     } else if entry_type.is_file() {
-        let mut builder = libpna::EntryBuilder::new_file(entry_name, write_options)?;
+        let mut builder = libpna::FileEntryBuilder::new_with_options(entry_name, write_options)?;
         io::copy(entry, &mut builder)?;
-        builder.modified(mtime_duration);
-        owner.apply(&mut builder);
+        builder.metadata(owner.metadata(mtime_duration));
         archive.add_entry(builder.build()?)?;
     } else {
         eprintln!(
@@ -417,12 +413,14 @@ impl TarOwner {
         }
     }
 
-    fn apply(&self, builder: &mut libpna::EntryBuilder) {
-        builder.owner_uid(libpna::OwnerUid::from(self.uid));
-        builder.owner_gid(libpna::OwnerGid::from(self.gid));
-        builder.permission_mode(libpna::PermissionMode::from(self.mode));
-        builder.owner_user_name(owner_name_opt(&self.uname));
-        builder.owner_group_name(owner_group_name_opt(&self.gname));
+    fn metadata(&self, modified: libpna::Duration) -> libpna::Metadata {
+        libpna::Metadata::new()
+            .with_modified(Some(modified))
+            .with_owner_uid(Some(libpna::OwnerUid::from(self.uid)))
+            .with_owner_gid(Some(libpna::OwnerGid::from(self.gid)))
+            .with_permission_mode(Some(libpna::PermissionMode::from(self.mode)))
+            .with_owner_user_name(owner_name_opt(&self.uname))
+            .with_owner_group_name(owner_group_name_opt(&self.gname))
     }
 }
 
@@ -467,25 +465,22 @@ fn convert_zip_entry<R: Read + io::Seek, W: Write>(
     let entry_name = libpna::EntryName::from_utf8_preserve_root(&path);
 
     if entry.is_dir() {
-        let mut builder = libpna::EntryBuilder::new_dir(entry_name);
-        builder.modified(mtime);
-        apply_zip_owner(&mut builder, entry);
+        let mut builder = libpna::DirEntryBuilder::new(entry_name);
+        builder.metadata(zip_entry_metadata(entry, mtime));
         archive.add_entry(builder.build()?)?;
     } else if entry.is_symlink() {
         let mut target = String::new();
         entry.read_to_string(&mut target)?;
-        let mut builder = libpna::EntryBuilder::new_symlink(
+        let mut builder = libpna::SymlinkEntryBuilder::new(
             entry_name,
             libpna::EntryReference::from_utf8_preserve_root(&target),
         )?;
-        builder.modified(mtime);
-        apply_zip_owner(&mut builder, entry);
+        builder.metadata(zip_entry_metadata(entry, mtime));
         archive.add_entry(builder.build()?)?;
     } else if entry.is_file() {
-        let mut builder = libpna::EntryBuilder::new_file(entry_name, write_options)?;
+        let mut builder = libpna::FileEntryBuilder::new_with_options(entry_name, write_options)?;
         io::copy(entry, &mut builder)?;
-        builder.modified(mtime);
-        apply_zip_owner(&mut builder, entry);
+        builder.metadata(zip_entry_metadata(entry, mtime));
         archive.add_entry(builder.build()?)?;
     } else {
         eprintln!("warning: skipping unsupported entry: {path}");
@@ -519,12 +514,14 @@ fn zip_last_modified<R: Read + io::Seek>(
     }
 }
 
-fn apply_zip_owner<R: Read + io::Seek>(
-    builder: &mut libpna::EntryBuilder,
+fn zip_entry_metadata<R: Read + io::Seek>(
     entry: &zip::read::ZipFile<'_, R>,
-) {
-    if let Some(mode) = entry.unix_mode() {
-        let mode_bits = (mode & 0o7777) as u16;
-        builder.permission_mode(libpna::PermissionMode::from(mode_bits));
-    }
+    modified: libpna::Duration,
+) -> libpna::Metadata {
+    let permission_mode = entry
+        .unix_mode()
+        .map(|mode| libpna::PermissionMode::from((mode & 0o7777) as u16));
+    libpna::Metadata::new()
+        .with_modified(Some(modified))
+        .with_permission_mode(permission_mode)
 }


### PR DESCRIPTION
## Summary
A single `EntryBuilder` handled all 4 entry kinds, which caused: (a) link entries could not be encrypted or compressed (symlink targets stayed in plaintext in `--password`-protected archives), (b) `Write` semantics were kind-dependent (discarded for directories, silently appended to an already-built target for links, corrupting it), and (c) there was no way to construct entries of a private kind. This introduces kind-specific builders (`FileEntryBuilder`/`DirEntryBuilder`/`SymlinkEntryBuilder`/`HardLinkEntryBuilder`), and renames the current `EntryBuilder` to `OpaqueEntryBuilder`, kept as an escape hatch that accepts an arbitrary `DataKind`.

## Notes
- `EntryBuilder` remains as a deprecated type alias; legacy constructors and individual metadata setters are deprecated at the method level (scheduled for removal in the next breaking release). During the deprecation period, known gaps in the legacy path still work, with a deprecation warning.
- Metadata input is now unified through `metadata(Metadata)` passed by value. `pna::EntryBuilderExt` is deprecated (timestamps move to the existing `MetadataTimeExt::with_*_time`; fPRM rescue moves to the new `MetadataPermissionExt::rescue_permission`).
- CLI behavior and wire output are unchanged: links are still stored as before, and the FHED cipher_mode byte for stored data remains CBC as before. The default for encrypting links under `--password` is left for a separate issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated builders for files, directories, symlinks, hard links, and opaque entries.
  * Added metadata support for consistently applying timestamps, ownership, permissions, extended attributes, and archive-specific metadata.
  * Added a helper to recover modern ownership and permission fields from legacy permission metadata.

* **Bug Fixes**
  * Improved preservation and conversion of ownership and permission information during archive creation and conversion.
  * Improved handling of metadata across platforms and entry types.

* **Documentation**
  * Updated examples and API guidance to use the dedicated entry builders and metadata APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->