### PR TITLE
:recycle: Let one field hold what a flag pair resolves to

### DIFF
--- a/cli/src/command/append.rs
+++ b/cli/src/command/append.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     utils::{PathPartExt, VCS_FILES, fs::HardlinkResolver},
 };
-use clap::{ArgGroup, Parser, ValueHint};
+use clap::{ArgAction, ArgGroup, Parser, ValueHint, builder::ArgPredicate};
 use pna::{Archive, prelude::*};
 use std::{
     fs, io,
@@ -26,7 +26,6 @@ use std::{
 
 #[derive(Parser, Clone, Debug)]
 #[command(
-    group(ArgGroup::new("keep-acl-flag").args(["keep_acl", "no_keep_acl"])),
     group(ArgGroup::new("path-transform").args(["substitutions", "transforms"])),
     group(ArgGroup::new("read-files-from").args(["files_from", "files_from_stdin"])),
     group(
@@ -40,11 +39,7 @@ use std::{
     group(ArgGroup::new("store-numeric-owner").args(["numeric_owner"]).requires("keep_permission")),
     group(ArgGroup::new("user-flag").args(["numeric_owner", "uname"])),
     group(ArgGroup::new("group-flag").args(["numeric_owner", "gname"])),
-    group(ArgGroup::new("recursive-flag").args(["recursive", "no_recursive"])),
-    group(ArgGroup::new("keep-dir-flag").args(["keep_dir", "no_keep_dir"])),
-    group(ArgGroup::new("keep-xattr-flag").args(["keep_xattr", "no_keep_xattr"])),
     group(ArgGroup::new("keep-timestamp-flag").args(["keep_timestamp", "no_keep_timestamp"])),
-    group(ArgGroup::new("keep-permission-flag").args(["keep_permission", "no_keep_permission"])),
     group(ArgGroup::new("ctime-older-than-source").args(["older_ctime", "older_ctime_than"])),
     group(ArgGroup::new("ctime-newer-than-source").args(["newer_ctime", "newer_ctime_than"])),
     group(ArgGroup::new("mtime-older-than-source").args(["older_mtime", "older_mtime_than"])),
@@ -70,26 +65,32 @@ pub(crate) struct AppendCommand {
         long,
         visible_alias = "recursion",
         help = "Add the directory to the archive recursively",
-        default_value_t = true
+        default_value_t = true,
+        default_value_if("no_recursive", ArgPredicate::Equals("true".into()), "false"),
+        conflicts_with = "no_recursive"
     )]
     recursive: bool,
     #[arg(
         long,
         visible_alias = "no-recursion",
+        action = ArgAction::SetTrue,
         help = "Do not recursively add directories to the archives. This is the inverse option of --recursive"
     )]
-    no_recursive: bool,
+    no_recursive: (),
     #[arg(
         long,
         help = "Include directories in archive (default)",
-        default_value_t = true
+        default_value_t = true,
+        default_value_if("no_keep_dir", ArgPredicate::Equals("true".into()), "false"),
+        conflicts_with = "no_keep_dir"
     )]
     keep_dir: bool,
     #[arg(
         long,
+        action = ArgAction::SetTrue,
         help = "Do not archive directories. This is the inverse option of --keep-dir"
     )]
-    no_keep_dir: bool,
+    no_keep_dir: (),
     #[arg(
         long = "preserve-timestamps",
         visible_alias = "keep-timestamp",
@@ -105,6 +106,7 @@ pub(crate) struct AppendCommand {
     #[arg(
         long = "preserve-permissions",
         visible_alias = "keep-permission",
+        conflicts_with = "no_keep_permission",
         help = "Preserve file permissions"
     )]
     #[cfg_attr(windows, arg(requires = "unstable", help_heading = "Unstable Options"))]
@@ -112,27 +114,31 @@ pub(crate) struct AppendCommand {
     #[arg(
         long = "no-preserve-permissions",
         visible_alias = "no-keep-permission",
+        action = ArgAction::SetTrue,
         help = "Do not archive permissions of files. This is the inverse option of --preserve-permissions"
     )]
     #[cfg_attr(windows, arg(requires = "unstable", help_heading = "Unstable Options"))]
-    no_keep_permission: bool,
+    no_keep_permission: (),
     #[arg(
         long = "preserve-xattrs",
         visible_alias = "keep-xattr",
+        conflicts_with = "no_keep_xattr",
         help = "Preserve extended attributes"
     )]
     keep_xattr: bool,
     #[arg(
         long = "no-preserve-xattrs",
         visible_alias = "no-keep-xattr",
+        action = ArgAction::SetTrue,
         help = "Do not archive extended attributes of files. This is the inverse option of --preserve-xattrs"
     )]
-    pub(crate) no_keep_xattr: bool,
+    pub(crate) no_keep_xattr: (),
     #[arg(
         long = "preserve-acls",
         visible_alias = "keep-acl",
         requires = "unstable",
         help_heading = "Unstable Options",
+        conflicts_with = "no_keep_acl",
         help = "Preserve ACLs"
     )]
     keep_acl: bool,
@@ -141,9 +147,10 @@ pub(crate) struct AppendCommand {
         visible_alias = "no-keep-acl",
         requires = "unstable",
         help_heading = "Unstable Options",
+        action = ArgAction::SetTrue,
         help = "Do not archive ACLs. This is the inverse option of --preserve-acls"
     )]
-    no_keep_acl: bool,
+    no_keep_acl: (),
     #[arg(long, value_name = "NAME", help = "Set user name for archive entries")]
     uname: Option<String>,
     #[arg(long, value_name = "NAME", help = "Set group name for archive entries")]
@@ -391,7 +398,6 @@ fn append_to_archive(args: AppendCommand) -> anyhow::Result<()> {
     let option = entry_option(args.compression, args.cipher, args.hash, password);
     let (mode_strategy, owner_strategy) = PermissionStrategyResolver {
         keep_permission: args.keep_permission,
-        no_keep_permission: args.no_keep_permission,
         same_owner: true, // Must be `true` for creation
         uname: args.uname,
         gname: args.gname,
@@ -415,8 +421,8 @@ fn append_to_archive(args: AppendCommand) -> anyhow::Result<()> {
         .resolve(),
         mode_strategy,
         owner_strategy,
-        xattr_strategy: XattrStrategy::from_flags(args.keep_xattr, args.no_keep_xattr, false),
-        acl_strategy: AclStrategy::from_flags(args.keep_acl, args.no_keep_acl),
+        xattr_strategy: XattrStrategy::from_flag(args.keep_xattr),
+        acl_strategy: AclStrategy::from_flag(args.keep_acl),
         fflags_strategy: FflagsStrategy::Never,
         mac_metadata_strategy: MacMetadataStrategy::Never,
     };
@@ -466,8 +472,8 @@ fn append_to_archive(args: AppendCommand) -> anyhow::Result<()> {
         exclude.iter().map(|s| s.as_str()).chain(vcs_patterns),
     );
     let collect_options = CollectOptions {
-        recursive: !args.no_recursive,
-        keep_dir: !args.no_keep_dir,
+        recursive: args.recursive,
+        keep_dir: args.keep_dir,
         gitignore: args.gitignore,
         nodump: args.nodump,
         follow_links: args.follow_links,

--- a/cli/src/command/bsdtar.rs
+++ b/cli/src/command/bsdtar.rs
@@ -841,8 +841,8 @@ impl ExtractionPermissionStrategyResolver {
         (
             mode_strategy,
             owner_strategy,
-            XattrStrategy::from_flags(self.keep_xattr || p_enables, self.no_keep_xattr, false),
-            AclStrategy::from_flags(self.keep_acl || p_enables, self.no_keep_acl),
+            XattrStrategy::from_flag(!self.no_keep_xattr && (self.keep_xattr || p_enables)),
+            AclStrategy::from_flag(!self.no_keep_acl && (self.keep_acl || p_enables)),
             FflagsStrategy::from_flags(self.keep_fflags || p_enables, self.no_keep_fflags),
             MacMetadataStrategy::from_flags(self.mac_metadata || p_enables, self.no_mac_metadata),
         )
@@ -957,8 +957,8 @@ fn run_create_archive(args: BsdtarCommand) -> anyhow::Result<()> {
         .resolve(),
         mode_strategy,
         owner_strategy,
-        xattr_strategy: XattrStrategy::from_flags(args.keep_xattr, args.no_keep_xattr, true),
-        acl_strategy: AclStrategy::from_flags(args.keep_acl, args.no_keep_acl),
+        xattr_strategy: XattrStrategy::from_flag(!args.no_keep_xattr),
+        acl_strategy: AclStrategy::from_flag(!args.no_keep_acl && args.keep_acl),
         fflags_strategy: FflagsStrategy::from_flags(args.keep_fflags, args.no_keep_fflags),
         mac_metadata_strategy: MacMetadataStrategy::from_flags(
             args.mac_metadata,
@@ -1279,8 +1279,8 @@ fn run_append(args: BsdtarCommand) -> anyhow::Result<()> {
         .resolve(),
         mode_strategy,
         owner_strategy,
-        xattr_strategy: XattrStrategy::from_flags(args.keep_xattr, args.no_keep_xattr, true),
-        acl_strategy: AclStrategy::from_flags(args.keep_acl, args.no_keep_acl),
+        xattr_strategy: XattrStrategy::from_flag(!args.no_keep_xattr),
+        acl_strategy: AclStrategy::from_flag(!args.no_keep_acl && args.keep_acl),
         fflags_strategy: FflagsStrategy::from_flags(args.keep_fflags, args.no_keep_fflags),
         mac_metadata_strategy: MacMetadataStrategy::from_flags(
             args.mac_metadata,
@@ -1441,8 +1441,8 @@ fn run_update(args: BsdtarCommand) -> anyhow::Result<()> {
         .resolve(),
         mode_strategy,
         owner_strategy,
-        xattr_strategy: XattrStrategy::from_flags(args.keep_xattr, args.no_keep_xattr, true),
-        acl_strategy: AclStrategy::from_flags(args.keep_acl, args.no_keep_acl),
+        xattr_strategy: XattrStrategy::from_flag(!args.no_keep_xattr),
+        acl_strategy: AclStrategy::from_flag(!args.no_keep_acl && args.keep_acl),
         fflags_strategy: FflagsStrategy::from_flags(args.keep_fflags, args.no_keep_fflags),
         mac_metadata_strategy: MacMetadataStrategy::from_flags(
             args.mac_metadata,

--- a/cli/src/command/chown.rs
+++ b/cli/src/command/chown.rs
@@ -12,14 +12,11 @@ use crate::{
         fs::{Group, User},
     },
 };
-use clap::{ArgGroup, Parser, ValueHint};
+use clap::{ArgAction, Parser, ValueHint, builder::ArgPredicate};
 use pna::NormalEntry;
 use std::{io, ops::Not, path::PathBuf, str::FromStr};
 
 #[derive(Parser, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[command(
-    group(ArgGroup::new("lookup").args(["owner_lookup", "no_owner_lookup"])),
-)]
 pub(crate) struct ChownCommand {
     #[arg(short = 'f', long = "file", value_hint = ValueHint::FilePath)]
     archive: PathBuf,
@@ -30,11 +27,13 @@ pub(crate) struct ChownCommand {
     #[arg(
         long,
         help = "resolve user and group (default)",
-        default_value_t = true
+        default_value_t = true,
+        default_value_if("no_owner_lookup", ArgPredicate::Equals("true".into()), "false"),
+        conflicts_with = "no_owner_lookup"
     )]
     owner_lookup: bool,
-    #[arg(long, help = "do not resolve user and group")]
-    no_owner_lookup: bool,
+    #[arg(long, action = ArgAction::SetTrue, help = "do not resolve user and group")]
+    no_owner_lookup: (),
     #[arg(value_hint = ValueHint::AnyPath)]
     files: Vec<String>,
     #[command(flatten)]
@@ -60,7 +59,7 @@ fn archive_chown(args: ChownCommand) -> anyhow::Result<()> {
 
     let owner = args
         .owner
-        .lookup_platform_owner(args.numeric_owner, !args.no_owner_lookup)?;
+        .lookup_platform_owner(args.numeric_owner, args.owner_lookup)?;
 
     let mut source = SplitArchiveReader::new(collect_split_archives(&args.archive)?)?;
 

--- a/cli/src/command/concat.rs
+++ b/cli/src/command/concat.rs
@@ -7,24 +7,22 @@ use crate::{
     utils::{self, PathWithCwd},
 };
 use anyhow::Context;
-use clap::{ArgGroup, Parser, ValueHint};
+use clap::{ArgAction, Parser, ValueHint};
 use pna::Archive;
 #[cfg(feature = "memmap")]
 use std::io;
 use std::path::PathBuf;
 
 #[derive(Parser, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[command(
-    group(ArgGroup::new("overwrite-flag").args(["overwrite", "no_overwrite"])),
-)]
 pub(crate) struct ConcatCommand {
-    #[arg(long, help = "Overwrite file")]
+    #[arg(long, conflicts_with = "no_overwrite", help = "Overwrite file")]
     overwrite: bool,
     #[arg(
         long,
+        action = ArgAction::SetTrue,
         help = "Do not overwrite files. This is the inverse option of --overwrite"
     )]
-    no_overwrite: bool,
+    no_overwrite: (),
     #[arg(short, long, required = true, help = "Archive files to concatenate", value_hint = ValueHint::FilePath)]
     files: Vec<PathBuf>,
 }

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -163,18 +163,8 @@ pub(crate) enum XattrStrategy {
 }
 
 impl XattrStrategy {
-    pub(crate) const fn from_flags(
-        keep_xattr: bool,
-        no_keep_xattr: bool,
-        default_preserve: bool,
-    ) -> Self {
-        if no_keep_xattr {
-            Self::Never
-        } else if keep_xattr || default_preserve {
-            Self::Always
-        } else {
-            Self::Never
-        }
+    pub(crate) const fn from_flag(preserve: bool) -> Self {
+        if preserve { Self::Always } else { Self::Never }
     }
 }
 
@@ -185,14 +175,8 @@ pub(crate) enum AclStrategy {
 }
 
 impl AclStrategy {
-    pub(crate) const fn from_flags(keep_acl: bool, no_keep_acl: bool) -> Self {
-        if no_keep_acl {
-            Self::Never
-        } else if keep_acl {
-            Self::Always
-        } else {
-            Self::Never
-        }
+    pub(crate) const fn from_flag(preserve: bool) -> Self {
+        if preserve { Self::Always } else { Self::Never }
     }
 }
 
@@ -310,13 +294,11 @@ impl TimestampStrategyResolver {
 /// Resolves CLI permission options into split mode and owner strategies.
 ///
 /// This struct encapsulates the CLI-specific logic for determining permission behavior:
-/// - `no_keep_permission` forces both mode and owner to `Never`
 /// - `keep_permission` enables `Preserve` for mode, and ownership handling via `same_owner`
 /// - `same_owner` controls whether to restore ownership (extraction only)
 /// - Owner override fields (uid, gid, uname, gname) are used in both creation and extraction
 pub(crate) struct PermissionStrategyResolver {
     pub(crate) keep_permission: bool,
-    pub(crate) no_keep_permission: bool,
     pub(crate) same_owner: bool,
     pub(crate) uname: Option<String>,
     pub(crate) gname: Option<String>,
@@ -335,9 +317,7 @@ impl PermissionStrategyResolver {
     /// For creation contexts, pass `same_owner: true` since ownership
     /// is always stored when `--keep-permission` is enabled.
     pub(crate) fn resolve(self) -> (ModeStrategy, OwnerStrategy) {
-        if self.no_keep_permission {
-            (ModeStrategy::Never, OwnerStrategy::Never)
-        } else if self.keep_permission {
+        if self.keep_permission {
             let mode_strategy = ModeStrategy::Preserve;
             let owner_strategy = if self.same_owner {
                 OwnerStrategy::Preserve {

--- a/cli/src/command/create.rs
+++ b/cli/src/command/create.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 use anyhow::ensure;
 use bytesize::ByteSize;
-use clap::{ArgGroup, Parser, ValueHint};
+use clap::{ArgAction, ArgGroup, Parser, ValueHint, builder::ArgPredicate};
 use pna::{Archive, SolidEntryBuilder, WriteOptions};
 use std::{
     env, fs,
@@ -31,7 +31,6 @@ use std::{
 
 #[derive(Parser, Clone, Debug)]
 #[command(
-    group(ArgGroup::new("keep-acl-flag").args(["keep_acl", "no_keep_acl"])),
     group(ArgGroup::new("path-transform").args(["substitutions", "transforms"])),
     group(ArgGroup::new("read-files-from").args(["files_from", "files_from_stdin"])),
     group(
@@ -45,16 +44,11 @@ use std::{
     group(ArgGroup::new("store-numeric-owner").args(["numeric_owner"]).requires("keep_permission")),
     group(ArgGroup::new("user-flag").args(["numeric_owner", "uname"])),
     group(ArgGroup::new("group-flag").args(["numeric_owner", "gname"])),
-    group(ArgGroup::new("recursive-flag").args(["recursive", "no_recursive"])),
-    group(ArgGroup::new("keep-dir-flag").args(["keep_dir", "no_keep_dir"])),
-    group(ArgGroup::new("keep-xattr-flag").args(["keep_xattr", "no_keep_xattr"])),
     group(ArgGroup::new("keep-timestamp-flag").args(["keep_timestamp", "no_keep_timestamp"])),
     group(ArgGroup::new("ctime-older-than-source").args(["older_ctime", "older_ctime_than"])),
     group(ArgGroup::new("ctime-newer-than-source").args(["newer_ctime", "newer_ctime_than"])),
     group(ArgGroup::new("mtime-older-than-source").args(["older_mtime", "older_mtime_than"])),
     group(ArgGroup::new("mtime-newer-than-source").args(["newer_mtime", "newer_mtime_than"])),
-    group(ArgGroup::new("overwrite-flag").args(["overwrite", "no_overwrite"])),
-    group(ArgGroup::new("keep-permission-flag").args(["keep_permission", "no_keep_permission"])),
 )]
 pub(crate) struct CreateCommand {
     #[arg(
@@ -76,33 +70,43 @@ pub(crate) struct CreateCommand {
         long,
         visible_alias = "recursion",
         help = "Add the directory to the archive recursively",
-        default_value_t = true
+        default_value_t = true,
+        default_value_if("no_recursive", ArgPredicate::Equals("true".into()), "false"),
+        conflicts_with = "no_recursive"
     )]
     recursive: bool,
     #[arg(
         long,
         visible_alias = "no-recursion",
+        action = ArgAction::SetTrue,
         help = "Do not recursively add directories to the archives. This is the inverse option of --recursive"
     )]
-    no_recursive: bool,
-    #[arg(long, help = "Overwrite file")]
+    no_recursive: (),
+    #[arg(long, conflicts_with = "no_overwrite", help = "Overwrite file")]
     overwrite: bool,
     #[arg(
         long,
+        action = ArgAction::SetTrue,
         help = "Do not overwrite files. This is the inverse option of --overwrite"
     )]
-    no_overwrite: bool,
+    no_overwrite: (),
+    // The pair resolves into this field, so reading it needs no knowledge of `--no-keep-dir`.
+    // The predicate is `Equals` rather than `IsPresent` because a default value counts as
+    // present, which would make the result depend on the order the args are declared in.
     #[arg(
         long,
         help = "Include directories in archive (default)",
-        default_value_t = true
+        default_value_t = true,
+        default_value_if("no_keep_dir", ArgPredicate::Equals("true".into()), "false"),
+        conflicts_with = "no_keep_dir"
     )]
     keep_dir: bool,
     #[arg(
         long,
+        action = ArgAction::SetTrue,
         help = "Do not archive directories. This is the inverse option of --keep-dir"
     )]
-    no_keep_dir: bool,
+    no_keep_dir: (),
     #[arg(
         long = "preserve-timestamps",
         visible_alias = "keep-timestamp",
@@ -118,6 +122,7 @@ pub(crate) struct CreateCommand {
     #[arg(
         long = "preserve-permissions",
         visible_alias = "keep-permission",
+        conflicts_with = "no_keep_permission",
         help = "Preserve file permissions"
     )]
     #[cfg_attr(windows, arg(requires = "unstable", help_heading = "Unstable Options"))]
@@ -125,27 +130,31 @@ pub(crate) struct CreateCommand {
     #[arg(
         long = "no-preserve-permissions",
         visible_alias = "no-keep-permission",
+        action = ArgAction::SetTrue,
         help = "Do not archive permissions of files. This is the inverse option of --preserve-permissions"
     )]
     #[cfg_attr(windows, arg(requires = "unstable", help_heading = "Unstable Options"))]
-    no_keep_permission: bool,
+    no_keep_permission: (),
     #[arg(
         long = "preserve-xattrs",
         visible_alias = "keep-xattr",
+        conflicts_with = "no_keep_xattr",
         help = "Preserve extended attributes"
     )]
     keep_xattr: bool,
     #[arg(
         long = "no-preserve-xattrs",
         visible_alias = "no-keep-xattr",
+        action = ArgAction::SetTrue,
         help = "Do not archive extended attributes of files. This is the inverse option of --preserve-xattrs"
     )]
-    pub(crate) no_keep_xattr: bool,
+    pub(crate) no_keep_xattr: (),
     #[arg(
         long = "preserve-acls",
         visible_alias = "keep-acl",
         requires = "unstable",
         help_heading = "Unstable Options",
+        conflicts_with = "no_keep_acl",
         help = "Preserve ACLs"
     )]
     keep_acl: bool,
@@ -154,9 +163,10 @@ pub(crate) struct CreateCommand {
         visible_alias = "no-keep-acl",
         requires = "unstable",
         help_heading = "Unstable Options",
+        action = ArgAction::SetTrue,
         help = "Do not archive ACLs. This is the inverse option of --preserve-acls"
     )]
-    no_keep_acl: bool,
+    no_keep_acl: (),
     #[arg(
         long,
         value_name = "size",
@@ -463,8 +473,8 @@ fn create_archive(args: CreateCommand) -> anyhow::Result<()> {
     }
     .resolve()?;
     let collect_options = CollectOptions {
-        recursive: !args.no_recursive,
-        keep_dir: !args.no_keep_dir,
+        recursive: args.recursive,
+        keep_dir: args.keep_dir,
         gitignore: args.gitignore,
         nodump: args.nodump,
         follow_links: args.follow_links,
@@ -484,7 +494,6 @@ fn create_archive(args: CreateCommand) -> anyhow::Result<()> {
     }
     let (mode_strategy, owner_strategy) = PermissionStrategyResolver {
         keep_permission: args.keep_permission,
-        no_keep_permission: args.no_keep_permission,
         same_owner: true, // Must be `true` for creation
         uname: args.uname,
         gname: args.gname,
@@ -508,8 +517,8 @@ fn create_archive(args: CreateCommand) -> anyhow::Result<()> {
         .resolve(),
         mode_strategy,
         owner_strategy,
-        xattr_strategy: XattrStrategy::from_flags(args.keep_xattr, args.no_keep_xattr, false),
-        acl_strategy: AclStrategy::from_flags(args.keep_acl, args.no_keep_acl),
+        xattr_strategy: XattrStrategy::from_flag(args.keep_xattr),
+        acl_strategy: AclStrategy::from_flag(args.keep_acl),
         fflags_strategy: FflagsStrategy::Never,
         mac_metadata_strategy: MacMetadataStrategy::Never,
     };

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -25,7 +25,7 @@ use crate::{
     },
 };
 use anyhow::Context;
-use clap::{ArgGroup, Parser, ValueHint};
+use clap::{ArgAction, ArgGroup, Parser, ValueHint, builder::ArgPredicate};
 use pna::{
     DataKind, EntryContent, EntryName, EntryReference, LinkTargetType, NormalEntry, ReadOptions,
     prelude::*,
@@ -55,11 +55,7 @@ use std::{
     ),
     group(ArgGroup::new("null-requires").arg("null").requires("from-input")),
     group(ArgGroup::new("keep-timestamp-flag").args(["keep_timestamp", "no_keep_timestamp"])),
-    group(ArgGroup::new("keep-permission-flag").args(["keep_permission", "no_keep_permission"])),
-    group(ArgGroup::new("keep-xattr-flag").args(["keep_xattr", "no_keep_xattr"])),
-    group(ArgGroup::new("keep-acl-flag").args(["keep_acl", "no_keep_acl"])),
     group(ArgGroup::new("path-transform").args(["substitutions", "transforms"])),
-    group(ArgGroup::new("owner-flag").args(["same_owner", "no_same_owner"])),
     group(ArgGroup::new("user-flag").args(["numeric_owner", "uname"])),
     group(ArgGroup::new("group-flag").args(["numeric_owner", "gname"])),
     group(ArgGroup::new("ctime-older-than-source").args(["older_ctime", "older_ctime_than"])),
@@ -71,8 +67,6 @@ use std::{
         ArgGroup::new("overwrite-flag")
             .args(["overwrite", "no_overwrite", "keep_newer_files", "keep_old_files"])
     ),
-    group(ArgGroup::new("safe-writes-flag").args(["safe_writes", "no_safe_writes"])),
-    group(ArgGroup::new("unsafe-links-flag").args(["allow_unsafe_links", "no_allow_unsafe_links"])),
 )]
 pub(crate) struct ExtractCommand {
     #[arg(long, help = "Overwrite file")]
@@ -143,6 +137,7 @@ pub(crate) struct ExtractCommand {
     #[arg(
         long = "preserve-permissions",
         visible_alias = "keep-permission",
+        conflicts_with = "no_keep_permission",
         help = "Restore the permissions of the files"
     )]
     #[cfg_attr(windows, arg(requires = "unstable", help_heading = "Unstable Options"))]
@@ -150,27 +145,31 @@ pub(crate) struct ExtractCommand {
     #[arg(
         long = "no-preserve-permissions",
         visible_alias = "no-keep-permission",
+        action = ArgAction::SetTrue,
         help = "Do not restore permissions of files. This is the inverse option of --preserve-permissions"
     )]
     #[cfg_attr(windows, arg(requires = "unstable", help_heading = "Unstable Options"))]
-    no_keep_permission: bool,
+    no_keep_permission: (),
     #[arg(
         long = "preserve-xattrs",
         visible_alias = "keep-xattr",
+        conflicts_with = "no_keep_xattr",
         help = "Restore the extended attributes of the files"
     )]
     pub(crate) keep_xattr: bool,
     #[arg(
         long = "no-preserve-xattrs",
         visible_alias = "no-keep-xattr",
+        action = ArgAction::SetTrue,
         help = "Do not restore extended attributes of files. This is the inverse option of --preserve-xattrs"
     )]
-    pub(crate) no_keep_xattr: bool,
+    pub(crate) no_keep_xattr: (),
     #[arg(
         long = "preserve-acls",
         visible_alias = "keep-acl",
         requires = "unstable",
         help_heading = "Unstable Options",
+        conflicts_with = "no_keep_acl",
         help = "Restore ACLs"
     )]
     keep_acl: bool,
@@ -179,9 +178,10 @@ pub(crate) struct ExtractCommand {
         visible_alias = "no-keep-acl",
         requires = "unstable",
         help_heading = "Unstable Options",
+        action = ArgAction::SetTrue,
         help = "Do not restore ACLs. This is the inverse option of --preserve-acls"
     )]
-    no_keep_acl: bool,
+    no_keep_acl: (),
     #[arg(long, value_name = "NAME", help = "Restore user from given name")]
     uname: Option<String>,
     #[arg(long, value_name = "NAME", help = "Restore group from given name")]
@@ -348,26 +348,33 @@ pub(crate) struct ExtractCommand {
     transforms: Option<Vec<TransformRule>>,
     #[arg(
         long,
-        help = "Try extracting files with the same ownership as exists in the archive"
+        help = "Try extracting files with the same ownership as exists in the archive (default)",
+        default_value_t = true,
+        default_value_if("no_same_owner", ArgPredicate::Equals("true".into()), "false"),
+        conflicts_with = "no_same_owner"
     )]
     same_owner: bool,
-    #[arg(long, help = "Extract files as yourself")]
-    no_same_owner: bool,
+    #[arg(long, action = ArgAction::SetTrue, help = "Extract files as yourself")]
+    no_same_owner: (),
     #[arg(
         long,
+        action = ArgAction::SetTrue,
         help = "Allow extracting symbolic links and hard links that contain root or parent paths"
     )]
-    allow_unsafe_links: bool,
+    allow_unsafe_links: (),
     #[arg(
         long,
         help = "Do not allow extracting symbolic links and hard links that contain root or parent paths (default)",
-        default_value_t = true
+        default_value_t = true,
+        default_value_if("allow_unsafe_links", ArgPredicate::Equals("true".into()), "false"),
+        conflicts_with = "allow_unsafe_links"
     )]
     no_allow_unsafe_links: bool,
     #[arg(
         long,
         requires = "unstable",
         help_heading = "Unstable Options",
+        conflicts_with = "no_safe_writes",
         help = "Extract files atomically via temp file and rename"
     )]
     safe_writes: bool,
@@ -375,9 +382,10 @@ pub(crate) struct ExtractCommand {
         long,
         requires = "unstable",
         help_heading = "Unstable Options",
+        action = ArgAction::SetTrue,
         help = "Disable atomic extraction. This is the inverse option of --safe-writes"
     )]
-    no_safe_writes: bool,
+    no_safe_writes: (),
     #[command(flatten)]
     pub(crate) file: FileArgs,
 }
@@ -446,8 +454,7 @@ fn extract_archive(args: ExtractCommand) -> anyhow::Result<()> {
     );
     let (mode_strategy, owner_strategy) = PermissionStrategyResolver {
         keep_permission: args.keep_permission,
-        no_keep_permission: args.no_keep_permission,
-        same_owner: !args.no_same_owner,
+        same_owner: args.same_owner,
         uname: args.uname,
         gname: args.gname,
         uid: args.uid,
@@ -470,14 +477,14 @@ fn extract_archive(args: ExtractCommand) -> anyhow::Result<()> {
         .resolve(),
         mode_strategy,
         owner_strategy,
-        xattr_strategy: XattrStrategy::from_flags(args.keep_xattr, args.no_keep_xattr, false),
-        acl_strategy: AclStrategy::from_flags(args.keep_acl, args.no_keep_acl),
+        xattr_strategy: XattrStrategy::from_flag(args.keep_xattr),
+        acl_strategy: AclStrategy::from_flag(args.keep_acl),
         fflags_strategy: FflagsStrategy::Never,
         mac_metadata_strategy: MacMetadataStrategy::Never,
     };
     let output_options = OutputOption {
         overwrite_strategy,
-        allow_unsafe_links: args.allow_unsafe_links,
+        allow_unsafe_links: !args.no_allow_unsafe_links,
         out_dir: args.out_dir,
         to_stdout: false,
         filter,
@@ -491,7 +498,7 @@ fn extract_archive(args: ExtractCommand) -> anyhow::Result<()> {
         ordered_path_locks: Arc::new(OrderedPathLocks::default()),
         unlink_first: false,
         time_filters,
-        safe_writes: args.safe_writes && !args.no_safe_writes,
+        safe_writes: args.safe_writes,
         verbose: false,
         absolute_paths: false,
         warned_lead_slash: Arc::new(AtomicBool::new(false)),

--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -13,8 +13,11 @@ use crate::{
 };
 use base64::Engine;
 use clap::{
-    ArgGroup, Parser, ValueEnum, ValueHint,
-    builder::styling::{AnsiColor, Color as Colour, Style},
+    ArgAction, ArgGroup, Parser, ValueEnum, ValueHint,
+    builder::{
+        ArgPredicate,
+        styling::{AnsiColor, Color as Colour, Style},
+    },
 };
 use jiff::{Timestamp, Zoned, tz::TimeZone};
 use pna::{
@@ -44,7 +47,6 @@ use tabled::{
 #[clap(disable_help_flag = true)]
 #[command(
     group(ArgGroup::new("null-requires").arg("null").requires("exclude_from")),
-    group(ArgGroup::new("recursive-flag").args(["recursive", "no_recursive"])),
     group(ArgGroup::new("ctime-older-than-source").args(["older_ctime", "older_ctime_than"])),
     group(ArgGroup::new("ctime-newer-than-source").args(["newer_ctime", "newer_ctime_than"])),
     group(ArgGroup::new("mtime-older-than-source").args(["older_mtime", "older_mtime_than"])),
@@ -180,16 +182,19 @@ pub(crate) struct ListCommand {
         long,
         visible_alias = "recursion",
         help = "Operate recursively on the content of directories (default)",
-        default_value_t = true
+        default_value_t = true,
+        default_value_if("no_recursive", ArgPredicate::Equals("true".into()), "false"),
+        conflicts_with = "no_recursive"
     )]
     recursive: bool,
     #[arg(
         short = 'n',
         long = "no-recursive",
         visible_aliases = ["norecurse", "no-recursion"],
+        action = ArgAction::SetTrue,
         help = "Do not operate recursively on the content of directories"
     )]
-    no_recursive: bool,
+    no_recursive: (),
     #[arg(
         long,
         value_name = "PATTERN",
@@ -524,8 +529,8 @@ fn list_archive(ctx: &crate::cli::GlobalContext, args: ListCommand) -> anyhow::R
     };
     let archive = args.file.archive;
     let files = args.file.files;
-    let files_globs = BsdGlobMatcher::new(files.iter().map(|it| it.as_str()))
-        .with_no_recursive(args.no_recursive);
+    let files_globs =
+        BsdGlobMatcher::new(files.iter().map(|it| it.as_str())).with_no_recursive(!args.recursive);
 
     let mut exclude = args.exclude;
     if let Some(p) = args.exclude_from {

--- a/cli/src/command/split.rs
+++ b/cli/src/command/split.rs
@@ -7,26 +7,24 @@ use crate::{
 };
 use anyhow::{Context, ensure};
 use bytesize::ByteSize;
-use clap::{ArgGroup, Parser, ValueHint};
+use clap::{ArgAction, Parser, ValueHint};
 use pna::Archive;
 use std::{borrow::Cow, fs, path::PathBuf};
 
 #[derive(Parser, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-#[command(
-    group(ArgGroup::new("overwrite-flag").args(["overwrite", "no_overwrite"]))
-)]
 pub(crate) struct SplitCommand {
     #[arg(short = 'f', long = "file", help = "Archive file path", value_hint = ValueHint::FilePath)]
     file: PathBuf,
     #[arg(long, value_name = "DIRECTORY", help = "Output directory for split archives", value_hint = ValueHint::DirPath)]
     out_dir: Option<PathBuf>,
-    #[arg(long, help = "Overwrite file")]
+    #[arg(long, conflicts_with = "no_overwrite", help = "Overwrite file")]
     overwrite: bool,
     #[arg(
         long,
+        action = ArgAction::SetTrue,
         help = "Do not overwrite files. This is the inverse option of --overwrite"
     )]
-    no_overwrite: bool,
+    no_overwrite: (),
     #[arg(
         long,
         value_name = "size",

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -20,7 +20,7 @@ use crate::{
     },
     utils::{PathPartExt, VCS_FILES, fs::HardlinkResolver},
 };
-use clap::{ArgGroup, Parser, ValueHint};
+use clap::{ArgAction, ArgGroup, Parser, ValueHint, builder::ArgPredicate};
 use indexmap::IndexMap;
 use pna::{Archive, EntryName, Metadata, prelude::*};
 use std::{
@@ -30,7 +30,6 @@ use std::{
 
 #[derive(Parser, Clone, Debug)]
 #[command(
-    group(ArgGroup::new("keep-acl-flag").args(["keep_acl", "no_keep_acl"])),
     group(ArgGroup::new("path-transform").args(["substitutions", "transforms"])),
     group(ArgGroup::new("read-files-from").args(["files_from", "files_from_stdin"])),
     group(
@@ -44,11 +43,7 @@ use std::{
     group(ArgGroup::new("store-numeric-owner").args(["numeric_owner"]).requires("keep_permission")),
     group(ArgGroup::new("user-flag").args(["numeric_owner", "uname"])),
     group(ArgGroup::new("group-flag").args(["numeric_owner", "gname"])),
-    group(ArgGroup::new("recursive-flag").args(["recursive", "no_recursive"])),
-    group(ArgGroup::new("keep-dir-flag").args(["keep_dir", "no_keep_dir"])),
-    group(ArgGroup::new("keep-xattr-flag").args(["keep_xattr", "no_keep_xattr"])),
     group(ArgGroup::new("keep-timestamp-flag").args(["keep_timestamp", "no_keep_timestamp"])),
-    group(ArgGroup::new("keep-permission-flag").args(["keep_permission", "no_keep_permission"])),
     group(ArgGroup::new("ctime-older-than-source").args(["older_ctime", "older_ctime_than"])),
     group(ArgGroup::new("ctime-newer-than-source").args(["newer_ctime", "newer_ctime_than"])),
     group(ArgGroup::new("mtime-older-than-source").args(["older_mtime", "older_mtime_than"])),
@@ -76,26 +71,32 @@ pub(crate) struct UpdateCommand {
         long,
         visible_alias = "recursion",
         help = "Add the directory to the archive recursively",
-        default_value_t = true
+        default_value_t = true,
+        default_value_if("no_recursive", ArgPredicate::Equals("true".into()), "false"),
+        conflicts_with = "no_recursive"
     )]
     recursive: bool,
     #[arg(
         long,
         visible_alias = "no-recursion",
+        action = ArgAction::SetTrue,
         help = "Do not recursively add directories to the archives. This is the inverse option of --recursive"
     )]
-    no_recursive: bool,
+    no_recursive: (),
     #[arg(
         long,
         help = "Include directories in archive (default)",
-        default_value_t = true
+        default_value_t = true,
+        default_value_if("no_keep_dir", ArgPredicate::Equals("true".into()), "false"),
+        conflicts_with = "no_keep_dir"
     )]
     keep_dir: bool,
     #[arg(
         long,
+        action = ArgAction::SetTrue,
         help = "Do not archive directories. This is the inverse option of --keep-dir"
     )]
-    no_keep_dir: bool,
+    no_keep_dir: (),
     #[arg(
         long = "preserve-timestamps",
         visible_alias = "keep-timestamp",
@@ -111,6 +112,7 @@ pub(crate) struct UpdateCommand {
     #[arg(
         long = "preserve-permissions",
         visible_alias = "keep-permission",
+        conflicts_with = "no_keep_permission",
         help = "Preserve file permissions"
     )]
     #[cfg_attr(windows, arg(requires = "unstable", help_heading = "Unstable Options"))]
@@ -118,27 +120,31 @@ pub(crate) struct UpdateCommand {
     #[arg(
         long = "no-preserve-permissions",
         visible_alias = "no-keep-permission",
+        action = ArgAction::SetTrue,
         help = "Do not archive permissions of files. This is the inverse option of --preserve-permissions"
     )]
     #[cfg_attr(windows, arg(requires = "unstable", help_heading = "Unstable Options"))]
-    no_keep_permission: bool,
+    no_keep_permission: (),
     #[arg(
         long = "preserve-xattrs",
         visible_alias = "keep-xattr",
+        conflicts_with = "no_keep_xattr",
         help = "Preserve extended attributes"
     )]
     keep_xattr: bool,
     #[arg(
         long = "no-preserve-xattrs",
         visible_alias = "no-keep-xattr",
+        action = ArgAction::SetTrue,
         help = "Do not archive extended attributes of files. This is the inverse option of --preserve-xattrs"
     )]
-    pub(crate) no_keep_xattr: bool,
+    pub(crate) no_keep_xattr: (),
     #[arg(
         long = "preserve-acls",
         visible_alias = "keep-acl",
         requires = "unstable",
         help_heading = "Unstable Options",
+        conflicts_with = "no_keep_acl",
         help = "Preserve ACLs"
     )]
     keep_acl: bool,
@@ -147,9 +153,10 @@ pub(crate) struct UpdateCommand {
         visible_alias = "no-keep-acl",
         requires = "unstable",
         help_heading = "Unstable Options",
+        action = ArgAction::SetTrue,
         help = "Do not archive ACLs. This is the inverse option of --preserve-acls"
     )]
-    no_keep_acl: bool,
+    no_keep_acl: (),
     #[arg(long, value_name = "NAME", help = "Set user name for archive entries")]
     uname: Option<String>,
     #[arg(long, value_name = "NAME", help = "Set group name for archive entries")]
@@ -417,7 +424,6 @@ fn update_archive(args: UpdateCommand) -> anyhow::Result<()> {
     let option = entry_option(args.compression, args.cipher, args.hash, password);
     let (mode_strategy, owner_strategy) = PermissionStrategyResolver {
         keep_permission: args.keep_permission,
-        no_keep_permission: args.no_keep_permission,
         same_owner: true, // Must be `true` for creation
         uname: args.uname,
         gname: args.gname,
@@ -441,8 +447,8 @@ fn update_archive(args: UpdateCommand) -> anyhow::Result<()> {
         .resolve(),
         mode_strategy,
         owner_strategy,
-        xattr_strategy: XattrStrategy::from_flags(args.keep_xattr, args.no_keep_xattr, false),
-        acl_strategy: AclStrategy::from_flags(args.keep_acl, args.no_keep_acl),
+        xattr_strategy: XattrStrategy::from_flag(args.keep_xattr),
+        acl_strategy: AclStrategy::from_flag(args.keep_acl),
         fflags_strategy: FflagsStrategy::Never,
         mac_metadata_strategy: MacMetadataStrategy::Never,
     };
@@ -496,8 +502,8 @@ fn update_archive(args: UpdateCommand) -> anyhow::Result<()> {
 
     let archive_path = current_dir.join(args.file.archive);
     let collect_options = CollectOptions {
-        recursive: !args.no_recursive,
-        keep_dir: !args.no_keep_dir,
+        recursive: args.recursive,
+        keep_dir: args.keep_dir,
         gitignore: args.gitignore,
         nodump: args.nodump,
         follow_links: args.follow_links,

--- a/cli/tests/cli/flag_pairs.rs
+++ b/cli/tests/cli/flag_pairs.rs
@@ -1,0 +1,140 @@
+use clap::Parser;
+use portable_network_archive::cli;
+
+/// Every flag that has a `--no-` counterpart, per command that exposes the pair.
+const PAIRS: &[(&[&str], &str, &str)] = &[
+    (&["c", "-f", "a.pna"], "--recursive", "--no-recursive"),
+    (&["c", "-f", "a.pna"], "--keep-dir", "--no-keep-dir"),
+    (&["c", "-f", "a.pna"], "--overwrite", "--no-overwrite"),
+    (
+        &["c", "-f", "a.pna"],
+        "--preserve-xattrs",
+        "--no-preserve-xattrs",
+    ),
+    (
+        &["c", "-f", "a.pna", "--unstable"],
+        "--preserve-permissions",
+        "--no-preserve-permissions",
+    ),
+    (
+        &["c", "-f", "a.pna", "--unstable"],
+        "--preserve-acls",
+        "--no-preserve-acls",
+    ),
+    (&["append", "-f", "a.pna"], "--recursive", "--no-recursive"),
+    (&["append", "-f", "a.pna"], "--keep-dir", "--no-keep-dir"),
+    (
+        &["append", "-f", "a.pna"],
+        "--preserve-xattrs",
+        "--no-preserve-xattrs",
+    ),
+    (
+        &["append", "-f", "a.pna", "--unstable"],
+        "--preserve-permissions",
+        "--no-preserve-permissions",
+    ),
+    (
+        &["append", "-f", "a.pna", "--unstable"],
+        "--preserve-acls",
+        "--no-preserve-acls",
+    ),
+    (
+        &["experimental", "update", "-f", "a.pna"],
+        "--recursive",
+        "--no-recursive",
+    ),
+    (
+        &["experimental", "update", "-f", "a.pna"],
+        "--keep-dir",
+        "--no-keep-dir",
+    ),
+    (
+        &["experimental", "update", "-f", "a.pna"],
+        "--preserve-xattrs",
+        "--no-preserve-xattrs",
+    ),
+    (
+        &["experimental", "update", "-f", "a.pna", "--unstable"],
+        "--preserve-permissions",
+        "--no-preserve-permissions",
+    ),
+    (
+        &["experimental", "update", "-f", "a.pna", "--unstable"],
+        "--preserve-acls",
+        "--no-preserve-acls",
+    ),
+    (
+        &["x", "-f", "a.pna"],
+        "--preserve-xattrs",
+        "--no-preserve-xattrs",
+    ),
+    (
+        &["x", "-f", "a.pna", "--unstable"],
+        "--preserve-permissions",
+        "--no-preserve-permissions",
+    ),
+    (
+        &["x", "-f", "a.pna", "--unstable"],
+        "--preserve-acls",
+        "--no-preserve-acls",
+    ),
+    (&["x", "-f", "a.pna"], "--same-owner", "--no-same-owner"),
+    (
+        &["x", "-f", "a.pna", "--unstable"],
+        "--safe-writes",
+        "--no-safe-writes",
+    ),
+    (
+        &["x", "-f", "a.pna", "--unstable"],
+        "--allow-unsafe-links",
+        "--no-allow-unsafe-links",
+    ),
+    (&["list", "-f", "a.pna"], "--recursive", "--no-recursive"),
+    (&["split", "-f", "a.pna"], "--overwrite", "--no-overwrite"),
+    (&["concat", "-f", "a.pna"], "--overwrite", "--no-overwrite"),
+    (
+        &["experimental", "chown", "-f", "a.pna", "owner"],
+        "--owner-lookup",
+        "--no-owner-lookup",
+    ),
+];
+
+/// Precondition: A native command exposes a flag together with its `--no-` counterpart.
+/// Action: Pass both spellings in one invocation, in either order.
+/// Expectation: Parsing reports the combination as ambiguous instead of picking one.
+#[test]
+fn native_commands_reject_a_flag_with_its_negation() {
+    for (base, yes, no) in PAIRS {
+        for pair in [[yes, no], [no, yes]] {
+            let argv = std::iter::once(&"pna")
+                .chain(base.iter())
+                .chain(pair)
+                .copied()
+                .collect::<Vec<_>>();
+            let err = cli::Cli::try_parse_from(&argv)
+                .err()
+                .unwrap_or_else(|| panic!("accepted {argv:?}"));
+            assert!(
+                err.to_string().contains("cannot be used with"),
+                "{argv:?} was rejected for another reason: {err}"
+            );
+        }
+    }
+}
+
+/// Precondition: A native command exposes a flag with a `--no-` counterpart.
+/// Action: Pass each spelling on its own.
+/// Expectation: Both are accepted.
+#[test]
+fn native_commands_accept_either_spelling_alone() {
+    for (base, yes, no) in PAIRS {
+        for single in [yes, no] {
+            let argv = std::iter::once(&"pna")
+                .chain(base.iter())
+                .chain(std::iter::once(single))
+                .copied()
+                .collect::<Vec<_>>();
+            cli::Cli::try_parse_from(&argv).unwrap_or_else(|e| panic!("rejected {argv:?}: {e}"));
+        }
+    }
+}

--- a/cli/tests/cli/main.rs
+++ b/cli/tests/cli/main.rs
@@ -19,6 +19,7 @@ mod delete;
 mod diff;
 mod encrypt;
 mod extract;
+mod flag_pairs;
 mod hardlink;
 mod keep_acl;
 mod keep_all;


### PR DESCRIPTION
## Summary

A flag and its `--no-` counterpart each carried their own value, so neither field held the resolved outcome: `--no-keep-dir` left `keep_dir` at its `true` default, and every reader had to know to consult `no_keep_dir` instead. The `--no-` side is now a valueless flag typed `()`, and the side that is true when neither flag is given holds the resolved value, flipped by a conditional default when its counterpart is set.

## Notes

Reading the wrong field is a type error rather than a convention to remember, so `!args.no_x` is gone from the call sites: `XattrStrategy` and `AclStrategy` take the resolved flag, and `PermissionStrategyResolver` no longer needs the negative field.

The pair's exclusivity moves from a per-command `ArgGroup` registration to `conflicts_with` on the declaration, dropping 26 registrations. `compat bsdtar` uses `overrides_with` instead, because bsdtar accepts both spellings and lets the last one win — rejecting the combination was a divergence, so `--mac-metadata --no-mac-metadata` succeeds there now.

`default_value_if` uses `Equals` rather than `IsPresent`: a default value counts as present, so `IsPresent` fires on whichever side clap processed first and the outcome then depends on the order the args are declared in.

Two groups of pairs keep both `bool` fields. `--preserve-timestamps`, because `TimestampStrategyResolver` consults `--mtime`/`--ctime`/`--atime` alongside the flags; and `compat bsdtar`'s metadata pairs, because their defaults depend on the mode and on `-p`, so neither outcome is a function of the pair alone.

## Verification

Against bsdtar 3.5.3 / libarchive 3.7.4, extracting with `--xattrs --no-xattrs`, `--no-xattrs --xattrs`, `-p --no-same-permissions` and `--no-same-permissions -p` each exits 0, which is what the `compat bsdtar` change matches.

Stacked on #3300.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated command-line option handling for clearer positive and `--no-` flag behavior.
  - Conflicting flag pairs are now rejected consistently, preventing ambiguous commands.
  - Recursive operations, overwrite behavior, ownership, permissions, extended attributes, ACLs, links, and safe writes now apply options more predictably.

- **Tests**
  - Added coverage confirming supported flag pairs work individually and reject simultaneous use.
  - Removed outdated same-permissions flag combination tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->