### PR TITLE
Save rust build cache only for stable toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,17 +135,11 @@ jobs:
           key: ${{ join(matrix.targets, '-') }}
           cache-provider: ${{ matrix.cache_provider }}
           save-if: ${{ github.ref_name == github.event.repository.default_branch }}
-      - name: Cache dist binary
-        if: ${{ !contains(matrix.targets, 'riscv64gc-unknown-linux-gnu') }}
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cargo/bin/dist
-          key: dist-${{ runner.os }}-${{ runner.arch }}-v0.31.0
       - name: Install dist
         if: ${{ !contains(matrix.targets, 'riscv64gc-unknown-linux-gnu') }}
         shell: bash
         run: |
-          dist --version 2>/dev/null | grep -q "0.31.0" || (${{ matrix.install_dist.run }} || cargo install --locked --version 0.31.0 cargo-dist)
+          ${{ matrix.install_dist.run }} || cargo install --locked --version 0.31.0 cargo-dist
       - name: Install dist from crates.io
         if: ${{ contains(matrix.targets, 'riscv64gc-unknown-linux-gnu') }}
         uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
         env:
           RUST_BACKTRACE: 1
       - name: Save rust build cache
-        if: github.ref_name == github.event.repository.default_branch && steps.restore-rust-build-cache.outputs.cache-hit != 'true'
+        if: github.ref_name == github.event.repository.default_branch && matrix.rust == 'stable' && steps.restore-rust-build-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |

--- a/.github/workflows/webassembly.yml
+++ b/.github/workflows/webassembly.yml
@@ -68,7 +68,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
           rustflags: ''
           cache-key: ${{ matrix.target }}
-          cache-save-if: ${{ github.ref_name == github.event.repository.default_branch }}
+          cache-save-if: ${{ github.ref_name == github.event.repository.default_branch && matrix.rust == 'stable' }}
       - if: ${{ startsWith(matrix.target, 'wasm32-wasi') }}
         name: Setup wasmtime
         uses: bytecodealliance/actions/wasmtime/setup@9152e710e9f7182e4c29ad218e4f335a7b203613 # v1.1.3


### PR DESCRIPTION
## Summary
Restrict `actions/cache` save to the `stable` toolchain in `test.yml` and `webassembly.yml`, and drop the separate dist binary cache step in `release.yml`.

## Notes
Caches were hitting GitHub's 10GB per-repo limit, so writes from non-stable jobs (and the extra dist binary cache) were evicting the rust build cache before it could be reused effectively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined release artifact tooling setup for more reliable builds.
  * Restricted Rust build-cache saves to stable toolchain runs, reducing unnecessary cache updates.
  * Applied the same stable-toolchain cache policy to WebAssembly builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->