### PR TITLE
:bug: Feed the stored entry name to the pathname editor

### DIFF
--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -2102,8 +2102,10 @@ fn transform_normal_entry(
         ..
     }: &CreateOptions,
 ) -> io::Result<Option<NormalEntry>> {
-    // Apply path transformation
-    let original_name = entry.header().path();
+    // The editor applies the name policy, which may be to keep the name exactly as
+    // received, so it has to see the stored name. A sanitized path arrives with the
+    // strictest policy already applied and no policy can decline it.
+    let original_name = entry.name();
     let Some(new_name) = pathname_editor.edit_entry_name(original_name.as_ref()) else {
         log::debug!("Skip: {original_name}");
         return Ok(None);

--- a/cli/tests/cli/bsdtar.rs
+++ b/cli/tests/cli/bsdtar.rs
@@ -1,4 +1,5 @@
 mod archive_inclusion;
+mod archive_source_name_policy;
 mod archive_source_uid_override;
 mod files_from;
 mod list_line_ending;

--- a/cli/tests/cli/bsdtar/archive_source_name_policy.rs
+++ b/cli/tests/cli/bsdtar/archive_source_name_policy.rs
@@ -1,0 +1,113 @@
+use crate::utils::{archive::for_each_entry, setup};
+use assert_cmd::cargo::cargo_bin_cmd;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Stored names, which the shared `get_archive_entry_names` does not report: it
+/// returns `header().path()`, and the `./` prefix it sanitizes away is the
+/// difference under test.
+fn stored_names(archive: impl AsRef<Path>) -> Vec<String> {
+    let mut names = Vec::new();
+    for_each_entry(archive, |entry| names.push(entry.name().to_string())).unwrap();
+    names.sort();
+    names
+}
+
+#[test]
+fn bsdtar_archive_source_keeps_curdir_prefix() {
+    setup();
+
+    let base = PathBuf::from("bsdtar_archive_source_keeps_curdir_prefix");
+    fs::create_dir_all(base.join("d")).unwrap();
+    fs::write(base.join("d/f"), "content").unwrap();
+
+    let source = base.join("source.pna");
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "compat",
+            "bsdtar",
+            "--create",
+            "--overwrite",
+            "-f",
+            source.to_str().unwrap(),
+            "-C",
+            base.to_str().unwrap(),
+            "./d/f",
+        ])
+        .assert()
+        .success();
+    assert_eq!(stored_names(&source), ["./d/f"]);
+
+    let copied = base.join("copied.pna");
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "compat",
+            "bsdtar",
+            "--create",
+            "--unstable",
+            "--overwrite",
+            "-f",
+            copied.to_str().unwrap(),
+            "-C",
+            base.to_str().unwrap(),
+            "@source.pna",
+        ])
+        .assert()
+        .success();
+    assert_eq!(stored_names(&copied), ["./d/f"]);
+}
+
+#[cfg(unix)]
+#[test]
+fn bsdtar_archive_source_keeps_absolute_path_with_absolute_paths() {
+    setup();
+
+    let base = PathBuf::from("bsdtar_archive_source_keeps_absolute_path");
+    fs::create_dir_all(base.join("d")).unwrap();
+    fs::write(base.join("d/f"), "content").unwrap();
+    let absolute = base
+        .join("d/f")
+        .canonicalize()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_owned();
+
+    let source = base.join("source.pna");
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "compat",
+            "bsdtar",
+            "--create",
+            "--unstable",
+            "--absolute-paths",
+            "--overwrite",
+            "-f",
+            source.to_str().unwrap(),
+            &absolute,
+        ])
+        .assert()
+        .success();
+    assert_eq!(stored_names(&source), [absolute.as_str()]);
+
+    let copied = base.join("copied.pna");
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "compat",
+            "bsdtar",
+            "--create",
+            "--unstable",
+            "--absolute-paths",
+            "--overwrite",
+            "-f",
+            copied.to_str().unwrap(),
+            &format!("@{}", source.display()),
+        ])
+        .assert()
+        .success();
+    assert_eq!(stored_names(&copied), [absolute.as_str()]);
+}


### PR DESCRIPTION
## Summary

`pna compat bsdtar` ignored `-P` and `--preserve-curdir` when copying entries from `@archive`. `transform_normal_entry` handed the pathname editor `header().path()`, which is already sanitized, so the sanitizing default was applied before the editor could decline it. It now receives the stored name.

## Verification

Against bsdtar 3.5.3 / libarchive 3.7.4, copying an entry stored as `./d/f` out of an archive:

| | stored name after copy |
|---|---|
| before | `d/f` |
| after | `./d/f` |
| bsdtar | `./d/f` |

An absolute name copied with `-P` behaves the same way: the leading `/` was dropped before, and is kept now.

The added tests read `entry.name()` rather than the shared `get_archive_entry_names` helper, which reports `header().path()` and would sanitize away the very difference under test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved archive entry source names consistently when creating archives from relative paths.
  * Preserved absolute source paths when the absolute-path option is enabled.
  * Ensured names remain consistent when archives are created from existing archive references.

* **Tests**
  * Added coverage for relative, absolute, and archive-referenced source paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->