### PR TITLE
:sparkles: Add Cipher mode 2 (AEAD, STREAM-based GCM) support to libpna

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout",
+]
+
+[[package]]
 name = "aes"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17,6 +27,20 @@ dependencies = [
  "cipher",
  "cpubits",
  "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf011db2e21ce0d575593d749db5554b47fed37aff429e4dc50bc91ac93a028"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -968,6 +992,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
+dependencies = [
+ "polyval",
+]
+
+[[package]]
 name = "gix-command"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1116,6 +1149,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
+]
 
 [[package]]
 name = "hmac"
@@ -1480,6 +1522,7 @@ name = "libpna"
 version = "0.36.0"
 dependencies = [
  "aes",
+ "aes-gcm",
  "argon2",
  "arrayvec",
  "block-buffer 0.12.1",
@@ -1495,11 +1538,14 @@ dependencies = [
  "futures-io",
  "futures-util",
  "getrandom 0.2.15",
+ "hkdf",
  "liblzma",
  "password-hash",
  "pbkdf2 0.12.2",
  "rand",
  "rand_chacha",
+ "sha2",
+ "subtle",
  "time",
  "tokio",
  "tokio-util",
@@ -1883,6 +1929,17 @@ dependencies = [
  "libpna",
  "tempfile",
  "version-sync",
+]
+
+[[package]]
+name = "polyval"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
+dependencies = [
+ "cpubits",
+ "cpufeatures 0.3.0",
+ "universal-hash",
 ]
 
 [[package]]
@@ -2388,9 +2445,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.12",
@@ -2791,6 +2848,16 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
+]
 
 [[package]]
 name = "url"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.88"
 
 [dependencies]
 aes = "0.9.1"
+aes-gcm = { version = "0.11.0", default-features = false, features = ["aes", "alloc"] }
 argon2 = { version = "0.5.3", features = ["std"] }
 arrayvec = "0.7.6"
 block-buffer = "0.12.0"
@@ -26,11 +27,14 @@ ctr = "0.10.1"
 flate2 = "1.1.9"
 futures-io = { version = "0.3.32", optional = true }
 futures-util = { version = "0.3.32", features = ["io"], optional = true }
+hkdf = "0.12.4"
 liblzma = { version = "0.4.6", features = ["static"] }
 password-hash = { version = "0.5.0", default-features = false }
 pbkdf2 = { version = "0.12.2", features = ["simple"] }
 rand = "0.8.6"
 rand_chacha = "0.3.1"
+sha2 = "0.10.9"
+subtle = { version = "2.5.0", default-features = false }
 time = "0.3.47"
 zstd = { version = "0.13.3", default-features = false }
 

--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -1053,6 +1053,59 @@ mod tests {
                 REPRESENTATIVE
             );
         }
+
+        /// A datastream carried across an `ANXT` boundary reaches the decoder as
+        /// one stream, so the segment look-ahead must not read the end of a part
+        /// as the end of the datastream and verify a non-final segment as final.
+        #[test]
+        fn entry_split_across_archive_parts_remains_decryptable() {
+            let options = gcm_options(Encryption::AES, Compression::NO, 4);
+            let mut builder =
+                FileEntryBuilder::new_with_options("dir/file".into(), &options).unwrap();
+            builder.write_all(REPRESENTATIVE).unwrap();
+            let entry = EntryPart::from(builder.build().unwrap());
+
+            let mut remaining = entry.as_ref();
+            let mut parts = Vec::new();
+            loop {
+                let (head, tail) = remaining
+                    .try_split(entry.bytes_len() / 2)
+                    .expect("half an entry leaves room for a chunk header");
+                parts.push(head);
+                match tail {
+                    Some(tail) => remaining = tail,
+                    None => break,
+                }
+            }
+            assert!(parts.len() >= 2, "the entry must span both parts");
+
+            let mut part1 = Vec::new();
+            let mut part2 = Vec::new();
+            let mut writer = Archive::write_header(&mut part1).unwrap();
+            writer.add_entry_part(parts[0].clone()).unwrap();
+            let mut writer = writer.split_to_next_archive(&mut part2).unwrap();
+            for part in &parts[1..] {
+                writer.add_entry_part(part.clone()).unwrap();
+            }
+            writer.finalize().unwrap();
+
+            let mut reader = Archive::read_header(part1.as_slice()).unwrap();
+            let mut out = Vec::new();
+            loop {
+                for entry in reader.entries().skip_solid() {
+                    let entry = entry.unwrap();
+                    let mut r = entry
+                        .reader(ReadOptions::with_password(Some("password")))
+                        .unwrap();
+                    r.read_to_end(&mut out).unwrap();
+                }
+                if !reader.has_next_archive() {
+                    break;
+                }
+                reader = reader.read_next_archive(part2.as_slice()).unwrap();
+            }
+            assert_eq!(out, REPRESENTATIVE);
+        }
     }
 
     mod gcm_negative {

--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -751,4 +751,769 @@ mod tests {
             read_entry.metadata().raw_file_size()
         );
     }
+
+    mod gcm_roundtrip {
+        use super::*;
+        use crate::chunk::{Chunk, ChunkExt, ChunkType, RawChunk, read_as_chunks};
+        use std::num::NonZeroU32;
+        #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+        use wasm_bindgen_test::wasm_bindgen_test as test;
+
+        fn gcm_options(
+            encryption: Encryption,
+            compression: Compression,
+            segment_size: u32,
+        ) -> WriteOptions {
+            let mut builder = WriteOptions::builder();
+            builder
+                .compression(compression)
+                .encryption(encryption)
+                .cipher_mode(CipherMode::GCM)
+                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+                .password(Some("password"));
+            builder.segment_size(segment_size);
+            builder.build()
+        }
+
+        fn per_entry_archive(
+            options: &WriteOptions,
+            plain: &[u8],
+            max_chunk: Option<u32>,
+        ) -> Vec<u8> {
+            let mut writer = Archive::write_header(Vec::new()).unwrap();
+            let mut builder =
+                FileEntryBuilder::new_with_options("dir/file".into(), options).unwrap();
+            if let Some(size) = max_chunk {
+                builder.max_chunk_size(NonZeroU32::new(size).unwrap());
+            }
+            builder.write_all(plain).unwrap();
+            writer.add_entry(builder.build().unwrap()).unwrap();
+            writer.finalize().unwrap()
+        }
+
+        fn read_per_entry(archived: &[u8], password: Option<&str>) -> io::Result<Vec<u8>> {
+            let mut reader = Archive::read_header(archived).unwrap();
+            let entry = reader.entries().skip_solid().next().unwrap().unwrap();
+            let mut r = entry.reader(ReadOptions::with_password(password))?;
+            let mut out = Vec::new();
+            r.read_to_end(&mut out)?;
+            Ok(out)
+        }
+
+        /// Rewrites a single-entry archive so that its datastream is carried by
+        /// `FDAT` chunks split at the given byte offsets, regardless of how the
+        /// encoder originally chunked it.
+        fn resplit_datastream(archive: &[u8], boundaries: &[usize]) -> Vec<u8> {
+            let mut stream = Vec::new();
+            for chunk in read_as_chunks(archive).unwrap() {
+                let chunk = chunk.unwrap();
+                if chunk.ty() == ChunkType::FDAT {
+                    stream.extend_from_slice(chunk.data());
+                }
+            }
+            let mut segments = Vec::new();
+            let mut prev = 0;
+            for &b in boundaries {
+                segments.push(&stream[prev..b]);
+                prev = b;
+            }
+            segments.push(&stream[prev..]);
+
+            let mut out = PNA_HEADER.to_vec();
+            let mut emitted = false;
+            for chunk in read_as_chunks(archive).unwrap() {
+                let chunk = chunk.unwrap();
+                if chunk.ty() == ChunkType::FDAT {
+                    if !emitted {
+                        for segment in &segments {
+                            RawChunk::from_data(ChunkType::FDAT, segment.to_vec())
+                                .write_chunk_in(&mut out)
+                                .unwrap();
+                        }
+                        emitted = true;
+                    }
+                    continue;
+                }
+                RawChunk::from_data(chunk.ty(), chunk.data().to_vec())
+                    .write_chunk_in(&mut out)
+                    .unwrap();
+            }
+            out
+        }
+
+        fn assert_per_entry_roundtrip(
+            encryption: Encryption,
+            compression: Compression,
+            plain: &[u8],
+        ) {
+            let options = gcm_options(encryption, compression, 4);
+            let archived = per_entry_archive(&options, plain, None);
+            assert_eq!(read_per_entry(&archived, Some("password")).unwrap(), plain);
+        }
+
+        fn assert_solid_roundtrip(encryption: Encryption, compression: Compression, plain: &[u8]) {
+            let options = gcm_options(encryption, compression, 4);
+            let mut writer = Archive::write_solid_header(Vec::new(), options).unwrap();
+            writer
+                .add_entry({
+                    let mut b = FileEntryBuilder::new("dir/file".into()).unwrap();
+                    b.write_all(plain).unwrap();
+                    b.build().unwrap()
+                })
+                .unwrap();
+            let archived = writer.finalize().unwrap();
+
+            let mut reader = Archive::read_header(archived.as_slice()).unwrap();
+            let entry = reader.entries().next().unwrap().unwrap();
+            let ReadEntry::Solid(solid) = entry else {
+                panic!("expected a solid entry");
+            };
+            let options = ReadOptions::with_password(Some(b"password"));
+            let inner = solid.entries(&options).unwrap().next().unwrap().unwrap();
+            let mut r = inner.reader(ReadOptions::builder().build()).unwrap();
+            let mut out = Vec::new();
+            r.read_to_end(&mut out).unwrap();
+            assert_eq!(out, plain);
+        }
+
+        const REPRESENTATIVE: &[u8] = b"012345678";
+
+        #[test]
+        fn per_entry_aes_uncompressed() {
+            assert_per_entry_roundtrip(Encryption::AES, Compression::NO, REPRESENTATIVE);
+        }
+
+        #[test]
+        fn per_entry_aes_zstd() {
+            assert_per_entry_roundtrip(Encryption::AES, Compression::ZSTANDARD, REPRESENTATIVE);
+        }
+
+        #[test]
+        fn per_entry_camellia_uncompressed() {
+            assert_per_entry_roundtrip(Encryption::CAMELLIA, Compression::NO, REPRESENTATIVE);
+        }
+
+        #[test]
+        fn per_entry_camellia_zstd() {
+            assert_per_entry_roundtrip(
+                Encryption::CAMELLIA,
+                Compression::ZSTANDARD,
+                REPRESENTATIVE,
+            );
+        }
+
+        #[test]
+        fn solid_aes_uncompressed() {
+            assert_solid_roundtrip(Encryption::AES, Compression::NO, REPRESENTATIVE);
+        }
+
+        #[test]
+        fn solid_aes_zstd() {
+            assert_solid_roundtrip(Encryption::AES, Compression::ZSTANDARD, REPRESENTATIVE);
+        }
+
+        #[test]
+        fn solid_camellia_uncompressed() {
+            assert_solid_roundtrip(Encryption::CAMELLIA, Compression::NO, REPRESENTATIVE);
+        }
+
+        #[test]
+        fn solid_camellia_zstd() {
+            assert_solid_roundtrip(Encryption::CAMELLIA, Compression::ZSTANDARD, REPRESENTATIVE);
+        }
+
+        #[test]
+        fn plaintext_length_zero() {
+            assert_per_entry_roundtrip(Encryption::AES, Compression::NO, b"");
+        }
+
+        #[test]
+        fn plaintext_length_below_segment() {
+            assert_per_entry_roundtrip(Encryption::AES, Compression::NO, b"abc");
+        }
+
+        #[test]
+        fn plaintext_length_exact_segment() {
+            assert_per_entry_roundtrip(Encryption::AES, Compression::NO, b"abcd");
+        }
+
+        #[test]
+        fn plaintext_length_two_segments() {
+            assert_per_entry_roundtrip(Encryption::AES, Compression::NO, b"abcdefgh");
+        }
+
+        #[test]
+        fn plaintext_length_partial_tail() {
+            assert_per_entry_roundtrip(Encryption::AES, Compression::NO, b"abcdefghi");
+        }
+
+        #[test]
+        fn chunk_split_default() {
+            let options = gcm_options(Encryption::AES, Compression::NO, 4);
+            let archived = per_entry_archive(&options, REPRESENTATIVE, None);
+            assert_eq!(
+                read_per_entry(&archived, Some("password")).unwrap(),
+                REPRESENTATIVE
+            );
+        }
+
+        #[test]
+        fn chunk_split_one_byte() {
+            let options = gcm_options(Encryption::AES, Compression::NO, 4);
+            let archived = per_entry_archive(&options, REPRESENTATIVE, Some(1));
+            assert_eq!(
+                read_per_entry(&archived, Some("password")).unwrap(),
+                REPRESENTATIVE
+            );
+        }
+
+        #[test]
+        fn fdat_boundary_inside_stream_header() {
+            let options = gcm_options(Encryption::AES, Compression::NO, 4);
+            let archived = per_entry_archive(&options, REPRESENTATIVE, None);
+            let resplit = resplit_datastream(&archived, &[20]);
+            assert_eq!(
+                read_per_entry(&resplit, Some("password")).unwrap(),
+                REPRESENTATIVE
+            );
+        }
+
+        #[test]
+        fn fdat_boundary_inside_segment_tag() {
+            let options = gcm_options(Encryption::AES, Compression::NO, 4);
+            let archived = per_entry_archive(&options, REPRESENTATIVE, None);
+            // 75-byte header + 4-byte first-segment ciphertext + 8 bytes into its
+            // 16-byte GCM tag.
+            let resplit = resplit_datastream(&archived, &[75 + 4 + 8]);
+            assert_eq!(
+                read_per_entry(&resplit, Some("password")).unwrap(),
+                REPRESENTATIVE
+            );
+        }
+
+        #[test]
+        fn slice_path_reads_gcm_entry() {
+            let options = gcm_options(Encryption::AES, Compression::NO, 4);
+            let archived = per_entry_archive(&options, REPRESENTATIVE, None);
+            let mut reader = Archive::read_header_from_slice(&archived).unwrap();
+            let entry = reader.entries_slice().next().unwrap().unwrap();
+            let ReadEntry::Normal(entry) = entry else {
+                panic!("expected a normal entry");
+            };
+            let mut r = entry
+                .reader(ReadOptions::with_password(Some("password")))
+                .unwrap();
+            let mut out = Vec::new();
+            r.read_to_end(&mut out).unwrap();
+            assert_eq!(out, REPRESENTATIVE);
+        }
+
+        #[test]
+        fn entries_with_options_reads_solid_gcm_entry() {
+            let options = gcm_options(Encryption::AES, Compression::NO, 4);
+            let mut writer = Archive::write_solid_header(Vec::new(), options).unwrap();
+            writer
+                .add_entry({
+                    let mut b = FileEntryBuilder::new("dir/file".into()).unwrap();
+                    b.write_all(REPRESENTATIVE).unwrap();
+                    b.build().unwrap()
+                })
+                .unwrap();
+            let archived = writer.finalize().unwrap();
+
+            let mut reader = Archive::read_header(archived.as_slice()).unwrap();
+            let entry = reader
+                .entries_with_options(&ReadOptions::with_password(Some(b"password")))
+                .next()
+                .unwrap()
+                .unwrap();
+            let mut r = entry.reader(ReadOptions::builder().build()).unwrap();
+            let mut out = Vec::new();
+            r.read_to_end(&mut out).unwrap();
+            assert_eq!(out, REPRESENTATIVE);
+        }
+
+        /// Copying re-serializes the parsed header, so the entry stays
+        /// decryptable only while that reproduces the header bytes the stream key
+        /// was derived from.
+        #[test]
+        fn copied_entry_remains_decryptable() {
+            let options = gcm_options(Encryption::AES, Compression::NO, 4);
+            let archived = per_entry_archive(&options, REPRESENTATIVE, None);
+
+            let mut reader = Archive::read_header(archived.as_slice()).unwrap();
+            let mut writer = Archive::write_header(Vec::new()).unwrap();
+            for entry in reader.entries().skip_solid() {
+                writer.add_entry(entry.unwrap()).unwrap();
+            }
+            let copied = writer.finalize().unwrap();
+
+            assert_eq!(
+                read_per_entry(&copied, Some("password")).unwrap(),
+                REPRESENTATIVE
+            );
+        }
+    }
+
+    mod gcm_negative {
+        use super::*;
+        use crate::chunk::{Chunk, ChunkExt, ChunkType, RawChunk, read_as_chunks};
+        use crate::error::AeadError;
+        #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+        use wasm_bindgen_test::wasm_bindgen_test as test;
+
+        const PASSWORD: &str = "password";
+        const SEGMENT_SIZE: u32 = 4;
+        const STREAM_HEADER_LEN: usize = 75;
+        const GCM_TAG_LEN: usize = 16;
+        const SALT_OFFSET: usize = 0;
+        const NONCE_PREFIX_OFFSET: usize = 32;
+        const SEGMENT_SIZE_OFFSET: usize = 39;
+        const KEY_CONFIRMATION_OFFSET: usize = 43;
+
+        fn gcm_options() -> WriteOptions {
+            gcm_options_with_segment(SEGMENT_SIZE)
+        }
+
+        fn gcm_options_with_segment(segment_size: u32) -> WriteOptions {
+            let mut builder = WriteOptions::builder();
+            builder
+                .compression(Compression::NO)
+                .encryption(Encryption::AES)
+                .cipher_mode(CipherMode::GCM)
+                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+                .password(Some(PASSWORD));
+            builder.segment_size(segment_size);
+            builder.build()
+        }
+
+        fn archive_of(entries: &[(&str, &[u8])]) -> Vec<u8> {
+            let options = gcm_options();
+            let mut writer = Archive::write_header(Vec::new()).unwrap();
+            for (path, plain) in entries {
+                let mut builder =
+                    FileEntryBuilder::new_with_options((*path).into(), &options).unwrap();
+                builder.write_all(plain).unwrap();
+                writer.add_entry(builder.build().unwrap()).unwrap();
+            }
+            writer.finalize().unwrap()
+        }
+
+        fn single(plain: &[u8]) -> Vec<u8> {
+            archive_of(&[("dir/file", plain)])
+        }
+
+        fn read_nth(archive: &[u8], index: usize, password: Option<&str>) -> io::Result<Vec<u8>> {
+            let mut reader = Archive::read_header(archive).unwrap();
+            let entry = reader.entries().skip_solid().nth(index).unwrap().unwrap();
+            let mut r = entry.reader(ReadOptions::with_password(password))?;
+            let mut out = Vec::new();
+            r.read_to_end(&mut out)?;
+            Ok(out)
+        }
+
+        fn read_first(archive: &[u8]) -> io::Result<Vec<u8>> {
+            read_nth(archive, 0, Some(PASSWORD))
+        }
+
+        /// Builds an entry's data reader without reading from it, so an error
+        /// here is raised before any segment is processed.
+        fn open_nth(archive: &[u8], index: usize, password: Option<&str>) -> io::Result<()> {
+            let mut reader = Archive::read_header(archive).unwrap();
+            let entry = reader.entries().skip_solid().nth(index).unwrap().unwrap();
+            entry
+                .reader(ReadOptions::with_password(password))
+                .map(|_| ())
+        }
+
+        fn tamper_chunk(
+            archive: &[u8],
+            chunk_type: ChunkType,
+            index: usize,
+            f: impl FnOnce(&mut Vec<u8>),
+        ) -> Vec<u8> {
+            let mut out = PNA_HEADER.to_vec();
+            let mut f = Some(f);
+            let mut seen = 0;
+            for chunk in read_as_chunks(archive).unwrap() {
+                let chunk = chunk.unwrap();
+                let mut data = chunk.data().to_vec();
+                if chunk.ty() == chunk_type {
+                    if seen == index {
+                        (f.take().expect("target chunk is tampered once"))(&mut data);
+                    }
+                    seen += 1;
+                }
+                RawChunk::from_data(chunk.ty(), data)
+                    .write_chunk_in(&mut out)
+                    .unwrap();
+            }
+            assert!(f.is_none(), "target chunk was found and tampered");
+            out
+        }
+
+        fn datastream_of(archive: &[u8], entry_index: usize) -> Vec<u8> {
+            let mut current: isize = -1;
+            let mut stream = Vec::new();
+            for chunk in read_as_chunks(archive).unwrap() {
+                let chunk = chunk.unwrap();
+                if chunk.ty() == ChunkType::FHED {
+                    current += 1;
+                }
+                if chunk.ty() == ChunkType::FDAT && current == entry_index as isize {
+                    stream.extend_from_slice(chunk.data());
+                }
+            }
+            stream
+        }
+
+        fn tamper_datastream(
+            archive: &[u8],
+            entry_index: usize,
+            f: impl FnOnce(&mut Vec<u8>),
+        ) -> Vec<u8> {
+            let mut out = PNA_HEADER.to_vec();
+            let mut f = Some(f);
+            let mut current: isize = -1;
+            let mut stream: Option<Vec<u8>> = None;
+            for chunk in read_as_chunks(archive).unwrap() {
+                let chunk = chunk.unwrap();
+                let ty = chunk.ty();
+                if ty == ChunkType::FHED {
+                    current += 1;
+                }
+                if ty == ChunkType::FDAT && current == entry_index as isize {
+                    stream
+                        .get_or_insert_with(Vec::new)
+                        .extend_from_slice(chunk.data());
+                    continue;
+                }
+                if let Some(mut data) = stream.take() {
+                    (f.take().expect("target datastream is tampered once"))(&mut data);
+                    RawChunk::from_data(ChunkType::FDAT, data)
+                        .write_chunk_in(&mut out)
+                        .unwrap();
+                }
+                RawChunk::from_data(ty, chunk.data().to_vec())
+                    .write_chunk_in(&mut out)
+                    .unwrap();
+            }
+            assert!(f.is_none(), "target datastream was found and tampered");
+            out
+        }
+
+        fn aead(err: &io::Error) -> &AeadError {
+            err.get_ref()
+                .and_then(|e| e.downcast_ref::<AeadError>())
+                .expect("decrypt error carries an AeadError")
+        }
+
+        fn solid_datastream(archive: &[u8]) -> Vec<u8> {
+            let mut stream = Vec::new();
+            for chunk in read_as_chunks(archive).unwrap() {
+                let chunk = chunk.unwrap();
+                if chunk.ty() == ChunkType::SDAT {
+                    stream.extend_from_slice(chunk.data());
+                }
+            }
+            stream
+        }
+
+        fn tamper_solid_datastream(archive: &[u8], f: impl FnOnce(&mut Vec<u8>)) -> Vec<u8> {
+            let mut out = PNA_HEADER.to_vec();
+            let mut f = Some(f);
+            let mut stream: Option<Vec<u8>> = None;
+            for chunk in read_as_chunks(archive).unwrap() {
+                let chunk = chunk.unwrap();
+                let ty = chunk.ty();
+                if ty == ChunkType::SDAT {
+                    stream
+                        .get_or_insert_with(Vec::new)
+                        .extend_from_slice(chunk.data());
+                    continue;
+                }
+                if let Some(mut data) = stream.take() {
+                    (f.take().expect("target datastream is tampered once"))(&mut data);
+                    RawChunk::from_data(ChunkType::SDAT, data)
+                        .write_chunk_in(&mut out)
+                        .unwrap();
+                }
+                RawChunk::from_data(ty, chunk.data().to_vec())
+                    .write_chunk_in(&mut out)
+                    .unwrap();
+            }
+            assert!(f.is_none(), "target datastream was found and tampered");
+            out
+        }
+
+        /// Reads inner entry contents, stopping at the first error (the iterator
+        /// reproduces a decryption error indefinitely rather than ending).
+        fn read_solid_contents(archive: &[u8], password: Option<&str>) -> Vec<io::Result<Vec<u8>>> {
+            let mut reader = Archive::read_header(archive).unwrap();
+            let ReadEntry::Solid(solid) = reader.entries().next().unwrap().unwrap() else {
+                panic!("expected a solid entry");
+            };
+            let mut contents = Vec::new();
+            let options = ReadOptions::with_password(password);
+            for entry in solid.entries(&options).unwrap() {
+                let result = entry.and_then(|e| {
+                    let mut r = e.reader(ReadOptions::builder().build())?;
+                    let mut out = Vec::new();
+                    r.read_to_end(&mut out)?;
+                    Ok(out)
+                });
+                let stop = result.is_err();
+                contents.push(result);
+                if stop {
+                    break;
+                }
+            }
+            contents
+        }
+
+        #[test]
+        fn wrong_password_is_key_mismatch_before_any_segment_is_processed() {
+            let archive = single(b"abcdefgh");
+            assert_eq!(read_first(&archive).unwrap(), b"abcdefgh");
+            let err = open_nth(&archive, 0, Some("wrong")).unwrap_err();
+            assert!(matches!(aead(&err), AeadError::KeyMismatch));
+        }
+
+        /// With both a wrong password and a corrupted segment present, the
+        /// reported class is `KeyMismatch`: key confirmation runs before any
+        /// segment is processed, so tampering cannot mask a wrong password.
+        #[test]
+        fn wrong_password_with_a_corrupted_segment_is_still_key_mismatch() {
+            let archive = single(b"abcdefgh");
+            assert_eq!(read_first(&archive).unwrap(), b"abcdefgh");
+            let tampered = tamper_datastream(&archive, 0, |data| {
+                data[STREAM_HEADER_LEN] ^= 0x01;
+            });
+            let err = read_nth(&tampered, 0, Some("wrong")).unwrap_err();
+            assert!(matches!(aead(&err), AeadError::KeyMismatch));
+        }
+
+        #[test]
+        fn modifying_key_confirmation_is_key_mismatch() {
+            let archive = single(b"abcdefgh");
+            assert_eq!(read_first(&archive).unwrap(), b"abcdefgh");
+            let tampered = tamper_datastream(&archive, 0, |data| {
+                data[KEY_CONFIRMATION_OFFSET] ^= 0x01;
+            });
+            let err = open_nth(&tampered, 0, Some(PASSWORD)).unwrap_err();
+            assert!(matches!(aead(&err), AeadError::KeyMismatch));
+        }
+
+        /// K_master is shared across entries written with the same options, so
+        /// per-stream key and nonce uniqueness rests entirely on the random
+        /// stream salt and nonce prefix in each stream header.
+        #[test]
+        fn entries_use_distinct_stream_salts_and_nonce_prefixes() {
+            let archive = archive_of(&[("dir/a", b"abcdefgh"), ("dir/b", b"abcdefgh")]);
+            let first = datastream_of(&archive, 0);
+            let second = datastream_of(&archive, 1);
+            assert_ne!(first[..32], second[..32], "stream salts must differ");
+            assert_ne!(first[32..39], second[32..39], "nonce prefixes must differ");
+        }
+
+        #[test]
+        fn truncating_solid_datastream_at_inner_entry_boundary_is_truncation() {
+            let entry = |path: &str, plain: &[u8]| {
+                let mut b = FileEntryBuilder::new(path.into()).unwrap();
+                b.write_all(plain).unwrap();
+                b.build().unwrap()
+            };
+            let first = entry("dir/a", b"first");
+            let second = entry("dir/b", b"second");
+
+            let mut writer =
+                Archive::write_solid_header(Vec::new(), WriteOptions::store()).unwrap();
+            writer.add_entry(first.clone()).unwrap();
+            let first_len = solid_datastream(&writer.finalize().unwrap()).len();
+
+            // The first GCM segment ends exactly at the first inner entry's FEND.
+            let mut writer =
+                Archive::write_solid_header(Vec::new(), gcm_options_with_segment(first_len as u32))
+                    .unwrap();
+            writer.add_entry(first).unwrap();
+            writer.add_entry(second).unwrap();
+            let archived = writer.finalize().unwrap();
+            let contents = read_solid_contents(&archived, Some(PASSWORD));
+            assert_eq!(
+                contents
+                    .into_iter()
+                    .map(|it| it.unwrap())
+                    .collect::<Vec<_>>(),
+                [b"first".to_vec(), b"second".to_vec()]
+            );
+
+            let truncated = tamper_solid_datastream(&archived, |data| {
+                data.truncate(STREAM_HEADER_LEN + first_len + GCM_TAG_LEN + 8);
+            });
+            let results = read_solid_contents(&truncated, Some(PASSWORD));
+            assert_eq!(results[0].as_ref().unwrap(), b"first");
+            assert_eq!(
+                results.len(),
+                2,
+                "truncation must surface as an error instead of ending iteration cleanly"
+            );
+            assert!(matches!(
+                aead(results[1].as_ref().unwrap_err()),
+                AeadError::Truncation
+            ));
+        }
+
+        #[test]
+        fn swapping_datastreams_between_entries_fails_authentication() {
+            let archive = archive_of(&[("dir/a", b"abcdefgh"), ("dir/b", b"abcdefgh")]);
+            assert_eq!(read_nth(&archive, 0, Some(PASSWORD)).unwrap(), b"abcdefgh");
+            assert_eq!(read_nth(&archive, 1, Some(PASSWORD)).unwrap(), b"abcdefgh");
+            let stream0 = datastream_of(&archive, 0);
+            let stream1 = datastream_of(&archive, 1);
+            let archive = tamper_datastream(&archive, 0, |data| *data = stream1);
+            let archive = tamper_datastream(&archive, 1, |data| *data = stream0);
+            let err = read_nth(&archive, 0, Some(PASSWORD)).unwrap_err();
+            assert!(matches!(aead(&err), AeadError::AuthenticationFailure));
+        }
+
+        #[test]
+        fn modifying_phsf_salt_is_key_mismatch() {
+            let archive = single(b"abcdefgh");
+            assert_eq!(read_first(&archive).unwrap(), b"abcdefgh");
+            let tampered = tamper_chunk(&archive, ChunkType::PHSF, 0, |data| {
+                let phsf = std::str::from_utf8(data).unwrap();
+                let mut fields = phsf.split('$').map(str::to_owned).collect::<Vec<_>>();
+                let salt = &mut fields[3];
+                let mut bytes = std::mem::take(salt).into_bytes();
+                bytes[0] = if bytes[0] == b'A' { b'B' } else { b'A' };
+                *salt = String::from_utf8(bytes).unwrap();
+                *data = fields.join("$").into_bytes();
+            });
+            let err = open_nth(&tampered, 0, Some(PASSWORD)).unwrap_err();
+            assert!(matches!(aead(&err), AeadError::KeyMismatch));
+        }
+
+        #[test]
+        fn modifying_fhed_path_fails_authentication() {
+            let archive = single(b"abcdefgh");
+            assert_eq!(read_first(&archive).unwrap(), b"abcdefgh");
+            let tampered = tamper_chunk(&archive, ChunkType::FHED, 0, |data| {
+                data[6] ^= 0x01;
+            });
+            let err = read_first(&tampered).unwrap_err();
+            assert!(matches!(aead(&err), AeadError::AuthenticationFailure));
+        }
+
+        #[test]
+        fn modifying_stream_salt_fails_authentication() {
+            let archive = single(b"abcdefgh");
+            assert_eq!(read_first(&archive).unwrap(), b"abcdefgh");
+            let tampered = tamper_datastream(&archive, 0, |data| {
+                data[SALT_OFFSET] ^= 0x01;
+            });
+            let err = read_first(&tampered).unwrap_err();
+            assert!(matches!(aead(&err), AeadError::AuthenticationFailure));
+        }
+
+        #[test]
+        fn modifying_nonce_prefix_fails_authentication() {
+            let archive = single(b"abcdefgh");
+            assert_eq!(read_first(&archive).unwrap(), b"abcdefgh");
+            let tampered = tamper_datastream(&archive, 0, |data| {
+                data[NONCE_PREFIX_OFFSET] ^= 0x01;
+            });
+            let err = read_first(&tampered).unwrap_err();
+            assert!(matches!(aead(&err), AeadError::AuthenticationFailure));
+        }
+
+        #[test]
+        fn modifying_segment_size_fails_authentication() {
+            let archive = single(b"abcdefgh");
+            assert_eq!(read_first(&archive).unwrap(), b"abcdefgh");
+            let tampered = tamper_datastream(&archive, 0, |data| {
+                data[SEGMENT_SIZE_OFFSET + 3] = (SEGMENT_SIZE + 1) as u8;
+            });
+            let err = read_first(&tampered).unwrap_err();
+            assert!(matches!(aead(&err), AeadError::AuthenticationFailure));
+        }
+
+        /// Appended bytes make the encoder's final segment no longer the last,
+        /// so the look-ahead decrypts it without the final flag and its tag
+        /// fails: extension is caught as an authentication failure, never as
+        /// trailing bytes after a segment verified as final.
+        #[test]
+        fn appending_bytes_after_the_final_segment_fails_authentication() {
+            let archive = single(b"abcdefgh");
+            assert_eq!(read_first(&archive).unwrap(), b"abcdefgh");
+            let tampered = tamper_datastream(&archive, 0, |data| data.push(0x00));
+            let err = read_first(&tampered).unwrap_err();
+            assert!(matches!(aead(&err), AeadError::AuthenticationFailure));
+        }
+
+        #[test]
+        fn datastream_shorter_than_the_stream_header_is_malformed() {
+            let archive = single(b"012345678");
+            assert_eq!(read_first(&archive).unwrap(), b"012345678");
+            let tampered = tamper_datastream(&archive, 0, |data| {
+                data.truncate(STREAM_HEADER_LEN - 1);
+            });
+            let err = read_first(&tampered).unwrap_err();
+            assert!(matches!(aead(&err), AeadError::Malformed(_)));
+        }
+
+        #[test]
+        fn datastream_without_a_complete_segment_is_malformed() {
+            let archive = single(b"012345678");
+            assert_eq!(read_first(&archive).unwrap(), b"012345678");
+            let tampered = tamper_datastream(&archive, 0, |data| {
+                data.truncate(STREAM_HEADER_LEN + GCM_TAG_LEN - 1);
+            });
+            let err = read_first(&tampered).unwrap_err();
+            assert!(matches!(aead(&err), AeadError::Malformed(_)));
+        }
+
+        fn solid_archive(plain: &[u8]) -> Vec<u8> {
+            let mut writer = Archive::write_solid_header(Vec::new(), gcm_options()).unwrap();
+            let mut builder = FileEntryBuilder::new("dir/file".into()).unwrap();
+            builder.write_all(plain).unwrap();
+            writer.add_entry(builder.build().unwrap()).unwrap();
+            writer.finalize().unwrap()
+        }
+
+        /// Every `SHED` byte is interpreted on read, so the compression method
+        /// is the only field that accepts another value. Decryption sits below
+        /// decompression, so the segment tag fails before the switched
+        /// decompressor sees a byte.
+        #[test]
+        fn modifying_shed_header_fails_authentication() {
+            let archive = solid_archive(b"solid payload");
+            assert_eq!(
+                read_solid_contents(&archive, Some(PASSWORD))[0]
+                    .as_ref()
+                    .unwrap(),
+                b"solid payload"
+            );
+            let tampered = tamper_chunk(&archive, ChunkType::SHED, 0, |data| {
+                data[2] = Compression::DEFLATE.to_byte();
+            });
+            let results = read_solid_contents(&tampered, Some(PASSWORD));
+            assert!(matches!(
+                aead(results[0].as_ref().unwrap_err()),
+                AeadError::AuthenticationFailure
+            ));
+        }
+
+        #[test]
+        fn wrong_password_for_a_solid_entry_is_key_mismatch() {
+            let archive = solid_archive(b"solid payload");
+            let mut reader = Archive::read_header(archive.as_slice()).unwrap();
+            let ReadEntry::Solid(solid) = reader.entries().next().unwrap().unwrap() else {
+                panic!("expected a solid entry");
+            };
+            let Err(err) = solid.entries(&ReadOptions::with_password(Some("wrong"))) else {
+                panic!("a wrong password must not open a solid entry");
+            };
+            assert!(matches!(aead(&err), AeadError::KeyMismatch));
+        }
+    }
 }

--- a/lib/src/archive/write.rs
+++ b/lib/src/archive/write.rs
@@ -377,12 +377,12 @@ impl<W: Write> Archive<W> {
             option.encryption(),
             option.cipher_mode(),
         );
-        let context = get_writer_context(option)?;
+        let context = get_writer_context(option, ChunkType::SHED, &header.to_bytes())?;
 
         (ChunkType::SHED, header.to_bytes()).write_chunk_in(&mut self.inner)?;
         if let Some(WriteCipher { context: c, .. }) = &context.cipher {
             (ChunkType::PHSF, c.phsf.as_bytes()).write_chunk_in(&mut self.inner)?;
-            (ChunkType::SDAT, c.iv.as_slice()).write_chunk_in(&mut self.inner)?;
+            (ChunkType::SDAT, c.prefix_bytes().as_slice()).write_chunk_in(&mut self.inner)?;
         }
         self.inner.flush()?;
         let max_chunk_size = self.max_chunk_size;
@@ -595,10 +595,10 @@ where
     for xattr in metadata.xattrs {
         (ChunkType::xATR, xattr.to_bytes()).write_chunk_in(inner)?;
     }
-    let context = get_writer_context(option)?;
+    let context = get_writer_context(option, ChunkType::FHED, &header.to_bytes())?;
     if let Some(WriteCipher { context: c, .. }) = &context.cipher {
         (ChunkType::PHSF, c.phsf.as_bytes()).write_chunk_in(inner)?;
-        (ChunkType::FDAT, &c.iv[..]).write_chunk_in(inner)?;
+        (ChunkType::FDAT, c.prefix_bytes().as_slice()).write_chunk_in(inner)?;
     }
     let inner = {
         let writer = ChunkStreamWriter::new(ChunkType::FDAT, inner, max_chunk_size);

--- a/lib/src/archive/write.rs
+++ b/lib/src/archive/write.rs
@@ -382,14 +382,14 @@ impl<W: Write> Archive<W> {
         (ChunkType::SHED, header.to_bytes()).write_chunk_in(&mut self.inner)?;
         if let Some(WriteCipher { context: c, .. }) = &context.cipher {
             (ChunkType::PHSF, c.phsf.as_bytes()).write_chunk_in(&mut self.inner)?;
-            (ChunkType::SDAT, c.prefix_bytes().as_slice()).write_chunk_in(&mut self.inner)?;
         }
         self.inner.flush()?;
         let max_chunk_size = self.max_chunk_size;
-        let writer = get_writer(
-            ChunkStreamWriter::new(ChunkType::SDAT, self.inner, max_chunk_size),
-            &context,
-        )?;
+        let mut writer = ChunkStreamWriter::new(ChunkType::SDAT, self.inner, max_chunk_size);
+        if let Some(WriteCipher { context: c, .. }) = &context.cipher {
+            writer.write_all(&c.prefix_bytes())?;
+        }
+        let writer = get_writer(writer, &context)?;
 
         Ok(SolidArchive {
             archive_header: self.header,
@@ -598,10 +598,12 @@ where
     let context = get_writer_context(option, ChunkType::FHED, &header.to_bytes())?;
     if let Some(WriteCipher { context: c, .. }) = &context.cipher {
         (ChunkType::PHSF, c.phsf.as_bytes()).write_chunk_in(inner)?;
-        (ChunkType::FDAT, c.prefix_bytes().as_slice()).write_chunk_in(inner)?;
     }
     let inner = {
-        let writer = ChunkStreamWriter::new(ChunkType::FDAT, inner, max_chunk_size);
+        let mut writer = ChunkStreamWriter::new(ChunkType::FDAT, inner, max_chunk_size);
+        if let Some(WriteCipher { context: c, .. }) = &context.cipher {
+            writer.write_all(&c.prefix_bytes())?;
+        }
         let writer = get_writer(writer, &context)?;
         let mut writer = f(writer)?;
         writer.flush()?;
@@ -614,7 +616,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ReadOptions;
+    use crate::{CipherMode, Encryption, HashAlgorithm, ReadOptions};
     use std::io::Read;
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
@@ -764,6 +766,85 @@ mod tests {
             .unwrap()
             .filter(|c| c.as_ref().unwrap().ty() == ty)
             .count()
+    }
+
+    fn assert_chunk_sizes_at_most(archive: &[u8], ty: ChunkType, max: usize) {
+        let sizes = crate::chunk::read_chunks_from_slice(archive)
+            .unwrap()
+            .filter_map(|chunk| {
+                let chunk = chunk.unwrap();
+                (chunk.ty() == ty).then(|| chunk.data().len())
+            })
+            .collect::<Vec<_>>();
+        assert!(!sizes.is_empty(), "expected at least one {ty:?} chunk");
+        assert!(
+            sizes.iter().all(|&size| size <= max),
+            "{ty:?} chunk sizes {sizes:?} must all be <= {max}"
+        );
+    }
+
+    fn gcm_write_options() -> WriteOptions {
+        WriteOptions::builder()
+            .encryption(Encryption::AES)
+            .cipher_mode(CipherMode::GCM)
+            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .password(Some("password"))
+            .build()
+    }
+
+    #[test]
+    fn archive_write_file_gcm_header_respects_max_chunk_size() {
+        let mut writer = Archive::write_header(Vec::new()).expect("failed to write header");
+        writer.set_max_chunk_size(NonZeroU32::new(8).unwrap());
+        writer
+            .write_file(
+                EntryName::from_lossy("file"),
+                Metadata::new(),
+                gcm_write_options(),
+                |writer| writer.write_all(b"x"),
+            )
+            .expect("failed to write");
+        let file = writer.finalize().expect("failed to finalize");
+
+        assert_chunk_sizes_at_most(&file, ChunkType::FDAT, 8);
+
+        let mut reader = Archive::read_header(file.as_slice()).unwrap();
+        let entry = reader.entries().skip_solid().next().unwrap().unwrap();
+        let mut data = entry
+            .reader(ReadOptions::with_password(Some("password")))
+            .unwrap();
+        let mut plain = Vec::new();
+        data.read_to_end(&mut plain).unwrap();
+        assert_eq!(plain, b"x");
+    }
+
+    #[test]
+    fn solid_archive_gcm_header_respects_max_chunk_size() {
+        let mut archive = Archive::write_header(Vec::new()).expect("failed to write header");
+        archive.set_max_chunk_size(NonZeroU32::new(8).unwrap());
+        let mut writer = archive
+            .into_solid_archive(gcm_write_options())
+            .expect("failed to create solid archive");
+        writer
+            .write_file(EntryName::from_lossy("file"), Metadata::new(), |writer| {
+                writer.write_all(b"x")
+            })
+            .expect("failed to write");
+        let file = writer.finalize().expect("failed to finalize");
+
+        assert_chunk_sizes_at_most(&file, ChunkType::SDAT, 8);
+
+        let mut reader = Archive::read_header(file.as_slice()).unwrap();
+        let entry = reader
+            .entries()
+            .extract_solid_entries(&ReadOptions::with_password(Some("password")))
+            .next()
+            .unwrap()
+            .unwrap();
+        let mut data = entry.reader(ReadOptions::builder().build()).unwrap();
+        let mut plain = Vec::new();
+        data.read_to_end(&mut plain).unwrap();
+        assert_eq!(plain, b"x");
     }
 
     #[test]

--- a/lib/src/cipher.rs
+++ b/lib/src/cipher.rs
@@ -11,7 +11,7 @@ pub(crate) use aead::{
     derive_stream_key, key_confirmation,
 };
 #[cfg(test)]
-pub(crate) use aead::{GCM_TAG_LEN, segment_nonce};
+pub(crate) use aead::{GCM_TAG_LEN, MAX_SEGMENT_SIZE, segment_nonce};
 use aes::Aes256;
 use camellia::Camellia256;
 use cipher::block_padding::Pkcs7;

--- a/lib/src/cipher.rs
+++ b/lib/src/cipher.rs
@@ -1,9 +1,16 @@
 //! Cipher implementations for PNA archive encryption and decryption.
 
+mod aead;
 mod block;
 mod stream;
 
 use crate::io::TryIntoInner;
+pub(crate) use aead::{
+    DEFAULT_SEGMENT_SIZE, STREAM_HEADER_LEN, SegmentSize, StreamHeader, StreamKey,
+    derive_stream_key, key_confirmation,
+};
+#[cfg(test)]
+pub(crate) use aead::{GCM_TAG_LEN, segment_nonce};
 use aes::Aes256;
 use camellia::Camellia256;
 use cipher::block_padding::Pkcs7;

--- a/lib/src/cipher.rs
+++ b/lib/src/cipher.rs
@@ -2,6 +2,7 @@
 
 mod aead;
 mod block;
+mod gcm;
 mod stream;
 
 use crate::io::TryIntoInner;
@@ -49,11 +50,24 @@ pub(crate) type EncryptCbcCamellia256Writer<W> =
 pub(crate) type DecryptCbcCamellia256Reader<R> =
     block::CbcBlockCipherDecryptReader<R, Camellia256, Pkcs7>;
 
+/// A type alias for an AES-256 GCM mode STREAM encryption writer.
+pub(crate) type EncryptGcmAes256Writer<W> = gcm::GcmEncryptWriter<W, Aes256>;
+
+/// A type alias for a Camellia-256 GCM mode STREAM encryption writer.
+pub(crate) type EncryptGcmCamellia256Writer<W> = gcm::GcmEncryptWriter<W, Camellia256>;
+
+/// A type alias for an AES-256 GCM mode STREAM decryption reader.
+pub(crate) type DecryptGcmAes256Reader<R> = gcm::GcmDecryptReader<R, Aes256>;
+
+/// A type alias for a Camellia-256 GCM mode STREAM decryption reader.
+pub(crate) type DecryptGcmCamellia256Reader<R> = gcm::GcmDecryptReader<R, Camellia256>;
+
 /// An enum representing different encryption writers for PNA archives.
 ///
 /// This enum provides different encryption implementations for writing data to a PNA archive.
-/// It supports both block ciphers (AES-256 and Camellia-256 in CBC mode) and stream ciphers
-/// (AES-256 and Camellia-256 in CTR mode).
+/// It supports block ciphers (AES-256 and Camellia-256 in CBC mode), stream ciphers
+/// (AES-256 and Camellia-256 in CTR mode), and authenticated encryption
+/// (AES-256 and Camellia-256 in GCM STREAM mode).
 pub(crate) enum CipherWriter<W: Write> {
     /// No encryption, data is written as-is.
     No(W),
@@ -65,6 +79,10 @@ pub(crate) enum CipherWriter<W: Write> {
     CtrAes(Ctr128BEWriter<W, Aes256>),
     /// Camellia-256 encryption in CTR mode.
     CtrCamellia(Ctr128BEWriter<W, Camellia256>),
+    /// AES-256 encryption in GCM STREAM mode.
+    GcmAes(EncryptGcmAes256Writer<W>),
+    /// Camellia-256 encryption in GCM STREAM mode.
+    GcmCamellia(EncryptGcmCamellia256Writer<W>),
 }
 
 impl<W: Write> Write for CipherWriter<W> {
@@ -76,6 +94,8 @@ impl<W: Write> Write for CipherWriter<W> {
             Self::CbcCamellia(w) => w.write(buf),
             Self::CtrAes(w) => w.write(buf),
             Self::CtrCamellia(w) => w.write(buf),
+            Self::GcmAes(w) => w.write(buf),
+            Self::GcmCamellia(w) => w.write(buf),
         }
     }
 
@@ -87,6 +107,8 @@ impl<W: Write> Write for CipherWriter<W> {
             Self::CbcCamellia(w) => w.flush(),
             Self::CtrAes(w) => w.flush(),
             Self::CtrCamellia(w) => w.flush(),
+            Self::GcmAes(w) => w.flush(),
+            Self::GcmCamellia(w) => w.flush(),
         }
     }
 }
@@ -100,6 +122,8 @@ impl<W: Write> CipherWriter<W> {
             Self::CbcCamellia(w) => w.get_mut(),
             Self::CtrAes(w) => w.get_mut(),
             Self::CtrCamellia(w) => w.get_mut(),
+            Self::GcmAes(w) => w.get_mut(),
+            Self::GcmCamellia(w) => w.get_mut(),
         }
     }
 }
@@ -113,6 +137,8 @@ impl<W: Write> TryIntoInner<W> for CipherWriter<W> {
             Self::CbcCamellia(w) => w.finish(),
             Self::CtrAes(w) => w.finish(),
             Self::CtrCamellia(w) => w.finish(),
+            Self::GcmAes(w) => w.finish(),
+            Self::GcmCamellia(w) => w.finish(),
         }
     }
 }
@@ -120,8 +146,9 @@ impl<W: Write> TryIntoInner<W> for CipherWriter<W> {
 /// An enum representing different decryption readers for PNA archives.
 ///
 /// This enum provides different decryption implementations for reading data from a PNA archive.
-/// It supports both block ciphers (AES-256 and Camellia-256 in CBC mode) and stream ciphers
-/// (AES-256 and Camellia-256 in CTR mode).
+/// It supports block ciphers (AES-256 and Camellia-256 in CBC mode), stream ciphers
+/// (AES-256 and Camellia-256 in CTR mode), and authenticated encryption
+/// (AES-256 and Camellia-256 in GCM STREAM mode).
 pub(crate) enum DecryptReader<R: Read> {
     /// No decryption, data is read as-is.
     No(R),
@@ -133,6 +160,10 @@ pub(crate) enum DecryptReader<R: Read> {
     CtrAes(Ctr128BEReader<R, Aes256>),
     /// Camellia-256 decryption in CTR mode.
     CtrCamellia(Ctr128BEReader<R, Camellia256>),
+    /// AES-256 decryption in GCM STREAM mode.
+    GcmAes(DecryptGcmAes256Reader<R>),
+    /// Camellia-256 decryption in GCM STREAM mode.
+    GcmCamellia(DecryptGcmCamellia256Reader<R>),
 }
 
 impl<R: Read> Read for DecryptReader<R> {
@@ -143,6 +174,8 @@ impl<R: Read> Read for DecryptReader<R> {
             DecryptReader::CbcCamellia(r) => r.read(buf),
             DecryptReader::CtrAes(r) => r.read(buf),
             DecryptReader::CtrCamellia(r) => r.read(buf),
+            DecryptReader::GcmAes(r) => r.read(buf),
+            DecryptReader::GcmCamellia(r) => r.read(buf),
         }
     }
 }

--- a/lib/src/cipher/aead.rs
+++ b/lib/src/cipher/aead.rs
@@ -1,0 +1,430 @@
+//! Key and nonce derivation for cipher mode 2 (GCM STREAM).
+//!
+//! Binding the entry header into the stream key means an entry cannot be moved
+//! or renamed without re-encrypting it. The key confirmation exists so that a
+//! decoder can tell a wrong password from tampered data before it processes a
+//! segment, which a GCM tag alone cannot distinguish.
+
+use crate::{ChunkType, error::AeadError};
+use hkdf::Hkdf;
+use sha2::{Digest, Sha256};
+use std::fmt;
+use std::num::NonZeroU32;
+use subtle::ConstantTimeEq;
+
+pub(crate) const STREAM_HEADER_LEN: usize = 75;
+pub(crate) const GCM_TAG_LEN: usize = 16;
+pub(crate) const MAX_SEGMENT_SIZE: u32 = 67_108_864; // 64 MiB
+pub(crate) const DEFAULT_SEGMENT_SIZE: u32 = 1_048_576; // 1 MiB
+const DOMAIN_TAG: &[u8; 13] = b"PNA-STREAM-v1";
+const KEY_CONFIRMATION_INFO: &[u8; 9] = b"PNA-KC-v1";
+const ENTRY_CONTEXT_LEN: usize = 88;
+
+/// The key confirmation value carried by a stream header.
+///
+/// Deliberately not [`PartialEq`]: one operand of a real comparison is always
+/// attacker-supplied archive bytes, and `==` would leak how far a guessed
+/// password's confirmation agrees with the stored one. Use
+/// [`StreamHeader::confirms_key`], which compares in constant time.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct KeyConfirmation([u8; 32]);
+
+impl KeyConfirmation {
+    #[cfg(test)]
+    #[inline]
+    pub(crate) const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+}
+
+/// A per-stream AEAD key derived from the master key and the entry context.
+///
+/// Distinct from the master key so that the two cannot be swapped at a cipher
+/// construction site, where the mistake would produce archives that decrypt
+/// only with the same mistake.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct StreamKey([u8; 32]);
+
+impl StreamKey {
+    #[cfg(test)]
+    #[inline]
+    pub(crate) const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    #[inline]
+    pub(crate) fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl fmt::Debug for StreamKey {
+    /// Redacted: this is key material, and `StreamKey` is reachable from types
+    /// that derive [`Debug`].
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("StreamKey(..)")
+    }
+}
+
+/// A segment size that is in range: non-zero and at most [`MAX_SEGMENT_SIZE`].
+///
+/// [`SegmentSize::new`] is the only way to obtain one, so a value of this type
+/// carries the check with it — a segment loop cannot be handed a zero that would
+/// leave it making no progress, and no downstream use has to re-validate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SegmentSize(NonZeroU32);
+
+impl SegmentSize {
+    /// Returns [`None`] when out of range, leaving the meaning of that to the
+    /// caller: an out-of-range value read off the wire is a malformed
+    /// datastream, while one handed in by a caller is invalid input.
+    pub(crate) fn new(value: u32) -> Option<Self> {
+        match NonZeroU32::new(value) {
+            Some(value) if value.get() <= MAX_SEGMENT_SIZE => Some(Self(value)),
+            _ => None,
+        }
+    }
+
+    pub(crate) const fn get(self) -> u32 {
+        self.0.get()
+    }
+}
+
+/// On-wire GCM stream header:
+/// `salt(32) || nonce_prefix(7) || segment_size(u32 BE) || key_confirmation(32)`.
+#[derive(Debug)]
+pub(crate) struct StreamHeader {
+    pub(crate) salt: [u8; 32],
+    pub(crate) nonce_prefix: [u8; 7],
+    segment_size: SegmentSize,
+    key_confirmation: KeyConfirmation,
+}
+
+impl StreamHeader {
+    pub(crate) const fn new(
+        salt: [u8; 32],
+        nonce_prefix: [u8; 7],
+        segment_size: SegmentSize,
+        key_confirmation: KeyConfirmation,
+    ) -> Self {
+        Self {
+            salt,
+            nonce_prefix,
+            segment_size,
+            key_confirmation,
+        }
+    }
+
+    pub(crate) const fn segment_size(&self) -> SegmentSize {
+        self.segment_size
+    }
+
+    /// Whether the stored key confirmation matches the one `k_master` derives,
+    /// compared in constant time.
+    pub(crate) fn confirms_key(&self, k_master: &[u8]) -> bool {
+        key_confirmation(k_master)
+            .0
+            .ct_eq(&self.key_confirmation.0)
+            .into()
+    }
+
+    pub(crate) fn to_bytes(&self) -> [u8; STREAM_HEADER_LEN] {
+        let mut bytes = [0u8; STREAM_HEADER_LEN];
+        bytes[..32].copy_from_slice(&self.salt);
+        bytes[32..39].copy_from_slice(&self.nonce_prefix);
+        bytes[39..43].copy_from_slice(&self.segment_size.get().to_be_bytes());
+        bytes[43..75].copy_from_slice(&self.key_confirmation.0);
+        bytes
+    }
+
+    pub(crate) fn try_from_bytes(bytes: &[u8; STREAM_HEADER_LEN]) -> Result<Self, AeadError> {
+        let segment_size = SegmentSize::new(u32::from_be_bytes(bytes[39..43].try_into().unwrap()))
+            .ok_or(AeadError::Malformed("segment size out of range"))?;
+        Ok(Self::new(
+            bytes[..32].try_into().unwrap(),
+            bytes[32..39].try_into().unwrap(),
+            segment_size,
+            KeyConfirmation(bytes[43..75].try_into().unwrap()),
+        ))
+    }
+}
+
+pub(crate) fn hkdf_sha256(ikm: &[u8], salt: &[u8], info: &[u8]) -> [u8; 32] {
+    let hk = Hkdf::<Sha256>::new(Some(salt), ikm);
+    let mut okm = [0u8; 32];
+    hk.expand(info, &mut okm)
+        .expect("32 bytes is a valid HKDF-SHA-256 output length");
+    okm
+}
+
+/// Derives the key confirmation value that every stream header of an archive
+/// protected by `k_master` carries.
+pub(crate) fn key_confirmation(k_master: &[u8]) -> KeyConfirmation {
+    KeyConfirmation(hkdf_sha256(k_master, &[], KEY_CONFIRMATION_INFO))
+}
+
+pub(crate) fn entry_context(
+    header: &StreamHeader,
+    header_chunk_type: ChunkType,
+    header_chunk_data: &[u8],
+    phsf_chunk_data: &[u8],
+) -> [u8; ENTRY_CONTEXT_LEN] {
+    let mut ctx = [0u8; ENTRY_CONTEXT_LEN];
+    let mut header_hasher = Sha256::new();
+    header_hasher.update(header_chunk_type.as_bytes());
+    header_hasher.update(header_chunk_data);
+
+    ctx[..13].copy_from_slice(DOMAIN_TAG);
+    ctx[13..45].copy_from_slice(&header_hasher.finalize());
+    ctx[45..77].copy_from_slice(&Sha256::digest(phsf_chunk_data));
+    ctx[77..84].copy_from_slice(&header.nonce_prefix);
+    ctx[84..88].copy_from_slice(&header.segment_size.get().to_be_bytes());
+    ctx
+}
+
+pub(crate) fn derive_stream_key(
+    k_master: &[u8],
+    header: &StreamHeader,
+    header_chunk_type: ChunkType,
+    header_chunk_data: &[u8],
+    phsf_chunk_data: &[u8],
+) -> StreamKey {
+    let info = entry_context(
+        header,
+        header_chunk_type,
+        header_chunk_data,
+        phsf_chunk_data,
+    );
+    StreamKey(hkdf_sha256(k_master, &header.salt, &info))
+}
+
+pub(crate) fn segment_nonce(nonce_prefix: &[u8; 7], counter: u32, is_final: bool) -> [u8; 12] {
+    let mut nonce = [0u8; 12];
+    nonce[..7].copy_from_slice(nonce_prefix);
+    nonce[7..11].copy_from_slice(&counter.to_be_bytes());
+    nonce[11] = if is_final { 0x01 } else { 0x00 };
+    nonce
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const OKM_42_BYTES: [u8; 42] = [
+        0x3c, 0xb2, 0x5f, 0x25, 0xfa, 0xac, 0xd5, 0x7a, 0x90, 0x43, 0x4f, 0x64, 0xd0, 0x36, 0x2f,
+        0x2a, 0x2d, 0x2d, 0x0a, 0x90, 0xcf, 0x1a, 0x5a, 0x4c, 0x5d, 0xb0, 0x2d, 0x56, 0xec, 0xc4,
+        0xc5, 0xbf, 0x34, 0x00, 0x72, 0x08, 0xd5, 0xb8, 0x87, 0x18, 0x58, 0x65,
+    ];
+
+    const SALT: [u8; 32] = [0x42; 32];
+    const PREFIX: [u8; 7] = [0x5A; 7];
+    const SEGMENT_SIZE: u32 = 0x01020304;
+    const K_MASTER: &[u8] = b"master_key";
+    const HEADER_DATA: &[u8] = b"header";
+    const PHSF_DATA: &[u8] = b"phsf";
+
+    /// `HKDF-SHA-256(ikm = K_MASTER, salt = SALT, info = entry_context(FHED))`.
+    ///
+    /// Produced by an RFC 5869 implementation outside this crate. Regenerating it
+    /// from `derive_stream_key` would bless whatever that function currently does
+    /// and lose the only external check on the derivation.
+    const K_STREAM_FHED: StreamKey = StreamKey::from_bytes([
+        0xb8, 0x8e, 0x2e, 0xdc, 0x07, 0x53, 0x8b, 0xdd, 0x2b, 0x9a, 0xff, 0xf5, 0x7f, 0xb0, 0xd3,
+        0x43, 0x3a, 0x1f, 0x44, 0x98, 0xd2, 0x2a, 0x59, 0x11, 0x50, 0x7e, 0x68, 0x27, 0x59, 0x0f,
+        0xad, 0xb5,
+    ]);
+
+    fn header() -> StreamHeader {
+        header_of(SALT, PREFIX, SEGMENT_SIZE)
+    }
+
+    fn header_of(salt: [u8; 32], nonce_prefix: [u8; 7], segment_size: u32) -> StreamHeader {
+        StreamHeader::new(
+            salt,
+            nonce_prefix,
+            SegmentSize::new(segment_size).unwrap(),
+            KeyConfirmation::from_bytes([0x33; 32]),
+        )
+    }
+
+    #[test]
+    fn stream_header_roundtrips_through_bytes() {
+        let header = StreamHeader::new(
+            [0xA5; 32],
+            PREFIX,
+            SegmentSize::new(SEGMENT_SIZE).unwrap(),
+            KeyConfirmation::from_bytes([0x3C; 32]),
+        );
+        let bytes = header.to_bytes();
+        assert_eq!(bytes[..32], [0xA5; 32]);
+        assert_eq!(bytes[32..39], PREFIX);
+        assert_eq!(bytes[39..43], [0x01, 0x02, 0x03, 0x04]);
+        assert_eq!(bytes[43..75], [0x3C; 32]);
+        let parsed = StreamHeader::try_from_bytes(&bytes).unwrap();
+        assert_eq!(parsed.salt, header.salt);
+        assert_eq!(parsed.nonce_prefix, header.nonce_prefix);
+        assert_eq!(parsed.segment_size(), header.segment_size());
+        assert_eq!(parsed.key_confirmation.0, header.key_confirmation.0);
+    }
+
+    #[test]
+    fn segment_size_rejects_zero() {
+        assert!(SegmentSize::new(0).is_none());
+    }
+
+    #[test]
+    fn segment_size_rejects_oversized() {
+        assert!(SegmentSize::new(MAX_SEGMENT_SIZE + 1).is_none());
+    }
+
+    #[test]
+    fn stream_header_rejects_zero_segment_size() {
+        let bytes = [0u8; STREAM_HEADER_LEN];
+        assert!(matches!(
+            StreamHeader::try_from_bytes(&bytes),
+            Err(AeadError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn stream_header_rejects_oversized_segment_size() {
+        let mut bytes = [0u8; STREAM_HEADER_LEN];
+        bytes[39..43].copy_from_slice(&(MAX_SEGMENT_SIZE + 1).to_be_bytes());
+        assert!(matches!(
+            StreamHeader::try_from_bytes(&bytes),
+            Err(AeadError::Malformed(_))
+        ));
+    }
+
+    #[test]
+    fn stream_header_accepts_boundary_segment_sizes() {
+        for segment_size in [1, MAX_SEGMENT_SIZE] {
+            let bytes = StreamHeader::new(
+                SALT,
+                PREFIX,
+                SegmentSize::new(segment_size).unwrap(),
+                KeyConfirmation::from_bytes([0; 32]),
+            )
+            .to_bytes();
+            assert_eq!(
+                StreamHeader::try_from_bytes(&bytes)
+                    .unwrap()
+                    .segment_size()
+                    .get(),
+                segment_size
+            );
+        }
+    }
+
+    #[test]
+    fn hkdf_sha256_rfc5869_test_case_1() {
+        let ikm = [0x0bu8; 22];
+        let salt: Vec<u8> = (0x00u8..=0x0c).collect();
+        let info: Vec<u8> = (0xf0u8..=0xf9).collect();
+        assert_eq!(
+            hkdf_sha256(&ikm, &salt, &info).as_slice(),
+            &OKM_42_BYTES[..32]
+        );
+    }
+
+    #[test]
+    fn key_confirmation_is_hkdf_with_empty_salt_and_domain_info() {
+        assert_eq!(
+            key_confirmation(b"master_key").0,
+            hkdf_sha256(b"master_key", &[], b"PNA-KC-v1")
+        );
+    }
+
+    #[test]
+    fn key_confirmation_differs_per_k_master() {
+        assert_ne!(
+            key_confirmation(b"master_key_1").0,
+            key_confirmation(b"master_key_2").0
+        );
+    }
+
+    #[test]
+    fn stream_header_confirms_the_deriving_key() {
+        let header = StreamHeader::new(
+            SALT,
+            PREFIX,
+            SegmentSize::new(SEGMENT_SIZE).unwrap(),
+            key_confirmation(b"master_key"),
+        );
+        assert!(header.confirms_key(b"master_key"));
+    }
+
+    #[test]
+    fn stream_header_rejects_another_key() {
+        let header = StreamHeader::new(
+            SALT,
+            PREFIX,
+            SegmentSize::new(SEGMENT_SIZE).unwrap(),
+            key_confirmation(b"master_key"),
+        );
+        assert!(!header.confirms_key(b"other_key"));
+    }
+
+    #[test]
+    fn entry_context_layout() {
+        let ctx = entry_context(&header(), ChunkType::FHED, b"test_header", b"test_phsf");
+        let mut expected = Vec::with_capacity(ENTRY_CONTEXT_LEN);
+        expected.extend_from_slice(b"PNA-STREAM-v1");
+        expected.extend_from_slice(&Sha256::digest(b"FHEDtest_header"));
+        expected.extend_from_slice(&Sha256::digest(b"test_phsf"));
+        expected.extend_from_slice(&PREFIX);
+        expected.extend_from_slice(&SEGMENT_SIZE.to_be_bytes());
+
+        assert_eq!(ctx.as_slice(), expected);
+    }
+
+    #[test]
+    fn entry_context_solid_header_hash_includes_shed_type() {
+        let ctx = entry_context(&header(), ChunkType::SHED, b"test_header", b"test_phsf");
+        let expected = Sha256::digest([b"SHED".as_slice(), b"test_header".as_slice()].concat());
+        assert_eq!(&ctx[13..45], expected.as_slice());
+    }
+
+    #[test]
+    fn derive_stream_key_ignores_key_confirmation() {
+        let header1 = StreamHeader::new(
+            SALT,
+            PREFIX,
+            SegmentSize::new(SEGMENT_SIZE).unwrap(),
+            KeyConfirmation::from_bytes([0x01; 32]),
+        );
+        let header2 = StreamHeader::new(
+            SALT,
+            PREFIX,
+            SegmentSize::new(SEGMENT_SIZE).unwrap(),
+            KeyConfirmation::from_bytes([0x02; 32]),
+        );
+        let key1 = derive_stream_key(K_MASTER, &header1, ChunkType::FHED, HEADER_DATA, PHSF_DATA);
+        let key2 = derive_stream_key(K_MASTER, &header2, ChunkType::FHED, HEADER_DATA, PHSF_DATA);
+        assert_eq!(key1, key2);
+    }
+
+    /// Pins every input's contribution and the order they are fed to HKDF. A
+    /// differential test cannot: transposing `ikm` with `salt`, or the `FHED` data
+    /// with the `PHSF` data, still yields a value that depends on both.
+    #[test]
+    fn derive_stream_key_matches_a_fixed_vector() {
+        assert_eq!(
+            derive_stream_key(K_MASTER, &header(), ChunkType::FHED, HEADER_DATA, PHSF_DATA),
+            K_STREAM_FHED
+        );
+    }
+
+    #[test]
+    fn segment_nonce_layout() {
+        assert_eq!(
+            segment_nonce(&[1u8; 7], 0x01020304, false),
+            [1, 1, 1, 1, 1, 1, 1, 0x01, 0x02, 0x03, 0x04, 0x00]
+        );
+        assert_eq!(
+            segment_nonce(&[1u8; 7], 0x01020304, true),
+            [1, 1, 1, 1, 1, 1, 1, 0x01, 0x02, 0x03, 0x04, 0x01]
+        );
+    }
+}

--- a/lib/src/cipher/gcm.rs
+++ b/lib/src/cipher/gcm.rs
@@ -1,0 +1,703 @@
+//! STREAM-based GCM segment encryption writer and decryption reader.
+
+use crate::cipher::aead::{GCM_TAG_LEN, StreamHeader, StreamKey, segment_nonce};
+use crate::error::AeadError;
+use aes_gcm::AesGcm;
+use aes_gcm::aead::array::Array;
+use aes_gcm::aead::{Aead, AeadCore, KeyInit, consts::U12};
+use std::io::{self, Read, Write};
+
+/// Bounds how far a segment buffer can outrun the bytes that actually arrived.
+const SEGMENT_READ_STEP: usize = 64 * 1024;
+
+pub(crate) struct GcmEncryptWriter<W, C>
+where
+    AesGcm<C, U12>: KeyInit + Aead + AeadCore<NonceSize = U12>,
+{
+    w: W,
+    cipher: AesGcm<C, U12>,
+    nonce_prefix: [u8; 7],
+    segment_size: usize,
+    counter: u32,
+    buf: Vec<u8>,
+}
+
+impl<W, C> GcmEncryptWriter<W, C>
+where
+    W: Write,
+    AesGcm<C, U12>: KeyInit + Aead + AeadCore<NonceSize = U12>,
+{
+    pub(crate) fn new(writer: W, k_stream: &StreamKey, header: &StreamHeader) -> Self {
+        let segment_size = header.segment_size().get() as usize;
+        Self {
+            w: writer,
+            cipher: AesGcm::<C, U12>::new_from_slice(k_stream.as_bytes())
+                .expect("32-byte stream key length matches cipher key size"),
+            nonce_prefix: header.nonce_prefix,
+            segment_size,
+            counter: 0,
+            // Grown by `write` and reused across segments, so an entry smaller
+            // than one segment never reserves a whole segment.
+            buf: Vec::new(),
+        }
+    }
+
+    fn flush_segment(&mut self, is_final: bool) -> io::Result<()> {
+        let nonce =
+            Array::<u8, U12>::from(segment_nonce(&self.nonce_prefix, self.counter, is_final));
+        let segment = self
+            .cipher
+            .encrypt(&nonce, self.buf.as_slice())
+            .map_err(|_| io::Error::other("GCM segment encryption failed"))?;
+        self.w.write_all(&segment)?;
+        self.buf.clear();
+        self.counter = self
+            .counter
+            .checked_add(1)
+            .ok_or_else(|| io::Error::other("GCM segment counter overflow"))?;
+        Ok(())
+    }
+
+    pub(crate) fn finish(mut self) -> io::Result<W> {
+        self.flush_segment(true)?;
+        Ok(self.w)
+    }
+
+    #[inline]
+    pub(crate) fn get_mut(&mut self) -> &mut W {
+        &mut self.w
+    }
+}
+
+impl<W, C> Write for GcmEncryptWriter<W, C>
+where
+    W: Write,
+    AesGcm<C, U12>: KeyInit + Aead + AeadCore<NonceSize = U12>,
+{
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut rest = buf;
+        while !rest.is_empty() {
+            let space = self.segment_size - self.buf.len();
+            let take = space.min(rest.len());
+            self.buf.extend_from_slice(&rest[..take]);
+            rest = &rest[take..];
+            if self.buf.len() == self.segment_size && !rest.is_empty() {
+                self.flush_segment(false)?;
+            }
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.w.flush()
+    }
+}
+
+/// Why the reader stopped.
+///
+/// Latched so that a later `read` cannot resume a segment whose bytes were
+/// already consumed. `AeadError` alone cannot carry the second case: a failure
+/// that came from the source is not one of the classes a decoder is meant to
+/// report about the datastream.
+enum Stopped {
+    Aead(AeadError),
+    /// The inner reader or an allocation failed partway through a segment. Those
+    /// bytes leave with `read_full`'s buffer, so the framing cannot be picked up
+    /// again — re-reporting the failure is the only honest answer.
+    Source(io::ErrorKind, String),
+}
+
+impl Stopped {
+    fn to_error(&self) -> io::Error {
+        match self {
+            Self::Aead(e) => e.clone().into(),
+            Self::Source(kind, message) => io::Error::new(*kind, message.clone()),
+        }
+    }
+}
+
+/// STREAM-based GCM segment decryption reader.
+///
+/// Reads one segment ahead so that a segment is decrypted with the final flag
+/// set only when no datastream bytes follow it. Only tag-verified plaintext is
+/// ever returned to the caller.
+pub(crate) struct GcmDecryptReader<R, C>
+where
+    AesGcm<C, U12>: KeyInit + Aead + AeadCore<NonceSize = U12>,
+{
+    r: R,
+    cipher: AesGcm<C, U12>,
+    nonce_prefix: [u8; 7],
+    segment_size: usize,
+    counter: u32,
+    pending: Option<Vec<u8>>,
+    started: bool,
+    plain: Vec<u8>,
+    pos: usize,
+    done: bool,
+    fuse: Option<Stopped>,
+}
+
+impl<R, C> GcmDecryptReader<R, C>
+where
+    R: Read,
+    AesGcm<C, U12>: KeyInit + Aead + AeadCore<NonceSize = U12>,
+{
+    pub(crate) fn new(reader: R, k_stream: &StreamKey, header: &StreamHeader) -> Self {
+        Self {
+            r: reader,
+            cipher: AesGcm::<C, U12>::new_from_slice(k_stream.as_bytes())
+                .expect("32-byte stream key length matches cipher key size"),
+            nonce_prefix: header.nonce_prefix,
+            segment_size: header.segment_size().get() as usize,
+            counter: 0,
+            pending: None,
+            started: false,
+            plain: Vec::new(),
+            pos: 0,
+            done: false,
+            fuse: None,
+        }
+    }
+
+    fn fail(&mut self, e: AeadError) -> io::Error {
+        self.fuse = Some(Stopped::Aead(e.clone()));
+        e.into()
+    }
+
+    fn stop_on_source(&mut self, e: io::Error) -> io::Error {
+        self.fuse = Some(Stopped::Source(e.kind(), e.to_string()));
+        e
+    }
+
+    fn read_full(&mut self) -> io::Result<Vec<u8>> {
+        // The segment size comes from the unauthenticated stream header, so
+        // committing it up front would let a hostile archive turn a few hundred
+        // bytes into a 64 MiB allocation before any tag is verified. Growing in
+        // bounded steps keeps the commitment proportional to the bytes that
+        // actually arrived; `try_reserve` reports exhaustion instead of aborting.
+        let cap = self.segment_size + GCM_TAG_LEN;
+        let mut buf = Vec::new();
+        let mut filled = 0;
+        while filled < cap {
+            if filled == buf.len() {
+                let grown = buf.len() + (cap - buf.len()).min(SEGMENT_READ_STEP);
+                buf.try_reserve(grown - buf.len()).map_err(|_| {
+                    self.stop_on_source(io::Error::new(
+                        io::ErrorKind::OutOfMemory,
+                        format!("failed to allocate {grown} bytes for segment"),
+                    ))
+                })?;
+                buf.resize(grown, 0);
+            }
+            match self.r.read(&mut buf[filled..]) {
+                Ok(0) => break,
+                Ok(n) => filled += n,
+                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                Err(e) => return Err(self.stop_on_source(e)),
+            }
+        }
+        buf.truncate(filled);
+        Ok(buf)
+    }
+
+    fn refill(&mut self) -> io::Result<()> {
+        if !self.started {
+            self.pending = Some(self.read_full()?);
+            self.started = true;
+        }
+        let b = self.read_full()?;
+        let a = self
+            .pending
+            .take()
+            .expect("a started reader always holds a buffered segment");
+        let i = self.counter;
+        if b.is_empty() {
+            if a.len() < GCM_TAG_LEN {
+                // Zero segments is a structural violation (no empty final segment
+                // was even present); a short tail after earlier segments is a cut.
+                let f = if i == 0 {
+                    AeadError::Malformed("datastream shorter than one empty final segment")
+                } else {
+                    AeadError::Truncation
+                };
+                return Err(self.fail(f));
+            }
+            let plain = self.decrypt(i, true, &a)?;
+            self.plain = plain;
+            self.pos = 0;
+            self.done = true;
+        } else {
+            if a.len() < self.segment_size + GCM_TAG_LEN {
+                return Err(self.fail(AeadError::Malformed(
+                    "non-final segment shorter than segment size",
+                )));
+            }
+            let plain = self.decrypt(i, false, &a)?;
+            self.counter = self
+                .counter
+                .checked_add(1)
+                .ok_or_else(|| self.fail(AeadError::Malformed("segment counter overflow")))?;
+            self.plain = plain;
+            self.pos = 0;
+            self.pending = Some(b);
+        }
+        Ok(())
+    }
+
+    fn decrypt(&mut self, counter: u32, is_final: bool, segment: &[u8]) -> io::Result<Vec<u8>> {
+        let nonce = Array::<u8, U12>::from(segment_nonce(&self.nonce_prefix, counter, is_final));
+        match self.cipher.decrypt(&nonce, segment) {
+            Ok(plain) => Ok(plain),
+            Err(_) => Err(self.fail(AeadError::AuthenticationFailure)),
+        }
+    }
+}
+
+impl<R, C> Read for GcmDecryptReader<R, C>
+where
+    R: Read,
+    AesGcm<C, U12>: KeyInit + Aead + AeadCore<NonceSize = U12>,
+{
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if let Some(stopped) = &self.fuse {
+            return Err(stopped.to_error());
+        }
+        // Refilling would consume and decrypt a segment that the caller has no
+        // room for, so a zero-length probe would report `Ok(0)` with data still
+        // pending — the same guard `ChainReader` carries.
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        if self.pos >= self.plain.len() {
+            if self.done {
+                return Ok(0);
+            }
+            self.refill()?;
+            if self.pos >= self.plain.len() {
+                return Ok(0);
+            }
+        }
+        let n = (self.plain.len() - self.pos).min(buf.len());
+        buf[..n].copy_from_slice(&self.plain[self.pos..self.pos + n]);
+        self.pos += n;
+        Ok(n)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cipher::aead::{KeyConfirmation, SegmentSize};
+    use crate::error::AeadError;
+    use aes::Aes256;
+    use camellia::Camellia256;
+    use std::io::{Cursor, Read};
+
+    const KEY: StreamKey = StreamKey::from_bytes([7u8; 32]);
+    const PREFIX: [u8; 7] = [3u8; 7];
+    const SEG: u32 = 4;
+
+    fn header(segment_size: u32) -> StreamHeader {
+        StreamHeader::new(
+            [0u8; 32],
+            PREFIX,
+            SegmentSize::new(segment_size).unwrap(),
+            KeyConfirmation::from_bytes([0u8; 32]),
+        )
+    }
+
+    fn encrypt_all<C>(plain: &[u8]) -> Vec<u8>
+    where
+        AesGcm<C, U12>: KeyInit + Aead + AeadCore<NonceSize = U12>,
+    {
+        let mut w = GcmEncryptWriter::<_, C>::new(Vec::new(), &KEY, &header(SEG));
+        w.write_all(plain).unwrap();
+        w.finish().unwrap()
+    }
+
+    fn encrypt_byte_by_byte<C>(plain: &[u8]) -> Vec<u8>
+    where
+        AesGcm<C, U12>: KeyInit + Aead + AeadCore<NonceSize = U12>,
+    {
+        let mut w = GcmEncryptWriter::<_, C>::new(Vec::new(), &KEY, &header(SEG));
+        for b in plain {
+            w.write_all(std::slice::from_ref(b)).unwrap();
+        }
+        w.finish().unwrap()
+    }
+
+    fn decrypt_stream<C>(plain_len: usize, ciphertext: &[u8]) -> Vec<u8>
+    where
+        AesGcm<C, U12>: KeyInit + Aead + AeadCore<NonceSize = U12>,
+    {
+        let cipher = AesGcm::<C, U12>::new_from_slice(KEY.as_bytes()).unwrap();
+        let non_final = if plain_len == 0 {
+            0
+        } else {
+            (plain_len - 1) / SEG as usize
+        };
+        let mut out = Vec::new();
+        let mut rest = ciphertext;
+        let mut counter = 0u32;
+        for _ in 0..non_final {
+            let nonce = Array::<u8, U12>::from(segment_nonce(&PREFIX, counter, false));
+            let (segment, tail) = rest.split_at(SEG as usize + GCM_TAG_LEN);
+            out.extend_from_slice(&cipher.decrypt(&nonce, segment).unwrap());
+            rest = tail;
+            counter += 1;
+        }
+        let nonce = Array::<u8, U12>::from(segment_nonce(&PREFIX, counter, true));
+        out.extend_from_slice(&cipher.decrypt(&nonce, rest).unwrap());
+        out
+    }
+
+    #[test]
+    fn empty_plaintext_emits_single_tag_only_segment() {
+        let ct = encrypt_all::<Aes256>(b"");
+        assert_eq!(ct.len(), GCM_TAG_LEN);
+        assert_eq!(decrypt_stream::<Aes256>(0, &ct).as_slice(), b"");
+    }
+
+    #[test]
+    fn below_segment_size_emits_single_final_segment() {
+        let plain = b"abc";
+        let ct = encrypt_all::<Aes256>(plain);
+        assert_eq!(ct.len(), plain.len() + GCM_TAG_LEN);
+        assert_eq!(decrypt_stream::<Aes256>(plain.len(), &ct).as_slice(), plain);
+    }
+
+    #[test]
+    fn exact_segment_size_has_no_trailing_empty_segment() {
+        let plain = b"abcd";
+        let ct = encrypt_all::<Aes256>(plain);
+        assert_eq!(ct.len(), plain.len() + GCM_TAG_LEN);
+        assert_eq!(decrypt_stream::<Aes256>(plain.len(), &ct).as_slice(), plain);
+    }
+
+    #[test]
+    fn two_segments_split_into_non_final_and_final() {
+        let plain = b"abcdefgh";
+        let ct = encrypt_all::<Aes256>(plain);
+        assert_eq!(ct.len(), plain.len() + 2 * GCM_TAG_LEN);
+        assert_eq!(decrypt_stream::<Aes256>(plain.len(), &ct).as_slice(), plain);
+    }
+
+    #[test]
+    fn partial_tail_after_two_full_segments() {
+        let plain = b"abcdefghi";
+        let ct = encrypt_all::<Aes256>(plain);
+        assert_eq!(ct.len(), plain.len() + 3 * GCM_TAG_LEN);
+        assert_eq!(decrypt_stream::<Aes256>(plain.len(), &ct).as_slice(), plain);
+    }
+
+    #[test]
+    fn output_independent_of_write_boundaries() {
+        let plain = b"abcdefghi";
+        assert_eq!(
+            encrypt_all::<Aes256>(plain),
+            encrypt_byte_by_byte::<Aes256>(plain)
+        );
+    }
+
+    #[test]
+    fn camellia_segments_decrypt_with_the_derived_nonces() {
+        let plain = b"abcdefgh";
+        let ct = encrypt_all::<Camellia256>(plain);
+        assert_eq!(
+            decrypt_stream::<Camellia256>(plain.len(), &ct).as_slice(),
+            plain
+        );
+    }
+
+    fn decrypt_all<C>(ciphertext: Vec<u8>) -> io::Result<Vec<u8>>
+    where
+        AesGcm<C, U12>: KeyInit + Aead + AeadCore<NonceSize = U12>,
+    {
+        let mut r = GcmDecryptReader::<_, C>::new(Cursor::new(ciphertext), &KEY, &header(SEG));
+        let mut out = Vec::new();
+        r.read_to_end(&mut out)?;
+        Ok(out)
+    }
+
+    fn roundtrip<C>(plain: &[u8])
+    where
+        AesGcm<C, U12>: KeyInit + Aead + AeadCore<NonceSize = U12>,
+    {
+        let ct = encrypt_all::<C>(plain);
+        assert_eq!(decrypt_all::<C>(ct).unwrap().as_slice(), plain);
+    }
+
+    fn classify(err: &io::Error) -> &AeadError {
+        err.get_ref()
+            .and_then(|e| e.downcast_ref::<AeadError>())
+            .expect("decrypt error carries an AeadError")
+    }
+
+    struct OneByteReader<R>(R);
+
+    impl<R: Read> Read for OneByteReader<R> {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            if buf.is_empty() {
+                return Ok(0);
+            }
+            self.0.read(&mut buf[..1])
+        }
+    }
+
+    struct InterruptingReader<R> {
+        inner: R,
+        armed: bool,
+    }
+
+    impl<R: Read> Read for InterruptingReader<R> {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            if self.armed {
+                self.armed = false;
+                return Err(io::Error::from(io::ErrorKind::Interrupted));
+            }
+            self.armed = true;
+            self.inner.read(buf)
+        }
+    }
+
+    /// Fails once with a non-`Interrupted` error partway through the stream,
+    /// then keeps serving bytes — a source that hiccups rather than dies.
+    struct FailingOnceReader<R> {
+        inner: R,
+        remaining_before_failure: usize,
+        armed: bool,
+    }
+
+    impl<R: Read> Read for FailingOnceReader<R> {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            if self.armed && self.remaining_before_failure == 0 {
+                self.armed = false;
+                return Err(io::Error::other("source hiccup"));
+            }
+            let n = buf.len().min(self.remaining_before_failure.max(1));
+            let n = self.inner.read(&mut buf[..n])?;
+            self.remaining_before_failure = self.remaining_before_failure.saturating_sub(n);
+            Ok(n)
+        }
+    }
+
+    struct StallReader {
+        segments: Vec<Vec<u8>>,
+        index: usize,
+        pos: usize,
+    }
+
+    impl Read for StallReader {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            if self.index >= self.segments.len() || buf.is_empty() {
+                return Ok(0);
+            }
+            let current = &self.segments[self.index];
+            if self.pos >= current.len() {
+                self.index += 1;
+                self.pos = 0;
+                return Ok(0);
+            }
+            let n = (current.len() - self.pos).min(buf.len());
+            buf[..n].copy_from_slice(&current[self.pos..self.pos + n]);
+            self.pos += n;
+            Ok(n)
+        }
+    }
+
+    #[test]
+    fn roundtrip_empty_aes() {
+        roundtrip::<Aes256>(b"");
+    }
+
+    #[test]
+    fn zero_length_read_leaves_the_stream_untouched() {
+        let ct = encrypt_all::<Aes256>(b"abcdefgh");
+        let mut r = GcmDecryptReader::<_, Aes256>::new(Cursor::new(ct), &KEY, &header(SEG));
+
+        assert_eq!(r.read(&mut []).unwrap(), 0);
+
+        let mut out = Vec::new();
+        r.read_to_end(&mut out).unwrap();
+        assert_eq!(out, b"abcdefgh");
+    }
+
+    #[test]
+    fn roundtrip_three_bytes_aes() {
+        roundtrip::<Aes256>(b"abc");
+    }
+
+    #[test]
+    fn roundtrip_exact_segment_aes() {
+        roundtrip::<Aes256>(b"abcd");
+    }
+
+    #[test]
+    fn roundtrip_two_segments_aes() {
+        roundtrip::<Aes256>(b"abcdefgh");
+    }
+
+    #[test]
+    fn roundtrip_partial_tail_aes() {
+        roundtrip::<Aes256>(b"abcdefghi");
+    }
+
+    /// The segment framing is generic over the cipher, and Camellia matches AES
+    /// in block, nonce and tag size, so the payload shapes above do not need a
+    /// second run per cipher — only the instantiation does.
+    #[test]
+    fn roundtrip_two_segments_camellia() {
+        roundtrip::<Camellia256>(b"abcdefgh");
+    }
+
+    #[test]
+    fn roundtrip_survives_one_byte_at_a_time() {
+        let plain = b"abcdefghi";
+        let ct = encrypt_all::<Aes256>(plain);
+        let mut r =
+            GcmDecryptReader::<_, Aes256>::new(OneByteReader(Cursor::new(ct)), &KEY, &header(SEG));
+        let mut out = Vec::new();
+        r.read_to_end(&mut out).unwrap();
+        assert_eq!(out.as_slice(), plain);
+    }
+
+    #[test]
+    fn roundtrip_survives_interrupted_reads() {
+        let plain = b"abcdefghi";
+        let ct = encrypt_all::<Aes256>(plain);
+        let mut r = GcmDecryptReader::<_, Aes256>::new(
+            InterruptingReader {
+                inner: Cursor::new(ct),
+                armed: true,
+            },
+            &KEY,
+            &header(SEG),
+        );
+        let mut out = Vec::new();
+        r.read_to_end(&mut out).unwrap();
+        assert_eq!(out.as_slice(), plain);
+    }
+
+    #[test]
+    fn flipped_ciphertext_byte_is_authentication_failure() {
+        let mut ct = encrypt_all::<Aes256>(b"abcdefgh");
+        ct[0] ^= 0x01;
+        let err = decrypt_all::<Aes256>(ct).unwrap_err();
+        assert!(matches!(classify(&err), AeadError::AuthenticationFailure));
+    }
+
+    #[test]
+    fn flipped_tag_byte_is_authentication_failure() {
+        let mut ct = encrypt_all::<Aes256>(b"abc");
+        let last = ct.len() - 1;
+        ct[last] ^= 0x01;
+        let err = decrypt_all::<Aes256>(ct).unwrap_err();
+        assert!(matches!(classify(&err), AeadError::AuthenticationFailure));
+    }
+
+    #[test]
+    fn short_non_final_segment_with_trailing_bytes_is_malformed() {
+        let reader = StallReader {
+            segments: vec![vec![0u8; SEG as usize + GCM_TAG_LEN - 1], vec![0u8; 1]],
+            index: 0,
+            pos: 0,
+        };
+        let mut r = GcmDecryptReader::<_, Aes256>::new(reader, &KEY, &header(SEG));
+        let mut out = [0u8; 8];
+        let err = r.read(&mut out).unwrap_err();
+        assert!(matches!(classify(&err), AeadError::Malformed(_)));
+    }
+
+    #[test]
+    fn fifteen_byte_stream_is_malformed() {
+        let err = decrypt_all::<Aes256>(vec![0u8; GCM_TAG_LEN - 1]).unwrap_err();
+        assert!(matches!(classify(&err), AeadError::Malformed(_)));
+    }
+
+    #[test]
+    fn full_segment_then_short_final_is_truncation() {
+        let ct = encrypt_all::<Aes256>(b"abcdefgh");
+        let mut truncated = ct[..SEG as usize + GCM_TAG_LEN].to_vec();
+        truncated.extend_from_slice(&ct[SEG as usize + GCM_TAG_LEN..][..GCM_TAG_LEN - 1]);
+        let err = decrypt_all::<Aes256>(truncated).unwrap_err();
+        assert!(matches!(classify(&err), AeadError::Truncation));
+    }
+
+    #[test]
+    fn swapped_segments_are_authentication_failure() {
+        let ct = encrypt_all::<Aes256>(b"abcdefgh");
+        let seg = SEG as usize + GCM_TAG_LEN;
+        let mut swapped = ct[seg..].to_vec();
+        swapped.extend_from_slice(&ct[..seg]);
+        let err = decrypt_all::<Aes256>(swapped).unwrap_err();
+        assert!(matches!(classify(&err), AeadError::AuthenticationFailure));
+    }
+
+    #[test]
+    fn duplicated_segment_is_authentication_failure() {
+        let ct = encrypt_all::<Aes256>(b"abcdefgh");
+        let seg = SEG as usize + GCM_TAG_LEN;
+        let mut duplicated = ct[..seg].to_vec();
+        duplicated.extend_from_slice(&ct);
+        let err = decrypt_all::<Aes256>(duplicated).unwrap_err();
+        assert!(matches!(classify(&err), AeadError::AuthenticationFailure));
+    }
+
+    #[test]
+    fn removed_final_segment_is_authentication_failure() {
+        let ct = encrypt_all::<Aes256>(b"abcdefgh");
+        let seg = SEG as usize + GCM_TAG_LEN;
+        let err = decrypt_all::<Aes256>(ct[..seg].to_vec()).unwrap_err();
+        assert!(matches!(classify(&err), AeadError::AuthenticationFailure));
+    }
+
+    #[test]
+    fn a_source_error_is_not_reported_as_an_authentication_failure() {
+        let ct = encrypt_all::<Aes256>(b"abcdefgh");
+        let reader = FailingOnceReader {
+            inner: Cursor::new(ct),
+            remaining_before_failure: 6,
+            armed: true,
+        };
+        let mut r = GcmDecryptReader::<_, Aes256>::new(reader, &KEY, &header(SEG));
+        let mut out = [0u8; 8];
+
+        let first = r.read(&mut out).unwrap_err();
+        assert_eq!(first.kind(), io::ErrorKind::Other, "{first}");
+
+        // Not `InvalidData`, which is what every `AeadError` converts to, and
+        // still the source's own failure rather than a fresh one.
+        let second = r.read(&mut out).unwrap_err();
+        assert_eq!(second.kind(), io::ErrorKind::Other, "{second}");
+        assert!(second.to_string().contains("source hiccup"), "{second}");
+    }
+
+    #[test]
+    fn error_is_reproduced_on_subsequent_reads() {
+        let mut ct = encrypt_all::<Aes256>(b"abcdefgh");
+        ct[0] ^= 0x01;
+        let mut r = GcmDecryptReader::<_, Aes256>::new(Cursor::new(ct), &KEY, &header(SEG));
+        let mut out = [0u8; 8];
+        let first = r.read(&mut out).unwrap_err();
+        let second = r.read(&mut out).unwrap_err();
+        assert!(matches!(classify(&first), AeadError::AuthenticationFailure));
+        assert!(matches!(
+            classify(&second),
+            AeadError::AuthenticationFailure
+        ));
+    }
+
+    #[test]
+    fn verified_plaintext_precedes_a_later_error() {
+        let mut ct = encrypt_all::<Aes256>(b"abcdefgh");
+        let tag_start = 2 * (SEG as usize) + GCM_TAG_LEN;
+        ct[tag_start] ^= 0x01;
+        let mut r = GcmDecryptReader::<_, Aes256>::new(Cursor::new(ct), &KEY, &header(SEG));
+        let mut first = [0u8; 4];
+        assert_eq!(r.read(&mut first).unwrap(), 4);
+        assert_eq!(&first, b"abcd");
+        let err = r.read(&mut first).unwrap_err();
+        assert!(matches!(classify(&err), AeadError::AuthenticationFailure));
+    }
+}

--- a/lib/src/cipher/gcm.rs
+++ b/lib/src/cipher/gcm.rs
@@ -4,7 +4,7 @@ use crate::cipher::aead::{GCM_TAG_LEN, StreamHeader, StreamKey, segment_nonce};
 use crate::error::AeadError;
 use aes_gcm::AesGcm;
 use aes_gcm::aead::array::Array;
-use aes_gcm::aead::{Aead, AeadCore, KeyInit, consts::U12};
+use aes_gcm::aead::{AeadCore, AeadInOut, KeyInit, consts::U12};
 use std::io::{self, Read, Write};
 
 /// Bounds how far a segment buffer can outrun the bytes that actually arrived.
@@ -12,7 +12,7 @@ const SEGMENT_READ_STEP: usize = 64 * 1024;
 
 pub(crate) struct GcmEncryptWriter<W, C>
 where
-    AesGcm<C, U12>: KeyInit + Aead + AeadCore<NonceSize = U12>,
+    AesGcm<C, U12>: KeyInit + AeadInOut + AeadCore<NonceSize = U12>,
 {
     w: W,
     cipher: AesGcm<C, U12>,
@@ -25,7 +25,7 @@ where
 impl<W, C> GcmEncryptWriter<W, C>
 where
     W: Write,
-    AesGcm<C, U12>: KeyInit + Aead + AeadCore<NonceSize = U12>,
+    AesGcm<C, U12>: KeyInit + AeadInOut + AeadCore<NonceSize = U12>,
 {
     pub(crate) fn new(writer: W, k_stream: &StreamKey, header: &StreamHeader) -> Self {
         let segment_size = header.segment_size().get() as usize;
@@ -45,11 +45,12 @@ where
     fn flush_segment(&mut self, is_final: bool) -> io::Result<()> {
         let nonce =
             Array::<u8, U12>::from(segment_nonce(&self.nonce_prefix, self.counter, is_final));
-        let segment = self
+        let tag = self
             .cipher
-            .encrypt(&nonce, self.buf.as_slice())
+            .encrypt_inout_detached(&nonce, &[], self.buf.as_mut_slice().into())
             .map_err(|_| io::Error::other("GCM segment encryption failed"))?;
-        self.w.write_all(&segment)?;
+        self.w.write_all(&self.buf)?;
+        self.w.write_all(tag.as_slice())?;
         self.buf.clear();
         self.counter = self
             .counter
@@ -72,7 +73,7 @@ where
 impl<W, C> Write for GcmEncryptWriter<W, C>
 where
     W: Write,
-    AesGcm<C, U12>: KeyInit + Aead + AeadCore<NonceSize = U12>,
+    AesGcm<C, U12>: KeyInit + AeadInOut + AeadCore<NonceSize = U12>,
 {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let mut rest = buf;
@@ -102,8 +103,8 @@ where
 enum Stopped {
     Aead(AeadError),
     /// The inner reader or an allocation failed partway through a segment. Those
-    /// bytes leave with `read_full`'s buffer, so the framing cannot be picked up
-    /// again — re-reporting the failure is the only honest answer.
+    /// bytes leave with `read_segment`'s local buffer, so the framing cannot be
+    /// picked up again — re-reporting the failure is the only honest answer.
     Source(io::ErrorKind, String),
 }
 
@@ -118,20 +119,19 @@ impl Stopped {
 
 /// STREAM-based GCM segment decryption reader.
 ///
-/// Reads one segment ahead so that a segment is decrypted with the final flag
-/// set only when no datastream bytes follow it. Only tag-verified plaintext is
-/// ever returned to the caller.
+/// Reads one byte ahead so that a full-sized segment is decrypted with the
+/// final flag set only when no datastream bytes follow it. Only tag-verified
+/// plaintext is ever returned to the caller.
 pub(crate) struct GcmDecryptReader<R, C>
 where
-    AesGcm<C, U12>: KeyInit + Aead + AeadCore<NonceSize = U12>,
+    AesGcm<C, U12>: KeyInit + AeadInOut + AeadCore<NonceSize = U12>,
 {
     r: R,
     cipher: AesGcm<C, U12>,
     nonce_prefix: [u8; 7],
     segment_size: usize,
     counter: u32,
-    pending: Option<Vec<u8>>,
-    started: bool,
+    lookahead: Option<u8>,
     plain: Vec<u8>,
     pos: usize,
     done: bool,
@@ -141,7 +141,7 @@ where
 impl<R, C> GcmDecryptReader<R, C>
 where
     R: Read,
-    AesGcm<C, U12>: KeyInit + Aead + AeadCore<NonceSize = U12>,
+    AesGcm<C, U12>: KeyInit + AeadInOut + AeadCore<NonceSize = U12>,
 {
     pub(crate) fn new(reader: R, k_stream: &StreamKey, header: &StreamHeader) -> Self {
         Self {
@@ -151,8 +151,7 @@ where
             nonce_prefix: header.nonce_prefix,
             segment_size: header.segment_size().get() as usize,
             counter: 0,
-            pending: None,
-            started: false,
+            lookahead: None,
             plain: Vec::new(),
             pos: 0,
             done: false,
@@ -170,25 +169,57 @@ where
         e
     }
 
-    fn read_full(&mut self) -> io::Result<Vec<u8>> {
+    fn grow_segment_buffer(
+        &mut self,
+        buf: &mut Vec<u8>,
+        filled: usize,
+        limit: usize,
+    ) -> io::Result<()> {
+        let grown = filled + (limit - filled).min(SEGMENT_READ_STEP);
+        if grown > buf.capacity() {
+            let doubled = buf.capacity().saturating_mul(2);
+            let target_capacity = limit.min(doubled.max(grown));
+            buf.try_reserve_exact(target_capacity - buf.len())
+                .map_err(|_| {
+                    self.stop_on_source(io::Error::new(
+                        io::ErrorKind::OutOfMemory,
+                        format!("failed to allocate {target_capacity} bytes for segment"),
+                    ))
+                })?;
+        }
+        buf.resize(grown, 0);
+        Ok(())
+    }
+
+    fn read_one(&mut self) -> io::Result<Option<u8>> {
+        let mut byte = [0u8; 1];
+        loop {
+            match self.r.read(&mut byte) {
+                Ok(0) => return Ok(None),
+                Ok(_) => return Ok(Some(byte[0])),
+                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                Err(e) => return Err(self.stop_on_source(e)),
+            }
+        }
+    }
+
+    fn read_segment(&mut self, mut buf: Vec<u8>) -> io::Result<(Vec<u8>, bool)> {
         // The segment size comes from the unauthenticated stream header, so
         // committing it up front would let a hostile archive turn a few hundred
         // bytes into a 64 MiB allocation before any tag is verified. Growing in
-        // bounded steps keeps the commitment proportional to the bytes that
-        // actually arrived; `try_reserve` reports exhaustion instead of aborting.
-        let cap = self.segment_size + GCM_TAG_LEN;
-        let mut buf = Vec::new();
-        let mut filled = 0;
-        while filled < cap {
+        // bounded steps keeps committed memory proportional to the bytes that
+        // actually arrived, and the geometric growth is clamped to that limit so
+        // the tag cannot trigger one final doubling. `try_reserve_exact` reports
+        // exhaustion instead of aborting.
+        let limit = self.segment_size + GCM_TAG_LEN;
+        buf.clear();
+        if let Some(byte) = self.lookahead.take() {
+            buf.push(byte);
+        }
+        let mut filled = buf.len();
+        while filled < limit {
             if filled == buf.len() {
-                let grown = buf.len() + (cap - buf.len()).min(SEGMENT_READ_STEP);
-                buf.try_reserve(grown - buf.len()).map_err(|_| {
-                    self.stop_on_source(io::Error::new(
-                        io::ErrorKind::OutOfMemory,
-                        format!("failed to allocate {grown} bytes for segment"),
-                    ))
-                })?;
-                buf.resize(grown, 0);
+                self.grow_segment_buffer(&mut buf, filled, limit)?;
             }
             match self.r.read(&mut buf[filled..]) {
                 Ok(0) => break,
@@ -198,57 +229,55 @@ where
             }
         }
         buf.truncate(filled);
-        Ok(buf)
+        let lookahead = self.read_one()?;
+        self.lookahead = lookahead;
+        Ok((buf, lookahead.is_none()))
     }
 
     fn refill(&mut self) -> io::Result<()> {
-        if !self.started {
-            self.pending = Some(self.read_full()?);
-            self.started = true;
-        }
-        let b = self.read_full()?;
-        let a = self
-            .pending
-            .take()
-            .expect("a started reader always holds a buffered segment");
+        let segment = std::mem::take(&mut self.plain);
+        let (mut segment, is_final) = self.read_segment(segment)?;
         let i = self.counter;
-        if b.is_empty() {
-            if a.len() < GCM_TAG_LEN {
-                // Zero segments is a structural violation (no empty final segment
-                // was even present); a short tail after earlier segments is a cut.
-                let f = if i == 0 {
-                    AeadError::Malformed("datastream shorter than one empty final segment")
-                } else {
-                    AeadError::Truncation
-                };
-                return Err(self.fail(f));
-            }
-            let plain = self.decrypt(i, true, &a)?;
-            self.plain = plain;
-            self.pos = 0;
+        // Checked before the short-tail case below so that a segment with bytes
+        // after it is reported as the layout violation it is, whatever its length.
+        if !is_final && segment.len() < self.segment_size + GCM_TAG_LEN {
+            return Err(self.fail(AeadError::Malformed(
+                "non-final segment shorter than segment size",
+            )));
+        }
+        if segment.len() < GCM_TAG_LEN {
+            // Zero segments is a structural violation (no empty final segment
+            // was even present); a short tail after earlier segments is a cut.
+            let f = if i == 0 {
+                AeadError::Malformed("datastream shorter than one empty final segment")
+            } else {
+                AeadError::Truncation
+            };
+            return Err(self.fail(f));
+        }
+        self.decrypt_in_place(i, is_final, &mut segment)?;
+        if is_final {
             self.done = true;
         } else {
-            if a.len() < self.segment_size + GCM_TAG_LEN {
-                return Err(self.fail(AeadError::Malformed(
-                    "non-final segment shorter than segment size",
-                )));
-            }
-            let plain = self.decrypt(i, false, &a)?;
             self.counter = self
                 .counter
                 .checked_add(1)
                 .ok_or_else(|| self.fail(AeadError::Malformed("segment counter overflow")))?;
-            self.plain = plain;
-            self.pos = 0;
-            self.pending = Some(b);
         }
+        self.plain = segment;
+        self.pos = 0;
         Ok(())
     }
 
-    fn decrypt(&mut self, counter: u32, is_final: bool, segment: &[u8]) -> io::Result<Vec<u8>> {
+    fn decrypt_in_place(
+        &mut self,
+        counter: u32,
+        is_final: bool,
+        segment: &mut Vec<u8>,
+    ) -> io::Result<()> {
         let nonce = Array::<u8, U12>::from(segment_nonce(&self.nonce_prefix, counter, is_final));
-        match self.cipher.decrypt(&nonce, segment) {
-            Ok(plain) => Ok(plain),
+        match self.cipher.decrypt_in_place(&nonce, &[], segment) {
+            Ok(()) => Ok(()),
             Err(_) => Err(self.fail(AeadError::AuthenticationFailure)),
         }
     }
@@ -257,7 +286,7 @@ where
 impl<R, C> Read for GcmDecryptReader<R, C>
 where
     R: Read,
-    AesGcm<C, U12>: KeyInit + Aead + AeadCore<NonceSize = U12>,
+    AesGcm<C, U12>: KeyInit + AeadInOut + AeadCore<NonceSize = U12>,
 {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if let Some(stopped) = &self.fuse {
@@ -291,6 +320,7 @@ mod tests {
     use crate::cipher::aead::{KeyConfirmation, SegmentSize};
     use crate::error::AeadError;
     use aes::Aes256;
+    use aes_gcm::aead::Aead;
     use camellia::Camellia256;
     use std::io::{Cursor, Read};
 
@@ -309,7 +339,7 @@ mod tests {
 
     fn encrypt_all<C>(plain: &[u8]) -> Vec<u8>
     where
-        AesGcm<C, U12>: KeyInit + Aead + AeadCore<NonceSize = U12>,
+        AesGcm<C, U12>: KeyInit + AeadInOut + AeadCore<NonceSize = U12>,
     {
         let mut w = GcmEncryptWriter::<_, C>::new(Vec::new(), &KEY, &header(SEG));
         w.write_all(plain).unwrap();
@@ -318,7 +348,7 @@ mod tests {
 
     fn encrypt_byte_by_byte<C>(plain: &[u8]) -> Vec<u8>
     where
-        AesGcm<C, U12>: KeyInit + Aead + AeadCore<NonceSize = U12>,
+        AesGcm<C, U12>: KeyInit + AeadInOut + AeadCore<NonceSize = U12>,
     {
         let mut w = GcmEncryptWriter::<_, C>::new(Vec::new(), &KEY, &header(SEG));
         for b in plain {
@@ -350,6 +380,38 @@ mod tests {
         let nonce = Array::<u8, U12>::from(segment_nonce(&PREFIX, counter, true));
         out.extend_from_slice(&cipher.decrypt(&nonce, rest).unwrap());
         out
+    }
+
+    #[derive(Default)]
+    struct RecordingWriter {
+        bytes: Vec<u8>,
+        write_sizes: Vec<usize>,
+    }
+
+    impl Write for RecordingWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.write_sizes.push(buf.len());
+            self.bytes.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn encryption_writes_in_place_buffer_and_detached_tag() {
+        let mut writer =
+            GcmEncryptWriter::<_, Aes256>::new(RecordingWriter::default(), &KEY, &header(SEG));
+        writer.write_all(b"abcd").unwrap();
+        let output = writer.finish().unwrap();
+
+        assert_eq!(output.write_sizes, [SEG as usize, GCM_TAG_LEN]);
+        assert_eq!(
+            decrypt_stream::<Aes256>(SEG as usize, &output.bytes),
+            b"abcd"
+        );
     }
 
     #[test]
@@ -412,7 +474,7 @@ mod tests {
 
     fn decrypt_all<C>(ciphertext: Vec<u8>) -> io::Result<Vec<u8>>
     where
-        AesGcm<C, U12>: KeyInit + Aead + AeadCore<NonceSize = U12>,
+        AesGcm<C, U12>: KeyInit + AeadInOut + AeadCore<NonceSize = U12>,
     {
         let mut r = GcmDecryptReader::<_, C>::new(Cursor::new(ciphertext), &KEY, &header(SEG));
         let mut out = Vec::new();
@@ -422,7 +484,7 @@ mod tests {
 
     fn roundtrip<C>(plain: &[u8])
     where
-        AesGcm<C, U12>: KeyInit + Aead + AeadCore<NonceSize = U12>,
+        AesGcm<C, U12>: KeyInit + AeadInOut + AeadCore<NonceSize = U12>,
     {
         let ct = encrypt_all::<C>(plain);
         assert_eq!(decrypt_all::<C>(ct).unwrap().as_slice(), plain);
@@ -523,6 +585,55 @@ mod tests {
         assert_eq!(out, b"abcdefgh");
     }
 
+    /// A segment of exactly `SEGMENT_READ_STEP` needs a second growth step for
+    /// its tag alone, which is where unclamped doubling would commit twice the
+    /// ciphertext a segment can hold.
+    #[test]
+    fn segment_capacity_is_clamped_to_the_ciphertext_limit() {
+        let stream = header(SEGMENT_READ_STEP as u32);
+        let plain = vec![0u8; SEGMENT_READ_STEP + 1];
+        let mut w = GcmEncryptWriter::<_, Aes256>::new(Vec::new(), &KEY, &stream);
+        w.write_all(&plain).unwrap();
+        let ct = w.finish().unwrap();
+
+        let mut r = GcmDecryptReader::<_, Aes256>::new(Cursor::new(ct), &KEY, &stream);
+        let mut out = Vec::new();
+        r.read_to_end(&mut out).unwrap();
+        assert_eq!(out, plain);
+
+        let limit = SEGMENT_READ_STEP + GCM_TAG_LEN;
+        assert!(
+            r.plain.capacity() <= limit,
+            "segment capacity {} should be clamped to {limit}",
+            r.plain.capacity()
+        );
+    }
+
+    #[test]
+    fn decrypts_with_one_byte_lookahead_and_reuses_the_segment_buffer() {
+        let ct = encrypt_all::<Aes256>(b"abcdefgh");
+        let mut r = GcmDecryptReader::<_, Aes256>::new(Cursor::new(ct), &KEY, &header(SEG));
+        let mut first = [0u8; SEG as usize];
+
+        assert_eq!(r.read(&mut first).unwrap(), first.len());
+        assert_eq!(&first, b"abcd");
+        assert_eq!(
+            r.r.position() as usize,
+            SEG as usize + GCM_TAG_LEN + 1,
+            "only one byte of the next segment should be consumed"
+        );
+        let segment_ptr = r.plain.as_ptr();
+
+        let mut second = [0u8; SEG as usize];
+        assert_eq!(r.read(&mut second).unwrap(), second.len());
+        assert_eq!(&second, b"efgh");
+        assert_eq!(
+            r.plain.as_ptr(),
+            segment_ptr,
+            "the consumed plaintext allocation should hold the next segment"
+        );
+    }
+
     #[test]
     fn roundtrip_three_bytes_aes() {
         roundtrip::<Aes256>(b"abc");
@@ -607,6 +718,29 @@ mod tests {
         let mut out = [0u8; 8];
         let err = r.read(&mut out).unwrap_err();
         assert!(matches!(classify(&err), AeadError::Malformed(_)));
+    }
+
+    /// Bytes after a segment make it a layout violation rather than a cut end,
+    /// even when the segment is too short to hold a tag at all. Distinguishable
+    /// from [`AeadError::Truncation`] only once a segment has been verified, so
+    /// the first stall carries a whole valid segment plus its look-ahead byte.
+    #[test]
+    fn non_final_segment_shorter_than_a_tag_is_malformed() {
+        let ct = encrypt_all::<Aes256>(b"abcdefgh");
+        let first = SEG as usize + GCM_TAG_LEN;
+        let reader = StallReader {
+            segments: vec![ct[..first + 1].to_vec(), vec![0u8; 1], vec![0u8; 1]],
+            index: 0,
+            pos: 0,
+        };
+        let mut r = GcmDecryptReader::<_, Aes256>::new(reader, &KEY, &header(SEG));
+        let mut out = [0u8; SEG as usize];
+
+        assert_eq!(r.read(&mut out).unwrap(), out.len());
+        assert_eq!(&out, b"abcd");
+
+        let err = r.read(&mut out).unwrap_err();
+        assert!(matches!(classify(&err), AeadError::Malformed(_)), "{err}");
     }
 
     #[test]

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -490,8 +490,9 @@ impl<T: AsRef<[u8]>> SolidEntry<T> {
             self.header.encryption,
             self.header.cipher_mode,
             self.phsf.as_deref(),
-            options.password(),
-            options.key_cache(),
+            &options,
+            ChunkType::SHED,
+            &self.header.to_bytes(),
         )?;
         let reader = decompress_reader(reader, self.header.compression)?;
 
@@ -521,8 +522,9 @@ where
             self.header.encryption,
             self.header.cipher_mode,
             self.phsf.as_deref(),
-            options.password(),
-            options.key_cache(),
+            options,
+            ChunkType::SHED,
+            &self.header.to_bytes(),
         )?;
         let reader = decompress_reader(reader, self.header.compression)?;
         Ok(SolidIntoEntries(EntryReader(reader)))
@@ -1211,8 +1213,9 @@ impl<T: AsRef<[u8]>> NormalEntry<T> {
             self.header.encryption,
             self.header.cipher_mode,
             self.phsf.as_deref(),
-            option.password(),
-            option.key_cache(),
+            option,
+            ChunkType::FHED,
+            &self.header.to_bytes(),
         )?;
         let reader = decompress_reader(decrypt_reader, self.header.compression)?;
         Ok(EntryDataReader(EntryReader(reader)))

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -12,7 +12,7 @@ pub use solid::SolidEntryBuilder;
 use crate::entry::Permission;
 use crate::{
     Duration,
-    chunk::RawChunk,
+    chunk::{ChunkType, RawChunk},
     cipher::CipherWriter,
     compress::CompressionWriter,
     entry::{
@@ -37,21 +37,26 @@ use std::{
 };
 
 /// Constructs the compression/encryption writer stack for entry data.
+///
+/// `header_chunk_data` is the exact on-wire `FHED` Data field for this entry.
+/// The raw `FHED` Type field and this Data field feed AEAD (GCM) stream-key
+/// derivation; block/stream cipher modes ignore them.
 #[allow(clippy::type_complexity)]
 pub(crate) fn data_writer(
     option: impl WriteOption,
+    header_chunk_data: &[u8],
 ) -> io::Result<(
     CompressionWriter<CipherWriter<FlattenWriter>>,
     Option<Vec<u8>>,
     Option<String>,
 )> {
-    let context = get_writer_context(option)?;
+    let context = get_writer_context(option, ChunkType::FHED, header_chunk_data)?;
     let writer = get_writer(FlattenWriter::new(), &context)?;
-    let (iv, phsf) = match context.cipher {
+    let (prefix, phsf) = match context.cipher {
         None => (None, None),
-        Some(WriteCipher { context: c, .. }) => (Some(c.iv), Some(c.phsf)),
+        Some(WriteCipher { context: c, .. }) => (Some(c.prefix_bytes()), Some(c.phsf)),
     };
-    Ok((writer, iv, phsf))
+    Ok((writer, prefix, phsf))
 }
 
 /// Largest UTF-8 char-boundary prefix of `s` whose byte length is ≤ 255 —
@@ -73,7 +78,7 @@ fn owner_name_bounded(s: &str) -> &str {
 pub(crate) struct EntryBuilderCore {
     header: EntryHeader,
     phsf: Option<String>,
-    iv: Option<Vec<u8>>,
+    prefix: Option<Vec<u8>>,
     metadata: Metadata,
     extra_chunks: Vec<RawChunk>,
 }
@@ -83,14 +88,14 @@ impl EntryBuilderCore {
         Self {
             header,
             phsf: None,
-            iv: None,
+            prefix: None,
             metadata: Metadata::new(),
             extra_chunks: Vec::new(),
         }
     }
 
-    pub(crate) fn set_cipher(&mut self, iv: Option<Vec<u8>>, phsf: Option<String>) {
-        self.iv = iv;
+    pub(crate) fn set_cipher(&mut self, prefix: Option<Vec<u8>>, phsf: Option<String>) {
+        self.prefix = prefix;
         self.phsf = phsf;
     }
 
@@ -153,8 +158,8 @@ impl EntryBuilderCore {
         mut data: Vec<Vec<u8>>,
         raw_file_size: Option<u128>,
     ) -> NormalEntry {
-        if let Some(iv) = self.iv {
-            data.insert(0, iv);
+        if let Some(prefix) = self.prefix {
+            data.insert(0, prefix);
         }
         self.metadata.raw_file_size = raw_file_size;
         self.metadata.compressed_size = data.iter().map(|d| d.len()).sum();
@@ -283,9 +288,9 @@ impl OpaqueEntryBuilder {
             option.cipher_mode(),
             name,
         );
-        let (writer, iv, phsf) = data_writer(option)?;
+        let (writer, prefix, phsf) = data_writer(option, &header.to_bytes())?;
         let mut core = EntryBuilderCore::new(header);
-        core.set_cipher(iv, phsf);
+        core.set_cipher(prefix, phsf);
         Ok(Self {
             core,
             data: Some(writer),
@@ -320,10 +325,10 @@ impl OpaqueEntryBuilder {
     /// Internal helper for creating link entries (symlink or hard link).
     fn new_link(header: EntryHeader, source: EntryReference) -> io::Result<Self> {
         let option = WriteOptions::store();
-        let (mut writer, iv, phsf) = data_writer(option)?;
+        let (mut writer, prefix, phsf) = data_writer(option, &header.to_bytes())?;
         writer.write_all(source.as_bytes())?;
         let mut core = EntryBuilderCore::new(header);
-        core.set_cipher(iv, phsf);
+        core.set_cipher(prefix, phsf);
         Ok(Self {
             core,
             data: Some(writer),
@@ -1140,5 +1145,175 @@ mod tests {
         let new = new.build().unwrap();
 
         assert_eq!(old.into_chunks(), new.into_chunks());
+    }
+
+    mod gcm {
+        use super::*;
+        use crate::cipher::{
+            GCM_TAG_LEN, STREAM_HEADER_LEN, StreamHeader, StreamKey, derive_stream_key,
+            segment_nonce,
+        };
+        use crate::{CipherMode, Encryption, HashAlgorithm};
+        use aes::Aes256;
+        use aes_gcm::AesGcm;
+        use aes_gcm::aead::array::Array;
+        use aes_gcm::aead::{Aead, AeadCore, KeyInit, consts::U12};
+        use camellia::Camellia256;
+        // `use super::*` re-imports `test` from the parent's own
+        // `#[cfg(...)] use wasm_bindgen_test::... as test;`, but a
+        // glob-imported name loses to (rather than shadows) the `#[test]`
+        // prelude attribute, so wasm builds see it as ambiguous. Re-declare
+        // it directly in this module to disambiguate.
+        #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+        use wasm_bindgen_test::wasm_bindgen_test as test;
+
+        fn gcm_write_options(encryption: Encryption, segment_size: u32) -> WriteOptions {
+            let mut builder = WriteOptions::builder();
+            builder
+                .encryption(encryption)
+                .cipher_mode(CipherMode::GCM)
+                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+                .password(Some("password"));
+            builder.segment_size(segment_size);
+            builder.build()
+        }
+
+        fn stream_header(bytes: &[u8]) -> StreamHeader {
+            StreamHeader::try_from_bytes(bytes.try_into().unwrap()).unwrap()
+        }
+
+        fn gcm_decrypt<C>(
+            k_stream: &StreamKey,
+            nonce_prefix: &[u8; 7],
+            segment_size: u32,
+            ciphertext: &[u8],
+        ) -> Result<Vec<u8>, aes_gcm::aead::Error>
+        where
+            AesGcm<C, U12>: KeyInit + Aead + AeadCore<NonceSize = U12>,
+        {
+            let cipher = AesGcm::<C, U12>::new_from_slice(k_stream.as_bytes()).unwrap();
+            let full = segment_size as usize + GCM_TAG_LEN;
+            let mut out = Vec::new();
+            let mut rest = ciphertext;
+            let mut counter = 0u32;
+            while rest.len() > full {
+                let (segment, tail) = rest.split_at(full);
+                let nonce = Array::<u8, U12>::from(segment_nonce(nonce_prefix, counter, false));
+                out.extend_from_slice(&cipher.decrypt(&nonce, segment)?);
+                rest = tail;
+                counter += 1;
+            }
+            let nonce = Array::<u8, U12>::from(segment_nonce(nonce_prefix, counter, true));
+            out.extend_from_slice(&cipher.decrypt(&nonce, rest)?);
+            Ok(out)
+        }
+
+        fn assert_gcm_file_roundtrip<C>(encryption: Encryption, segment_size: u32, plain: &[u8])
+        where
+            AesGcm<C, U12>: KeyInit + Aead + AeadCore<NonceSize = U12>,
+        {
+            let options = gcm_write_options(encryption, segment_size);
+            let mut builder =
+                FileEntryBuilder::new_with_options("dir/file".into(), &options).unwrap();
+            builder.write_all(plain).unwrap();
+            let entry = builder.build().unwrap();
+
+            let cipher = options.cipher().unwrap();
+            assert_eq!(entry.phsf.as_deref(), Some(cipher.derived.phsf.as_str()));
+
+            assert_eq!(entry.data[0].len(), STREAM_HEADER_LEN);
+            let header = stream_header(&entry.data[0]);
+            assert_eq!(header.segment_size().get(), segment_size);
+            assert!(header.confirms_key(cipher.derived.key.as_bytes()));
+
+            let k_stream = derive_stream_key(
+                cipher.derived.key.as_bytes(),
+                &header,
+                ChunkType::FHED,
+                &entry.header.to_bytes(),
+                cipher.derived.phsf.as_bytes(),
+            );
+            let ciphertext = entry.data[1..].concat();
+            let decrypted =
+                gcm_decrypt::<C>(&k_stream, &header.nonce_prefix, segment_size, &ciphertext)
+                    .unwrap();
+            assert_eq!(decrypted, plain);
+        }
+
+        #[test]
+        fn new_file_gcm_aes_decrypts_to_plaintext() {
+            assert_gcm_file_roundtrip::<Aes256>(Encryption::AES, 4, b"hello gcm stream");
+        }
+
+        #[test]
+        fn new_file_gcm_camellia_decrypts_to_plaintext() {
+            assert_gcm_file_roundtrip::<Camellia256>(Encryption::CAMELLIA, 4, b"hello gcm stream");
+        }
+
+        #[test]
+        fn new_file_gcm_multiple_segments_decrypts_to_plaintext() {
+            assert_gcm_file_roundtrip::<Aes256>(Encryption::AES, 4, b"0123456789");
+        }
+
+        #[test]
+        fn new_file_gcm_empty_plaintext_is_tag_only_segment() {
+            let options = gcm_write_options(Encryption::AES, 4);
+            let mut builder =
+                FileEntryBuilder::new_with_options("dir/file".into(), &options).unwrap();
+            builder.write_all(b"").unwrap();
+            let entry = builder.build().unwrap();
+
+            let ciphertext = entry.data[1..].concat();
+            assert_eq!(ciphertext.len(), GCM_TAG_LEN);
+
+            let cipher = options.cipher().unwrap();
+            let header = stream_header(&entry.data[0]);
+            let k_stream = derive_stream_key(
+                cipher.derived.key.as_bytes(),
+                &header,
+                ChunkType::FHED,
+                &entry.header.to_bytes(),
+                cipher.derived.phsf.as_bytes(),
+            );
+            assert!(
+                gcm_decrypt::<Aes256>(&k_stream, &header.nonce_prefix, 4, &ciphertext)
+                    .unwrap()
+                    .is_empty()
+            );
+        }
+
+        #[test]
+        fn solid_gcm_decrypts_with_shed_header_type() {
+            let options = gcm_write_options(Encryption::AES, 4);
+            let mut builder = SolidEntryBuilder::new(&options).unwrap();
+            builder
+                .write_file("dir/file".into(), Metadata::new(), |w| {
+                    w.write_all(b"solid gcm payload")
+                })
+                .unwrap();
+            let entry = builder.build().unwrap();
+
+            let cipher = options.cipher().unwrap();
+            let header = stream_header(&entry.data[0]);
+            let ciphertext = entry.data[1..].concat();
+
+            let solid_key = derive_stream_key(
+                cipher.derived.key.as_bytes(),
+                &header,
+                ChunkType::SHED,
+                &entry.header.to_bytes(),
+                cipher.derived.phsf.as_bytes(),
+            );
+            assert!(
+                !gcm_decrypt::<Aes256>(
+                    &solid_key,
+                    &header.nonce_prefix,
+                    header.segment_size().get(),
+                    &ciphertext
+                )
+                .unwrap()
+                .is_empty()
+            );
+        }
     }
 }

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -59,6 +59,15 @@ pub(crate) fn data_writer(
     Ok((writer, prefix, phsf))
 }
 
+pub(super) fn prepend_data_prefix(
+    data: &mut Vec<Vec<u8>>,
+    prefix: Vec<u8>,
+    max_chunk_size: NonZeroU32,
+) {
+    let max_chunk_size = max_chunk_size.get() as usize;
+    data.splice(0..0, prefix.chunks(max_chunk_size).map(<[u8]>::to_vec));
+}
+
 /// Largest UTF-8 char-boundary prefix of `s` whose byte length is ≤ 255 —
 /// the `fONm`/`fGNm` owner-name wire bound (1-byte length prefix). Used to
 /// rescue a legacy fPRM name that exceeds the bounded owner-facet limit.
@@ -79,6 +88,7 @@ pub(crate) struct EntryBuilderCore {
     header: EntryHeader,
     phsf: Option<String>,
     prefix: Option<Vec<u8>>,
+    max_chunk_size: NonZeroU32,
     metadata: Metadata,
     extra_chunks: Vec<RawChunk>,
 }
@@ -89,6 +99,7 @@ impl EntryBuilderCore {
             header,
             phsf: None,
             prefix: None,
+            max_chunk_size: NonZeroU32::MAX,
             metadata: Metadata::new(),
             extra_chunks: Vec::new(),
         }
@@ -97,6 +108,10 @@ impl EntryBuilderCore {
     pub(crate) fn set_cipher(&mut self, prefix: Option<Vec<u8>>, phsf: Option<String>) {
         self.prefix = prefix;
         self.phsf = phsf;
+    }
+
+    pub(crate) fn set_max_chunk_size(&mut self, size: NonZeroU32) {
+        self.max_chunk_size = size;
     }
 
     pub(crate) fn header(&self) -> &EntryHeader {
@@ -159,7 +174,7 @@ impl EntryBuilderCore {
         raw_file_size: Option<u128>,
     ) -> NormalEntry {
         if let Some(prefix) = self.prefix {
-            data.insert(0, prefix);
+            prepend_data_prefix(&mut data, prefix, self.max_chunk_size);
         }
         self.metadata.raw_file_size = raw_file_size;
         self.metadata.compressed_size = data.iter().map(|d| d.len()).sum();
@@ -590,6 +605,7 @@ impl OpaqueEntryBuilder {
     /// ```
     #[inline]
     pub fn max_chunk_size(&mut self, size: NonZeroU32) -> &mut Self {
+        self.core.set_max_chunk_size(size);
         if let Some(data) = &mut self.data {
             data.get_mut()
                 .get_mut()
@@ -1280,6 +1296,28 @@ mod tests {
                     .unwrap()
                     .is_empty()
             );
+        }
+
+        #[test]
+        fn new_file_gcm_header_respects_max_chunk_size() {
+            let options = gcm_write_options(Encryption::AES, 4);
+            let mut builder =
+                FileEntryBuilder::new_with_options("dir/file".into(), &options).unwrap();
+            builder.max_chunk_size(NonZeroU32::new(1).unwrap());
+            builder.write_all(b"x").unwrap();
+            let entry = builder.build().unwrap();
+
+            assert!(
+                entry.data.iter().all(|chunk| chunk.len() <= 1),
+                "every FDAT body must respect max_chunk_size"
+            );
+
+            let mut reader = entry
+                .reader(ReadOptions::with_password(Some("password")))
+                .unwrap();
+            let mut plain = Vec::new();
+            reader.read_to_end(&mut plain).unwrap();
+            assert_eq!(plain, b"x");
         }
 
         #[test]

--- a/lib/src/entry/builder/file.rs
+++ b/lib/src/entry/builder/file.rs
@@ -69,9 +69,9 @@ impl FileEntryBuilder {
             option.cipher_mode(),
             name,
         );
-        let (writer, iv, phsf) = data_writer(option)?;
+        let (writer, prefix, phsf) = data_writer(option, &header.to_bytes())?;
         let mut core = EntryBuilderCore::new(header);
-        core.set_cipher(iv, phsf);
+        core.set_cipher(prefix, phsf);
         Ok(Self {
             core,
             data: writer,

--- a/lib/src/entry/builder/file.rs
+++ b/lib/src/entry/builder/file.rs
@@ -103,6 +103,7 @@ impl FileEntryBuilder {
     /// The default is the maximum allowed chunk size (~4GB).
     #[inline]
     pub fn max_chunk_size(&mut self, size: NonZeroU32) -> &mut Self {
+        self.core.set_max_chunk_size(size);
         self.data
             .get_mut()
             .get_mut()

--- a/lib/src/entry/builder/link.rs
+++ b/lib/src/entry/builder/link.rs
@@ -21,10 +21,10 @@ impl LinkEntryBuilder {
         source: EntryReference,
         option: impl WriteOption,
     ) -> io::Result<Self> {
-        let (mut writer, iv, phsf) = data_writer(option)?;
+        let (mut writer, prefix, phsf) = data_writer(option, &header.to_bytes())?;
         writer.write_all(source.as_bytes())?;
         let mut core = EntryBuilderCore::new(header);
-        core.set_cipher(iv, phsf);
+        core.set_cipher(prefix, phsf);
         Ok(Self { core, data: writer })
     }
 

--- a/lib/src/entry/builder/solid.rs
+++ b/lib/src/entry/builder/solid.rs
@@ -1,6 +1,6 @@
 use crate::{
     archive::{InternalArchiveDataWriter, InternalDataWriter, write_file_entry},
-    chunk::RawChunk,
+    chunk::{ChunkType, RawChunk},
     cipher::CipherWriter,
     compress::CompressionWriter,
     entry::{
@@ -66,7 +66,7 @@ impl Write for SolidEntryDataWriter<'_> {
 pub struct SolidEntryBuilder {
     header: SolidHeader,
     phsf: Option<String>,
-    iv: Option<Vec<u8>>,
+    prefix: Option<Vec<u8>>,
     data: CompressionWriter<CipherWriter<FlattenWriter>>,
     extra: Vec<RawChunk>,
     max_file_chunk_size: Option<NonZeroU32>,
@@ -85,15 +85,15 @@ impl SolidEntryBuilder {
             option.encryption(),
             option.cipher_mode(),
         );
-        let context = get_writer_context(option)?;
+        let context = get_writer_context(option, ChunkType::SHED, &header.to_bytes())?;
         let writer = get_writer(FlattenWriter::new(), &context)?;
-        let (iv, phsf) = match context.cipher {
+        let (prefix, phsf) = match context.cipher {
             None => (None, None),
-            Some(WriteCipher { context: c, .. }) => (Some(c.iv), Some(c.phsf)),
+            Some(WriteCipher { context: c, .. }) => (Some(c.prefix_bytes()), Some(c.phsf)),
         };
         Ok(Self {
             header,
-            iv,
+            prefix,
             phsf,
             data: writer,
             extra: Vec::new(),
@@ -234,8 +234,8 @@ impl SolidEntryBuilder {
             phsf: self.phsf,
             data: {
                 let mut data = self.data.try_into_inner()?.try_into_inner()?.inner;
-                if let Some(iv) = self.iv {
-                    data.insert(0, iv);
+                if let Some(prefix) = self.prefix {
+                    data.insert(0, prefix);
                 }
                 data
             },

--- a/lib/src/entry/builder/solid.rs
+++ b/lib/src/entry/builder/solid.rs
@@ -1,3 +1,4 @@
+use super::prepend_data_prefix;
 use crate::{
     archive::{InternalArchiveDataWriter, InternalDataWriter, write_file_entry},
     chunk::{ChunkType, RawChunk},
@@ -67,6 +68,7 @@ pub struct SolidEntryBuilder {
     header: SolidHeader,
     phsf: Option<String>,
     prefix: Option<Vec<u8>>,
+    max_chunk_size: NonZeroU32,
     data: CompressionWriter<CipherWriter<FlattenWriter>>,
     extra: Vec<RawChunk>,
     max_file_chunk_size: Option<NonZeroU32>,
@@ -94,6 +96,7 @@ impl SolidEntryBuilder {
         Ok(Self {
             header,
             prefix,
+            max_chunk_size: NonZeroU32::MAX,
             phsf,
             data: writer,
             extra: Vec::new(),
@@ -208,6 +211,7 @@ impl SolidEntryBuilder {
     /// ```
     #[inline]
     pub fn max_chunk_size(&mut self, size: NonZeroU32) -> &mut Self {
+        self.max_chunk_size = size;
         self.data
             .get_mut()
             .get_mut()
@@ -235,7 +239,7 @@ impl SolidEntryBuilder {
             data: {
                 let mut data = self.data.try_into_inner()?.try_into_inner()?.inner;
                 if let Some(prefix) = self.prefix {
-                    data.insert(0, prefix);
+                    prepend_data_prefix(&mut data, prefix, self.max_chunk_size);
                 }
                 data
             },
@@ -271,7 +275,7 @@ impl SolidEntryBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ChunkType, ReadOptions};
+    use crate::{ChunkType, CipherMode, Encryption, HashAlgorithm, ReadOptions};
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
@@ -310,6 +314,36 @@ mod tests {
             solid_entry.data.len() > 1,
             "Data should be split into multiple chunks"
         );
+    }
+
+    #[test]
+    fn solid_entry_gcm_header_respects_max_chunk_size() {
+        let options = WriteOptions::builder()
+            .encryption(Encryption::AES)
+            .cipher_mode(CipherMode::GCM)
+            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .password(Some("password"))
+            .build();
+        let mut builder = SolidEntryBuilder::new(options).unwrap();
+        builder.max_chunk_size(NonZeroU32::new(8).unwrap());
+        builder
+            .write_file("entry".into(), Metadata::new(), |w| w.write_all(b"x"))
+            .unwrap();
+        let solid_entry = builder.build_as_entry().unwrap();
+
+        assert!(
+            solid_entry.data.iter().all(|chunk| chunk.len() <= 8),
+            "every SDAT body must respect max_chunk_size"
+        );
+
+        let mut entries = solid_entry
+            .entries(ReadOptions::with_password(Some("password")))
+            .unwrap();
+        let entry = entries.next().unwrap().unwrap();
+        let mut reader = entry.reader(ReadOptions::builder().build()).unwrap();
+        let mut plain = Vec::new();
+        reader.read_to_end(&mut plain).unwrap();
+        assert_eq!(plain, b"x");
     }
 
     #[test]

--- a/lib/src/entry/content.rs
+++ b/lib/src/entry/content.rs
@@ -269,14 +269,23 @@ mod tests {
 
     /// Wire format allows encrypted link entries, but the public builder
     /// always writes links with store options; assemble one manually the
-    /// same way `SymlinkEntryBuilder::build` does.
+    /// same way `SymlinkEntryBuilder::build` does. The header is finalized
+    /// before encryption because the stream key is derived from it.
     fn encrypted_symlink_entry(target: &str, password: &str) -> NormalEntry {
         let options = WriteOptions::builder()
             .encryption(Encryption::AES)
             .password(Some(password))
             .try_build()
             .unwrap();
-        let context = get_writer_context(&options).unwrap();
+        let mut entry =
+            SymlinkEntryBuilder::new("l".into(), EntryReference::from_utf8_preserve_root(target))
+                .unwrap()
+                .build()
+                .unwrap();
+        entry.header.encryption = options.encryption();
+        entry.header.cipher_mode = options.cipher_mode();
+        let context =
+            get_writer_context(&options, ChunkType::FHED, &entry.header.to_bytes()).unwrap();
         let mut writer = get_writer(crate::io::FlattenWriter::new(), &context).unwrap();
         writer.write_all(target.as_bytes()).unwrap();
         let mut data = writer
@@ -285,20 +294,13 @@ mod tests {
             .try_into_inner()
             .unwrap()
             .inner;
-        let (iv, phsf) = match context.cipher {
+        let (prefix, phsf) = match context.cipher {
             None => (None, None),
-            Some(WriteCipher { context: c, .. }) => (Some(c.iv), Some(c.phsf)),
+            Some(WriteCipher { context: c, .. }) => (Some(c.prefix_bytes()), Some(c.phsf)),
         };
-        if let Some(iv) = iv {
-            data.insert(0, iv);
+        if let Some(prefix) = prefix {
+            data.insert(0, prefix);
         }
-        let mut entry =
-            SymlinkEntryBuilder::new("l".into(), EntryReference::from_utf8_preserve_root(target))
-                .unwrap()
-                .build()
-                .unwrap();
-        entry.header.encryption = options.encryption();
-        entry.header.cipher_mode = options.cipher_mode();
         entry.phsf = phsf;
         entry.data = data;
         entry

--- a/lib/src/entry/header.rs
+++ b/lib/src/entry/header.rs
@@ -117,6 +117,9 @@ impl EntryHeader {
         self.cipher_mode
     }
 
+    /// Must stay byte-identical to the bytes [`Self::try_from_bytes`] accepted:
+    /// AEAD stream-key derivation is specified over the received `FHED` Data
+    /// field and reads it back through this method.
     pub(crate) fn to_bytes(&self) -> Vec<u8> {
         let name = self.name.as_bytes();
         let mut data = Vec::with_capacity(6 + name.len());
@@ -263,6 +266,10 @@ impl SolidHeader {
     }
 
     /// Converts to [`ChunkType::SHED`](crate::ChunkType::SHED) body bytes.
+    ///
+    /// For a header read from an archive this reproduces the `SHED` Data field
+    /// byte for byte, which [`CipherMode::GCM`] relies on: stream-key
+    /// derivation is specified over that field as received.
     #[inline]
     pub const fn to_bytes(&self) -> [u8; 5] {
         [
@@ -323,6 +330,23 @@ mod tests {
     }
 
     #[test]
+    fn entry_header_to_bytes_reproduces_the_parsed_bytes() {
+        for bytes in [
+            b"\x00\x00\x00\x00\x00\x00".as_slice(),
+            b"\x00\x00\x00\x00\x00\x00file",
+            b"\x00\x00\x02\x02\x01\x01dir/file",
+            b"\x00\x00\x00\x00\x00\x00/abs//dir/../trailing/",
+            b"\x00\x00\x7f\x3f\xc8\xff\xe6\x97\xa5",
+            b"\xff\xff\xff\xff\xff\xffa",
+        ] {
+            assert_eq!(
+                EntryHeader::try_from_bytes(bytes).unwrap().to_bytes(),
+                bytes
+            );
+        }
+    }
+
+    #[test]
     fn solid_header_try_from_bytes() {
         assert!(SolidHeader::try_from_bytes(&[0; 5]).is_ok());
         assert_eq!(
@@ -342,6 +366,21 @@ mod tests {
             header,
             SolidHeader::try_from_bytes(&header.to_bytes()).unwrap(),
         );
+    }
+
+    #[test]
+    fn solid_header_to_bytes_reproduces_the_parsed_bytes() {
+        for bytes in [
+            [0x00, 0x00, 0x00, 0x00, 0x00],
+            [0x00, 0x00, 0x02, 0x01, 0x02],
+            [0x00, 0x00, 0x3f, 0xc8, 0x7f],
+            [0xff, 0xff, 0xff, 0xff, 0xff],
+        ] {
+            assert_eq!(
+                SolidHeader::try_from_bytes(&bytes).unwrap().to_bytes(),
+                bytes
+            );
+        }
     }
 
     #[test]

--- a/lib/src/entry/options.rs
+++ b/lib/src/entry/options.rs
@@ -591,6 +591,8 @@ impl CipherMode {
     pub const CBC: Self = Self(0);
     /// Counter mode.
     pub const CTR: Self = Self(1);
+    /// Galois/Counter mode (AEAD, STREAM-based).
+    pub const GCM: Self = Self(2);
 
     /// Deserializes a cipher mode from its u8 representation.
     ///
@@ -640,7 +642,7 @@ impl CipherMode {
     /// (unassigned and raw value < 128).
     #[inline]
     pub const fn is_reserved(self) -> bool {
-        !matches!(self.0, 0..=1) && self.0 < 128
+        !matches!(self.0, 0..=2) && self.0 < 128
     }
 
     /// Returns `true` if this is an application-specific private value
@@ -657,6 +659,7 @@ impl fmt::Debug for CipherMode {
         match *self {
             Self::CBC => f.write_str("CBC"),
             Self::CTR => f.write_str("CTR"),
+            Self::GCM => f.write_str("GCM"),
             Self(v) if v < 128 => f.debug_tuple("Reserved").field(&v).finish(),
             Self(v) => f.debug_tuple("Private").field(&v).finish(),
         }
@@ -1443,6 +1446,22 @@ mod tests {
         let _ = WriteOptions::builder().encryption(Encryption::AES).build();
     }
 
+    #[test]
+    fn cipher_mode_2_from_byte_returns_gcm() {
+        assert_eq!(CipherMode::from_byte(2), CipherMode::GCM);
+    }
+
+    #[test]
+    fn cipher_mode_gcm_to_byte_is_2() {
+        assert_eq!(CipherMode::GCM.to_byte(), 2);
+    }
+
+    #[test]
+    fn cipher_mode_gcm_roundtrips_through_byte() {
+        let byte = CipherMode::GCM.to_byte();
+        assert_eq!(CipherMode::from_byte(byte), CipherMode::GCM);
+    }
+
     fn test_output(byte: u8) -> Output {
         Output::new(&[byte; 32]).unwrap()
     }
@@ -1744,7 +1763,8 @@ mod tests {
         assert!(!CipherMode::CBC.is_reserved());
         assert!(!CipherMode::CTR.is_reserved());
         assert!(!CipherMode::CTR.is_private());
-        assert!(CipherMode::from_byte(2).is_reserved());
+        assert!(!CipherMode::GCM.is_reserved());
+        assert!(CipherMode::from_byte(3).is_reserved());
         assert!(CipherMode::from_byte(127).is_reserved());
         assert!(!CipherMode::from_byte(127).is_private());
         assert!(!CipherMode::from_byte(128).is_reserved());
@@ -1756,7 +1776,8 @@ mod tests {
     fn cipher_mode_debug_matches_former_enum_output() {
         assert_eq!(format!("{:?}", CipherMode::CBC), "CBC");
         assert_eq!(format!("{:?}", CipherMode::CTR), "CTR");
-        assert_eq!(format!("{:?}", CipherMode::from_byte(2)), "Reserved(2)");
+        assert_eq!(format!("{:?}", CipherMode::GCM), "GCM");
+        assert_eq!(format!("{:?}", CipherMode::from_byte(3)), "Reserved(3)");
         assert_eq!(format!("{:?}", CipherMode::from_byte(200)), "Private(200)");
     }
 

--- a/lib/src/entry/options.rs
+++ b/lib/src/entry/options.rs
@@ -1,6 +1,11 @@
 //! Read and write options for archive entries.
 
-use crate::{compress, entry::write::derive_key_material, error::UnknownValueError};
+use crate::{
+    cipher::{DEFAULT_SEGMENT_SIZE, SegmentSize},
+    compress,
+    entry::write::derive_key_material,
+    error::UnknownValueError,
+};
 use password_hash::Output;
 pub(crate) use private::*;
 use std::{
@@ -30,6 +35,8 @@ mod private {
         pub(crate) hash_algorithm: HashAlgorithm,
         pub(crate) cipher_algorithm: CipherAlgorithm,
         pub(crate) mode: CipherMode,
+        /// GCM datastream segment size; unused by CBC/CTR modes.
+        pub(crate) segment_size: SegmentSize,
     }
 
     impl Cipher {
@@ -41,6 +48,7 @@ mod private {
             hash_algorithm: HashAlgorithm,
             cipher_algorithm: CipherAlgorithm,
             mode: CipherMode,
+            segment_size: SegmentSize,
         ) -> Self {
             Self {
                 password,
@@ -48,6 +56,7 @@ mod private {
                 hash_algorithm,
                 cipher_algorithm,
                 mode,
+                segment_size,
             }
         }
     }
@@ -950,13 +959,13 @@ impl TryFrom<u8> for DataKind {
 ///   systems or when Argon2 is not available.
 /// - **Cipher Mode**: CTR mode ([`CipherMode::CTR`]) is recommended over CBC for most use cases
 ///   as it allows parallel processing and has simpler security requirements.
-/// - **IV Generation**: Initialization vectors (IVs) are automatically generated using
-///   cryptographically secure random number generation. You do not need to provide IVs.
+/// - **Per-Entry Randomness**: Each entry receives its own randomly generated encryption
+///   material — an IV for CBC/CTR, or a salt and nonce prefix for GCM — generated using
+///   cryptographically secure random number generation. You do not need to provide this yourself.
 /// - **Key Derivation**: The encryption key is derived from the password once when the
 ///   options are built ([`WriteOptionsBuilder::build()`] / [`WriteOptionsBuilder::try_build()`]),
-///   and shared by every entry written with the same [`WriteOptions`]. Each entry still
-///   receives a unique, randomly generated IV. Build a fresh [`WriteOptions`] per archive
-///   so that each archive uses an independent salt and key.
+///   and shared by every entry written with the same [`WriteOptions`]. Build a fresh
+///   [`WriteOptions`] per archive so that each archive uses an independent salt and key.
 /// - **Password Strength**: Use strong passwords (12+ characters, mixed case, numbers, symbols)
 ///   as the encryption key is derived from the password.
 ///
@@ -1073,6 +1082,7 @@ pub struct WriteOptionsBuilder {
     cipher_mode: CipherMode,
     hash_algorithm: HashAlgorithm,
     password: Option<Vec<u8>>,
+    segment_size: u32,
 }
 
 impl Default for WriteOptionsBuilder {
@@ -1098,6 +1108,9 @@ impl From<WriteOptions> for WriteOptionsBuilder {
             cipher_mode: value.cipher_mode(),
             hash_algorithm: value.hash_algorithm(),
             password: value.password().map(|p| p.to_vec()),
+            segment_size: value
+                .cipher()
+                .map_or(DEFAULT_SEGMENT_SIZE, |it| it.segment_size.get()),
         }
     }
 }
@@ -1111,6 +1124,7 @@ impl WriteOptionsBuilder {
             cipher_mode: CipherMode::CTR,
             hash_algorithm: HashAlgorithm::argon2id(),
             password: None,
+            segment_size: DEFAULT_SEGMENT_SIZE,
         }
     }
 
@@ -1170,12 +1184,23 @@ impl WriteOptionsBuilder {
         self
     }
 
+    /// Sets the GCM datastream segment size in bytes.
+    #[cfg(test)]
+    #[inline]
+    pub(crate) fn segment_size(&mut self, size: u32) -> &mut Self {
+        self.segment_size = size;
+        self
+    }
+
     /// Creates a new [`WriteOptions`] from this builder, deriving the encryption
     /// key when encryption is enabled.
     ///
     /// The key derivation function (KDF) runs once here with a freshly generated
     /// random salt. Every entry written with the resulting [`WriteOptions`] shares
-    /// the derived key and salt; a unique random IV is still generated per entry.
+    /// the derived key and salt; fresh per-entry encryption material — an IV for
+    /// CBC/CTR, or a salt and nonce prefix for GCM — is still generated per entry.
+    /// Build a fresh [`WriteOptions`] for each archive so that no two archives
+    /// reuse the same KDF salt.
     ///
     /// # Errors
     ///
@@ -1216,13 +1241,21 @@ impl WriteOptionsBuilder {
             let password = self.password.as_deref().ok_or_else(|| {
                 io::Error::new(io::ErrorKind::InvalidInput, "Password was not provided.")
             })?;
-            let derived = derive_key_material(cipher_algorithm, self.hash_algorithm, password)?;
+            let segment_size = SegmentSize::new(self.segment_size).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("segment size out of range: {}", self.segment_size),
+                )
+            })?;
+            let hash_algorithm = self.hash_algorithm;
+            let derived = derive_key_material(cipher_algorithm, hash_algorithm, password)?;
             Some(Cipher::new(
                 password.into(),
                 derived,
-                self.hash_algorithm,
+                hash_algorithm,
                 cipher_algorithm,
                 self.cipher_mode,
+                segment_size,
             ))
         } else {
             None
@@ -1428,6 +1461,34 @@ mod tests {
             .try_build()
             .unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn try_build_with_out_of_range_segment_size_returns_error() {
+        for size in [0, crate::cipher::MAX_SEGMENT_SIZE + 1] {
+            let mut builder = WriteOptions::builder();
+            builder
+                .encryption(Encryption::AES)
+                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+                .password(Some("password"));
+            builder.segment_size(size);
+            let err = builder.try_build().unwrap_err();
+            assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        }
+    }
+
+    #[test]
+    fn try_build_accepts_boundary_segment_sizes() {
+        for size in [1, crate::cipher::MAX_SEGMENT_SIZE] {
+            let mut builder = WriteOptions::builder();
+            builder
+                .encryption(Encryption::AES)
+                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+                .password(Some("password"));
+            builder.segment_size(size);
+            let options = builder.try_build().unwrap();
+            assert_eq!(options.cipher().unwrap().segment_size.get(), size);
+        }
     }
 
     #[test]

--- a/lib/src/entry/read.rs
+++ b/lib/src/entry/read.rs
@@ -1,10 +1,15 @@
 //! Entry decryption and decompression reading.
 
 use crate::{
-    CipherMode, Compression, Encryption,
-    cipher::{Ctr128BEReader, DecryptCbcAes256Reader, DecryptCbcCamellia256Reader, DecryptReader},
+    ChunkType, CipherMode, Compression, Encryption,
+    cipher::{
+        Ctr128BEReader, DecryptCbcAes256Reader, DecryptCbcCamellia256Reader,
+        DecryptGcmAes256Reader, DecryptGcmCamellia256Reader, DecryptReader, STREAM_HEADER_LEN,
+        StreamHeader, derive_stream_key,
+    },
     compress::DecompressReader,
-    entry::KeyCache,
+    entry::{KeyCache, ReadOption},
+    error::AeadError,
     hash::derive_password_hash,
 };
 use aes::Aes256;
@@ -35,46 +40,113 @@ fn resolve_key(phsf: &str, password: &[u8], key_cache: Option<&KeyCache>) -> io:
     Ok(key)
 }
 
+#[inline]
+fn derive_key(
+    phsf: &str,
+    password: Option<&[u8]>,
+    key_cache: Option<&KeyCache>,
+) -> io::Result<Output> {
+    let password = password
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "password was not provided"))?;
+    resolve_key(phsf, password, key_cache)
+}
+
 /// Decrypt reader according to an encryption type.
-pub(crate) fn decrypt_reader<R: Read>(
+///
+/// `header_chunk_type` and `header_chunk_data` are the `FHED`/`SHED` Type and
+/// Data fields; both feed AEAD (GCM) stream-key derivation and are ignored by
+/// the block/stream cipher modes.
+pub(crate) fn decrypt_reader<R: Read, O: ReadOption>(
     mut reader: R,
     encryption: Encryption,
     cipher_mode: CipherMode,
     phsf: Option<&str>,
-    password: Option<&[u8]>,
-    key_cache: Option<&KeyCache>,
+    options: O,
+    header_chunk_type: ChunkType,
+    header_chunk_data: &[u8],
 ) -> io::Result<DecryptReader<R>> {
+    let password = options.password();
+    let key_cache = options.key_cache();
     Ok(match encryption {
         Encryption::NO => DecryptReader::No(reader),
         encryption @ (Encryption::AES | Encryption::CAMELLIA) => {
             let s = phsf.ok_or_else(|| {
                 io::Error::new(io::ErrorKind::InvalidData, "`PHSF` chunk not found")
             })?;
-            let password = password.ok_or_else(|| {
-                io::Error::new(io::ErrorKind::InvalidInput, "password was not provided")
-            })?;
-            let hash = resolve_key(s, password, key_cache)?;
-            let key = hash.as_bytes();
             match (encryption, cipher_mode) {
                 (Encryption::AES, CipherMode::CBC) => {
+                    let key = derive_key(s, password, key_cache)?;
                     let mut iv = vec![0; Aes256::block_size()];
                     reader.read_exact(&mut iv)?;
-                    DecryptReader::CbcAes(DecryptCbcAes256Reader::new(reader, key, &iv)?)
+                    DecryptReader::CbcAes(DecryptCbcAes256Reader::new(reader, key.as_bytes(), &iv)?)
                 }
                 (Encryption::AES, CipherMode::CTR) => {
+                    let key = derive_key(s, password, key_cache)?;
                     let mut iv = vec![0u8; Aes256::block_size()];
                     reader.read_exact(&mut iv)?;
-                    DecryptReader::CtrAes(Ctr128BEReader::new(reader, key, &iv)?)
+                    DecryptReader::CtrAes(Ctr128BEReader::new(reader, key.as_bytes(), &iv)?)
                 }
                 (Encryption::CAMELLIA, CipherMode::CBC) => {
+                    let key = derive_key(s, password, key_cache)?;
                     let mut iv = vec![0; Camellia256::block_size()];
                     reader.read_exact(&mut iv)?;
-                    DecryptReader::CbcCamellia(DecryptCbcCamellia256Reader::new(reader, key, &iv)?)
+                    DecryptReader::CbcCamellia(DecryptCbcCamellia256Reader::new(
+                        reader,
+                        key.as_bytes(),
+                        &iv,
+                    )?)
                 }
                 (Encryption::CAMELLIA, CipherMode::CTR) => {
+                    let key = derive_key(s, password, key_cache)?;
                     let mut iv = vec![0u8; Camellia256::block_size()];
                     reader.read_exact(&mut iv)?;
-                    DecryptReader::CtrCamellia(Ctr128BEReader::new(reader, key, &iv)?)
+                    DecryptReader::CtrCamellia(Ctr128BEReader::new(reader, key.as_bytes(), &iv)?)
+                }
+                (enc, CipherMode::GCM) => {
+                    let mut header = [0u8; STREAM_HEADER_LEN];
+                    reader.read_exact(&mut header).map_err(|e| {
+                        if e.kind() == io::ErrorKind::UnexpectedEof {
+                            AeadError::Malformed("datastream shorter than the stream header").into()
+                        } else {
+                            e
+                        }
+                    })?;
+                    // Parsed (and the segment size range-checked) before the
+                    // password KDF runs, so a malformed stream fails without
+                    // paying for the deliberately expensive KDF that `PHSF`
+                    // records.
+                    let header = StreamHeader::try_from_bytes(&header)?;
+                    let k_master = derive_key(s, password, key_cache)?;
+                    if k_master.as_bytes().len() != 32 {
+                        return Err(AeadError::Malformed("K_master is not 32 bytes").into());
+                    }
+                    // Segments are only reachable once the password is known to
+                    // match the recorded KDF parameters, so a tag failure below
+                    // means tampering rather than a wrong password.
+                    if !header.confirms_key(k_master.as_bytes()) {
+                        return Err(AeadError::KeyMismatch.into());
+                    }
+                    let k_stream = derive_stream_key(
+                        k_master.as_bytes(),
+                        &header,
+                        header_chunk_type,
+                        header_chunk_data,
+                        s.as_bytes(),
+                    );
+                    match enc {
+                        Encryption::AES => DecryptReader::GcmAes(DecryptGcmAes256Reader::new(
+                            reader, &k_stream, &header,
+                        )),
+                        Encryption::CAMELLIA => DecryptReader::GcmCamellia(
+                            DecryptGcmCamellia256Reader::new(reader, &k_stream, &header),
+                        ),
+                        _ => {
+                            return Err(io::Error::new(
+                                io::ErrorKind::Unsupported,
+                                format!("unsupported encryption algorithm for GCM: {enc:?}"),
+                            ));
+                        }
+                    }
                 }
                 _ => {
                     return Err(io::Error::new(
@@ -140,8 +212,9 @@ mod tests {
             Encryption::CAMELLIA,
             CipherMode::from_byte(3),
             Some(phsf),
-            Some(b"password"),
-            None,
+            crate::ReadOptions::with_password(Some("password")),
+            ChunkType::FHED,
+            b"",
         );
         assert!(matches!(
             result,

--- a/lib/src/entry/write.rs
+++ b/lib/src/entry/write.rs
@@ -1,8 +1,12 @@
 //! Entry compression and encryption writing.
 
 use crate::{
-    Cipher, CipherAlgorithm, HashAlgorithm,
-    cipher::{CipherWriter, Ctr128BEWriter, EncryptCbcAes256Writer, EncryptCbcCamellia256Writer},
+    ChunkType, Cipher, CipherAlgorithm, HashAlgorithm,
+    cipher::{
+        CipherWriter, Ctr128BEWriter, EncryptCbcAes256Writer, EncryptCbcCamellia256Writer,
+        EncryptGcmAes256Writer, EncryptGcmCamellia256Writer, StreamHeader, StreamKey,
+        derive_stream_key, key_confirmation,
+    },
     compress::CompressionWriter,
     entry::{CipherMode, Compress, DerivedKeyMaterial, HashAlgorithmParams, WriteOption},
     hash, random,
@@ -18,9 +22,33 @@ use zstd::stream::write::Encoder as ZstdEncoder;
 
 pub(crate) struct CipherContext {
     pub(crate) phsf: String,
-    pub(crate) iv: Vec<u8>,
-    pub(crate) key: Output,
-    pub(crate) mode: CipherMode,
+    pub(crate) payload: CipherPayload,
+}
+
+pub(crate) enum CipherPayload {
+    /// CBC/CTR: the KDF output is used directly as the encryption key.
+    Block {
+        mode: CipherMode,
+        iv: Vec<u8>,
+        key: Output,
+    },
+    /// GCM: the per-stream key is derived from the entry header, so it cannot be
+    /// derived before that header is final.
+    GcmStream {
+        header: StreamHeader,
+        k_stream: StreamKey,
+    },
+}
+
+impl CipherContext {
+    /// On-wire datastream prefix: the block IV for CBC/CTR, or the stream
+    /// header for GCM.
+    pub(crate) fn prefix_bytes(&self) -> Vec<u8> {
+        match &self.payload {
+            CipherPayload::Block { iv, .. } => iv.clone(),
+            CipherPayload::GcmStream { header, .. } => header.to_bytes().to_vec(),
+        }
+    }
 }
 
 pub(crate) struct WriteCipher {
@@ -44,25 +72,69 @@ pub(crate) fn derive_key_material(
 }
 
 #[inline]
-fn to_hashed(cipher: &Cipher) -> io::Result<WriteCipher> {
-    let iv = match cipher.cipher_algorithm {
-        CipherAlgorithm::Aes => random::random_vec(Aes256::block_size()),
-        CipherAlgorithm::Camellia => random::random_vec(Camellia256::block_size()),
-    }?;
+fn to_hashed(
+    cipher: &Cipher,
+    header_chunk_type: ChunkType,
+    header_chunk_data: &[u8],
+) -> io::Result<WriteCipher> {
+    let context = match cipher.mode {
+        CipherMode::GCM => {
+            let mut salt = [0u8; 32];
+            random::random_bytes(&mut salt)?;
+            let mut nonce_prefix = [0u8; 7];
+            random::random_bytes(&mut nonce_prefix)?;
+            // Every entry written with these options shares one K_master and
+            // therefore one key confirmation. Deriving it per entry costs a
+            // single HKDF, so only K_master itself is worth caching.
+            let header = StreamHeader::new(
+                salt,
+                nonce_prefix,
+                cipher.segment_size,
+                key_confirmation(cipher.derived.key.as_bytes()),
+            );
+            let k_stream = derive_stream_key(
+                cipher.derived.key.as_bytes(),
+                &header,
+                header_chunk_type,
+                header_chunk_data,
+                cipher.derived.phsf.as_bytes(),
+            );
+            CipherContext {
+                phsf: cipher.derived.phsf.clone(),
+                payload: CipherPayload::GcmStream { header, k_stream },
+            }
+        }
+        _ => {
+            let iv = match cipher.cipher_algorithm {
+                CipherAlgorithm::Aes => random::random_vec(Aes256::block_size()),
+                CipherAlgorithm::Camellia => random::random_vec(Camellia256::block_size()),
+            }?;
+            CipherContext {
+                phsf: cipher.derived.phsf.clone(),
+                payload: CipherPayload::Block {
+                    mode: cipher.mode,
+                    iv,
+                    key: cipher.derived.key,
+                },
+            }
+        }
+    };
     Ok(WriteCipher {
         algorithm: cipher.cipher_algorithm,
-        context: CipherContext {
-            phsf: cipher.derived.phsf.clone(),
-            iv,
-            key: cipher.derived.key,
-            mode: cipher.mode,
-        },
+        context,
     })
 }
 
 #[inline]
-pub(crate) fn get_writer_context(option: impl WriteOption) -> io::Result<EntryWriterContext> {
-    let cipher = option.cipher().map(to_hashed).transpose()?;
+pub(crate) fn get_writer_context(
+    option: impl WriteOption,
+    header_chunk_type: ChunkType,
+    header_chunk_data: &[u8],
+) -> io::Result<EntryWriterContext> {
+    let cipher = option
+        .cipher()
+        .map(|c| to_hashed(c, header_chunk_type, header_chunk_data))
+        .transpose()?;
     Ok(EntryWriterContext {
         compress: option.compress(),
         cipher,
@@ -120,56 +192,58 @@ fn encryption_writer<W: Write>(
 ) -> io::Result<CipherWriter<W>> {
     Ok(match cipher {
         None => CipherWriter::No(writer),
-        Some(WriteCipher {
-            algorithm: CipherAlgorithm::Aes,
-            context:
-                CipherContext {
-                    iv,
-                    key,
+        Some(WriteCipher { algorithm, context }) => match (algorithm, &context.payload) {
+            (
+                CipherAlgorithm::Aes,
+                CipherPayload::Block {
                     mode: CipherMode::CBC,
-                    ..
-                },
-        }) => CipherWriter::CbcAes(EncryptCbcAes256Writer::new(writer, key.as_bytes(), iv)?),
-        Some(WriteCipher {
-            algorithm: CipherAlgorithm::Aes,
-            context:
-                CipherContext {
                     iv,
                     key,
+                },
+            ) => CipherWriter::CbcAes(EncryptCbcAes256Writer::new(writer, key.as_bytes(), iv)?),
+            (
+                CipherAlgorithm::Aes,
+                CipherPayload::Block {
                     mode: CipherMode::CTR,
-                    ..
-                },
-        }) => CipherWriter::CtrAes(Ctr128BEWriter::new(writer, key.as_bytes(), iv)?),
-        Some(WriteCipher {
-            algorithm: CipherAlgorithm::Camellia,
-            context:
-                CipherContext {
                     iv,
                     key,
+                },
+            ) => CipherWriter::CtrAes(Ctr128BEWriter::new(writer, key.as_bytes(), iv)?),
+            (
+                CipherAlgorithm::Camellia,
+                CipherPayload::Block {
                     mode: CipherMode::CBC,
-                    ..
-                },
-        }) => CipherWriter::CbcCamellia(EncryptCbcCamellia256Writer::new(
-            writer,
-            key.as_bytes(),
-            iv,
-        )?),
-        Some(WriteCipher {
-            algorithm: CipherAlgorithm::Camellia,
-            context:
-                CipherContext {
                     iv,
                     key,
-                    mode: CipherMode::CTR,
-                    ..
                 },
-        }) => CipherWriter::CtrCamellia(Ctr128BEWriter::new(writer, key.as_bytes(), iv)?),
-        Some(WriteCipher { context, .. }) => {
-            return Err(io::Error::new(
-                io::ErrorKind::Unsupported,
-                format!("unsupported cipher mode for writing: {:?}", context.mode),
-            ));
-        }
+            ) => CipherWriter::CbcCamellia(EncryptCbcCamellia256Writer::new(
+                writer,
+                key.as_bytes(),
+                iv,
+            )?),
+            (
+                CipherAlgorithm::Camellia,
+                CipherPayload::Block {
+                    mode: CipherMode::CTR,
+                    iv,
+                    key,
+                },
+            ) => CipherWriter::CtrCamellia(Ctr128BEWriter::new(writer, key.as_bytes(), iv)?),
+            (CipherAlgorithm::Aes, CipherPayload::GcmStream { header, k_stream }) => {
+                CipherWriter::GcmAes(EncryptGcmAes256Writer::new(writer, k_stream, header))
+            }
+            (CipherAlgorithm::Camellia, CipherPayload::GcmStream { header, k_stream }) => {
+                CipherWriter::GcmCamellia(EncryptGcmCamellia256Writer::new(
+                    writer, k_stream, header,
+                ))
+            }
+            (_, CipherPayload::Block { mode, .. }) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    format!("unsupported cipher mode for writing: {mode:?}"),
+                ));
+            }
+        },
     })
 }
 

--- a/lib/src/error.rs
+++ b/lib/src/error.rs
@@ -17,3 +17,70 @@ impl Display for UnknownValueError {
 }
 
 impl Error for UnknownValueError {}
+
+/// Error kinds reported while decrypting an AEAD (Cipher mode 2) datastream.
+///
+/// The variants correspond one-to-one with the failure classes the PNA
+/// specification requires a decoder to report distinctly.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub(crate) enum AeadError {
+    /// The datastream violates the AEAD layout; the detail names which rule.
+    Malformed(&'static str),
+    /// The stream header's key confirmation does not match the key derived
+    /// from the password, so the password does not match the recorded KDF
+    /// parameters. Tampering with the `PHSF` chunk or with the key
+    /// confirmation field itself presents the same way. Reported before any
+    /// segment is processed.
+    KeyMismatch,
+    /// A GCM authentication tag did not verify: the datastream has been
+    /// tampered with or corrupted. A wrong password is reported as
+    /// [`AeadError::KeyMismatch`] before segment processing starts, so it
+    /// cannot reach here.
+    AuthenticationFailure,
+    /// The datastream ended with a partial tail too short to be a final
+    /// segment, after at least one verified segment. A truncation that leaves
+    /// a plausible final segment is reported as
+    /// [`AeadError::AuthenticationFailure`] instead, since GCM cannot
+    /// distinguish it from tampering.
+    Truncation,
+}
+
+impl std::fmt::Display for AeadError {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Malformed(detail) => write!(f, "malformed AEAD datastream: {detail}"),
+            Self::KeyMismatch => f.write_str(
+                "key mismatch: the password does not match the recorded key derivation parameters",
+            ),
+            Self::AuthenticationFailure => {
+                f.write_str("authentication failed: the AEAD datastream is corrupted or tampered")
+            }
+            Self::Truncation => f.write_str("AEAD datastream is truncated"),
+        }
+    }
+}
+
+impl std::error::Error for AeadError {}
+
+impl From<AeadError> for std::io::Error {
+    #[inline]
+    fn from(e: AeadError) -> Self {
+        // Deliberately not `UnexpectedEof` even for `Truncation`: readers treat
+        // `UnexpectedEof` as a clean end of stream, which would let a truncated
+        // authenticated datastream terminate iteration without an error.
+        std::io::Error::new(std::io::ErrorKind::InvalidData, e)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncation_does_not_become_unexpected_eof() {
+        let io_err: std::io::Error = AeadError::Truncation.into();
+        assert_eq!(io_err.kind(), std::io::ErrorKind::InvalidData);
+    }
+}


### PR DESCRIPTION
## Summary

Add Cipher mode 2 (AEAD: AES-256-GCM / Camellia-256-GCM with a STREAM-based segmented layout) to libpna. Stream keys are derived per datastream via HKDF-SHA-256 from the KDF output and an 88-byte entry context that binds the raw FHED/SHED Type and Data fields, the PHSF Data field, and the stream header's nonce prefix and segment size.

## Notes

- A wrong password is detected deterministically by a key-confirmation check before any segment is processed, so it never surfaces as an authentication failure. Both reach callers as `io::ErrorKind::InvalidData` with distinct messages; the classification is crate-internal, not public API.
- `CipherMode` gains a `GCM` constant. Wire value 2 now parses as `GCM` instead of `Reserved(2)`, and `CipherMode::from_byte(2).is_reserved()` is now `false`.
- Because the raw FHED Type and Data fields are bound into the stream key, renaming a GCM entry via `NormalEntry::with_name` silently produces an undecryptable entry; this is fixed in a follow-up PR (#3192).
- CBC/CTR behavior is unchanged. The CLI does not expose GCM yet (follow-up PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authenticated GCM (Cipher mode 2) encryption/decryption for PNA archives using AES and Camellia.
  * Added configurable GCM datastream segment sizing for both solid and per-entry encryption.

* **Bug Fixes**
  * Improved decrypt/encrypt correctness by deriving GCM context from the exact on-wire entry header bytes, ensuring consistent behavior across read/copy paths.
  * Enhanced failure handling with clearer classification for wrong passwords, authentication failures, malformed inputs, and truncation.

* **Tests**
  * Expanded GCM round-trip and robustness coverage (segmentation, fragmentation, slice reads, and copy/decrypt).
  * Added extensive positive/negative test cases, including corruption scenarios and error classification checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
