### PR TITLE
:bug: Limit --fast verification to chunk integrity

### DIFF
--- a/cli/src/command/verify.rs
+++ b/cli/src/command/verify.rs
@@ -19,7 +19,7 @@ pub(crate) struct VerifyCommand {
     #[arg(
         long,
         help = "Verify chunk structure and CRC32 only, without decoding entry data",
-        long_help = "Verify chunk structure and CRC32 only, without decoding entry data. Solid blocks are still decoded because enumerating their entries requires decompression and decryption, so stream corruption inside a solid block is detected even with --fast. Encrypted normal entries are counted as ok because nothing is decoded, so the skipped category does not apply."
+        long_help = "Verify chunk structure and CRC32 only. No entry data is decoded, so neither the entries contained in a solid block nor corruption that leaves a chunk's CRC32 intact are checked. Every entry whose chunks are intact is counted as ok, and no password is required."
     )]
     fast: bool,
     #[command(flatten)]
@@ -78,6 +78,14 @@ fn verify_archive(args: VerifyCommand) -> anyhow::Result<()> {
                 Err(err) => Err(err),
                 Ok(read_entry) => {
                     resyncing = false;
+                    if fast {
+                        // Assembling the entry already validated every chunk's
+                        // CRC32, which is all `--fast` checks: no entry data is
+                        // decoded, so the entries inside a solid block are not
+                        // verified either.
+                        report.ok += 1;
+                        return Ok(());
+                    }
                     match read_entry {
                         ReadEntry::Solid(solid) => {
                             solid_blocks += 1;
@@ -87,7 +95,7 @@ fn verify_archive(args: VerifyCommand) -> anyhow::Result<()> {
                                 return Ok(());
                             }
                             if let Err(err) =
-                                verify_solid(&solid, password, &read_options, fast, &mut report)
+                                verify_solid(&solid, password, &read_options, &mut report)
                             {
                                 println!("<solid block #{solid_blocks}>: FAILED ({err})");
                                 report.failed += 1;
@@ -95,7 +103,7 @@ fn verify_archive(args: VerifyCommand) -> anyhow::Result<()> {
                             }
                         }
                         ReadEntry::Normal(entry) => {
-                            verify_entry(&entry, password, &read_options, fast, &mut report)
+                            verify_entry(&entry, password, &read_options, &mut report)
                         }
                     }
                     Ok(())
@@ -124,11 +132,10 @@ fn verify_solid(
     solid: &SolidEntry,
     password: Option<&[u8]>,
     read_options: &ReadOptions,
-    fast: bool,
     report: &mut VerifyReport,
 ) -> io::Result<()> {
     for entry in solid.entries(read_options)? {
-        verify_entry(&entry?, password, read_options, fast, report);
+        verify_entry(&entry?, password, read_options, report);
     }
     Ok(())
 }
@@ -137,14 +144,8 @@ fn verify_entry(
     entry: &NormalEntry,
     password: Option<&[u8]>,
     read_options: &ReadOptions,
-    fast: bool,
     report: &mut VerifyReport,
 ) {
-    if fast {
-        // Entry assembly already validated chunk CRC32 and structure.
-        report.ok += 1;
-        return;
-    }
     let encrypted = entry.header().encryption() != Encryption::NO;
     if encrypted && password.is_none() {
         // Decoding is impossible without the password.

--- a/cli/tests/cli/verify.rs
+++ b/cli/tests/cli/verify.rs
@@ -332,13 +332,56 @@ fn verify_with_solid_archive() {
         ));
 }
 
-/// Precondition: A plain solid archive whose first solid-data chunk was altered
-/// and the chunk CRC recomputed, so corruption is only detectable by decoding.
-/// Action: Run verify with --fast.
-/// Expectation: Exit failure with the solid block reported as FAILED — fast mode
-/// still decodes solid blocks because enumerating their entries requires it.
+/// Precondition: A solid archive whose solid-data chunk was altered and the
+/// chunk CRC recomputed, so corruption is only detectable by decoding.
+/// Action: Run verify in default (deep) mode.
+/// Expectation: Exit failure with the solid block reported as FAILED.
 #[test]
-fn verify_with_fast_on_corrupted_solid_archive() {
+fn verify_with_solid_stream_corruption() {
+    setup();
+    TestResources::extract_in("raw/", "verify_solid_stream/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "verify_solid_stream/verify_solid_stream.pna",
+        "--deflate",
+        "--overwrite",
+        "--solid",
+        "verify_solid_stream/in/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    assert!(
+        corrupt_first_chunk(
+            "verify_solid_stream/verify_solid_stream.pna",
+            *b"SDAT",
+            true
+        )
+        .unwrap()
+    );
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "verify",
+            "-f",
+            "verify_solid_stream/verify_solid_stream.pna",
+        ])
+        .assert()
+        .failure()
+        .stdout(contains("FAILED"));
+}
+
+/// Precondition: Same corruption as the deep-mode solid test (valid CRC, broken
+/// solid data stream).
+/// Action: Run verify with --fast.
+/// Expectation: Exit success — fast mode does not decode a solid block, so the
+/// entries it contains are not verified.
+#[test]
+fn verify_with_fast_on_solid_stream_corruption() {
     setup();
     TestResources::extract_in("raw/", "verify_fast_solid/in/").unwrap();
     cli::Cli::try_parse_from([
@@ -347,6 +390,7 @@ fn verify_with_fast_on_corrupted_solid_archive() {
         "c",
         "-f",
         "verify_fast_solid/verify_fast_solid.pna",
+        "--deflate",
         "--overwrite",
         "--solid",
         "verify_fast_solid/in/",
@@ -367,8 +411,52 @@ fn verify_with_fast_on_corrupted_solid_archive() {
             "--fast",
         ])
         .assert()
+        .success()
+        .stdout(contains("failed: 0"));
+}
+
+/// Precondition: A solid archive whose solid-data chunk's bytes were altered
+/// without updating the stored CRC.
+/// Action: Run verify with --fast.
+/// Expectation: Exit failure — fast mode validates chunk CRC32 inside a solid
+/// block as well.
+#[test]
+fn verify_with_fast_on_solid_crc_mismatch() {
+    setup();
+    TestResources::extract_in("raw/", "verify_fast_solid_crc/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "verify_fast_solid_crc/verify_fast_solid_crc.pna",
+        "--overwrite",
+        "--solid",
+        "verify_fast_solid_crc/in/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    assert!(
+        corrupt_first_chunk(
+            "verify_fast_solid_crc/verify_fast_solid_crc.pna",
+            *b"SDAT",
+            false
+        )
+        .unwrap()
+    );
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "verify",
+            "-f",
+            "verify_fast_solid_crc/verify_fast_solid_crc.pna",
+            "--fast",
+        ])
+        .assert()
         .failure()
-        .stdout(contains("FAILED"));
+        .stdout(contains("FAILED").and(contains("failed: 1,")));
 }
 
 /// Precondition: An encrypted solid archive exists and no password is supplied.
@@ -409,6 +497,48 @@ fn verify_without_password_on_encrypted_solid_archive() {
         .stdout(
             contains("<solid block #1>: skipped (encrypted)")
                 .and(contains("skipped (encrypted): 1")),
+        );
+}
+
+/// Precondition: An encrypted solid archive exists and no password is supplied.
+/// Action: Run verify with --fast.
+/// Expectation: Exit success with the block counted as ok rather than skipped —
+/// fast mode needs no password because it never decrypts.
+#[test]
+fn verify_with_fast_without_password_on_encrypted_solid_archive() {
+    setup();
+    TestResources::extract_in("raw/", "verify_fast_solid_enc/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "verify_fast_solid_enc/verify_fast_solid_enc.pna",
+        "--overwrite",
+        "--solid",
+        "verify_fast_solid_enc/in/",
+        "--password",
+        "password",
+        "--aes",
+        "ctr",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "verify",
+            "-f",
+            "verify_fast_solid_enc/verify_fast_solid_enc.pna",
+            "--fast",
+        ])
+        .assert()
+        .success()
+        .stdout(
+            contains("total: 1, ok: 1, failed: 0, skipped (encrypted): 0")
+                .and(contains("<solid block").not()),
         );
 }
 


### PR DESCRIPTION
## Summary

`pna experimental verify --fast` now checks chunk structure and CRC32 for every entry kind. Solid blocks were decoded even with `--fast`, because enumerating the entries inside a block requires decrypting and decompressing its data stream — so the flag was neither fast nor usable without a password on solid archives.

## Notes

- Corruption that leaves a chunk's CRC32 intact inside a solid block is no longer reported by `--fast`. Default (deep) mode still reports it, and `verify_with_solid_stream_corruption` pins that.
- `--fast` no longer needs a password for an encrypted solid archive; the block is counted as ok instead of skipped.
- Under `--fast` a solid block counts as one entry rather than as the number of entries it contains.
- Touches the same `ReadEntry::Solid` arm as #3193, so whichever lands second needs a small conflict resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added faster archive verification that checks chunk structure and CRC32 without decoding entry data.
  * Fast verification now counts intact entries as successful without requiring a password, including encrypted solid archives.

* **Bug Fixes**
  * Improved deep verification to detect corruption within solid-data streams.
  * Clarified fast-mode handling for solid archives and CRC mismatches.

* **Tests**
  * Added coverage for solid archive corruption, encrypted archives, and fast verification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->