### PR TITLE
:sparkles: Add low-level PNA signature parsing APIs

### DIFF
--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -202,7 +202,7 @@ pub struct SolidArchive<T: Write> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Duration, entry::*};
+    use crate::{Duration, PNA_SIGNATURE, entry::*};
     use std::io::{self, Cursor};
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;

--- a/lib/src/archive/header.rs
+++ b/lib/src/archive/header.rs
@@ -1,9 +1,7 @@
 //! Archive header constants and validation.
 
+use crate::PNA_SIGNATURE;
 use std::io;
-
-/// The signature at the beginning of every PNA archive.
-pub const PNA_SIGNATURE: &[u8; 8] = b"\x89PNA\r\n\x1A\n";
 
 /// Alias of [`PNA_SIGNATURE`].
 #[deprecated(since = "TBD", note = "renamed to `PNA_SIGNATURE`")]

--- a/lib/src/archive/read.rs
+++ b/lib/src/archive/read.rs
@@ -3,7 +3,8 @@
 mod slice;
 
 use crate::{
-    archive::{Archive, ArchiveHeader, PNA_SIGNATURE},
+    PNA_SIGNATURE,
+    archive::{Archive, ArchiveHeader},
     chunk::{Chunk, ChunkReader, ChunkType, RawChunk, read_chunk},
     entry::{Entry, NormalEntry, RawEntry, ReadEntry, ReadOptions},
 };

--- a/lib/src/archive/write.rs
+++ b/lib/src/archive/write.rs
@@ -1,7 +1,8 @@
 //! Archive writing and entry serialization.
 
 use crate::{
-    archive::{Archive, ArchiveHeader, PNA_SIGNATURE, SolidArchive},
+    PNA_SIGNATURE,
+    archive::{Archive, ArchiveHeader, SolidArchive},
     chunk::{Chunk, ChunkExt, ChunkStreamWriter, ChunkType, RawChunk},
     cipher::CipherWriter,
     compress::CompressionWriter,

--- a/lib/src/async_io.rs
+++ b/lib/src/async_io.rs
@@ -1,0 +1,56 @@
+//! Asynchronous I/O primitives for reading and writing PNA archives.
+
+use crate::PNA_SIGNATURE;
+use futures_io::AsyncRead;
+use futures_util::AsyncReadExt;
+use std::io;
+
+/// Reads and validates the PNA archive signature asynchronously.
+///
+/// On success, `reader` has consumed exactly the signature bytes. On failure an
+/// unspecified number of bytes has been consumed, so `reader` cannot be reused
+/// to probe for another format.
+///
+/// # Errors
+///
+/// Returns [`io::ErrorKind::UnexpectedEof`] when the signature cannot be fully
+/// read, [`io::ErrorKind::InvalidData`] when it does not match, and any other
+/// error produced by `reader`.
+#[inline]
+pub async fn read_signature<R: AsyncRead + Unpin + ?Sized>(reader: &mut R) -> io::Result<()> {
+    let mut signature = [0u8; PNA_SIGNATURE.len()];
+    reader.read_exact(&mut signature).await?;
+    crate::format::validate_signature(&signature)
+}
+
+#[cfg(all(test, not(target_family = "wasm")))]
+mod tests {
+    use super::*;
+    use futures_util::io::Cursor;
+
+    #[tokio::test]
+    async fn read_signature_consumes_exactly_the_signature() {
+        let input = [PNA_SIGNATURE.as_slice(), b"body"].concat();
+        let mut reader = Cursor::new(input);
+        read_signature(&mut reader).await.unwrap();
+        assert_eq!(reader.position(), PNA_SIGNATURE.len() as u64);
+    }
+
+    #[tokio::test]
+    async fn read_signature_rejects_input_one_byte_short() {
+        let mut reader = Cursor::new(&PNA_SIGNATURE[..7]);
+        assert_eq!(
+            read_signature(&mut reader).await.unwrap_err().kind(),
+            io::ErrorKind::UnexpectedEof
+        );
+    }
+
+    #[tokio::test]
+    async fn read_signature_rejects_mismatched_signature() {
+        let mut reader = Cursor::new(b"xxxxxxxx");
+        assert_eq!(
+            read_signature(&mut reader).await.unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+}

--- a/lib/src/bytes.rs
+++ b/lib/src/bytes.rs
@@ -1,0 +1,51 @@
+//! Byte-slice primitives for parsing PNA archives.
+
+use crate::PNA_SIGNATURE;
+use std::io;
+
+/// Reads and validates the PNA archive signature from `bytes`.
+///
+/// Returns the bytes following the signature on success.
+///
+/// # Errors
+///
+/// Returns [`io::ErrorKind::UnexpectedEof`] when the signature is incomplete,
+/// or [`io::ErrorKind::InvalidData`] when it does not match.
+#[inline]
+pub fn read_signature(bytes: &[u8]) -> io::Result<&[u8]> {
+    let (signature, rest) = bytes
+        .split_first_chunk::<{ PNA_SIGNATURE.len() }>()
+        .ok_or(io::ErrorKind::UnexpectedEof)?;
+    crate::format::validate_signature(signature)?;
+    Ok(rest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    use wasm_bindgen_test::wasm_bindgen_test as test;
+
+    #[test]
+    fn read_signature_returns_remaining_bytes() {
+        let input = [PNA_SIGNATURE.as_slice(), b"body"].concat();
+        assert_eq!(read_signature(&input).unwrap(), b"body");
+        assert_eq!(read_signature(PNA_SIGNATURE).unwrap(), b"");
+    }
+
+    #[test]
+    fn read_signature_rejects_input_one_byte_short() {
+        assert_eq!(
+            read_signature(&PNA_SIGNATURE[..7]).unwrap_err().kind(),
+            io::ErrorKind::UnexpectedEof
+        );
+    }
+
+    #[test]
+    fn read_signature_rejects_mismatched_signature() {
+        assert_eq!(
+            read_signature(b"xxxxxxxx").unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+}

--- a/lib/src/format.rs
+++ b/lib/src/format.rs
@@ -1,0 +1,6 @@
+//! Core definitions for the PNA file format.
+
+mod signature;
+
+pub use signature::PNA_SIGNATURE;
+pub(crate) use signature::validate_signature;

--- a/lib/src/format/signature.rs
+++ b/lib/src/format/signature.rs
@@ -1,0 +1,38 @@
+//! PNA signature definition and validation.
+
+use std::io;
+
+/// The signature at the beginning of every PNA archive.
+pub const PNA_SIGNATURE: &[u8; 8] = b"\x89PNA\r\n\x1A\n";
+
+/// Validates an exact-length PNA signature.
+#[inline]
+pub(crate) fn validate_signature(signature: &[u8; PNA_SIGNATURE.len()]) -> io::Result<()> {
+    if signature != PNA_SIGNATURE {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "not a PNA archive",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    use wasm_bindgen_test::wasm_bindgen_test as test;
+
+    #[test]
+    fn validate_signature_accepts_pna_signature() {
+        validate_signature(PNA_SIGNATURE).unwrap();
+    }
+
+    #[test]
+    fn validate_signature_rejects_mismatched_signature() {
+        assert_eq!(
+            validate_signature(b"xxxxxxxx").unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+}

--- a/lib/src/io.rs
+++ b/lib/src/io.rs
@@ -1,0 +1,63 @@
+//! I/O primitives for reading and writing PNA archives.
+
+use crate::PNA_SIGNATURE;
+use std::io;
+
+/// Reads and validates the PNA archive signature.
+///
+/// On success, `reader` has consumed exactly the signature bytes. On failure an
+/// unspecified number of bytes has been consumed, so `reader` cannot be reused
+/// to probe for another format.
+///
+/// # Errors
+///
+/// Returns [`io::ErrorKind::UnexpectedEof`] when the signature cannot be fully
+/// read, [`io::ErrorKind::InvalidData`] when it does not match, and any other
+/// error produced by `reader`.
+#[inline]
+pub fn read_signature<R: io::Read + ?Sized>(reader: &mut R) -> io::Result<()> {
+    let mut signature = [0u8; PNA_SIGNATURE.len()];
+    reader.read_exact(&mut signature)?;
+    crate::format::validate_signature(&signature)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::io::tests::PartialReader;
+    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    use wasm_bindgen_test::wasm_bindgen_test as test;
+
+    #[test]
+    fn read_signature_consumes_exactly_the_signature() {
+        let input = [PNA_SIGNATURE.as_slice(), b"body"].concat();
+        let mut reader = io::Cursor::new(input);
+        read_signature(&mut reader).unwrap();
+        assert_eq!(reader.position(), PNA_SIGNATURE.len() as u64);
+    }
+
+    #[test]
+    fn read_signature_accepts_signature_split_across_reads() {
+        let input = [PNA_SIGNATURE.as_slice(), b"body"].concat();
+        let mut reader = PartialReader::new(input, [3u8, 2, 4]);
+        read_signature(&mut reader).unwrap();
+    }
+
+    #[test]
+    fn read_signature_rejects_input_one_byte_short() {
+        let mut reader = io::Cursor::new(&PNA_SIGNATURE[..7]);
+        assert_eq!(
+            read_signature(&mut reader).unwrap_err().kind(),
+            io::ErrorKind::UnexpectedEof
+        );
+    }
+
+    #[test]
+    fn read_signature_rejects_mismatched_signature() {
+        let mut reader = io::Cursor::new(b"xxxxxxxx");
+        assert_eq!(
+            read_signature(&mut reader).unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -135,13 +135,18 @@
     clippy::missing_safety_doc
 )]
 pub(crate) mod archive;
+#[cfg(feature = "unstable-async")]
+pub mod async_io;
+pub mod bytes;
 pub(crate) mod chunk;
 pub(crate) mod cipher;
 pub(crate) mod compress;
 pub(crate) mod entry;
 pub(crate) mod error;
 mod ext;
+mod format;
 pub(crate) mod hash;
+pub mod io;
 pub mod prelude;
 pub(crate) mod random;
 pub(crate) mod util;
@@ -150,6 +155,7 @@ pub use archive::*;
 pub use chunk::*;
 pub use entry::*;
 pub use error::UnknownValueError;
+pub use format::PNA_SIGNATURE;
 pub use time::Duration;
 pub use util::bounded::LengthExceeded;
 


### PR DESCRIPTION
## Summary

Add `libpna::bytes::read_signature` for byte slices and `libpna::io::read_signature` for readers, so callers can validate an archive signature without constructing an `Archive`.

## Notes

`io` is promoted from `pub(crate)` to `pub`. Every other item in the module is `pub(crate)`, so `read_signature` is the only addition to the public API.

The reader variant consumes an unspecified number of bytes when it fails, so it cannot be used to probe for a signature and fall back to another format. This is stated in its documentation.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added synchronous, asynchronous, and byte-based PNA archive signature reading.
  * Added validation for standard PNA archive signatures.
  * Archive readers now clearly report truncated or invalid signatures.

* **Bug Fixes**
  * Improved handling of partial, empty, and mismatched archive headers.
  * Standardized signature errors for more consistent archive processing.

* **Refactor**
  * Reorganized archive-format and I/O handling while preserving archive behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->