### PR TITLE
:bug: Remove the staged file when the archive is not replaced

### DIFF
--- a/cli/src/command/core/staged_archive.rs
+++ b/cli/src/command/core/staged_archive.rs
@@ -52,8 +52,25 @@ fn temp_dir_or_else<'p>(default: impl Fn() -> &'p Path) -> Cow<'p, Path> {
     }
 }
 
+/// Path of a staged file, removed when it goes out of scope.
+///
+/// Owning the path separately from the open file keeps [`NamedTempFile::persist`] able to
+/// close the file before the move while the abandoned path is still cleaned up.
+struct TempPath(PathBuf);
+
+impl Drop for TempPath {
+    fn drop(&mut self) {
+        match fs::remove_file(&self.0) {
+            Ok(()) => {}
+            // `persist` moved the file away, so nothing is left to remove.
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+            Err(e) => log::warn!("failed to remove staged file '{}': {e}", self.0.display()),
+        }
+    }
+}
+
 struct NamedTempFile {
-    file_path: PathBuf,
+    file_path: TempPath,
     file: fs::File,
 }
 
@@ -65,7 +82,10 @@ impl NamedTempFile {
         let random = rand::random::<usize>();
         let file_path = temp_dir.join(format!("{random}.tmp"));
         let file = fs::File::create(&file_path)?;
-        Ok(Self { file, file_path })
+        Ok(Self {
+            file,
+            file_path: TempPath(file_path),
+        })
     }
 
     #[inline]
@@ -83,6 +103,6 @@ impl NamedTempFile {
         if let Some(parent) = new_path_ref.parent() {
             fs::create_dir_all(parent)?;
         }
-        utils::fs::mv(file_path, new_path_ref)
+        utils::fs::mv(&file_path.0, new_path_ref)
     }
 }

--- a/cli/tests/cli/delete.rs
+++ b/cli/tests/cli/delete.rs
@@ -1,3 +1,4 @@
+mod abandoned_staged_file;
 mod delete_all_entries;
 mod directory_entry;
 mod missing_file;

--- a/cli/tests/cli/delete/abandoned_staged_file.rs
+++ b/cli/tests/cli/delete/abandoned_staged_file.rs
@@ -1,0 +1,49 @@
+#![cfg(not(target_family = "wasm"))]
+
+use crate::utils::{EmbedExt, TestResources, setup};
+use assert_cmd::cargo::cargo_bin_cmd;
+use std::fs;
+
+/// Precondition: An archive exists, and a run is given a path pattern that matches nothing.
+/// Action: Run the deletion with a dedicated temp directory in the environment.
+/// Expectation: The run fails and leaves no staged file behind.
+#[test]
+fn delete_leaves_no_staged_file_when_a_pattern_is_missing() {
+    setup();
+    let _ = fs::remove_dir_all("delete_staged_cleanup");
+    TestResources::extract_in("raw/", "delete_staged_cleanup/in/").unwrap();
+    fs::create_dir_all("delete_staged_cleanup/tmp").unwrap();
+    let temp_dir = fs::canonicalize("delete_staged_cleanup/tmp").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "c",
+            "-f",
+            "delete_staged_cleanup/archive.pna",
+            "--overwrite",
+            "delete_staged_cleanup/in/",
+        ])
+        .assert()
+        .success();
+
+    cargo_bin_cmd!("pna")
+        .env("TMPDIR", &temp_dir)
+        .env("TMP", &temp_dir)
+        .env("TEMP", &temp_dir)
+        .args([
+            "--quiet",
+            "delete",
+            "-f",
+            "delete_staged_cleanup/archive.pna",
+            "delete_staged_cleanup/in/raw/not_found.txt",
+        ])
+        .assert()
+        .failure();
+
+    let left = fs::read_dir(&temp_dir)
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name())
+        .collect::<Vec<_>>();
+    assert!(left.is_empty(), "staged file left behind: {left:?}");
+}


### PR DESCRIPTION
## Summary

A run that gave up before the commit point left its staged file in the temp directory. #3297 turns that into an ordinary outcome: with the requested patterns checked before the archive is replaced, a mistyped path abandons a staged copy of the whole archive on every run. The staged path is now owned by a guard that removes it when it goes out of scope.

## Notes

Keeping the path in a type of its own leaves `persist` able to close the file before the move, which is the order the manual temp handling used before `NamedTempFile` replaced it. It also needs no "already persisted" flag: once the file has been moved away, nothing is at the path to remove.

## Verification

Reverting the guard makes the added test fail with a freshly staged file left behind, so it is not vacuous.

Stacked on #3297.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of temporary staged files after archive operations.
  * Prevented leftover staged files when deletion fails or a path pattern is invalid.
  * Improved handling and logging of temporary-file cleanup errors.

* **Tests**
  * Added regression coverage for failed deletion attempts and abandoned staged files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->