### PR TITLE
:wrench: Group hkdf and sha2 updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,3 +41,5 @@ updates:
           - "ctr"
           - "cipher"
           - "crypto-common"
+          - "hkdf"
+          - "sha2"


### PR DESCRIPTION
## Summary

- Add `hkdf` and `sha2` to the existing `rustcrypto-crates` Dependabot group.
- Allow available updates for the HKDF implementation and its SHA-2 digest dependency to be proposed together.

## Why

The standalone `hkdf` 0.13 update moved to the `digest` 0.11 generation while the directly used `sha2` dependency remained on `digest` 0.10, causing the build to fail with incompatible trait implementations. Grouping these RustCrypto dependencies reduces the risk of future version-skew PRs by letting Dependabot combine updates available in the same run.

## Impact

This changes only Dependabot update grouping. It does not modify dependency versions, application code, archive behavior, or the MSRV.

## Validation

- Parsed `.github/dependabot.yml` as YAML and asserted that the `rustcrypto-crates` group contains both `hkdf` and `sha2`.
- Ran `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Grouped `hkdf` and `sha2` dependency updates together for streamlined maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->