### PR TITLE
:recycle: Read the archive signature through the shared primitives

### DIFF
--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -12,7 +12,7 @@ use crate::{
 use core::num::NonZeroU32;
 pub use header::*;
 use std::io::prelude::*;
-pub(crate) use {read::*, write::*};
+pub(crate) use write::*;
 
 /// Provides read and write access to a PNA file.
 ///

--- a/lib/src/archive/read.rs
+++ b/lib/src/archive/read.rs
@@ -3,43 +3,14 @@
 mod slice;
 
 use crate::{
-    PNA_SIGNATURE,
     archive::{Archive, ArchiveHeader},
     chunk::{Chunk, ChunkReader, ChunkType, RawChunk, read_chunk},
     entry::{Entry, NormalEntry, RawEntry, ReadEntry, ReadOptions},
 };
-#[cfg(feature = "unstable-async")]
-use futures_util::AsyncReadExt;
-pub(crate) use slice::read_header_from_slice;
 use std::{
     io::{self, Read, Seek, SeekFrom},
     mem::swap,
 };
-
-pub(crate) fn read_pna_header<R: Read>(mut reader: R) -> io::Result<()> {
-    let mut header = [0u8; PNA_SIGNATURE.len()];
-    reader.read_exact(&mut header)?;
-    if &header != PNA_SIGNATURE {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "not a PNA archive",
-        ));
-    }
-    Ok(())
-}
-
-#[cfg(feature = "unstable-async")]
-async fn read_pna_header_async<R: futures_io::AsyncRead + Unpin>(mut reader: R) -> io::Result<()> {
-    let mut header = [0u8; PNA_SIGNATURE.len()];
-    reader.read_exact(&mut header).await?;
-    if &header != PNA_SIGNATURE {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "not a PNA archive",
-        ));
-    }
-    Ok(())
-}
 
 impl<R: Read> Archive<R> {
     /// Reads the archive header from the provided reader and returns a new [`Archive`].
@@ -53,7 +24,7 @@ impl<R: Read> Archive<R> {
     }
 
     fn read_header_with_buffer(mut reader: R, buf: Vec<RawChunk>) -> io::Result<Self> {
-        read_pna_header(&mut reader)?;
+        crate::io::read_signature(&mut reader)?;
         let mut chunk_reader = ChunkReader::new(&mut reader, None);
         let chunk = chunk_reader.read_chunk()?;
         if chunk.ty != ChunkType::AHED {
@@ -210,7 +181,7 @@ impl<R: futures_io::AsyncRead + Unpin> Archive<R> {
     }
 
     async fn read_header_with_buffer_async(mut reader: R, buf: Vec<RawChunk>) -> io::Result<Self> {
-        read_pna_header_async(&mut reader).await?;
+        crate::async_io::read_signature(&mut reader).await?;
         let mut chunk_reader = ChunkReader::new(&mut reader, None);
         let chunk = chunk_reader.read_chunk_async().await?;
         if chunk.ty != ChunkType::AHED {
@@ -484,14 +455,14 @@ mod tests {
 
     #[test]
     fn read_header_rejects_non_ahed_first_chunk() {
-        let mut bytes = PNA_SIGNATURE.to_vec();
+        let mut bytes = crate::PNA_SIGNATURE.to_vec();
         bytes.extend_from_slice(&RawChunk::from_data(ChunkType::FEND, Vec::new()).to_bytes());
         let err = Archive::read_header(&bytes[..]).err().unwrap();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 
     fn archive_bytes(header: ArchiveHeader) -> Vec<u8> {
-        let mut bytes = PNA_SIGNATURE.to_vec();
+        let mut bytes = crate::PNA_SIGNATURE.to_vec();
         bytes.extend_from_slice(
             &RawChunk::from_data(ChunkType::AHED, header.to_bytes().to_vec()).to_bytes(),
         );

--- a/lib/src/archive/read/slice.rs
+++ b/lib/src/archive/read/slice.rs
@@ -1,24 +1,11 @@
 //! Slice-based archive reading for memory-mapped access.
 
 use crate::{
-    Archive, Chunk, ChunkType, Entry, NormalEntry, PNA_SIGNATURE, RawChunk, ReadEntry, ReadOptions,
+    Archive, Chunk, ChunkType, Entry, NormalEntry, RawChunk, ReadEntry, ReadOptions,
     archive::ArchiveHeader, chunk::read_chunk_from_slice, entry::RawEntry,
 };
 use std::borrow::Cow;
 use std::io;
-
-pub(crate) fn read_header_from_slice(bytes: &[u8]) -> io::Result<&[u8]> {
-    let (header, body) = bytes
-        .split_at_checked(PNA_SIGNATURE.len())
-        .ok_or(io::ErrorKind::UnexpectedEof)?;
-    if header != PNA_SIGNATURE {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "not a PNA archive",
-        ));
-    }
-    Ok(body)
-}
 
 impl<'d> Archive<&'d [u8]> {
     /// Reads the archive header from the provided bytes and returns a new [`Archive`].
@@ -33,7 +20,7 @@ impl<'d> Archive<&'d [u8]> {
 
     #[inline]
     fn read_header_from_slice_with_buffer(bytes: &'d [u8], buf: Vec<RawChunk>) -> io::Result<Self> {
-        let bytes = read_header_from_slice(bytes)?;
+        let bytes = crate::bytes::read_signature(bytes)?;
         let (chunk, r) = read_chunk_from_slice(bytes)?;
         if chunk.ty != ChunkType::AHED {
             return Err(io::Error::new(
@@ -249,12 +236,6 @@ mod tests {
     use super::*;
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
-
-    #[test]
-    fn read_header() {
-        let result = read_header_from_slice(PNA_SIGNATURE).unwrap();
-        assert!(result.is_empty());
-    }
 
     #[test]
     fn decode() {

--- a/lib/src/chunk.rs
+++ b/lib/src/chunk.rs
@@ -383,7 +383,7 @@ pub fn read_as_chunks<R: Read>(
             }))
         }
     }
-    crate::archive::read_pna_header(&mut archive)?;
+    crate::io::read_signature(&mut archive)?;
 
     Ok(Chunks {
         reader: ChunkReader::new(archive, None),
@@ -440,7 +440,7 @@ pub fn read_chunks_from_slice<'a>(
             }))
         }
     }
-    let archive = crate::archive::read_header_from_slice(archive)?;
+    let archive = crate::bytes::read_signature(archive)?;
 
     Ok(Chunks {
         reader: archive,


### PR DESCRIPTION
## Summary

Route the streaming, slice, and async signature reads through the primitives added in the previous PR, leaving one place that compares the signature and builds the error.

## Notes

No behavior change: the error kinds and the `not a PNA archive` message are unchanged on all three paths.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
