### PR TITLE
:sparkles: Print diff missing-entry warning to stderr in plain format

### DIFF
--- a/cli/src/command/diff.rs
+++ b/cli/src/command/diff.rs
@@ -161,6 +161,9 @@ struct DiffRecord<'a> {
 /// Prints a single difference in the requested output format.
 fn report(kind: &DiffKind, path: &str, format: Format) {
     match format {
+        Format::Plain if matches!(kind, DiffKind::Missing) => {
+            eprintln!("{}", kind.display(path))
+        }
         Format::Plain => println!("{}", kind.display(path)),
         Format::JsonL => {
             let target = match kind {

--- a/cli/src/command/diff.rs
+++ b/cli/src/command/diff.rs
@@ -8,8 +8,6 @@ use crate::{
 };
 
 use clap::{Parser, ValueEnum};
-#[cfg(unix)]
-use pna::prelude::MetadataTimeExt;
 use pna::{DataKind, EntryContent, NormalEntry, ReadOptions};
 use same_file::is_same_file;
 #[cfg(unix)]
@@ -222,12 +220,21 @@ struct CompareOptions {
     format: Format,
 }
 
-/// Compare two SystemTime values with 1-second tolerance for filesystem precision.
+/// Compare an archived mtime against a filesystem mtime at the archive's stored precision:
+/// whole-second storage compares by whole seconds, sub-second storage requires exact equality.
 #[cfg(unix)]
-fn times_equal(a: SystemTime, b: SystemTime) -> bool {
-    match a.duration_since(b) {
-        Ok(d) => d.as_secs() == 0,
-        Err(e) => e.duration().as_secs() == 0,
+fn mtime_matches(archived: pna::Duration, fs: SystemTime) -> bool {
+    let fs = match fs.duration_since(SystemTime::UNIX_EPOCH) {
+        Ok(d) => pna::Duration::try_from(d),
+        Err(e) => pna::Duration::try_from(e.duration()).map(|d| -d),
+    };
+    let Ok(fs) = fs else {
+        return false;
+    };
+    if archived.subsec_nanoseconds() == 0 {
+        fs.whole_seconds() == archived.whole_seconds()
+    } else {
+        fs == archived
     }
 }
 
@@ -251,9 +258,9 @@ fn compare_file_metadata<T: AsRef<[u8]>>(
     }
 
     // Compare mtime
-    if let Some(archive_mtime) = entry.metadata().saturating_modified_time()
+    if let Some(archive_mtime) = entry.metadata().modified()
         && let Ok(fs_mtime) = fs_meta.modified()
-        && !times_equal(archive_mtime, fs_mtime)
+        && !mtime_matches(archive_mtime, fs_mtime)
     {
         diffs.push(DiffKind::MtimeDiffers);
     }
@@ -304,9 +311,9 @@ fn compare_directory_metadata<T: AsRef<[u8]>>(
 
     // Only compare mtime and ownership with --full-compare
     if options.full_compare {
-        if let Some(archive_mtime) = entry.metadata().saturating_modified_time()
+        if let Some(archive_mtime) = entry.metadata().modified()
             && let Ok(fs_mtime) = fs_meta.modified()
-            && !times_equal(archive_mtime, fs_mtime)
+            && !mtime_matches(archive_mtime, fs_mtime)
         {
             diffs.push(DiffKind::MtimeDiffers);
         }

--- a/cli/src/command/diff.rs
+++ b/cli/src/command/diff.rs
@@ -170,6 +170,9 @@ struct DiffRecord<'a> {
 
 fn report(kind: &DiffKind, path: &str, format: Format) {
     match format {
+        Format::Plain if matches!(kind, DiffKind::Missing) => {
+            eprintln!("{}", kind.display(path))
+        }
         Format::Plain => println!("{}", kind.display(path)),
         Format::JsonL => println!(
             "{}",

--- a/cli/tests/cli/diff/exit_code.rs
+++ b/cli/tests/cli/diff/exit_code.rs
@@ -61,7 +61,7 @@ fn diff_with_content_difference_exits_one() {
 
 /// Precondition: Archive contains a file that is later removed from disk.
 /// Action: Run `pna experimental diff`.
-/// Expectation: Exits with status 1 and writes nothing to stderr.
+/// Expectation: Exits with status 1, reports the difference on stderr, and writes nothing to stdout.
 #[test]
 fn diff_with_missing_file_exits_one() {
     setup();
@@ -84,8 +84,8 @@ fn diff_with_missing_file_exits_one() {
         .args(["experimental", "diff", "-f", &archive_path])
         .assert()
         .code(1)
-        .stdout(predicate::str::contains("Cannot stat"))
-        .stderr("");
+        .stdout("")
+        .stderr(predicate::str::contains("Cannot stat"));
 }
 
 /// Precondition: The given archive path does not exist.

--- a/cli/tests/cli/diff/metadata.rs
+++ b/cli/tests/cli/diff/metadata.rs
@@ -168,3 +168,278 @@ fn diff_detects_directory_mtime_with_full_compare() {
         .code(1)
         .stdout(predicate::str::contains("Mod time differs"));
 }
+
+/// Precondition: Archive stores a file mtime with zero sub-second precision.
+/// Action: Filesystem mtime is set to the same whole second with nonzero nanoseconds.
+/// Expectation: No "Mod time differs" is reported; whole-second storage compares by whole seconds.
+/// Returns early on filesystems without nanosecond timestamp support.
+#[cfg(unix)]
+#[test]
+fn diff_ignores_subsecond_when_archive_has_whole_second_mtime() {
+    setup();
+    let dir = "diff_mtime_ignores_subsecond_test";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let file_path = format!("{dir}/file.txt");
+    fs::write(&file_path, "content").unwrap();
+
+    let whole_second = SystemTime::UNIX_EPOCH + Duration::from_secs(86400);
+    filetime::set_file_mtime(
+        &file_path,
+        filetime::FileTime::from_system_time(whole_second),
+    )
+    .unwrap();
+
+    let archive_path = format!("{dir}/test.pna");
+    cargo_bin_cmd!("pna")
+        .args([
+            "create",
+            "-f",
+            &archive_path,
+            "--overwrite",
+            "--keep-timestamp",
+            &file_path,
+        ])
+        .assert()
+        .success();
+
+    let with_nanos = whole_second + Duration::from_nanos(123_456_789);
+    filetime::set_file_mtime(&file_path, filetime::FileTime::from_system_time(with_nanos)).unwrap();
+    if fs::symlink_metadata(&file_path)
+        .unwrap()
+        .modified()
+        .unwrap()
+        != with_nanos
+    {
+        return;
+    }
+
+    cargo_bin_cmd!("pna")
+        .args(["experimental", "diff", "-f", &archive_path])
+        .assert()
+        .success()
+        .stdout("");
+}
+
+/// Precondition: Archive stores a file mtime with nonzero sub-second precision.
+/// Action: Filesystem mtime is the same whole second but with different nanoseconds.
+/// Expectation: Reports "Mod time differs"; sub-second storage requires exact equality.
+/// Returns early on filesystems without nanosecond timestamp support.
+#[cfg(unix)]
+#[test]
+fn diff_detects_subsecond_difference_when_archive_stores_nanoseconds() {
+    setup();
+    let dir = "diff_mtime_detects_subsecond_diff_test";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let file_path = format!("{dir}/file.txt");
+    fs::write(&file_path, "content").unwrap();
+
+    let whole_second = SystemTime::UNIX_EPOCH + Duration::from_secs(86400);
+    let archived_time = whole_second + Duration::from_nanos(123_456_789);
+    filetime::set_file_mtime(
+        &file_path,
+        filetime::FileTime::from_system_time(archived_time),
+    )
+    .unwrap();
+    if fs::symlink_metadata(&file_path)
+        .unwrap()
+        .modified()
+        .unwrap()
+        != archived_time
+    {
+        return;
+    }
+
+    let archive_path = format!("{dir}/test.pna");
+    cargo_bin_cmd!("pna")
+        .args([
+            "create",
+            "-f",
+            &archive_path,
+            "--overwrite",
+            "--keep-timestamp",
+            &file_path,
+        ])
+        .assert()
+        .success();
+
+    let different_nanos = whole_second + Duration::from_nanos(987_654_321);
+    filetime::set_file_mtime(
+        &file_path,
+        filetime::FileTime::from_system_time(different_nanos),
+    )
+    .unwrap();
+    if fs::symlink_metadata(&file_path)
+        .unwrap()
+        .modified()
+        .unwrap()
+        != different_nanos
+    {
+        return;
+    }
+
+    cargo_bin_cmd!("pna")
+        .args(["experimental", "diff", "-f", &archive_path])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("Mod time differs"));
+}
+
+/// Precondition: Archive stores a file mtime with nonzero sub-second precision.
+/// Action: Filesystem mtime is left unchanged (exact nanosecond roundtrip).
+/// Expectation: No "Mod time differs" is reported.
+/// Returns early on filesystems without nanosecond timestamp support.
+#[cfg(unix)]
+#[test]
+fn diff_accepts_exact_nanosecond_roundtrip() {
+    setup();
+    let dir = "diff_mtime_exact_roundtrip_test";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let file_path = format!("{dir}/file.txt");
+    fs::write(&file_path, "content").unwrap();
+
+    let archived_time =
+        SystemTime::UNIX_EPOCH + Duration::from_secs(86400) + Duration::from_nanos(123_456_789);
+    filetime::set_file_mtime(
+        &file_path,
+        filetime::FileTime::from_system_time(archived_time),
+    )
+    .unwrap();
+    if fs::symlink_metadata(&file_path)
+        .unwrap()
+        .modified()
+        .unwrap()
+        != archived_time
+    {
+        return;
+    }
+
+    let archive_path = format!("{dir}/test.pna");
+    cargo_bin_cmd!("pna")
+        .args([
+            "create",
+            "-f",
+            &archive_path,
+            "--overwrite",
+            "--keep-timestamp",
+            &file_path,
+        ])
+        .assert()
+        .success();
+
+    cargo_bin_cmd!("pna")
+        .args(["experimental", "diff", "-f", &archive_path])
+        .assert()
+        .success()
+        .stdout("");
+}
+
+/// Precondition: Archive stores a file mtime with zero sub-second precision.
+/// Action: Filesystem mtime is set to the same whole second, at its last nanosecond.
+/// Expectation: No "Mod time differs" is reported (boundary: still within the same whole second).
+/// Returns early on filesystems without nanosecond timestamp support.
+#[cfg(unix)]
+#[test]
+fn diff_ignores_end_of_second_when_archive_has_whole_second_mtime() {
+    setup();
+    let dir = "diff_mtime_boundary_end_of_second_test";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let file_path = format!("{dir}/file.txt");
+    fs::write(&file_path, "content").unwrap();
+
+    let whole_second = SystemTime::UNIX_EPOCH + Duration::from_secs(86400);
+    filetime::set_file_mtime(
+        &file_path,
+        filetime::FileTime::from_system_time(whole_second),
+    )
+    .unwrap();
+
+    let archive_path = format!("{dir}/test.pna");
+    cargo_bin_cmd!("pna")
+        .args([
+            "create",
+            "-f",
+            &archive_path,
+            "--overwrite",
+            "--keep-timestamp",
+            &file_path,
+        ])
+        .assert()
+        .success();
+
+    let end_of_second = whole_second + Duration::from_nanos(999_999_999);
+    filetime::set_file_mtime(
+        &file_path,
+        filetime::FileTime::from_system_time(end_of_second),
+    )
+    .unwrap();
+    if fs::symlink_metadata(&file_path)
+        .unwrap()
+        .modified()
+        .unwrap()
+        != end_of_second
+    {
+        return;
+    }
+
+    cargo_bin_cmd!("pna")
+        .args(["experimental", "diff", "-f", &archive_path])
+        .assert()
+        .success()
+        .stdout("");
+}
+
+/// Precondition: Archive stores a file mtime with zero sub-second precision.
+/// Action: Filesystem mtime is set to exactly one whole second later.
+/// Expectation: Reports "Mod time differs" (boundary: crosses into the next whole second).
+#[cfg(unix)]
+#[test]
+fn diff_detects_next_second_when_archive_has_whole_second_mtime() {
+    setup();
+    let dir = "diff_mtime_boundary_next_second_test";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let file_path = format!("{dir}/file.txt");
+    fs::write(&file_path, "content").unwrap();
+
+    let whole_second = SystemTime::UNIX_EPOCH + Duration::from_secs(86400);
+    filetime::set_file_mtime(
+        &file_path,
+        filetime::FileTime::from_system_time(whole_second),
+    )
+    .unwrap();
+
+    let archive_path = format!("{dir}/test.pna");
+    cargo_bin_cmd!("pna")
+        .args([
+            "create",
+            "-f",
+            &archive_path,
+            "--overwrite",
+            "--keep-timestamp",
+            &file_path,
+        ])
+        .assert()
+        .success();
+
+    let next_second = whole_second + Duration::from_secs(1);
+    filetime::set_file_mtime(
+        &file_path,
+        filetime::FileTime::from_system_time(next_second),
+    )
+    .unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args(["experimental", "diff", "-f", &archive_path])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("Mod time differs"));
+}

--- a/cli/tests/cli/diff/missing.rs
+++ b/cli/tests/cli/diff/missing.rs
@@ -40,7 +40,7 @@ fn diff_missing_in_archive() {
 
 /// Precondition: The source tree contains files and directories.
 /// Action: Run `pna create` to build an archive, remove a file from the filesystem, then compare with `pna experimental diff`.
-/// Expectation: The missing file is detected.
+/// Expectation: The missing file is detected and reported on stderr.
 #[test]
 fn diff_missing_in_disk() {
     setup();
@@ -69,7 +69,7 @@ fn diff_missing_in_disk() {
         ])
         .assert();
 
-    assert.code(1).stdout(
+    assert.code(1).stdout("").stderr(
         "diff_missing_in_disk/in/raw/images/icon.svg: Warning: Cannot stat: No such file or directory\n",
     );
 }

--- a/cli/tests/cli/diff/multipart.rs
+++ b/cli/tests/cli/diff/multipart.rs
@@ -63,5 +63,6 @@ fn diff_multipart_with_missing_file() {
         .args(["experimental", "diff", "-f", &part1])
         .assert()
         .code(1)
-        .stdout(predicate::str::contains("Cannot stat"));
+        .stdout("")
+        .stderr(predicate::str::contains("Cannot stat"));
 }


### PR DESCRIPTION
## Summary
GNU tar `--compare` prints the missing-entry warning (`Cannot stat`) to stderr; `pna experimental diff` printed it to stdout. Align the plain format with GNU tar, per the reference comparison recorded on #3232. Missing entries still count as differences (exit 1). Part of #3232.

## Notes
- `--format jsonl` is unchanged: it still emits every difference record, including `missing`, on stdout — plain and jsonl intentionally differ in where missing entries appear.
- Stacked on #3244; base branch is `cli/diff/mtime-stored-precision`. The type-mismatch wording alignment was extracted to #3290.

## Verification
- Side-by-side E2E against GNU tar 1.35 (Homebrew, macOS): the missing-file scenario now matches GNU tar in message text, output stream, and exit status.