### PR TITLE
Restrict rust-cache save to default branch in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,7 @@ jobs:
         with:
           key: ${{ join(matrix.targets, '-') }}
           cache-provider: ${{ matrix.cache_provider }}
+          save-if: ${{ github.ref_name == github.event.repository.default_branch }}
       - name: Cache dist binary
         if: ${{ !contains(matrix.targets, 'riscv64gc-unknown-linux-gnu') }}
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0


### PR DESCRIPTION
## Summary
Gate `swatinem/rust-cache`'s save step in `release.yml` (build-local-artifacts job) behind `github.ref_name == github.event.repository.default_branch`, so PR/feature-branch runs only restore from cache instead of writing new entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build workflow caching by saving Rust build caches only for runs on the repository’s default branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->