### PR TITLE
:sparkles: Add --password-file-raw and warn on newlines in --password-file

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -220,7 +220,9 @@ pub(crate) struct FileArgs {
 }
 
 #[derive(Parser, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[command(group(ArgGroup::new("password_provider").args(["password", "password_file"])))]
+#[command(group(
+    ArgGroup::new("password_provider").args(["password", "password_file", "password_file_raw"])
+))]
 pub(crate) struct PasswordArgs {
     #[arg(
         long,
@@ -228,8 +230,18 @@ pub(crate) struct PasswordArgs {
         help = "Password of archive. If password is not given it's asked from the tty"
     )]
     pub(crate) password: Option<Option<String>>,
-    #[arg(long, value_name = "FILE", help = "Read password from specified file")]
+    #[arg(
+        long,
+        value_name = "FILE",
+        help = "Read password from the specified file (entire contents). Files containing newlines or non-UTF-8 content emit a warning; use --password-file-raw if the full file content is intentionally the password"
+    )]
     pub(crate) password_file: Option<PathBuf>,
+    #[arg(
+        long,
+        value_name = "FILE",
+        help = "Read password from the specified file as-is (entire file content, including newlines)"
+    )]
+    pub(crate) password_file_raw: Option<PathBuf>,
 }
 
 #[derive(Parser, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
@@ -515,12 +527,67 @@ mod tests {
                 "-f",
                 "a.pna",
                 "src",
+                "--aes",
+                "--password-file-raw",
+                "pw.txt",
+            ],
+            vec![
+                "pna",
+                "c",
+                "-f",
+                "a.pna",
+                "src",
                 "--argon2",
                 "--password=secret",
             ],
             vec!["pna", "c", "-f", "a.pna", "src", "--password=secret"],
         ] {
             Cli::try_parse_from(&args).unwrap_or_else(|e| panic!("args {args:?} rejected: {e}"));
+        }
+    }
+
+    #[test]
+    fn password_providers_are_mutually_exclusive() {
+        for args in [
+            vec![
+                "pna",
+                "c",
+                "-f",
+                "a.pna",
+                "src",
+                "--password=secret",
+                "--password-file",
+                "pw.txt",
+            ],
+            vec![
+                "pna",
+                "c",
+                "-f",
+                "a.pna",
+                "src",
+                "--password=secret",
+                "--password-file-raw",
+                "pw.txt",
+            ],
+            vec![
+                "pna",
+                "c",
+                "-f",
+                "a.pna",
+                "src",
+                "--password-file",
+                "pw.txt",
+                "--password-file-raw",
+                "pw.txt",
+            ],
+        ] {
+            let err = Cli::try_parse_from(&args).unwrap_err();
+            assert_eq!(
+                err.kind(),
+                clap::error::ErrorKind::ArgumentConflict,
+                "args {args:?} produced unexpected error kind: {}",
+                err.render()
+            );
         }
     }
 }

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -76,9 +76,18 @@ impl std::error::Error for ExitCodeError {
 }
 
 fn ask_password(args: PasswordArgs) -> io::Result<Option<Vec<u8>>> {
-    if let Some(path) = args.password_file {
+    if let Some(path) = args.password_file_raw {
         return Ok(Some(fs::read(path)?));
-    };
+    }
+    if let Some(path) = args.password_file {
+        let password = fs::read(path)?;
+        if password_bytes_need_raw_mode(&password) {
+            log::warn!(
+                "password file contains a newline or is not valid UTF-8; --password-file will change to use only the first non-empty UTF-8 line in a future release. If the full file content is your password, use --password-file-raw instead."
+            );
+        }
+        return Ok(Some(password));
+    }
     Ok(match args.password {
         Some(Some(password)) => {
             log::warn!("Using a password on the command line interface can be insecure.");
@@ -91,6 +100,16 @@ fn ask_password(args: PasswordArgs) -> io::Result<Option<Vec<u8>>> {
         ),
         None => None,
     })
+}
+
+/// Returns whether `password` will be read differently (or rejected) once
+/// `--password-file` switches to first-non-empty-UTF-8-line semantics.
+#[inline]
+fn password_bytes_need_raw_mode(password: &[u8]) -> bool {
+    match std::str::from_utf8(password) {
+        Ok(text) => text.contains('\n') || text.contains('\r'),
+        Err(_) => true,
+    }
 }
 
 pub(crate) trait Command {
@@ -118,5 +137,25 @@ impl Cli {
             Commands::Compat(cmd) => cmd.execute(ctx),
             Commands::Experimental(cmd) => cmd.execute(ctx),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::password_bytes_need_raw_mode;
+
+    #[test]
+    fn detects_lf_and_cr_as_newline() {
+        assert!(!password_bytes_need_raw_mode(b"secret"));
+        assert!(password_bytes_need_raw_mode(b"secret\n"));
+        assert!(password_bytes_need_raw_mode(b"secret\r\n"));
+        assert!(password_bytes_need_raw_mode(b"secret\r"));
+        assert!(password_bytes_need_raw_mode(b"line1\nline2"));
+    }
+
+    #[test]
+    fn detects_invalid_utf8() {
+        assert!(password_bytes_need_raw_mode(&[0xff, 0xfe, 0xfd]));
+        assert!(!password_bytes_need_raw_mode("secret".as_bytes()));
     }
 }

--- a/cli/tests/cli/create.rs
+++ b/cli/tests/cli/create.rs
@@ -26,6 +26,7 @@ mod option_older_mtime_than;
 #[cfg(unix)]
 mod option_one_file_system;
 mod option_password_from_file;
+mod option_password_from_file_raw;
 mod option_password_hash;
 mod option_strip_components;
 mod option_substitution;

--- a/cli/tests/cli/create/option_password_from_file_raw.rs
+++ b/cli/tests/cli/create/option_password_from_file_raw.rs
@@ -1,0 +1,133 @@
+use crate::utils::{EmbedExt, TestResources, archive, setup};
+use clap::Parser;
+use pna::prelude::*;
+use portable_network_archive::cli;
+use std::{collections::HashSet, fs};
+
+/// Precondition: Input files and a password file whose content includes a trailing newline.
+/// Action: Create an encrypted archive with `--password-file-raw`.
+/// Expectation: The entire file content (including the newline) is used as the password.
+#[test]
+fn create_with_password_file_raw() {
+    setup();
+    TestResources::extract_in("raw/", "create_with_password_file_raw/in/").unwrap();
+    let password_file_path = "create_with_password_file_raw/password_file";
+    // Include a trailing newline so the raw password differs from a line-trimmed one.
+    let password = "create_with_password_file_raw\n";
+    fs::write(password_file_path, password).unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "create_with_password_file_raw/password_from_file.pna",
+        "--overwrite",
+        "create_with_password_file_raw/in/",
+        "--password-file-raw",
+        password_file_path,
+        "--aes",
+        "ctr",
+        "--argon2",
+        "t=1,m=50",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut seen = HashSet::new();
+    archive::for_each_entry_with_password(
+        "create_with_password_file_raw/password_from_file.pna",
+        password,
+        |entry| {
+            seen.insert(entry.header().path().to_string());
+        },
+    )
+    .unwrap();
+
+    for required in [
+        "create_with_password_file_raw/in",
+        "create_with_password_file_raw/in/raw",
+        "create_with_password_file_raw/in/raw/empty.txt",
+        "create_with_password_file_raw/in/raw/text.txt",
+    ] {
+        assert!(
+            seen.take(required).is_some(),
+            "required entry missing: {required}"
+        );
+    }
+}
+
+/// Precondition: Input files and a password file whose content includes a trailing newline.
+/// Action: Create an encrypted archive with `--password-file` (legacy full-file read).
+/// Expectation: The entire file content (including the newline) is still accepted as the password.
+#[test]
+fn create_with_password_file_including_newline() {
+    setup();
+    TestResources::extract_in("raw/", "create_with_password_file_newline/in/").unwrap();
+    let password_file_path = "create_with_password_file_newline/password_file";
+    let password = "create_with_password_file_newline\n";
+    fs::write(password_file_path, password).unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "create_with_password_file_newline/password_from_file.pna",
+        "--overwrite",
+        "create_with_password_file_newline/in/",
+        "--password-file",
+        password_file_path,
+        "--aes",
+        "ctr",
+        "--argon2",
+        "t=1,m=50",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    archive::for_each_entry_with_password(
+        "create_with_password_file_newline/password_from_file.pna",
+        password,
+        |_entry| {},
+    )
+    .unwrap();
+}
+
+/// Precondition: Input files and a password file whose content is not valid UTF-8.
+/// Action: Create an encrypted archive with `--password-file` (legacy full-file read).
+/// Expectation: The entire byte sequence is still accepted as the password (only a warning is
+/// emitted; the upcoming first-non-empty-UTF-8-line behavior would reject this file outright).
+#[test]
+fn create_with_password_file_non_utf8() {
+    setup();
+    TestResources::extract_in("raw/", "create_with_password_file_non_utf8/in/").unwrap();
+    let password_file_path = "create_with_password_file_non_utf8/password_file";
+    let password: &[u8] = &[0xff, 0xfe, 0xfd];
+    fs::write(password_file_path, password).unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "create_with_password_file_non_utf8/password_from_file.pna",
+        "--overwrite",
+        "create_with_password_file_non_utf8/in/",
+        "--password-file",
+        password_file_path,
+        "--aes",
+        "ctr",
+        "--argon2",
+        "t=1,m=50",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut archive =
+        pna::Archive::open("create_with_password_file_non_utf8/password_from_file.pna").unwrap();
+    let read_options = pna::ReadOptions::with_password(Some(password));
+    for entry in archive.entries().extract_solid_entries(&read_options) {
+        entry.unwrap();
+    }
+}


### PR DESCRIPTION
## Summary
- Stage 1/2 of the `--password-file` behavior migration (stacked on top of this PR: #2156).
- Adds `--password-file-raw`, an explicit full-file-content password source.
- `--password-file` keeps its current entire-file-content behavior for compatibility, but now emits a warning when the file content contains a newline or is not valid UTF-8 — both are cases where the upcoming first-non-empty-UTF-8-line behavior (#2156) would read the password differently or reject the file outright.

## Why stacked, and why two releases
This is a password-derivation change: the same `--password-file` reading a different (or erroring) result on upgrade can silently change what password is used to encrypt/derive against, or break automation that never sees a stderr warning (`--quiet`/cron usage is exactly where `--password-file` is most used). To give users a real chance to see the warning and migrate to `--password-file-raw` before the breaking change lands, this PR should ship in its own release **before** #2156 merges/ships, not in the same release.

## Test plan
- [x] `cargo test -p portable-network-archive --lib` (576 passed)
- [x] `cargo test -p portable-network-archive --test cli password_file` (integration tests covering `--password-file`, `--password-file-raw`, newline, and non-UTF-8 cases)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--password-file-raw` for using password files exactly as written, including trailing newlines and non-text bytes.
  * Password input options now provide clearer guidance on when to use raw mode.
* **Bug Fixes**
  * Preserved compatibility for existing password files containing newlines or non-UTF-8 content, with warnings when applicable.
  * Prevented conflicting password input options from being used together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->