### PR TITLE
:recycle: Use the preserve vocabulary for the canonical option names

### DIFF
--- a/cli/src/command/append.rs
+++ b/cli/src/command/append.rs
@@ -91,57 +91,57 @@ pub(crate) struct AppendCommand {
     )]
     no_keep_dir: bool,
     #[arg(
-        long,
-        visible_alias = "preserve-timestamps",
+        long = "preserve-timestamps",
+        visible_alias = "keep-timestamp",
         help = "Preserve file timestamps"
     )]
     keep_timestamp: bool,
     #[arg(
-        long,
-        visible_alias = "no-preserve-timestamps",
+        long = "no-preserve-timestamps",
+        visible_alias = "no-keep-timestamp",
         help = "Do not archive timestamp of files. This is the inverse option of --preserve-timestamps"
     )]
     pub(crate) no_keep_timestamp: bool,
     #[arg(
-        long,
-        visible_alias = "preserve-permissions",
+        long = "preserve-permissions",
+        visible_alias = "keep-permission",
         help = "Preserve file permissions"
     )]
     #[cfg_attr(windows, arg(requires = "unstable", help_heading = "Unstable Options"))]
     keep_permission: bool,
     #[arg(
-        long,
-        visible_alias = "no-preserve-permissions",
+        long = "no-preserve-permissions",
+        visible_alias = "no-keep-permission",
         help = "Do not archive permissions of files. This is the inverse option of --preserve-permissions"
     )]
     #[cfg_attr(windows, arg(requires = "unstable", help_heading = "Unstable Options"))]
     no_keep_permission: bool,
     #[arg(
-        long,
-        visible_alias = "preserve-xattrs",
+        long = "preserve-xattrs",
+        visible_alias = "keep-xattr",
         help = "Preserve extended attributes"
     )]
     keep_xattr: bool,
     #[arg(
-        long,
-        visible_alias = "no-preserve-xattrs",
+        long = "no-preserve-xattrs",
+        visible_alias = "no-keep-xattr",
         help = "Do not archive extended attributes of files. This is the inverse option of --preserve-xattrs"
     )]
     pub(crate) no_keep_xattr: bool,
     #[arg(
-        long,
-        visible_alias = "preserve-acls",
+        long = "preserve-acls",
+        visible_alias = "keep-acl",
         requires = "unstable",
         help_heading = "Unstable Options",
         help = "Preserve ACLs"
     )]
     keep_acl: bool,
     #[arg(
-        long,
-        visible_alias = "no-preserve-acls",
+        long = "no-preserve-acls",
+        visible_alias = "no-keep-acl",
         requires = "unstable",
         help_heading = "Unstable Options",
-        help = "Do not archive ACLs. This is the inverse option of --keep-acl"
+        help = "Do not archive ACLs. This is the inverse option of --preserve-acls"
     )]
     no_keep_acl: bool,
     #[arg(long, value_name = "NAME", help = "Set user name for archive entries")]

--- a/cli/src/command/bsdtar.rs
+++ b/cli/src/command/bsdtar.rs
@@ -205,15 +205,15 @@ pub(crate) struct BsdtarCommand {
     )]
     no_keep_dir: bool,
     #[arg(
-        long,
-        visible_alias = "preserve-timestamps",
+        long = "preserve-timestamps",
+        visible_alias = "keep-timestamp",
         help = "Preserve file timestamps"
     )]
     keep_timestamp: bool,
     #[arg(
         short = 'm',
-        long,
-        visible_aliases = ["no-preserve-timestamps", "modification-time"],
+        long = "no-preserve-timestamps",
+        visible_aliases = ["no-keep-timestamp", "modification-time"],
         alias = "modification_time",
         help = "Do not archive timestamp of files. This is the inverse option of --preserve-timestamps"
     )]
@@ -234,47 +234,47 @@ pub(crate) struct BsdtarCommand {
     )]
     same_permissions: bool,
     #[arg(
-        long,
-        visible_aliases = ["preserve-xattrs", "xattrs"],
+        long = "preserve-xattrs",
+        visible_aliases = ["keep-xattr", "xattrs"],
         help = "Preserve extended attributes"
     )]
     keep_xattr: bool,
     #[arg(
-        long,
-        visible_aliases = ["no-preserve-xattrs", "no-xattrs"],
+        long = "no-preserve-xattrs",
+        visible_aliases = ["no-keep-xattr", "no-xattrs"],
         help = "Do not archive extended attributes of files. This is the inverse option of --preserve-xattrs"
     )]
     no_keep_xattr: bool,
     #[arg(
-        long,
-        visible_aliases = ["preserve-acls", "acls"],
+        long = "preserve-acls",
+        visible_aliases = ["keep-acl", "acls"],
         requires = "unstable",
         help_heading = "Unstable Options",
         help = "Preserve ACLs"
     )]
     keep_acl: bool,
     #[arg(
-        long,
-        visible_aliases = ["no-preserve-acls", "no-acls"],
+        long = "no-preserve-acls",
+        visible_aliases = ["no-keep-acl", "no-acls"],
         requires = "unstable",
         help_heading = "Unstable Options",
-        help = "Do not archive ACLs. This is the inverse option of --keep-acl"
+        help = "Do not archive ACLs. This is the inverse option of --preserve-acls"
     )]
     no_keep_acl: bool,
     #[arg(
-        long,
-        visible_aliases = ["preserve-fflags", "fflags"],
+        long = "preserve-fflags",
+        visible_aliases = ["keep-fflags", "fflags"],
         requires = "unstable",
         help_heading = "Unstable Options",
         help = "Archiving the file flags of the files"
     )]
     keep_fflags: bool,
     #[arg(
-        long,
-        visible_aliases = ["no-preserve-fflags", "no-fflags"],
+        long = "no-preserve-fflags",
+        visible_aliases = ["no-keep-fflags", "no-fflags"],
         requires = "unstable",
         help_heading = "Unstable Options",
-        help = "Do not archive file flags of files. This is the inverse option of --keep-fflags"
+        help = "Do not archive file flags of files. This is the inverse option of --preserve-fflags"
     )]
     no_keep_fflags: bool,
     #[arg(

--- a/cli/src/command/create.rs
+++ b/cli/src/command/create.rs
@@ -104,57 +104,57 @@ pub(crate) struct CreateCommand {
     )]
     no_keep_dir: bool,
     #[arg(
-        long,
-        visible_alias = "preserve-timestamps",
+        long = "preserve-timestamps",
+        visible_alias = "keep-timestamp",
         help = "Preserve file timestamps"
     )]
     keep_timestamp: bool,
     #[arg(
-        long,
-        visible_alias = "no-preserve-timestamps",
+        long = "no-preserve-timestamps",
+        visible_alias = "no-keep-timestamp",
         help = "Do not archive timestamp of files. This is the inverse option of --preserve-timestamps"
     )]
     pub(crate) no_keep_timestamp: bool,
     #[arg(
-        long,
-        visible_alias = "preserve-permissions",
+        long = "preserve-permissions",
+        visible_alias = "keep-permission",
         help = "Preserve file permissions"
     )]
     #[cfg_attr(windows, arg(requires = "unstable", help_heading = "Unstable Options"))]
     keep_permission: bool,
     #[arg(
-        long,
-        visible_alias = "no-preserve-permissions",
+        long = "no-preserve-permissions",
+        visible_alias = "no-keep-permission",
         help = "Do not archive permissions of files. This is the inverse option of --preserve-permissions"
     )]
     #[cfg_attr(windows, arg(requires = "unstable", help_heading = "Unstable Options"))]
     no_keep_permission: bool,
     #[arg(
-        long,
-        visible_alias = "preserve-xattrs",
+        long = "preserve-xattrs",
+        visible_alias = "keep-xattr",
         help = "Preserve extended attributes"
     )]
     keep_xattr: bool,
     #[arg(
-        long,
-        visible_alias = "no-preserve-xattrs",
+        long = "no-preserve-xattrs",
+        visible_alias = "no-keep-xattr",
         help = "Do not archive extended attributes of files. This is the inverse option of --preserve-xattrs"
     )]
     pub(crate) no_keep_xattr: bool,
     #[arg(
-        long,
-        visible_alias = "preserve-acls",
+        long = "preserve-acls",
+        visible_alias = "keep-acl",
         requires = "unstable",
         help_heading = "Unstable Options",
         help = "Preserve ACLs"
     )]
     keep_acl: bool,
     #[arg(
-        long,
-        visible_alias = "no-preserve-acls",
+        long = "no-preserve-acls",
+        visible_alias = "no-keep-acl",
         requires = "unstable",
         help_heading = "Unstable Options",
-        help = "Do not archive ACLs. This is the inverse option of --keep-acl"
+        help = "Do not archive ACLs. This is the inverse option of --preserve-acls"
     )]
     no_keep_acl: bool,
     #[arg(

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -101,14 +101,14 @@ pub(crate) struct ExtractCommand {
     #[command(flatten)]
     pub(crate) password: PasswordArgs,
     #[arg(
-        long,
-        visible_alias = "preserve-timestamps",
+        long = "preserve-timestamps",
+        visible_alias = "keep-timestamp",
         help = "Restore the timestamp of the files"
     )]
     pub(crate) keep_timestamp: bool,
     #[arg(
-        long,
-        visible_alias = "no-preserve-timestamps",
+        long = "no-preserve-timestamps",
+        visible_alias = "no-keep-timestamp",
         help = "Do not restore timestamp of files. This is the inverse option of --preserve-timestamps"
     )]
     pub(crate) no_keep_timestamp: bool,
@@ -141,45 +141,45 @@ pub(crate) struct ExtractCommand {
     )]
     clamp_atime: bool,
     #[arg(
-        long,
-        visible_alias = "preserve-permissions",
+        long = "preserve-permissions",
+        visible_alias = "keep-permission",
         help = "Restore the permissions of the files"
     )]
     #[cfg_attr(windows, arg(requires = "unstable", help_heading = "Unstable Options"))]
     keep_permission: bool,
     #[arg(
-        long,
-        visible_alias = "no-preserve-permissions",
+        long = "no-preserve-permissions",
+        visible_alias = "no-keep-permission",
         help = "Do not restore permissions of files. This is the inverse option of --preserve-permissions"
     )]
     #[cfg_attr(windows, arg(requires = "unstable", help_heading = "Unstable Options"))]
     no_keep_permission: bool,
     #[arg(
-        long,
-        visible_alias = "preserve-xattrs",
+        long = "preserve-xattrs",
+        visible_alias = "keep-xattr",
         help = "Restore the extended attributes of the files"
     )]
     pub(crate) keep_xattr: bool,
     #[arg(
-        long,
-        visible_alias = "no-preserve-xattrs",
+        long = "no-preserve-xattrs",
+        visible_alias = "no-keep-xattr",
         help = "Do not restore extended attributes of files. This is the inverse option of --preserve-xattrs"
     )]
     pub(crate) no_keep_xattr: bool,
     #[arg(
-        long,
-        visible_alias = "preserve-acls",
+        long = "preserve-acls",
+        visible_alias = "keep-acl",
         requires = "unstable",
         help_heading = "Unstable Options",
         help = "Restore ACLs"
     )]
     keep_acl: bool,
     #[arg(
-        long,
-        visible_alias = "no-preserve-acls",
+        long = "no-preserve-acls",
+        visible_alias = "no-keep-acl",
         requires = "unstable",
         help_heading = "Unstable Options",
-        help = "Do not restore ACLs. This is the inverse option of --keep-acl"
+        help = "Do not restore ACLs. This is the inverse option of --preserve-acls"
     )]
     no_keep_acl: bool,
     #[arg(long, value_name = "NAME", help = "Restore user from given name")]

--- a/cli/src/command/strip.rs
+++ b/cli/src/command/strip.rs
@@ -19,26 +19,30 @@ use std::path::PathBuf;
 #[derive(Args, Clone, Eq, PartialEq, Hash, Debug)]
 pub(crate) struct StripOptions {
     #[arg(
-        long,
-        visible_alias = "preserve-timestamps",
+        long = "preserve-timestamps",
+        visible_alias = "keep-timestamp",
         help = "Preserve file timestamps"
     )]
     keep_timestamp: bool,
     #[arg(
-        long,
-        visible_alias = "preserve-permissions",
+        long = "preserve-permissions",
+        visible_alias = "keep-permission",
         help = "Preserve file permissions"
     )]
     keep_permission: bool,
     #[arg(
-        long,
-        visible_alias = "preserve-xattrs",
+        long = "preserve-xattrs",
+        visible_alias = "keep-xattr",
         help = "Preserve extended attributes"
     )]
     keep_xattr: bool,
-    #[arg(long, visible_alias = "preserve-acls", help = "Preserve ACLs")]
+    #[arg(
+        long = "preserve-acls",
+        visible_alias = "keep-acl",
+        help = "Preserve ACLs"
+    )]
     keep_acl: bool,
-    #[arg(long, visible_alias = "preserve-private_chunks", value_name = "CHUNK_TYPE", help = "Keep private chunks. If no CHUNK_TYPE is specified, all private chunks are kept", value_delimiter = ',', num_args = 0..)]
+    #[arg(long = "preserve-private-chunks", visible_alias = "keep-private", alias = "preserve-private_chunks", value_name = "CHUNK_TYPE", help = "Preserve private chunks. If no CHUNK_TYPE is specified, all private chunks are preserved", value_delimiter = ',', num_args = 0..)]
     pub(crate) keep_private: Option<Vec<PrivateChunkType>>,
 }
 

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -97,57 +97,57 @@ pub(crate) struct UpdateCommand {
     )]
     no_keep_dir: bool,
     #[arg(
-        long,
-        visible_alias = "preserve-timestamps",
+        long = "preserve-timestamps",
+        visible_alias = "keep-timestamp",
         help = "Preserve file timestamps"
     )]
     keep_timestamp: bool,
     #[arg(
-        long,
-        visible_alias = "no-preserve-timestamps",
+        long = "no-preserve-timestamps",
+        visible_alias = "no-keep-timestamp",
         help = "Do not archive timestamp of files. This is the inverse option of --preserve-timestamps"
     )]
     pub(crate) no_keep_timestamp: bool,
     #[arg(
-        long,
-        visible_alias = "preserve-permissions",
+        long = "preserve-permissions",
+        visible_alias = "keep-permission",
         help = "Preserve file permissions"
     )]
     #[cfg_attr(windows, arg(requires = "unstable", help_heading = "Unstable Options"))]
     keep_permission: bool,
     #[arg(
-        long,
-        visible_alias = "no-preserve-permissions",
+        long = "no-preserve-permissions",
+        visible_alias = "no-keep-permission",
         help = "Do not archive permissions of files. This is the inverse option of --preserve-permissions"
     )]
     #[cfg_attr(windows, arg(requires = "unstable", help_heading = "Unstable Options"))]
     no_keep_permission: bool,
     #[arg(
-        long,
-        visible_alias = "preserve-xattrs",
+        long = "preserve-xattrs",
+        visible_alias = "keep-xattr",
         help = "Preserve extended attributes"
     )]
     keep_xattr: bool,
     #[arg(
-        long,
-        visible_alias = "no-preserve-xattrs",
+        long = "no-preserve-xattrs",
+        visible_alias = "no-keep-xattr",
         help = "Do not archive extended attributes of files. This is the inverse option of --preserve-xattrs"
     )]
     pub(crate) no_keep_xattr: bool,
     #[arg(
-        long,
-        visible_alias = "preserve-acls",
+        long = "preserve-acls",
+        visible_alias = "keep-acl",
         requires = "unstable",
         help_heading = "Unstable Options",
         help = "Preserve ACLs"
     )]
     keep_acl: bool,
     #[arg(
-        long,
-        visible_alias = "no-preserve-acls",
+        long = "no-preserve-acls",
+        visible_alias = "no-keep-acl",
         requires = "unstable",
         help_heading = "Unstable Options",
-        help = "Do not archive ACLs. This is the inverse option of --keep-acl"
+        help = "Do not archive ACLs. This is the inverse option of --preserve-acls"
     )]
     no_keep_acl: bool,
     #[arg(long, value_name = "NAME", help = "Set user name for archive entries")]


### PR DESCRIPTION
## Summary

The metadata options were spelled `--keep-*`, with `--preserve-*` reachable only as an alias. Swapping the two lets one word name one family: `preserve` for the metadata carried into and out of an archive, `keep` for what is left as it already is (`--keep-dir`, `--keep-old-files`, `--keep-newer-files`, `--keep-solid`).

## Notes

Every previous spelling still parses, as an alias. What changes is the canonical name in the help output, the generated reference and the completions.

`pna strip` gains `--preserve-private-chunks` in place of the malformed `--preserve-private_chunks` alias, and still accepts both that and `--keep-private`.

`compat bsdtar` keeps `-p, --same-permissions` and `--no-same-permissions` as bsdtar spells them, and `--keep-permission` stays absent there.

Stacked on #3298.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer `--preserve-*` and `--no-preserve-*` command-line options across archive creation, extraction, updating, appending, BSD tar, and stripping workflows.
  - Added an explicit `--preserve-private-chunks` option for the strip command.

- **Compatibility**
  - Existing `--keep-*` and `--no-keep-*` spellings remain available as visible aliases.

- **Documentation**
  - Updated related help text to consistently describe preserved timestamps, permissions, attributes, ACLs, file flags, and private chunks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->