### PR TITLE
:skull: Rename PNA_HEADER to PNA_SIGNATURE and deprecate the old name

### DIFF
--- a/cli/src/command/chunk.rs
+++ b/cli/src/command/chunk.rs
@@ -71,7 +71,7 @@ fn list_archive_chunks(args: ListCommand) -> anyhow::Result<()> {
     }
     let include: HashSet<pna::ChunkType> = args.ty.iter().map(|ty| ty.0).collect();
     let exclude: HashSet<pna::ChunkType> = args.exclude_ty.iter().map(|ty| ty.0).collect();
-    let mut offset = pna::PNA_HEADER.len();
+    let mut offset = pna::PNA_SIGNATURE.len();
     let mut idx = 0;
     for chunk in pna::read_as_chunks(archive)? {
         let chunk = chunk?;

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -31,8 +31,8 @@ pub(crate) use path_transformer::PathTransformers;
 use pna::{
     Archive, DataKind, DirEntryBuilder, EntryContent, EntryPart, FileEntryBuilder,
     HardLinkEntryBuilder, LinkTargetType, MIN_CHUNK_BYTES_SIZE, Metadata, NormalEntry,
-    OpaqueEntryBuilder, PNA_HEADER, ReadEntry, ReadOptions, SolidEntryBuilder, SymlinkEntryBuilder,
-    WriteOptions, prelude::*,
+    OpaqueEntryBuilder, PNA_SIGNATURE, ReadEntry, ReadOptions, SolidEntryBuilder,
+    SymlinkEntryBuilder, WriteOptions, prelude::*,
 };
 use std::{
     borrow::Cow,
@@ -62,7 +62,7 @@ pub(crate) enum SourceFormat {
 pub(crate) fn detect_format<R: io::BufRead>(reader: &mut R) -> io::Result<SourceFormat> {
     let buf = reader.fill_buf()?;
 
-    Ok(if buf.starts_with(PNA_HEADER) {
+    Ok(if buf.starts_with(PNA_SIGNATURE) {
         SourceFormat::Pna
     } else {
         SourceFormat::Mtree
@@ -151,9 +151,9 @@ impl TimeFilterResolver<'_> {
     }
 }
 
-/// Overhead for a split archive part in bytes, including PNA header, AHED, ANXT, and AEND chunks.
+/// Overhead for a split archive part in bytes, including PNA signature, AHED, ANXT, and AEND chunks.
 pub(crate) const SPLIT_ARCHIVE_OVERHEAD_BYTES: usize =
-    PNA_HEADER.len() + MIN_CHUNK_BYTES_SIZE * 3 + 8;
+    PNA_SIGNATURE.len() + MIN_CHUNK_BYTES_SIZE * 3 + 8;
 
 /// Minimum bytes required for a split archive part (overhead + one minimal chunk).
 pub(crate) const MIN_SPLIT_PART_BYTES: usize = SPLIT_ARCHIVE_OVERHEAD_BYTES + MIN_CHUNK_BYTES_SIZE;
@@ -1847,7 +1847,6 @@ where
     let mut part_num = 1;
     let mut writer = Archive::write_header(initial_writer)?;
 
-    // NOTE: max_file_size - (PNA_HEADER + AHED + ANXT + AEND)
     let max_file_size = max_file_size - SPLIT_ARCHIVE_OVERHEAD_BYTES;
     let mut written_entry_size = 0;
     for entry in entries {

--- a/cli/src/utils/io.rs
+++ b/cli/src/utils/io.rs
@@ -2,9 +2,9 @@ use crate::ext::BufReadExt;
 use std::io;
 
 pub(crate) fn is_pna<R: io::Read>(mut reader: R) -> io::Result<bool> {
-    let mut buf = [0u8; pna::PNA_HEADER.len()];
+    let mut buf = [0u8; pna::PNA_SIGNATURE.len()];
     reader.read_exact(&mut buf)?;
-    Ok(buf == *pna::PNA_HEADER)
+    Ok(buf == *pna::PNA_SIGNATURE)
 }
 
 #[inline]

--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -819,7 +819,7 @@ mod tests {
             }
             segments.push(&stream[prev..]);
 
-            let mut out = PNA_HEADER.to_vec();
+            let mut out = PNA_SIGNATURE.to_vec();
             let mut emitted = false;
             for chunk in read_as_chunks(archive).unwrap() {
                 let chunk = chunk.unwrap();
@@ -1185,7 +1185,7 @@ mod tests {
             index: usize,
             f: impl FnOnce(&mut Vec<u8>),
         ) -> Vec<u8> {
-            let mut out = PNA_HEADER.to_vec();
+            let mut out = PNA_SIGNATURE.to_vec();
             let mut f = Some(f);
             let mut seen = 0;
             for chunk in read_as_chunks(archive).unwrap() {
@@ -1225,7 +1225,7 @@ mod tests {
             entry_index: usize,
             f: impl FnOnce(&mut Vec<u8>),
         ) -> Vec<u8> {
-            let mut out = PNA_HEADER.to_vec();
+            let mut out = PNA_SIGNATURE.to_vec();
             let mut f = Some(f);
             let mut current: isize = -1;
             let mut stream: Option<Vec<u8>> = None;
@@ -1273,7 +1273,7 @@ mod tests {
         }
 
         fn tamper_solid_datastream(archive: &[u8], f: impl FnOnce(&mut Vec<u8>)) -> Vec<u8> {
-            let mut out = PNA_HEADER.to_vec();
+            let mut out = PNA_SIGNATURE.to_vec();
             let mut f = Some(f);
             let mut stream: Option<Vec<u8>> = None;
             for chunk in read_as_chunks(archive).unwrap() {

--- a/lib/src/archive/header.rs
+++ b/lib/src/archive/header.rs
@@ -2,8 +2,12 @@
 
 use std::io;
 
-/// The magic number of Portable-Network-Archive.
-pub const PNA_HEADER: &[u8; 8] = b"\x89PNA\r\n\x1A\n";
+/// The signature at the beginning of every PNA archive.
+pub const PNA_SIGNATURE: &[u8; 8] = b"\x89PNA\r\n\x1A\n";
+
+/// Alias of [`PNA_SIGNATURE`].
+#[deprecated(since = "TBD", note = "renamed to `PNA_SIGNATURE`")]
+pub const PNA_HEADER: &[u8; 8] = PNA_SIGNATURE;
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub(crate) struct ArchiveHeader {

--- a/lib/src/archive/read.rs
+++ b/lib/src/archive/read.rs
@@ -3,7 +3,7 @@
 mod slice;
 
 use crate::{
-    archive::{Archive, ArchiveHeader, PNA_HEADER},
+    archive::{Archive, ArchiveHeader, PNA_SIGNATURE},
     chunk::{Chunk, ChunkReader, ChunkType, RawChunk, read_chunk},
     entry::{Entry, NormalEntry, RawEntry, ReadEntry, ReadOptions},
 };
@@ -16,9 +16,9 @@ use std::{
 };
 
 pub(crate) fn read_pna_header<R: Read>(mut reader: R) -> io::Result<()> {
-    let mut header = [0u8; PNA_HEADER.len()];
+    let mut header = [0u8; PNA_SIGNATURE.len()];
     reader.read_exact(&mut header)?;
-    if &header != PNA_HEADER {
+    if &header != PNA_SIGNATURE {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "not a PNA archive",
@@ -29,9 +29,9 @@ pub(crate) fn read_pna_header<R: Read>(mut reader: R) -> io::Result<()> {
 
 #[cfg(feature = "unstable-async")]
 async fn read_pna_header_async<R: futures_io::AsyncRead + Unpin>(mut reader: R) -> io::Result<()> {
-    let mut header = [0u8; PNA_HEADER.len()];
+    let mut header = [0u8; PNA_SIGNATURE.len()];
     reader.read_exact(&mut header).await?;
-    if &header != PNA_HEADER {
+    if &header != PNA_SIGNATURE {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "not a PNA archive",
@@ -483,14 +483,14 @@ mod tests {
 
     #[test]
     fn read_header_rejects_non_ahed_first_chunk() {
-        let mut bytes = PNA_HEADER.to_vec();
+        let mut bytes = PNA_SIGNATURE.to_vec();
         bytes.extend_from_slice(&RawChunk::from_data(ChunkType::FEND, Vec::new()).to_bytes());
         let err = Archive::read_header(&bytes[..]).err().unwrap();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 
     fn archive_bytes(header: ArchiveHeader) -> Vec<u8> {
-        let mut bytes = PNA_HEADER.to_vec();
+        let mut bytes = PNA_SIGNATURE.to_vec();
         bytes.extend_from_slice(
             &RawChunk::from_data(ChunkType::AHED, header.to_bytes().to_vec()).to_bytes(),
         );

--- a/lib/src/archive/read/slice.rs
+++ b/lib/src/archive/read/slice.rs
@@ -1,7 +1,7 @@
 //! Slice-based archive reading for memory-mapped access.
 
 use crate::{
-    Archive, Chunk, ChunkType, Entry, NormalEntry, PNA_HEADER, RawChunk, ReadEntry, ReadOptions,
+    Archive, Chunk, ChunkType, Entry, NormalEntry, PNA_SIGNATURE, RawChunk, ReadEntry, ReadOptions,
     archive::ArchiveHeader, chunk::read_chunk_from_slice, entry::RawEntry,
 };
 use std::borrow::Cow;
@@ -9,9 +9,9 @@ use std::io;
 
 pub(crate) fn read_header_from_slice(bytes: &[u8]) -> io::Result<&[u8]> {
     let (header, body) = bytes
-        .split_at_checked(PNA_HEADER.len())
+        .split_at_checked(PNA_SIGNATURE.len())
         .ok_or(io::ErrorKind::UnexpectedEof)?;
-    if header != PNA_HEADER {
+    if header != PNA_SIGNATURE {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "not a PNA archive",
@@ -252,7 +252,7 @@ mod tests {
 
     #[test]
     fn read_header() {
-        let result = read_header_from_slice(PNA_HEADER).unwrap();
+        let result = read_header_from_slice(PNA_SIGNATURE).unwrap();
         assert!(result.is_empty());
     }
 

--- a/lib/src/archive/write.rs
+++ b/lib/src/archive/write.rs
@@ -1,7 +1,7 @@
 //! Archive writing and entry serialization.
 
 use crate::{
-    archive::{Archive, ArchiveHeader, PNA_HEADER, SolidArchive},
+    archive::{Archive, ArchiveHeader, PNA_SIGNATURE, SolidArchive},
     chunk::{Chunk, ChunkExt, ChunkStreamWriter, ChunkType, RawChunk},
     cipher::CipherWriter,
     compress::CompressionWriter,
@@ -89,7 +89,7 @@ impl<W: Write> Archive<W> {
 
     #[inline]
     fn write_header_with(mut write: W, header: ArchiveHeader) -> io::Result<Self> {
-        write.write_all(PNA_HEADER)?;
+        write.write_all(PNA_SIGNATURE)?;
         (ChunkType::AHED, header.to_bytes()).write_chunk_in(&mut write)?;
         Ok(Self::new(write, header))
     }
@@ -303,7 +303,7 @@ impl<W: AsyncWrite + Unpin> Archive<W> {
 
     #[inline]
     async fn write_header_with_async(mut write: W, header: ArchiveHeader) -> io::Result<Self> {
-        write.write_all(PNA_HEADER).await?;
+        write.write_all(PNA_SIGNATURE).await?;
         let mut chunk_writer = crate::chunk::ChunkWriter::new(&mut write);
         chunk_writer
             .write_chunk_async((ChunkType::AHED, header.to_bytes()))


### PR DESCRIPTION
## Summary

Rename the archive signature constant to `PNA_SIGNATURE`, matching the specification's term (§3.1 "PNA file signature"), and update every reference in the workspace. `PNA_HEADER` stays as a deprecated alias.

## Notes

`since = "TBD"` because the deprecation ships in a release after 0.36.0, whose number is not decided yet. clippy's `deprecated_semver` accepts only a semver version or `TBD`.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
