### PR TITLE
:boom: Remove deprecated experimental migrate subcommand

### DIFF
--- a/cli/src/command/experimental.rs
+++ b/cli/src/command/experimental.rs
@@ -16,17 +16,6 @@ impl Command for ExperimentalCommand {
             ExperimentalCommands::Chown(cmd) => cmd.execute(ctx),
             ExperimentalCommands::Chmod(cmd) => cmd.execute(ctx),
             ExperimentalCommands::Acl(cmd) => cmd.execute(ctx),
-            ExperimentalCommands::Migrate(cmd) => {
-                log::warn!(
-                    "`{0} experimental migrate` subcommand was stabilized, use `{0} migrate` instead. this command will be removed in the future.",
-                    std::env::current_exe()
-                        .ok()
-                        .and_then(|it| it.file_name().map(|n| n.to_os_string()))
-                        .unwrap_or_default()
-                        .to_string_lossy()
-                );
-                cmd.execute(ctx)
-            }
             ExperimentalCommands::Chunk(cmd) => cmd.execute(ctx),
             ExperimentalCommands::Diff(cmd) => cmd.execute(ctx),
             ExperimentalCommands::Verify(cmd) => cmd.execute(ctx),
@@ -45,10 +34,6 @@ pub(crate) enum ExperimentalCommands {
     Chmod(command::chmod::ChmodCommand),
     #[command(about = "Manipulate ACLs of entries")]
     Acl(command::acl::AclCommand),
-    #[command(
-        about = "Upgrade archives created by older PNA versions (stabilized, use `pna migrate` command instead. this command will be removed in the future)"
-    )]
-    Migrate(command::migrate::MigrateCommand),
     #[command(about = "Chunk level operation")]
     Chunk(command::chunk::ChunkCommand),
     #[command(about = "Compare archive entries with filesystem")]

--- a/cli/tests/cli/migrate/acl_0_19_1.rs
+++ b/cli/tests/cli/migrate/acl_0_19_1.rs
@@ -8,7 +8,7 @@ use clap::Parser;
 use portable_network_archive::cli;
 
 /// Precondition: A 0.19.1 format archive with Linux ACL data exists.
-/// Action: Run `pna experimental migrate` to convert to latest format.
+/// Action: Run `pna migrate` to convert to latest format.
 /// Expectation: Migration succeeds and output archive is readable with preserved ACL data.
 #[test]
 fn migrate_linux_acl() {
@@ -18,7 +18,6 @@ fn migrate_linux_acl() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "migrate",
         "-f",
         "0.19.1/linux_acl.pna",
@@ -39,7 +38,7 @@ fn migrate_linux_acl() {
 }
 
 /// Precondition: A 0.19.1 format archive with macOS ACL data exists.
-/// Action: Run `pna experimental migrate` to convert to latest format.
+/// Action: Run `pna migrate` to convert to latest format.
 /// Expectation: Migration succeeds and output archive is readable with preserved ACL data.
 #[test]
 fn migrate_macos_acl() {
@@ -49,7 +48,6 @@ fn migrate_macos_acl() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "migrate",
         "-f",
         "0.19.1/macos_acl.pna",
@@ -70,7 +68,7 @@ fn migrate_macos_acl() {
 }
 
 /// Precondition: A 0.19.1 format archive with FreeBSD ACL data exists.
-/// Action: Run `pna experimental migrate` to convert to latest format.
+/// Action: Run `pna migrate` to convert to latest format.
 /// Expectation: Migration succeeds and output archive is readable with preserved ACL data.
 #[test]
 fn migrate_freebsd_acl() {
@@ -80,7 +78,6 @@ fn migrate_freebsd_acl() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "migrate",
         "-f",
         "0.19.1/freebsd_acl.pna",
@@ -101,7 +98,7 @@ fn migrate_freebsd_acl() {
 }
 
 /// Precondition: A 0.19.1 format archive with Windows ACL data exists.
-/// Action: Run `pna experimental migrate` to convert to latest format.
+/// Action: Run `pna migrate` to convert to latest format.
 /// Expectation: Migration succeeds and output archive is readable with preserved ACL data.
 #[test]
 fn migrate_windows_acl() {
@@ -111,7 +108,6 @@ fn migrate_windows_acl() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "migrate",
         "-f",
         "0.19.1/windows_acl.pna",

--- a/cli/tests/cli/migrate/fprm_0_33_0.rs
+++ b/cli/tests/cli/migrate/fprm_0_33_0.rs
@@ -17,7 +17,7 @@ struct Captured {
 }
 
 /// Precondition: An fPRM-only archive carries ownership and timestamp metadata.
-/// Action: Run `pna experimental migrate` to a new output archive.
+/// Action: Run `pna migrate` to a new output archive.
 /// Expectation: Every entry's ownership is converted to owner-facet chunks
 /// (rescued from fPRM); the legacy fPRM chunk is not emitted; timestamps and
 /// entry count are preserved.
@@ -52,7 +52,6 @@ fn migrate_converts_fprm_to_owner_facet() {
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
-        "experimental",
         "migrate",
         "-f",
         LEGACY_FIXTURE,


### PR DESCRIPTION
Resolves #3215

### Summary of Changes
- Removed the deprecated `experimental migrate` subcommand from `cli/src/command/experimental.rs`.
- Updated test cases in `cli/tests/cli/migrate/acl_0_19_1.rs` and `cli/tests/cli/migrate/fprm_0_33_0.rs` to use `pna migrate`.