### PR TITLE
:sparkles: Align diff type-mismatch message with GNU tar

### DIFF
--- a/cli/src/command/diff.rs
+++ b/cli/src/command/diff.rs
@@ -101,7 +101,7 @@ enum DiffKind {
     /// Group ID differs
     #[cfg(unix)]
     GidDiffers,
-    /// File type mismatch (e.g., file vs directory)
+    /// File type differs (e.g., file vs directory)
     TypeMismatch,
     /// Symbolic link target differs
     SymlinkDiffers,
@@ -142,7 +142,7 @@ impl fmt::Display for DiffMessage<'_> {
             DiffKind::UidDiffers => write!(f, "{}: Uid differs", self.path),
             #[cfg(unix)]
             DiffKind::GidDiffers => write!(f, "{}: Gid differs", self.path),
-            DiffKind::TypeMismatch => write!(f, "{}: File type mismatch", self.path),
+            DiffKind::TypeMismatch => write!(f, "{}: File type differs", self.path),
             DiffKind::SymlinkDiffers => write!(f, "{}: Symlink differs", self.path),
             DiffKind::NotLinked(target) => write!(f, "{}: Not linked to {target}", self.path),
         }

--- a/cli/tests/cli/diff/hardlink.rs
+++ b/cli/tests/cli/diff/hardlink.rs
@@ -9,7 +9,7 @@ use std::fs;
 
 /// Precondition: Archive contains hardlink.
 /// Action: Replace hardlink with directory on the filesystem, run diff.
-/// Expectation: Reports "File type mismatch".
+/// Expectation: Reports "File type differs".
 #[cfg(unix)]
 #[test]
 fn diff_detects_hardlink_to_directory_mismatch() {
@@ -37,7 +37,7 @@ fn diff_detects_hardlink_to_directory_mismatch() {
         .assert()
         .code(1)
         .stdout(predicate::str::contains(format!(
-            "{link}: File type mismatch"
+            "{link}: File type differs"
         )));
 }
 

--- a/cli/tests/cli/diff/type_mismatch.rs
+++ b/cli/tests/cli/diff/type_mismatch.rs
@@ -7,7 +7,7 @@ use std::os::unix::fs::symlink;
 
 /// Precondition: Archive contains symlink.
 /// Action: Replace symlink with regular file on the filesystem, run diff.
-/// Expectation: Reports "File type mismatch".
+/// Expectation: Reports "File type differs".
 #[cfg(unix)]
 #[test]
 fn diff_detects_symlink_to_file_mismatch() {
@@ -35,13 +35,13 @@ fn diff_detects_symlink_to_file_mismatch() {
         .assert()
         .code(1)
         .stdout(predicate::str::contains(format!(
-            "{link}: File type mismatch"
+            "{link}: File type differs"
         )));
 }
 
 /// Precondition: Archive contains regular file.
 /// Action: Replace file with directory on the filesystem, run diff.
-/// Expectation: Reports "File type mismatch".
+/// Expectation: Reports "File type differs".
 #[test]
 fn diff_detects_file_to_directory_mismatch() {
     setup();
@@ -66,13 +66,13 @@ fn diff_detects_file_to_directory_mismatch() {
         .assert()
         .code(1)
         .stdout(predicate::str::contains(format!(
-            "{file_path}: File type mismatch"
+            "{file_path}: File type differs"
         )));
 }
 
 /// Precondition: Archive contains directory.
 /// Action: Replace directory with regular file on the filesystem, run diff.
-/// Expectation: Reports "File type mismatch".
+/// Expectation: Reports "File type differs".
 #[test]
 fn diff_detects_directory_to_file_mismatch() {
     setup();
@@ -104,6 +104,6 @@ fn diff_detects_directory_to_file_mismatch() {
         .assert()
         .code(1)
         .stdout(predicate::str::contains(format!(
-            "{subdir}: File type mismatch"
+            "{subdir}: File type differs"
         )));
 }


### PR DESCRIPTION
## Summary
GNU tar `--compare` reports `File type differs` for type mismatches; `pna experimental diff` said `File type mismatch`. Rename the message to match, per the reference comparison recorded on #3232. Part of #3232.

## Notes
- Extracted from #3286 so it can merge independently of the stacked diff branches; #3286 will be rebased to drop the duplicate commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated diff output to clearly report when a filesystem object’s type differs from the archived type.
  * Improved messaging for mismatches involving files, directories, and symbolic links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->