### PR TITLE
:white_check_mark: Cover archive signature rejection on the async path

### DIFF
--- a/lib/src/archive/read.rs
+++ b/lib/src/archive/read.rs
@@ -526,6 +526,29 @@ mod tests {
 
     #[cfg(feature = "unstable-async")]
     #[tokio::test]
+    async fn read_header_async_rejects_bad_magic() {
+        use tokio_util::compat::TokioAsyncReadCompatExt;
+
+        let mut bytes = include_bytes!("../../../resources/test/empty.pna").to_vec();
+        bytes[0] ^= 0xFF;
+        let file = io::Cursor::new(bytes).compat();
+        let err = Archive::read_header_async(file).await.err().unwrap();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[cfg(feature = "unstable-async")]
+    #[tokio::test]
+    async fn read_header_async_rejects_truncated_header() {
+        use tokio_util::compat::TokioAsyncReadCompatExt;
+
+        let bytes = include_bytes!("../../../resources/test/empty.pna");
+        let file = io::Cursor::new(&bytes[..4]).compat();
+        let err = Archive::read_header_async(file).await.err().unwrap();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[cfg(feature = "unstable-async")]
+    #[tokio::test]
     async fn decode_async() {
         use tokio_util::compat::TokioAsyncReadCompatExt;
 


### PR DESCRIPTION
## Summary

Add the async counterparts of `read_header_rejects_bad_magic` and `read_header_rejects_truncated_header`. `Archive::read_header_async` had no coverage for a rejected signature.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming asynchronous archive header reading reports clear errors for invalid file signatures and truncated headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->