### PR TITLE
:bug: Replace the destination in one step on Windows

### DIFF
--- a/cli/src/command/core/safe_writer.rs
+++ b/cli/src/command/core/safe_writer.rs
@@ -1,3 +1,4 @@
+use crate::utils;
 use std::{
     fs, io,
     path::{Path, PathBuf},
@@ -86,23 +87,21 @@ impl SafeWriter {
             .temp_path
             .take()
             .expect("persist called on already-persisted SafeWriter");
-        fs::rename(&temp_path, &self.final_path)
+        utils::fs::mv(&temp_path, &self.final_path)
     }
 
-    /// Prepares the destination path for the rename operation.
+    /// Removes a directory standing where the file is about to go.
+    ///
+    /// A file cannot be moved onto a directory, so an empty one is removed to make room; a
+    /// non-empty one makes the move fail. Everything else is left to the move itself, which
+    /// replaces an existing file in one step.
     fn prepare_destination(&self) -> io::Result<()> {
         #[cfg(windows)]
         use std::os::windows::fs::FileTypeExt;
         match fs::symlink_metadata(&self.final_path) {
-            // Empty directory blocking file extraction is removed (non-empty will fail)
             Ok(meta) if meta.file_type().is_dir() => fs::remove_dir(&self.final_path),
-            // Windows rename() fails if destination exists; remove it first
             #[cfg(windows)]
             Ok(meta) if meta.file_type().is_symlink_dir() => fs::remove_dir(&self.final_path),
-            // Windows rename() fails if destination exists; remove it first
-            #[cfg(windows)]
-            Ok(_) => fs::remove_file(&self.final_path),
-            #[cfg(not(windows))]
             Ok(_) => Ok(()),
             Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
             Err(e) => Err(e),


### PR DESCRIPTION
## Summary

`SafeWriter` removed an existing destination before renaming, because `fs::rename` on Windows fails when the destination exists. That leaves a window in which nothing is at the path, so an interrupted extraction could take the file away without putting the new one there. `utils::fs::mv` already replaces in a single step there (`MoveFileExW` with `MOVEFILE_REPLACE_EXISTING`), so extraction goes through it now.

## Notes

A directory standing where the file must go is still removed first, since no move can replace one: an empty directory is removed, a non-empty one makes the move fail.

The other platforms are unaffected — the staged file sits in the destination's own directory, so `mv` renames.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file replacement behavior when safely writing files.
  * Preserved existing destination files during preparation while ensuring temporary files are moved into place correctly.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->