### PR TITLE
:white_check_mark: Add diff tests for encrypted, multipart and solid archives

### DIFF
--- a/cli/tests/cli/diff.rs
+++ b/cli/tests/cli/diff.rs
@@ -1,9 +1,12 @@
 mod content;
+mod encryption;
 mod exit_code;
 mod hardlink;
 mod metadata;
 mod missing;
+mod multipart;
 mod no_diff;
 mod path_filter;
+mod solid_archive;
 mod symlink;
 mod type_mismatch;

--- a/cli/tests/cli/diff/encryption.rs
+++ b/cli/tests/cli/diff/encryption.rs
@@ -1,0 +1,125 @@
+use crate::utils::setup;
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use std::fs;
+
+/// Precondition: An encrypted archive matches the filesystem exactly.
+/// Action: Run `pna experimental diff` with the correct password.
+/// Expectation: Exits successfully and produces no stdout.
+#[test]
+fn diff_encrypted_without_differences() {
+    setup();
+    let dir = "diff_encrypted_without_differences_test";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let file_path = format!("{dir}/file.txt");
+    fs::write(&file_path, "old-a").unwrap();
+
+    let archive_path = format!("{dir}/test.pna");
+    cargo_bin_cmd!("pna")
+        .args([
+            "create",
+            "-f",
+            &archive_path,
+            "--overwrite",
+            &file_path,
+            "--password=secret",
+            "--aes",
+        ])
+        .assert()
+        .success();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "diff",
+            "-f",
+            &archive_path,
+            "--password=secret",
+        ])
+        .assert()
+        .success()
+        .stdout("");
+}
+
+/// Precondition: An encrypted archive contains a file whose content is later changed on disk to a different value of the same size.
+/// Action: Run `pna experimental diff` with the correct password supplied via `--password-file`.
+/// Expectation: Exits with status 1 and reports the difference on stdout, with nothing written to stderr.
+#[test]
+fn diff_encrypted_with_content_difference() {
+    setup();
+    let dir = "diff_encrypted_with_content_difference_test";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let file_path = format!("{dir}/file.txt");
+    fs::write(&file_path, "old-a").unwrap();
+
+    let archive_path = format!("{dir}/test.pna");
+    cargo_bin_cmd!("pna")
+        .args([
+            "create",
+            "-f",
+            &archive_path,
+            "--overwrite",
+            &file_path,
+            "--password=secret",
+            "--aes",
+        ])
+        .assert()
+        .success();
+
+    fs::write(&file_path, "new-a").unwrap();
+
+    let password_file = format!("{dir}/password.txt");
+    fs::write(&password_file, "secret").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "diff",
+            "-f",
+            &archive_path,
+            "--password-file",
+            &password_file,
+        ])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("Contents differ"))
+        .stderr("");
+}
+
+/// Precondition: An encrypted archive matches the filesystem exactly.
+/// Action: Run `pna experimental diff` without providing a password.
+/// Expectation: Exits with status 2 and writes an error to stderr.
+#[test]
+fn diff_encrypted_without_password() {
+    setup();
+    let dir = "diff_encrypted_without_password_test";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let file_path = format!("{dir}/file.txt");
+    fs::write(&file_path, "old-a").unwrap();
+
+    let archive_path = format!("{dir}/test.pna");
+    cargo_bin_cmd!("pna")
+        .args([
+            "create",
+            "-f",
+            &archive_path,
+            "--overwrite",
+            &file_path,
+            "--password=secret",
+            "--aes",
+        ])
+        .assert()
+        .success();
+
+    cargo_bin_cmd!("pna")
+        .args(["experimental", "diff", "-f", &archive_path])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::is_empty().not());
+}

--- a/cli/tests/cli/diff/multipart.rs
+++ b/cli/tests/cli/diff/multipart.rs
@@ -1,0 +1,67 @@
+use crate::utils::setup;
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use std::{fs, path::Path};
+
+fn create_multipart_archive(dir: &str) -> String {
+    fs::create_dir_all(dir).unwrap();
+    for name in ["a", "b", "c"] {
+        fs::write(format!("{dir}/{name}.txt"), "x".repeat(300)).unwrap();
+    }
+
+    let archive_path = format!("{dir}/test.pna");
+    cargo_bin_cmd!("pna")
+        .args([
+            "create",
+            "-f",
+            &archive_path,
+            "--overwrite",
+            "--unstable",
+            "--split",
+            "200",
+            &format!("{dir}/a.txt"),
+            &format!("{dir}/b.txt"),
+            &format!("{dir}/c.txt"),
+        ])
+        .assert()
+        .success();
+
+    assert!(Path::new(&format!("{dir}/test.part2.pna")).exists());
+    format!("{dir}/test.part1.pna")
+}
+
+/// Precondition: A multipart archive matches the filesystem exactly.
+/// Action: Run `pna experimental diff` against the first part.
+/// Expectation: Exits successfully and produces no stdout.
+#[test]
+fn diff_multipart_without_differences() {
+    setup();
+    let dir = "diff_multipart_without_differences_test";
+    let _ = fs::remove_dir_all(dir);
+    let part1 = create_multipart_archive(dir);
+
+    cargo_bin_cmd!("pna")
+        .args(["experimental", "diff", "-f", &part1])
+        .assert()
+        .success()
+        .stdout("");
+}
+
+/// Precondition: A multipart archive contains a file that is later removed from disk.
+/// Action: Run `pna experimental diff` against the first part.
+/// Expectation: Exits with status 1 and reports the missing file on stdout.
+#[test]
+fn diff_multipart_with_missing_file() {
+    setup();
+    let dir = "diff_multipart_with_missing_file_test";
+    let _ = fs::remove_dir_all(dir);
+    let part1 = create_multipart_archive(dir);
+
+    fs::remove_file(format!("{dir}/a.txt")).unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args(["experimental", "diff", "-f", &part1])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("Cannot stat"));
+}

--- a/cli/tests/cli/diff/solid_archive.rs
+++ b/cli/tests/cli/diff/solid_archive.rs
@@ -1,0 +1,73 @@
+use crate::utils::setup;
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use std::fs;
+
+/// Precondition: A solid archive matches the filesystem exactly.
+/// Action: Run `pna experimental diff`.
+/// Expectation: Exits successfully and produces no stdout.
+#[test]
+fn diff_solid_without_differences() {
+    setup();
+    let dir = "diff_solid_without_differences_test";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let file_path = format!("{dir}/file.txt");
+    fs::write(&file_path, "old-a").unwrap();
+
+    let archive_path = format!("{dir}/test.pna");
+    cargo_bin_cmd!("pna")
+        .args([
+            "create",
+            "-f",
+            &archive_path,
+            "--overwrite",
+            &file_path,
+            "--solid",
+        ])
+        .assert()
+        .success();
+
+    cargo_bin_cmd!("pna")
+        .args(["experimental", "diff", "-f", &archive_path])
+        .assert()
+        .success()
+        .stdout("");
+}
+
+/// Precondition: A solid archive contains a file whose content is later changed on disk to a different value of the same size.
+/// Action: Run `pna experimental diff`.
+/// Expectation: Exits with status 1 and reports the difference on stdout, with nothing written to stderr.
+#[test]
+fn diff_solid_with_content_difference() {
+    setup();
+    let dir = "diff_solid_with_content_difference_test";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let file_path = format!("{dir}/file.txt");
+    fs::write(&file_path, "old-a").unwrap();
+
+    let archive_path = format!("{dir}/test.pna");
+    cargo_bin_cmd!("pna")
+        .args([
+            "create",
+            "-f",
+            &archive_path,
+            "--overwrite",
+            &file_path,
+            "--solid",
+        ])
+        .assert()
+        .success();
+
+    fs::write(&file_path, "new-a").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args(["experimental", "diff", "-f", &archive_path])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("Contents differ"))
+        .stderr("");
+}


### PR DESCRIPTION
## Summary
Adds CLI integration tests exercising `pna experimental diff` against encrypted, split (multipart), and solid archives, pinning the exit status contract (0 = no differences, 1 = differences, 2 = error) for each input variant. Part of #3228.

## Notes
- The encrypted content-difference test supplies the password via `--password-file` because `--password` on the command line logs an insecurity warning to stderr, which would break the empty-stderr assertion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for comparing encrypted archives, including password-protected and missing-password scenarios.
  * Added coverage for multipart archives and detection of missing files.
  * Added coverage for solid archives and detection of changed file contents.
  * Verified expected exit codes and command output for matching and differing files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->