### PR TITLE
:bug: Declare the defaults that option help claims

### DIFF
--- a/cli/src/command/append.rs
+++ b/cli/src/command/append.rs
@@ -79,7 +79,11 @@ pub(crate) struct AppendCommand {
         help = "Do not recursively add directories to the archives. This is the inverse option of --recursive"
     )]
     no_recursive: bool,
-    #[arg(long, help = "Include directories in archive (default)")]
+    #[arg(
+        long,
+        help = "Include directories in archive (default)",
+        default_value_t = true
+    )]
     keep_dir: bool,
     #[arg(
         long,

--- a/cli/src/command/bsdtar.rs
+++ b/cli/src/command/bsdtar.rs
@@ -195,7 +195,11 @@ pub(crate) struct BsdtarCommand {
         help = "Skip extracting files if they already exist"
     )]
     keep_old_files: bool,
-    #[arg(long, help = "Include directories in archive (default)")]
+    #[arg(
+        long,
+        help = "Include directories in archive (default)",
+        default_value_t = true
+    )]
     keep_dir: bool,
     #[arg(
         long,
@@ -578,7 +582,8 @@ pub(crate) struct BsdtarCommand {
     to_stdout: bool,
     #[arg(
         long,
-        help = "Allow extracting symbolic links and hard links that contain root or parent paths (default)"
+        help = "Allow extracting symbolic links and hard links that contain root or parent paths (default)",
+        default_value_t = true
     )]
     allow_unsafe_links: bool,
     #[arg(

--- a/cli/src/command/chown.rs
+++ b/cli/src/command/chown.rs
@@ -28,7 +28,11 @@ pub(crate) struct ChownCommand {
     owner: RawOwnership,
     #[arg(long, help = "force numeric owner and group IDs (no name resolution)")]
     numeric_owner: bool,
-    #[arg(long, help = "resolve user and group (default)")]
+    #[arg(
+        long,
+        help = "resolve user and group (default)",
+        default_value_t = true
+    )]
     owner_lookup: bool,
     #[arg(long, help = "do not resolve user and group")]
     no_owner_lookup: bool,

--- a/cli/src/command/create.rs
+++ b/cli/src/command/create.rs
@@ -92,7 +92,11 @@ pub(crate) struct CreateCommand {
         help = "Do not overwrite files. This is the inverse option of --overwrite"
     )]
     no_overwrite: bool,
-    #[arg(long, help = "Include directories in archive (default)")]
+    #[arg(
+        long,
+        help = "Include directories in archive (default)",
+        default_value_t = true
+    )]
     keep_dir: bool,
     #[arg(
         long,

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -360,7 +360,8 @@ pub(crate) struct ExtractCommand {
     allow_unsafe_links: bool,
     #[arg(
         long,
-        help = "Do not allow extracting symbolic links and hard links that contain root or parent paths (default)"
+        help = "Do not allow extracting symbolic links and hard links that contain root or parent paths (default)",
+        default_value_t = true
     )]
     no_allow_unsafe_links: bool,
     #[arg(

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -85,7 +85,11 @@ pub(crate) struct UpdateCommand {
         help = "Do not recursively add directories to the archives. This is the inverse option of --recursive"
     )]
     no_recursive: bool,
-    #[arg(long, help = "Include directories in archive (default)")]
+    #[arg(
+        long,
+        help = "Include directories in archive (default)",
+        default_value_t = true
+    )]
     keep_dir: bool,
     #[arg(
         long,


### PR DESCRIPTION
## Summary

`--keep-dir`, `--owner-lookup`, `--allow-unsafe-links` of `compat bsdtar` and `--no-allow-unsafe-links` of `extract` each describe themselves as the default and were declared without one, so the generated reference printed `Default value: false` right under the claim. The effective behavior comes from the paired `--no-*` option and is unchanged.

## Notes

The `(default)` wording stays in the help text: clap prints no default for a boolean flag in terminal help, so the help text is the only place a terminal user sees it.

## Verification

`compat bsdtar` has no test covering the `--keep-dir` pair, so the cases were run against the built binary: the default stores directory entries, `--no-keep-dir` omits them, `--keep-dir` still parses, and passing both fails with the group conflict.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Clarified and standardized CLI defaults across append, create, update, and bsdtar commands.
  - Directory inclusion is enabled by default unless explicitly disabled.
  - Owner lookup is enabled by default.
  - bsdtar allows unsafe links by default, while extraction keeps unsafe link handling disabled by default.
  - Existing command options, help text, and override flags remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->