### PR TITLE
:shirt: Use canonical encryption constants in CLI tests

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -384,7 +384,7 @@ mod tests {
             aes: None,
             camellia: Some(Some(CipherMode::Cbc)),
         };
-        assert_eq!(args.algorithm(), pna::Encryption::Camellia);
+        assert_eq!(args.algorithm(), pna::Encryption::CAMELLIA);
     }
 
     #[test]
@@ -393,7 +393,7 @@ mod tests {
             aes: Some(Some(CipherMode::Cbc)),
             camellia: None,
         };
-        assert_eq!(args.algorithm(), pna::Encryption::Aes);
+        assert_eq!(args.algorithm(), pna::Encryption::AES);
     }
 
     #[test]
@@ -402,7 +402,7 @@ mod tests {
             aes: None,
             camellia: None,
         };
-        assert_eq!(args.algorithm(), pna::Encryption::Aes);
+        assert_eq!(args.algorithm(), pna::Encryption::AES);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- replace deprecated mixed-case `Encryption` aliases in CLI unit tests
- use the canonical `Encryption::AES` and `Encryption::CAMELLIA` constants
- restore warning-free `cargo clippy --all-targets` validation

## Root cause

The recently added cipher argument tests referenced deprecated compatibility aliases. Building test targets with warnings denied therefore failed even though the production CLI code was unaffected.

## Impact

All-target Clippy checks now pass without suppressing deprecation warnings. Runtime behavior is unchanged because only test assertions were updated.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked -p portable-network-archive cli::tests`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated encryption algorithm handling to use the current AES and Camellia options.
  * Corrected default and selected cipher behavior for improved CLI reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->