### PR TITLE
Fix/non mac clippy warnings

### DIFF
--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -1120,7 +1120,7 @@ pub(crate) fn build_entry_metadata(
         keep_options.mac_metadata_strategy,
         MacMetadataStrategy::Always
     );
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(all(unix, not(target_os = "macos")))]
     let skip_xattr_acl = false;
 
     #[cfg(unix)]

--- a/cli/tests/cli/extract/option_safe_writes.rs
+++ b/cli/tests/cli/extract/option_safe_writes.rs
@@ -1,9 +1,8 @@
 use crate::utils::setup;
 use clap::Parser;
-use pna::{
-    Archive, DirEntryBuilder, FileEntryBuilder, HardLinkEntryBuilder, SymlinkEntryBuilder,
-    WriteOptions,
-};
+use pna::{Archive, DirEntryBuilder, FileEntryBuilder, WriteOptions};
+#[cfg(unix)]
+use pna::{HardLinkEntryBuilder, SymlinkEntryBuilder};
 use portable_network_archive::cli;
 use std::{
     fs,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform compatibility during archive extraction and metadata handling.
  * Fixed platform-specific build behavior for Unix-only features, including hard links, symbolic links, extended attributes, and ACLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->