### PR TITLE
:recycle: Remove obsolete cwd resolution

### DIFF
--- a/cli/src/command/create.rs
+++ b/cli/src/command/create.rs
@@ -23,7 +23,7 @@ use bytesize::ByteSize;
 use clap::{ArgAction, ArgGroup, Parser, ValueHint, builder::ArgPredicate};
 use pna::{Archive, SolidEntryBuilder, WriteOptions};
 use std::{
-    env, fs,
+    fs,
     io::{self, prelude::*},
     path::{Path, PathBuf},
     time::Instant,
@@ -416,7 +416,6 @@ impl Command for CreateCommand {
 
 #[hooq::hooq(anyhow)]
 fn create_archive(args: CreateCommand) -> anyhow::Result<()> {
-    let current_dir = env::current_dir()?;
     let password = ask_password(args.password)?;
     let start = Instant::now();
     let archive = &args.file.archive;
@@ -458,7 +457,6 @@ fn create_archive(args: CreateCommand) -> anyhow::Result<()> {
         args.include.iter().map(|s| s.as_str()),
         exclude.iter().map(|s| s.as_str()).chain(vcs_patterns),
     );
-    let archive_path = current_dir.join(archive);
     let time_filters = TimeFilterResolver {
         newer_ctime_than: args.newer_ctime_than.as_deref(),
         older_ctime_than: args.older_ctime_than.as_deref(),
@@ -489,7 +487,7 @@ fn create_archive(args: CreateCommand) -> anyhow::Result<()> {
         .map(CollectedItem::Filesystem)
         .collect::<Vec<_>>();
 
-    if let Some(parent) = archive_path.parent() {
+    if let Some(parent) = archive.parent() {
         fs::create_dir_all(parent)?;
     }
     let (mode_strategy, owner_strategy) = PermissionStrategyResolver {
@@ -538,7 +536,7 @@ fn create_archive(args: CreateCommand) -> anyhow::Result<()> {
     };
     if let Some(size) = max_file_size {
         create_archive_with_split(
-            &archive_path,
+            archive,
             creation_context,
             target_items,
             size,
@@ -550,7 +548,7 @@ fn create_archive(args: CreateCommand) -> anyhow::Result<()> {
         )?;
     } else {
         create_archive_file(
-            || utils::fs::file_create(&archive_path, args.overwrite),
+            || utils::fs::file_create(archive, args.overwrite),
             creation_context,
             target_items,
             &filter,

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -24,7 +24,7 @@ use clap::{ArgAction, ArgGroup, Parser, ValueHint, builder::ArgPredicate};
 use indexmap::IndexMap;
 use pna::{Archive, EntryName, Metadata, prelude::*};
 use std::{
-    env, fs, io,
+    fs, io,
     path::{Path, PathBuf},
 };
 
@@ -414,7 +414,6 @@ impl Command for UpdateCommand {
 fn update_archive(args: UpdateCommand) -> anyhow::Result<()> {
     let transform_strategy = args.transform_strategy.strategy();
     let sync = args.sync;
-    let current_dir = env::current_dir()?;
     let password = ask_password(args.password)?;
     let archive_path = &args.file.archive;
     if !archive_path.exists() {
@@ -500,7 +499,6 @@ fn update_archive(args: UpdateCommand) -> anyhow::Result<()> {
         exclude.iter().map(|s| s.as_str()).chain(vcs_patterns),
     );
 
-    let archive_path = current_dir.join(args.file.archive);
     let collect_options = CollectOptions {
         recursive: args.recursive,
         keep_dir: args.keep_dir,


### PR DESCRIPTION
## Summary

- remove obsolete current-directory capture from `create` and `experimental update`
- pass user-supplied archive paths directly to archive creation and staging
- leave `compat bsdtar` directory switching and chroot behavior unchanged

## Why

The commands previously resolved archive paths against the initial working directory so they remained stable across the `-C` option. That option has since been removed, leaving the resolution redundant and introducing an unnecessary `current_dir()` failure point.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p portable-network-archive --test cli create::`
- `cargo test -p portable-network-archive --test cli update::`
- `cargo check -p portable-network-archive --tests`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Archive creation and updates now consistently use the path provided by the user.
  * Improved handling of relative archive paths, including split archives and output locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->