### PR TITLE
:sparkles: Add --format option to diff subcommand

### DIFF
--- a/cli/src/command/diff.rs
+++ b/cli/src/command/diff.rs
@@ -7,7 +7,7 @@ use crate::{
     utils::{BsdGlobMatcher, io::streams_equal},
 };
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 #[cfg(unix)]
 use pna::prelude::MetadataTimeExt;
 use pna::{DataKind, EntryContent, NormalEntry, ReadOptions};
@@ -31,12 +31,41 @@ pub(crate) struct DiffCommand {
         help = "Compare directory mtime and ownership (by default, only mode is compared for directories)"
     )]
     full_compare: bool,
+    #[arg(
+        long,
+        default_value = "plain",
+        help = "Output format [unstable: jsonl]",
+        long_help = "Output format. plain: tar-style text. jsonl: one JSON Lines record per difference with fields `path`, `kind` (one of: missing, size, content, mode, mtime, uid, gid, type, symlink, hardlink) and, for kind=hardlink only, `target` (the stored link target). mode/mtime/uid/gid comparisons only occur on Unix."
+    )]
+    format: Format,
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+#[value(rename_all = "lower")]
+enum Format {
+    Plain,
+    JsonL,
+}
+
+impl Format {
+    /// Returns true if this format is unstable and requires --unstable flag
+    #[inline]
+    const fn is_unstable(self) -> bool {
+        matches!(self, Self::JsonL)
+    }
+}
+
+impl fmt::Display for Format {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.to_possible_value().unwrap().get_name())
+    }
 }
 
 impl Command for DiffCommand {
     #[inline]
-    fn execute(self, _ctx: &crate::cli::GlobalContext) -> anyhow::Result<()> {
-        match diff_archive(self) {
+    fn execute(self, ctx: &crate::cli::GlobalContext) -> anyhow::Result<()> {
+        match diff_archive(ctx, self) {
             Ok(0) => Ok(()),
             Ok(_) => Err(ExitCodeError::silent(1).into()),
             Err(err) => Err(ExitCodeError::with_source(2, err).into()),
@@ -45,11 +74,18 @@ impl Command for DiffCommand {
 }
 
 #[hooq::hooq(anyhow)]
-fn diff_archive(args: DiffCommand) -> anyhow::Result<usize> {
+fn diff_archive(ctx: &crate::cli::GlobalContext, args: DiffCommand) -> anyhow::Result<usize> {
+    if args.format.is_unstable() && !ctx.unstable() {
+        anyhow::bail!(
+            "The '--format {}' option is unstable and requires --unstable flag",
+            args.format
+        );
+    }
     let password = ask_password(args.password)?;
     let archives = collect_split_archives(&args.file.archive)?;
     let options = CompareOptions {
         full_compare: args.full_compare,
+        format: args.format,
     };
 
     let mut globs = BsdGlobMatcher::new(args.file.files.iter().map(|s| s.as_str()));
@@ -81,38 +117,66 @@ fn diff_archive(args: DiffCommand) -> anyhow::Result<usize> {
 
 /// Difference types detected during archive-filesystem comparison.
 /// Message format follows tar --diff for compatibility.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+#[serde(tag = "kind")]
 enum DiffKind {
     /// File/directory does not exist on filesystem
+    #[serde(rename = "missing")]
     Missing,
     /// File size differs
+    #[serde(rename = "size")]
     SizeDiffers,
     /// File contents differ (same size)
+    #[serde(rename = "content")]
     ContentsDiffer,
     /// Permission mode differs
     #[cfg(unix)]
+    #[serde(rename = "mode")]
     ModeDiffers,
     /// Modification time differs
     #[cfg(unix)]
+    #[serde(rename = "mtime")]
     MtimeDiffers,
     /// User ID differs
     #[cfg(unix)]
+    #[serde(rename = "uid")]
     UidDiffers,
     /// Group ID differs
     #[cfg(unix)]
+    #[serde(rename = "gid")]
     GidDiffers,
     /// File type differs (e.g., file vs directory)
+    #[serde(rename = "type")]
     TypeMismatch,
     /// Symbolic link target differs
+    #[serde(rename = "symlink")]
     SymlinkDiffers,
     /// Hardlink relationship broken
-    NotLinked(String),
+    #[serde(rename = "hardlink")]
+    NotLinked { target: String },
 }
 
 impl DiffKind {
     /// Returns a displayable message for this difference.
     fn display<'a>(&'a self, path: &'a str) -> DiffMessage<'a> {
         DiffMessage { kind: self, path }
+    }
+}
+
+#[derive(serde::Serialize)]
+struct DiffRecord<'a> {
+    path: &'a str,
+    #[serde(flatten)]
+    kind: &'a DiffKind,
+}
+
+fn report(kind: &DiffKind, path: &str, format: Format) {
+    match format {
+        Format::Plain => println!("{}", kind.display(path)),
+        Format::JsonL => println!(
+            "{}",
+            serde_json::to_string(&DiffRecord { path, kind }).unwrap()
+        ),
     }
 }
 
@@ -144,17 +208,18 @@ impl fmt::Display for DiffMessage<'_> {
             DiffKind::GidDiffers => write!(f, "{}: Gid differs", self.path),
             DiffKind::TypeMismatch => write!(f, "{}: File type differs", self.path),
             DiffKind::SymlinkDiffers => write!(f, "{}: Symlink differs", self.path),
-            DiffKind::NotLinked(target) => write!(f, "{}: Not linked to {target}", self.path),
+            DiffKind::NotLinked { target } => write!(f, "{}: Not linked to {target}", self.path),
         }
     }
 }
 
 /// Options controlling what aspects to compare.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 struct CompareOptions {
     /// Compare directory mtime and ownership (not just mode)
     #[cfg_attr(not(unix), allow(dead_code))]
     full_compare: bool,
+    format: Format,
 }
 
 /// Compare two SystemTime values with 1-second tolerance for filesystem precision.
@@ -281,7 +346,7 @@ fn compare_entry<T: AsRef<[u8]>>(
     let meta = match fs::symlink_metadata(path) {
         Ok(meta) => meta,
         Err(e) if e.kind() == io::ErrorKind::NotFound => {
-            println!("{}", DiffKind::Missing.display(path_str));
+            report(&DiffKind::Missing, path_str, options.format);
             return Ok(1);
         }
         Err(e) => return Err(e),
@@ -292,21 +357,21 @@ fn compare_entry<T: AsRef<[u8]>>(
             // Compare metadata first
             let meta_diffs = compare_file_metadata(&entry, &meta, options);
             diff_count += meta_diffs.len();
-            for diff in meta_diffs {
-                println!("{}", diff.display(path_str));
+            for diff in &meta_diffs {
+                report(diff, path_str, options.format);
             }
 
             // Compare size first, then content
             let fs_size = meta.len();
             let archive_size = entry.metadata().raw_file_size();
             if archive_size.is_some_and(|s| s != fs_size as u128) {
-                println!("{}", DiffKind::SizeDiffers.display(path_str));
+                report(&DiffKind::SizeDiffers, path_str, options.format);
                 diff_count += 1;
             } else {
                 let fs_file = fs::File::open(path)?;
                 let archive_reader = entry.reader(read_options)?;
                 if !streams_equal(fs_file, archive_reader)? {
-                    println!("{}", DiffKind::ContentsDiffer.display(path_str));
+                    report(&DiffKind::ContentsDiffer, path_str, options.format);
                     diff_count += 1;
                 }
             }
@@ -314,8 +379,8 @@ fn compare_entry<T: AsRef<[u8]>>(
         DataKind::DIRECTORY if meta.is_dir() => {
             let diffs = compare_directory_metadata(&entry, &meta, options);
             diff_count += diffs.len();
-            for diff in diffs {
-                println!("{}", diff.display(path_str));
+            for diff in &diffs {
+                report(diff, path_str, options.format);
             }
         }
         DataKind::SYMBOLIC_LINK if meta.is_symlink() => {
@@ -324,7 +389,7 @@ fn compare_entry<T: AsRef<[u8]>>(
                 unreachable!("data_kind() returned SymbolicLink");
             };
             if link.as_path() != Path::new(stored.as_str()) {
-                println!("{}", DiffKind::SymlinkDiffers.display(path_str));
+                report(&DiffKind::SymlinkDiffers, path_str, options.format);
                 diff_count += 1;
             }
         }
@@ -335,21 +400,24 @@ fn compare_entry<T: AsRef<[u8]>>(
             match is_same_file(path, stored.as_str()) {
                 Ok(true) => (),
                 Ok(false) => {
-                    println!(
-                        "{}",
-                        DiffKind::NotLinked(stored.to_string()).display(path_str)
+                    report(
+                        &DiffKind::NotLinked {
+                            target: stored.to_string(),
+                        },
+                        path_str,
+                        options.format,
                     );
                     diff_count += 1;
                 }
                 Err(e) if e.kind() == io::ErrorKind::NotFound => {
-                    println!("{}", DiffKind::Missing.display(path_str));
+                    report(&DiffKind::Missing, path_str, options.format);
                     diff_count += 1;
                 }
                 Err(e) => return Err(e),
             }
         }
         _ => {
-            println!("{}", DiffKind::TypeMismatch.display(path_str));
+            report(&DiffKind::TypeMismatch, path_str, options.format);
             diff_count += 1;
         }
     }

--- a/cli/tests/cli/diff.rs
+++ b/cli/tests/cli/diff.rs
@@ -6,6 +6,7 @@ mod metadata;
 mod missing;
 mod multipart;
 mod no_diff;
+mod option_format;
 mod path_filter;
 mod solid_archive;
 mod symlink;

--- a/cli/tests/cli/diff/option_format.rs
+++ b/cli/tests/cli/diff/option_format.rs
@@ -1,0 +1,396 @@
+use crate::utils::setup;
+use assert_cmd::cargo::cargo_bin_cmd;
+use predicates::prelude::*;
+use std::fs;
+
+/// Precondition: Archive contains a file whose content changes but keeps the same size.
+/// Action: Run diff with `--format jsonl`.
+/// Expectation: A single JSON Lines record reports the content difference, without a `target` field.
+#[test]
+fn diff_with_format_jsonl_and_content_difference() {
+    setup();
+    let dir = "diff_format_jsonl_content_test";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let file_path = format!("{dir}/file.txt");
+    fs::write(&file_path, "old-a").unwrap();
+
+    let archive_path = format!("{dir}/test.pna");
+    cargo_bin_cmd!("pna")
+        .args(["create", "-f", &archive_path, "--overwrite", &file_path])
+        .assert()
+        .success();
+
+    fs::write(&file_path, "new-a").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "diff",
+            "-f",
+            &archive_path,
+            "--format",
+            "jsonl",
+            "--unstable",
+        ])
+        .assert()
+        .code(1)
+        .stderr("")
+        .stdout(format!(r#"{{"path":"{file_path}","kind":"content"}}"#) + "\n");
+}
+
+/// Precondition: Archive contains a file removed from the filesystem afterwards.
+/// Action: Run diff with `--format jsonl`.
+/// Expectation: A single JSON Lines record reports the path as missing.
+#[test]
+fn diff_with_format_jsonl_and_missing_file() {
+    setup();
+    let dir = "diff_format_jsonl_missing_test";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let file_path = format!("{dir}/file.txt");
+    fs::write(&file_path, "content").unwrap();
+
+    let archive_path = format!("{dir}/test.pna");
+    cargo_bin_cmd!("pna")
+        .args(["create", "-f", &archive_path, "--overwrite", &file_path])
+        .assert()
+        .success();
+
+    fs::remove_file(&file_path).unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "diff",
+            "-f",
+            &archive_path,
+            "--format",
+            "jsonl",
+            "--unstable",
+        ])
+        .assert()
+        .code(1)
+        .stderr("")
+        .stdout(format!(r#"{{"path":"{file_path}","kind":"missing"}}"#) + "\n");
+}
+
+/// Precondition: Archive contains a hardlink whose filesystem counterpart is later replaced
+/// by an independent file with matching content.
+/// Action: Run diff with `--format jsonl`.
+/// Expectation: A single JSON Lines record reports the broken link and carries the stored target.
+#[cfg(unix)]
+#[test]
+fn diff_with_format_jsonl_and_broken_hardlink() {
+    setup();
+    let dir = "diff_format_jsonl_hardlink_test";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let orig = format!("{dir}/orig.txt");
+    let link = format!("{dir}/link.txt");
+    fs::write(&orig, "content").unwrap();
+    fs::hard_link(&orig, &link).unwrap();
+
+    let archive_path = format!("{dir}/test.pna");
+    cargo_bin_cmd!("pna")
+        .args(["create", "-f", &archive_path, "--overwrite", &orig, &link])
+        .assert()
+        .success();
+
+    fs::remove_file(&link).unwrap();
+    fs::write(&link, "content").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "diff",
+            "-f",
+            &archive_path,
+            "--format",
+            "jsonl",
+            "--unstable",
+        ])
+        .assert()
+        .code(1)
+        .stderr("")
+        .stdout(format!(r#"{{"path":"{link}","kind":"hardlink","target":"{orig}"}}"#) + "\n");
+}
+
+/// Precondition: The filesystem tree matches the archive exactly.
+/// Action: Run diff with `--format jsonl`.
+/// Expectation: No differences are reported.
+#[test]
+fn diff_with_format_jsonl_without_differences() {
+    setup();
+    let dir = "diff_format_jsonl_no_diff_test";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let file_path = format!("{dir}/file.txt");
+    fs::write(&file_path, "content").unwrap();
+
+    let archive_path = format!("{dir}/test.pna");
+    cargo_bin_cmd!("pna")
+        .args(["create", "-f", &archive_path, "--overwrite", &file_path])
+        .assert()
+        .success();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "diff",
+            "-f",
+            &archive_path,
+            "--format",
+            "jsonl",
+            "--unstable",
+        ])
+        .assert()
+        .success()
+        .stderr("")
+        .stdout("");
+}
+
+/// Precondition: Archive entries differ from the filesystem in size and in entry type.
+/// Action: Run diff with `--format jsonl`.
+/// Expectation: One newline-terminated record per difference, in archive entry order,
+/// each carrying the kind of that difference.
+#[test]
+fn diff_with_format_jsonl_and_size_and_type_differences() {
+    setup();
+    let dir = "diff_format_jsonl_kinds_test";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let size = format!("{dir}/size.txt");
+    let kind = format!("{dir}/kind.txt");
+    fs::write(&size, "short").unwrap();
+    fs::write(&kind, "y").unwrap();
+
+    let archive_path = format!("{dir}/test.pna");
+    cargo_bin_cmd!("pna")
+        .args(["create", "-f", &archive_path, "--overwrite", &size, &kind])
+        .assert()
+        .success();
+
+    fs::write(&size, "much longer content").unwrap();
+    fs::remove_file(&kind).unwrap();
+    fs::create_dir(&kind).unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "diff",
+            "-f",
+            &archive_path,
+            "--format",
+            "jsonl",
+            "--unstable",
+        ])
+        .assert()
+        .code(1)
+        .stderr("")
+        .stdout(
+            format!(r#"{{"path":"{size}","kind":"size"}}"#)
+                + "\n"
+                + &format!(r#"{{"path":"{kind}","kind":"type"}}"#)
+                + "\n",
+        );
+}
+
+/// Precondition: Archive contains a symlink whose filesystem target changes.
+/// Action: Run diff with `--format jsonl`.
+/// Expectation: A record reports the differing link target.
+#[cfg(unix)]
+#[test]
+fn diff_with_format_jsonl_and_symlink_difference() {
+    use std::os::unix::fs::symlink;
+
+    setup();
+    let dir = "diff_format_jsonl_symlink_test";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let link = format!("{dir}/link");
+    symlink("orig", &link).unwrap();
+
+    let archive_path = format!("{dir}/test.pna");
+    cargo_bin_cmd!("pna")
+        .args(["create", "-f", &archive_path, "--overwrite", &link])
+        .assert()
+        .success();
+
+    fs::remove_file(&link).unwrap();
+    symlink("other", &link).unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "diff",
+            "-f",
+            &archive_path,
+            "--format",
+            "jsonl",
+            "--unstable",
+        ])
+        .assert()
+        .code(1)
+        .stderr("")
+        .stdout(format!(r#"{{"path":"{link}","kind":"symlink"}}"#) + "\n");
+}
+
+/// Precondition: Archive stores permissions, timestamps and ownership that all differ from the
+/// filesystem.
+/// Action: Run diff with `--format jsonl`.
+/// Expectation: One record per differing metadata facet.
+#[cfg(unix)]
+#[test]
+fn diff_with_format_jsonl_and_metadata_differences() {
+    setup();
+    let dir = "diff_format_jsonl_metadata_test";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let file_path = format!("{dir}/file.txt");
+    fs::write(&file_path, "content").unwrap();
+
+    // Ownership that cannot match the running user, so uid/gid always differ without root.
+    let archive_path = format!("{dir}/test.pna");
+    cargo_bin_cmd!("pna")
+        .args([
+            "create",
+            "-f",
+            &archive_path,
+            "--overwrite",
+            "--keep-permission",
+            "--keep-timestamp",
+            "--uid",
+            "12345",
+            "--uname",
+            "pna-absent-user",
+            "--gid",
+            "54321",
+            "--gname",
+            "pna-absent-group",
+            &file_path,
+        ])
+        .assert()
+        .success();
+
+    std::fs::set_permissions(
+        &file_path,
+        std::os::unix::fs::PermissionsExt::from_mode(0o700),
+    )
+    .unwrap();
+    filetime::set_file_mtime(
+        &file_path,
+        filetime::FileTime::from_unix_time(946_684_800, 0),
+    )
+    .unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "diff",
+            "-f",
+            &archive_path,
+            "--format",
+            "jsonl",
+            "--unstable",
+        ])
+        .assert()
+        .code(1)
+        .stderr("")
+        .stdout(
+            format!(r#"{{"path":"{file_path}","kind":"mode"}}"#)
+                + "\n"
+                + &format!(r#"{{"path":"{file_path}","kind":"mtime"}}"#)
+                + "\n"
+                + &format!(r#"{{"path":"{file_path}","kind":"uid"}}"#)
+                + "\n"
+                + &format!(r#"{{"path":"{file_path}","kind":"gid"}}"#)
+                + "\n",
+        );
+}
+
+/// Precondition: Any archive.
+/// Action: Run diff with `--format jsonl` but without `--unstable`.
+/// Expectation: The command is rejected and names the flag it requires.
+#[test]
+fn diff_with_format_jsonl_without_unstable() {
+    setup();
+    let dir = "diff_format_jsonl_gate_test";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let file_path = format!("{dir}/file.txt");
+    fs::write(&file_path, "content").unwrap();
+
+    let archive_path = format!("{dir}/test.pna");
+    cargo_bin_cmd!("pna")
+        .args(["create", "-f", &archive_path, "--overwrite", &file_path])
+        .assert()
+        .success();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "diff",
+            "-f",
+            &archive_path,
+            "--format",
+            "jsonl",
+        ])
+        .assert()
+        .code(2)
+        .stdout("")
+        .stderr(predicate::str::contains("requires --unstable flag"));
+}
+
+/// Precondition: Archive differs from the filesystem.
+/// Action: Run diff without `--format` and with `--format plain`.
+/// Expectation: Both produce identical output, neither requiring `--unstable`.
+#[test]
+fn diff_without_format_matches_plain() {
+    setup();
+    let dir = "diff_format_plain_test";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let file_path = format!("{dir}/file.txt");
+    fs::write(&file_path, "old-a").unwrap();
+
+    let archive_path = format!("{dir}/test.pna");
+    cargo_bin_cmd!("pna")
+        .args(["create", "-f", &archive_path, "--overwrite", &file_path])
+        .assert()
+        .success();
+
+    fs::write(&file_path, "new-a").unwrap();
+
+    let without_format = cargo_bin_cmd!("pna")
+        .args(["experimental", "diff", "-f", &archive_path])
+        .assert()
+        .code(1)
+        .stderr("")
+        .get_output()
+        .stdout
+        .clone();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "diff",
+            "-f",
+            &archive_path,
+            "--format",
+            "plain",
+        ])
+        .assert()
+        .code(1)
+        .stderr("")
+        .stdout(without_format);
+}


### PR DESCRIPTION
## Summary
`pna experimental diff` gains `--format <plain|jsonl>`. `plain` (default) keeps the current tar-style text unchanged; `jsonl` emits one JSON object per difference per line: `{"path", "kind", "target"?}`, where `kind` is one of `missing`, `size`, `content`, `mode`, `mtime`, `uid`, `gid`, `type`, `symlink`, `hardlink`, and `target` appears only for `hardlink`. Part of #3228.

## Notes
- The format value vocabulary follows `pna list --format` (`jsonl`).
- `kind` names are a fixed wire vocabulary decoupled from internal enum names; the schema evolves by adding fields only.
- `mode`/`mtime`/`uid`/`gid` records occur only on Unix (metadata comparison is Unix-only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `--format` option for experimental diff output: `plain` (default) or `jsonl`.
  * JSONL now emits newline-delimited records per detected difference, including relevant hardlink target details.
  * `jsonl` is gated behind the `--unstable` flag.
* **Bug Fixes**
  * Improved and standardized diff reporting so all scenarios produce consistent output while preserving accurate difference counts.
* **Tests**
  * Expanded CLI coverage for `jsonl` and `plain`, including content changes, missing entries, hardlink breaks, symlink and Unix metadata differences, ordering, and no-difference output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->