### PR TITLE
Use cached cargo-install for cargo-fuzz and run fuzz on standard runner

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -50,7 +50,7 @@ jobs:
 
   fuzz:
     name: Run cargo fuzz
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: fuzz_target
     strategy:
@@ -66,7 +66,9 @@ jobs:
           toolchain: nightly
           cache-save-if: ${{ github.ref_name == github.event.repository.default_branch }}
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz
+        uses: baptiste0928/cargo-install@f204293d9709061b7bc1756fec3ec4e2cd57dec0 # v3.4.0
+        with:
+          crate: cargo-fuzz
       - name: Run fuzzing
         env:
           FUZZ_TARGET: ${{ matrix.fuzz_target }}


### PR DESCRIPTION
## Summary
- Install `cargo-fuzz` via `baptiste0928/cargo-install` (same cached-install pattern as `test.yml`/`release.yml`) instead of a plain `cargo install`.
- Move the `fuzz` job from `ubuntu-slim` to `ubuntu-latest`; `fuzz_target` (target detection only) stays on `ubuntu-slim`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the fuzzing workflow to run on the latest Ubuntu environment.
  * Improved the cargo-fuzz installation process for more reliable automated testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->