### PR TITLE
:bug: Spell the bsdtar modification-time alias with a hyphen

### DIFF
--- a/cli/src/command/bsdtar.rs
+++ b/cli/src/command/bsdtar.rs
@@ -211,7 +211,8 @@ pub(crate) struct BsdtarCommand {
     #[arg(
         short = 'm',
         long,
-        visible_aliases = ["no-preserve-timestamps", "modification_time"],
+        visible_aliases = ["no-preserve-timestamps", "modification-time"],
+        alias = "modification_time",
         help = "Do not archive timestamp of files. This is the inverse option of --preserve-timestamps"
     )]
     no_keep_timestamp: bool,


### PR DESCRIPTION
## Summary

`compat bsdtar` listed `-m` under the alias `modification_time`; bsdtar spells it `-m, --modification-time`. The underscore form is still accepted, unlisted.
