### PR TITLE
Stream opaque entries with write attributes

### DIFF
--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -95,11 +95,13 @@ impl<T> Archive<T> {
     /// When set, this limit affects both reading and writing:
     /// - **Reading**: Chunks larger than this size will be rejected with an error,
     ///   protecting against maliciously crafted archives with extremely large chunks.
-    /// - **Writing**: Data written via [`write_file()`](Archive::write_file) will be
-    ///   split into chunks no larger than this size.
+    /// - **Writing**: Data written via [`write_file()`](Archive::write_file) or
+    ///   [`write_opaque()`](Archive::write_opaque) will be split into chunks no
+    ///   larger than this size.
     ///
     /// **Note**: This setting only affects the streaming write path
-    /// ([`write_file()`](Archive::write_file)). Pre-built entries added via
+    /// ([`write_file()`](Archive::write_file) and
+    /// [`write_opaque()`](Archive::write_opaque)). Pre-built entries added via
     /// [`add_entry()`](Archive::add_entry) use their own chunk size configured
     /// through [`FileEntryBuilder::max_chunk_size()`](crate::FileEntryBuilder::max_chunk_size).
     ///

--- a/lib/src/archive/write.rs
+++ b/lib/src/archive/write.rs
@@ -6,8 +6,9 @@ use crate::{
     cipher::CipherWriter,
     compress::CompressionWriter,
     entry::{
-        Entry, EntryHeader, EntryName, EntryPart, Metadata, NormalEntry, SealedEntryExt,
-        SolidHeader, WriteCipher, WriteOption, WriteOptions, get_writer, get_writer_context,
+        DataKind, Entry, EntryHeader, EntryName, EntryPart, EntryWriteAttributes, NormalEntry,
+        SealedEntryExt, SolidHeader, WriteCipher, WriteOption, WriteOptions, get_writer,
+        get_writer_context, write_metadata_facets,
     },
     io::TryIntoInner,
 };
@@ -24,7 +25,7 @@ pub(crate) type InternalDataWriter<W> = CompressionWriter<CipherWriter<W>>;
 /// Internal Writer type alias.
 pub(crate) type InternalArchiveDataWriter<W> = InternalDataWriter<ChunkStreamWriter<W>>;
 
-/// Writer that compresses and encrypts according to the given options.
+/// Writer for an entry payload, compressed and encrypted according to the given options.
 pub struct EntryDataWriter<W: Write>(InternalArchiveDataWriter<W>);
 
 impl<W: Write> Write for EntryDataWriter<W> {
@@ -39,11 +40,12 @@ impl<W: Write> Write for EntryDataWriter<W> {
     }
 }
 
-/// A writer for individual file entries within a solid archive.
+/// A writer for individual entry payloads within a solid archive.
 ///
-/// This type is passed by mutable reference to the closure in [`SolidArchive::write_file`] and implements
-/// [`Write`](std::io::Write), allowing callers to stream file data into the solid
-/// archive's shared compression and encryption pipeline.
+/// This type is passed by mutable reference to the closure in
+/// [`SolidArchive::write_file`] or [`SolidArchive::write_opaque`] and implements
+/// [`Write`](std::io::Write), allowing callers to stream entry data into the
+/// solid archive's shared compression and encryption pipeline.
 pub struct SolidArchiveEntryDataWriter<'w, W: Write>(
     InternalArchiveDataWriter<&'w mut InternalArchiveDataWriter<W>>,
 );
@@ -99,6 +101,8 @@ impl<W: Write> Archive<W> {
     /// # Errors
     ///
     /// Returns an error if an I/O error occurs while writing the entry, or if the closure returns an error.
+    /// If this method returns an error, the archive may contain a partial entry
+    /// and must be discarded without further use.
     ///
     /// # Examples
     /// ```no_run
@@ -124,17 +128,58 @@ impl<W: Write> Archive<W> {
     pub fn write_file<F>(
         &mut self,
         name: EntryName,
-        metadata: Metadata,
+        attributes: impl Into<EntryWriteAttributes>,
         option: impl WriteOption,
-        mut f: F,
+        f: F,
     ) -> io::Result<()>
     where
-        F: FnMut(&mut EntryDataWriter<&mut W>) -> io::Result<()>,
+        F: FnOnce(&mut EntryDataWriter<&mut W>) -> io::Result<()>,
     {
-        write_file_entry(
+        write_stream_entry(
             &mut self.inner,
             name,
-            metadata,
+            DataKind::FILE,
+            attributes.into(),
+            option,
+            self.max_chunk_size,
+            |w| {
+                let mut w = EntryDataWriter(w);
+                f(&mut w)?;
+                Ok(w.0)
+            },
+        )
+    }
+
+    /// Writes an opaque entry payload with the declared data kind.
+    ///
+    /// No validation is performed between `kind` and the payload written by
+    /// the closure. Prefer the kind-specific builder or [`Self::write_file`]
+    /// for data kinds defined by the PNA specification; this method is a
+    /// low-level escape hatch for private, reserved, or experimental kinds.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an I/O error occurs while writing the entry, or if
+    /// the closure returns an error. If this method returns an error, the
+    /// archive may contain a partial entry and must be discarded without
+    /// further use.
+    #[inline]
+    pub fn write_opaque<F>(
+        &mut self,
+        name: EntryName,
+        kind: DataKind,
+        attributes: impl Into<EntryWriteAttributes>,
+        option: impl WriteOption,
+        f: F,
+    ) -> io::Result<()>
+    where
+        F: FnOnce(&mut EntryDataWriter<&mut W>) -> io::Result<()>,
+    {
+        write_stream_entry(
+            &mut self.inner,
+            name,
+            kind,
+            attributes.into(),
             option,
             self.max_chunk_size,
             |w| {
@@ -435,6 +480,8 @@ impl<W: Write> SolidArchive<W> {
     /// # Errors
     ///
     /// Returns an error if an I/O error occurs while writing the entry, or if the closure returns an error.
+    /// If this method returns an error, the solid archive may contain a partial
+    /// entry and must be discarded without further use.
     ///
     /// # Examples
     /// ```no_run
@@ -455,15 +502,21 @@ impl<W: Write> SolidArchive<W> {
     /// # }
     /// ```
     #[inline]
-    pub fn write_file<F>(&mut self, name: EntryName, metadata: Metadata, mut f: F) -> io::Result<()>
+    pub fn write_file<F>(
+        &mut self,
+        name: EntryName,
+        attributes: impl Into<EntryWriteAttributes>,
+        f: F,
+    ) -> io::Result<()>
     where
-        F: FnMut(&mut SolidArchiveEntryDataWriter<W>) -> io::Result<()>,
+        F: FnOnce(&mut SolidArchiveEntryDataWriter<W>) -> io::Result<()>,
     {
         let option = WriteOptions::store();
-        write_file_entry(
+        write_stream_entry(
             &mut self.inner,
             name,
-            metadata,
+            DataKind::FILE,
+            attributes.into(),
             option,
             self.max_chunk_size,
             |w| {
@@ -474,8 +527,48 @@ impl<W: Write> SolidArchive<W> {
         )
     }
 
-    /// Sets the maximum chunk size for file data (FDAT) written via
-    /// [`write_file()`](SolidArchive::write_file).
+    /// Writes an opaque entry payload into the solid archive.
+    ///
+    /// The inner entry always uses STORE; compression and encryption are
+    /// provided only by the outer solid stream. No validation is performed
+    /// between `kind` and the payload. Prefer kind-specific APIs for data kinds
+    /// defined by the PNA specification.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an I/O error occurs while writing the entry, or if
+    /// the closure returns an error. If this method returns an error, the solid
+    /// archive may contain a partial entry and must be discarded without
+    /// further use.
+    #[inline]
+    pub fn write_opaque<F>(
+        &mut self,
+        name: EntryName,
+        kind: DataKind,
+        attributes: impl Into<EntryWriteAttributes>,
+        f: F,
+    ) -> io::Result<()>
+    where
+        F: FnOnce(&mut SolidArchiveEntryDataWriter<W>) -> io::Result<()>,
+    {
+        write_stream_entry(
+            &mut self.inner,
+            name,
+            kind,
+            attributes.into(),
+            WriteOptions::store(),
+            self.max_chunk_size,
+            |w| {
+                let mut w = SolidArchiveEntryDataWriter(w);
+                f(&mut w)?;
+                Ok(w.0)
+            },
+        )
+    }
+
+    /// Sets the maximum chunk size for entry data (FDAT) written via
+    /// [`write_file()`](SolidArchive::write_file) or
+    /// [`write_opaque()`](SolidArchive::write_opaque).
     ///
     /// This controls the inner FDAT chunk splitting for individual entries within
     /// the solid stream. The outer SDAT chunk size is fixed when `SolidArchive` is
@@ -530,72 +623,37 @@ impl<W: Write> SolidArchive<W> {
     }
 }
 
-#[allow(deprecated)]
-pub(crate) fn write_file_entry<W, F>(
+pub(crate) fn write_stream_entry<W, F>(
     inner: &mut W,
     name: EntryName,
-    metadata: Metadata,
+    kind: DataKind,
+    attributes: EntryWriteAttributes,
     option: impl WriteOption,
     max_chunk_size: Option<NonZeroU32>,
-    mut f: F,
+    f: F,
 ) -> io::Result<()>
 where
     W: Write,
-    F: FnMut(InternalArchiveDataWriter<&mut W>) -> io::Result<InternalArchiveDataWriter<&mut W>>,
+    F: FnOnce(InternalArchiveDataWriter<&mut W>) -> io::Result<InternalArchiveDataWriter<&mut W>>,
 {
-    let header = EntryHeader::for_file(
+    let EntryWriteAttributes {
+        metadata,
+        extra_chunks,
+    } = attributes;
+    let header = EntryHeader::new_with_options(
+        kind,
         option.compression(),
         option.encryption(),
         option.cipher_mode(),
         name,
     );
-    (ChunkType::FHED, header.to_bytes()).write_chunk_in(inner)?;
-    if let Some(c) = metadata.created {
-        (ChunkType::cTIM, c.whole_seconds().to_be_bytes()).write_chunk_in(inner)?;
-        if c.subsec_nanoseconds() != 0 {
-            (ChunkType::cTNS, c.subsec_nanoseconds().to_be_bytes()).write_chunk_in(inner)?;
-        }
+    let header_bytes = header.to_bytes();
+    (ChunkType::FHED, &header_bytes).write_chunk_in(inner)?;
+    for chunk in extra_chunks {
+        chunk.write_chunk_in(inner)?;
     }
-    if let Some(m) = metadata.modified {
-        (ChunkType::mTIM, m.whole_seconds().to_be_bytes()).write_chunk_in(inner)?;
-        if m.subsec_nanoseconds() != 0 {
-            (ChunkType::mTNS, m.subsec_nanoseconds().to_be_bytes()).write_chunk_in(inner)?;
-        }
-    }
-    if let Some(a) = metadata.accessed {
-        (ChunkType::aTIM, a.whole_seconds().to_be_bytes()).write_chunk_in(inner)?;
-        if a.subsec_nanoseconds() != 0 {
-            (ChunkType::aTNS, a.subsec_nanoseconds().to_be_bytes()).write_chunk_in(inner)?;
-        }
-    }
-    if let Some(p) = metadata.permission {
-        (ChunkType::fPRM, p.to_bytes()).write_chunk_in(inner)?;
-    }
-    if let Some(v) = metadata.owner_uid {
-        (ChunkType::fUId, v.to_bytes()).write_chunk_in(inner)?;
-    }
-    if let Some(v) = metadata.owner_gid {
-        (ChunkType::fGId, v.to_bytes()).write_chunk_in(inner)?;
-    }
-    if let Some(v) = metadata.owner_user_name {
-        (ChunkType::fONm, v.to_bytes()).write_chunk_in(inner)?;
-    }
-    if let Some(v) = metadata.owner_group_name {
-        (ChunkType::fGNm, v.to_bytes()).write_chunk_in(inner)?;
-    }
-    if let Some(v) = metadata.owner_user_sid {
-        (ChunkType::fOSi, v.to_bytes()).write_chunk_in(inner)?;
-    }
-    if let Some(v) = metadata.owner_group_sid {
-        (ChunkType::fGSi, v.to_bytes()).write_chunk_in(inner)?;
-    }
-    if let Some(v) = metadata.permission_mode {
-        (ChunkType::fMOd, v.to_bytes()).write_chunk_in(inner)?;
-    }
-    for xattr in metadata.xattrs {
-        (ChunkType::xATR, xattr.to_bytes()).write_chunk_in(inner)?;
-    }
-    let context = get_writer_context(option, ChunkType::FHED, &header.to_bytes())?;
+    write_metadata_facets(inner, &metadata)?;
+    let context = get_writer_context(option, ChunkType::FHED, &header_bytes)?;
     if let Some(WriteCipher { context: c, .. }) = &context.cipher {
         (ChunkType::PHSF, c.phsf.as_bytes()).write_chunk_in(inner)?;
     }
@@ -616,7 +674,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{CipherMode, Encryption, HashAlgorithm, ReadOptions};
+    use crate::{
+        CipherMode, Compression, Encryption, HashAlgorithm, LinkTargetType, Metadata, ReadOptions,
+    };
     use std::io::Read;
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
@@ -656,6 +716,161 @@ mod tests {
             .read_to_end(&mut data)
             .expect("failed to read data");
         assert_eq!(&data[..], b"text");
+    }
+
+    #[test]
+    fn archive_write_file_accepts_attributes_without_generating_file_size() {
+        let extra_type = ChunkType::private(*b"exTr").unwrap();
+        let extra = RawChunk::from_data(extra_type, b"extra".to_vec());
+        let mut attributes = EntryWriteAttributes::new(
+            Metadata::new().with_link_target_type(Some(LinkTargetType::Directory)),
+        );
+        attributes.add_extra_chunk(extra);
+        let payload = b"streamed".to_vec();
+
+        let mut writer = Archive::write_header(Vec::new()).unwrap();
+        writer
+            .write_file(
+                EntryName::from_lossy("text.txt"),
+                attributes,
+                WriteOptions::store(),
+                move |writer| {
+                    let payload = payload;
+                    writer.write_all(&payload)
+                },
+            )
+            .unwrap();
+        let archive = writer.finalize().unwrap();
+
+        assert_eq!(count_chunks(&archive, ChunkType::fSIZ), 0);
+        let chunk_types = crate::chunk::read_chunks_from_slice(&archive)
+            .unwrap()
+            .map(|chunk| chunk.unwrap().ty())
+            .collect::<Vec<_>>();
+        let header_index = chunk_types
+            .iter()
+            .position(|&ty| ty == ChunkType::FHED)
+            .unwrap();
+        assert_eq!(chunk_types[header_index + 1], extra_type);
+        assert_eq!(chunk_types[header_index + 2], ChunkType::fLTP);
+        let mut reader = Archive::read_header(archive.as_slice()).unwrap();
+        let entry = reader.entries().skip_solid().next().unwrap().unwrap();
+        assert_eq!(entry.metadata().raw_file_size(), None);
+        assert_eq!(
+            entry.metadata().link_target_type(),
+            Some(LinkTargetType::Directory)
+        );
+        assert_eq!(entry.extra_chunks().len(), 1);
+        assert_eq!(entry.extra_chunks()[0].ty(), extra_type);
+        assert_eq!(entry.extra_chunks()[0].data(), b"extra");
+        let mut data = Vec::new();
+        entry
+            .reader(ReadOptions::builder().build())
+            .unwrap()
+            .read_to_end(&mut data)
+            .unwrap();
+        assert_eq!(data, b"streamed");
+    }
+
+    #[test]
+    fn archive_write_opaque_round_trips_private_kind() {
+        let kind = DataKind::new_private(200).unwrap();
+        let extra_type = ChunkType::private(*b"opAq").unwrap();
+        let mut attributes = EntryWriteAttributes::new(
+            Metadata::new().with_modified(Some(crate::Duration::seconds(42))),
+        );
+        attributes.add_extra_chunk(RawChunk::from_data(extra_type, b"metadata".to_vec()));
+        let mut writer = Archive::write_header(Vec::new()).unwrap();
+        writer
+            .write_opaque(
+                EntryName::from_lossy("private"),
+                kind,
+                attributes,
+                WriteOptions::store(),
+                |writer| writer.write_all(b"opaque"),
+            )
+            .unwrap();
+        let archive = writer.finalize().unwrap();
+
+        let mut reader = Archive::read_header(archive.as_slice()).unwrap();
+        let entry = reader.entries().skip_solid().next().unwrap().unwrap();
+        assert_eq!(entry.header().data_kind(), kind);
+        assert_eq!(
+            entry.metadata().modified(),
+            Some(crate::Duration::seconds(42))
+        );
+        assert_eq!(entry.extra_chunks()[0].ty(), extra_type);
+        let mut data = Vec::new();
+        entry
+            .reader(ReadOptions::builder().build())
+            .unwrap()
+            .read_to_end(&mut data)
+            .unwrap();
+        assert_eq!(data, b"opaque");
+    }
+
+    #[test]
+    fn archive_write_opaque_accepts_standard_kind() {
+        let mut writer = Archive::write_header(Vec::new()).unwrap();
+        writer
+            .write_opaque(
+                EntryName::from_lossy("declared-directory"),
+                DataKind::DIRECTORY,
+                Metadata::new(),
+                WriteOptions::store(),
+                |writer| writer.write_all(b"unchecked payload"),
+            )
+            .unwrap();
+        let archive = writer.finalize().unwrap();
+
+        let mut reader = Archive::read_header(archive.as_slice()).unwrap();
+        let entry = reader.entries().skip_solid().next().unwrap().unwrap();
+        assert_eq!(entry.header().data_kind(), DataKind::DIRECTORY);
+        let mut data = Vec::new();
+        entry
+            .reader(ReadOptions::builder().build())
+            .unwrap()
+            .read_to_end(&mut data)
+            .unwrap();
+        assert_eq!(data, b"unchecked payload");
+    }
+
+    #[test]
+    fn solid_archive_write_opaque_uses_store_for_inner_entry() {
+        let kind = DataKind::new_private(201).unwrap();
+        let mut writer = Archive::write_solid_header(
+            Vec::new(),
+            WriteOptions::builder()
+                .compression(Compression::ZSTANDARD)
+                .build(),
+        )
+        .unwrap();
+        writer
+            .write_opaque(
+                EntryName::from_lossy("private"),
+                kind,
+                Metadata::new(),
+                |writer| writer.write_all(b"solid opaque"),
+            )
+            .unwrap();
+        let archive = writer.finalize().unwrap();
+
+        let mut reader = Archive::read_header(archive.as_slice()).unwrap();
+        let entry = reader
+            .entries()
+            .extract_solid_entries(&ReadOptions::builder().build())
+            .next()
+            .unwrap()
+            .unwrap();
+        assert_eq!(entry.header().data_kind(), kind);
+        assert_eq!(entry.header().compression(), Compression::NO);
+        let mut data = Vec::new();
+        entry
+            .reader(ReadOptions::builder().build())
+            .unwrap()
+            .read_to_end(&mut data)
+            .unwrap();
+        assert_eq!(data, b"solid opaque");
     }
 
     fn owner_facet_metadata() -> Metadata {

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -37,6 +37,7 @@ use crate::{
 use std::{
     borrow::Cow,
     collections::VecDeque,
+    convert::Infallible,
     io::{self, Read, Write},
 };
 
@@ -68,85 +69,97 @@ fn chunks_write_in<W: Write>(
 }
 
 #[allow(deprecated)]
-pub(crate) fn metadata_facet_chunks(metadata: &Metadata) -> Vec<RawChunk> {
-    let mut chunks = Vec::new();
+fn try_for_each_metadata_facet<E>(
+    metadata: &Metadata,
+    mut f: impl FnMut(RawChunk) -> Result<(), E>,
+) -> Result<(), E> {
     if let Some(value) = metadata.created {
-        chunks.push(RawChunk::from_data(
+        f(RawChunk::from_data(
             ChunkType::cTIM,
             value.whole_seconds().to_be_bytes(),
-        ));
+        ))?;
         if value.subsec_nanoseconds() != 0 {
-            chunks.push(RawChunk::from_data(
+            f(RawChunk::from_data(
                 ChunkType::cTNS,
                 value.subsec_nanoseconds().to_be_bytes(),
-            ));
+            ))?;
         }
     }
     if let Some(value) = metadata.modified {
-        chunks.push(RawChunk::from_data(
+        f(RawChunk::from_data(
             ChunkType::mTIM,
             value.whole_seconds().to_be_bytes(),
-        ));
+        ))?;
         if value.subsec_nanoseconds() != 0 {
-            chunks.push(RawChunk::from_data(
+            f(RawChunk::from_data(
                 ChunkType::mTNS,
                 value.subsec_nanoseconds().to_be_bytes(),
-            ));
+            ))?;
         }
     }
     if let Some(value) = metadata.accessed {
-        chunks.push(RawChunk::from_data(
+        f(RawChunk::from_data(
             ChunkType::aTIM,
             value.whole_seconds().to_be_bytes(),
-        ));
+        ))?;
         if value.subsec_nanoseconds() != 0 {
-            chunks.push(RawChunk::from_data(
+            f(RawChunk::from_data(
                 ChunkType::aTNS,
                 value.subsec_nanoseconds().to_be_bytes(),
-            ));
+            ))?;
         }
     }
     if let Some(value) = &metadata.permission {
-        chunks.push(RawChunk::from_data(ChunkType::fPRM, value.to_bytes()));
+        f(RawChunk::from_data(ChunkType::fPRM, value.to_bytes()))?;
     }
     if let Some(value) = metadata.owner_uid {
-        chunks.push(RawChunk::from_data(ChunkType::fUId, value.to_bytes()));
+        f(RawChunk::from_data(ChunkType::fUId, value.to_bytes()))?;
     }
     if let Some(value) = metadata.owner_gid {
-        chunks.push(RawChunk::from_data(ChunkType::fGId, value.to_bytes()));
+        f(RawChunk::from_data(ChunkType::fGId, value.to_bytes()))?;
     }
     if let Some(value) = &metadata.owner_user_name {
-        chunks.push(RawChunk::from_data(ChunkType::fONm, value.to_bytes()));
+        f(RawChunk::from_data(ChunkType::fONm, value.to_bytes()))?;
     }
     if let Some(value) = &metadata.owner_group_name {
-        chunks.push(RawChunk::from_data(ChunkType::fGNm, value.to_bytes()));
+        f(RawChunk::from_data(ChunkType::fGNm, value.to_bytes()))?;
     }
     if let Some(value) = &metadata.owner_user_sid {
-        chunks.push(RawChunk::from_data(ChunkType::fOSi, value.to_bytes()));
+        f(RawChunk::from_data(ChunkType::fOSi, value.to_bytes()))?;
     }
     if let Some(value) = &metadata.owner_group_sid {
-        chunks.push(RawChunk::from_data(ChunkType::fGSi, value.to_bytes()));
+        f(RawChunk::from_data(ChunkType::fGSi, value.to_bytes()))?;
     }
     if let Some(value) = metadata.permission_mode {
-        chunks.push(RawChunk::from_data(ChunkType::fMOd, value.to_bytes()));
+        f(RawChunk::from_data(ChunkType::fMOd, value.to_bytes()))?;
     }
     if let Some(value) = metadata.link_target_type {
-        chunks.push(RawChunk::from_data(ChunkType::fLTP, value.to_bytes()));
+        f(RawChunk::from_data(ChunkType::fLTP, value.to_bytes()))?;
     }
-    chunks.extend(
-        metadata
-            .xattrs
-            .iter()
-            .map(|value| RawChunk::from_data(ChunkType::xATR, value.to_bytes())),
-    );
-    chunks
+    for value in &metadata.xattrs {
+        f(RawChunk::from_data(ChunkType::xATR, value.to_bytes()))?;
+    }
+    Ok(())
+}
+
+fn append_metadata_facets(chunks: &mut Vec<RawChunk>, metadata: &Metadata) {
+    try_for_each_metadata_facet(metadata, |chunk| {
+        chunks.push(chunk);
+        Ok::<(), Infallible>(())
+    })
+    .expect("metadata facet collection is infallible");
 }
 
 pub(crate) fn write_metadata_facets<W: Write>(
     writer: &mut W,
     metadata: &Metadata,
 ) -> io::Result<usize> {
-    chunks_write_in(metadata_facet_chunks(metadata).iter(), writer)
+    let mut total = 0;
+    try_for_each_metadata_facet(metadata, |chunk| {
+        total += chunk.write_chunk_in(writer)?;
+        Ok::<(), io::Error>(())
+    })?;
+    Ok(total)
 }
 
 impl<T> SealedEntryExt for RawEntry<T>
@@ -927,7 +940,6 @@ where
 {
     #[allow(deprecated)]
     fn into_chunks(self) -> Vec<RawChunk> {
-        let metadata_chunks = metadata_facet_chunks(&self.metadata);
         let raw_file_size = self.metadata.raw_file_size;
         let mut vec = Vec::new();
         vec.push(RawChunk::from_data(ChunkType::FHED, self.header.to_bytes()));
@@ -938,7 +950,7 @@ where
                 skip_while(&raw_file_size.to_be_bytes(), |i| *i == 0),
             ));
         }
-        vec.extend(metadata_chunks);
+        append_metadata_facets(&mut vec, &self.metadata);
         if let Some(p) = self.phsf {
             vec.push(RawChunk::from_data(ChunkType::PHSF, p.into_bytes()));
         }

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -67,6 +67,88 @@ fn chunks_write_in<W: Write>(
     Ok(total)
 }
 
+#[allow(deprecated)]
+pub(crate) fn metadata_facet_chunks(metadata: &Metadata) -> Vec<RawChunk> {
+    let mut chunks = Vec::new();
+    if let Some(value) = metadata.created {
+        chunks.push(RawChunk::from_data(
+            ChunkType::cTIM,
+            value.whole_seconds().to_be_bytes(),
+        ));
+        if value.subsec_nanoseconds() != 0 {
+            chunks.push(RawChunk::from_data(
+                ChunkType::cTNS,
+                value.subsec_nanoseconds().to_be_bytes(),
+            ));
+        }
+    }
+    if let Some(value) = metadata.modified {
+        chunks.push(RawChunk::from_data(
+            ChunkType::mTIM,
+            value.whole_seconds().to_be_bytes(),
+        ));
+        if value.subsec_nanoseconds() != 0 {
+            chunks.push(RawChunk::from_data(
+                ChunkType::mTNS,
+                value.subsec_nanoseconds().to_be_bytes(),
+            ));
+        }
+    }
+    if let Some(value) = metadata.accessed {
+        chunks.push(RawChunk::from_data(
+            ChunkType::aTIM,
+            value.whole_seconds().to_be_bytes(),
+        ));
+        if value.subsec_nanoseconds() != 0 {
+            chunks.push(RawChunk::from_data(
+                ChunkType::aTNS,
+                value.subsec_nanoseconds().to_be_bytes(),
+            ));
+        }
+    }
+    if let Some(value) = &metadata.permission {
+        chunks.push(RawChunk::from_data(ChunkType::fPRM, value.to_bytes()));
+    }
+    if let Some(value) = metadata.owner_uid {
+        chunks.push(RawChunk::from_data(ChunkType::fUId, value.to_bytes()));
+    }
+    if let Some(value) = metadata.owner_gid {
+        chunks.push(RawChunk::from_data(ChunkType::fGId, value.to_bytes()));
+    }
+    if let Some(value) = &metadata.owner_user_name {
+        chunks.push(RawChunk::from_data(ChunkType::fONm, value.to_bytes()));
+    }
+    if let Some(value) = &metadata.owner_group_name {
+        chunks.push(RawChunk::from_data(ChunkType::fGNm, value.to_bytes()));
+    }
+    if let Some(value) = &metadata.owner_user_sid {
+        chunks.push(RawChunk::from_data(ChunkType::fOSi, value.to_bytes()));
+    }
+    if let Some(value) = &metadata.owner_group_sid {
+        chunks.push(RawChunk::from_data(ChunkType::fGSi, value.to_bytes()));
+    }
+    if let Some(value) = metadata.permission_mode {
+        chunks.push(RawChunk::from_data(ChunkType::fMOd, value.to_bytes()));
+    }
+    if let Some(value) = metadata.link_target_type {
+        chunks.push(RawChunk::from_data(ChunkType::fLTP, value.to_bytes()));
+    }
+    chunks.extend(
+        metadata
+            .xattrs
+            .iter()
+            .map(|value| RawChunk::from_data(ChunkType::xATR, value.to_bytes())),
+    );
+    chunks
+}
+
+pub(crate) fn write_metadata_facets<W: Write>(
+    writer: &mut W,
+    metadata: &Metadata,
+) -> io::Result<usize> {
+    chunks_write_in(metadata_facet_chunks(metadata).iter(), writer)
+}
+
 impl<T> SealedEntryExt for RawEntry<T>
 where
     RawChunk<T>: Chunk + Into<RawChunk>,
@@ -815,87 +897,18 @@ where
     fn chunks_write_in<W: Write>(&self, writer: &mut W) -> io::Result<usize> {
         let mut total = 0;
 
-        let Metadata {
-            raw_file_size,
-            compressed_size: _,
-            created,
-            modified,
-            accessed,
-            permission,
-            link_target_type,
-            owner_uid,
-            owner_gid,
-            owner_user_name,
-            owner_group_name,
-            owner_user_sid,
-            owner_group_sid,
-            permission_mode,
-            xattrs,
-        } = &self.metadata;
-
         total += (ChunkType::FHED, self.header.to_bytes()).write_chunk_in(writer)?;
         for ex in &self.extra {
             total += ex.write_chunk_in(writer)?;
         }
-        if let Some(raw_file_size) = raw_file_size {
+        if let Some(raw_file_size) = self.metadata.raw_file_size {
             total += (
                 ChunkType::fSIZ,
                 skip_while(&raw_file_size.to_be_bytes(), |i| *i == 0),
             )
                 .write_chunk_in(writer)?;
         }
-
-        if let Some(c) = created {
-            total += (ChunkType::cTIM, c.whole_seconds().to_be_bytes()).write_chunk_in(writer)?;
-            if c.subsec_nanoseconds() != 0 {
-                total += (ChunkType::cTNS, c.subsec_nanoseconds().to_be_bytes())
-                    .write_chunk_in(writer)?;
-            }
-        }
-        if let Some(d) = modified {
-            total += (ChunkType::mTIM, d.whole_seconds().to_be_bytes()).write_chunk_in(writer)?;
-            if d.subsec_nanoseconds() != 0 {
-                total += (ChunkType::mTNS, d.subsec_nanoseconds().to_be_bytes())
-                    .write_chunk_in(writer)?;
-            }
-        }
-        if let Some(a) = accessed {
-            total += (ChunkType::aTIM, a.whole_seconds().to_be_bytes()).write_chunk_in(writer)?;
-            if a.subsec_nanoseconds() != 0 {
-                total += (ChunkType::aTNS, a.subsec_nanoseconds().to_be_bytes())
-                    .write_chunk_in(writer)?;
-            }
-        }
-        if let Some(p) = permission {
-            total += (ChunkType::fPRM, p.to_bytes()).write_chunk_in(writer)?;
-        }
-        if let Some(v) = owner_uid {
-            total += (ChunkType::fUId, v.to_bytes()).write_chunk_in(writer)?;
-        }
-        if let Some(v) = owner_gid {
-            total += (ChunkType::fGId, v.to_bytes()).write_chunk_in(writer)?;
-        }
-        if let Some(v) = owner_user_name {
-            total += (ChunkType::fONm, v.to_bytes()).write_chunk_in(writer)?;
-        }
-        if let Some(v) = owner_group_name {
-            total += (ChunkType::fGNm, v.to_bytes()).write_chunk_in(writer)?;
-        }
-        if let Some(v) = owner_user_sid {
-            total += (ChunkType::fOSi, v.to_bytes()).write_chunk_in(writer)?;
-        }
-        if let Some(v) = owner_group_sid {
-            total += (ChunkType::fGSi, v.to_bytes()).write_chunk_in(writer)?;
-        }
-        if let Some(v) = permission_mode {
-            total += (ChunkType::fMOd, v.to_bytes()).write_chunk_in(writer)?;
-        }
-        if let Some(ltp) = link_target_type {
-            total += (ChunkType::fLTP, ltp.to_bytes()).write_chunk_in(writer)?;
-        }
-        for xattr in xattrs {
-            total += (ChunkType::xATR, xattr.to_bytes()).write_chunk_in(writer)?;
-        }
+        total += write_metadata_facets(writer, &self.metadata)?;
         if let Some(p) = &self.phsf {
             total += (ChunkType::PHSF, p.as_bytes()).write_chunk_in(writer)?;
         }
@@ -914,23 +927,8 @@ where
 {
     #[allow(deprecated)]
     fn into_chunks(self) -> Vec<RawChunk> {
-        let Metadata {
-            raw_file_size,
-            compressed_size: _,
-            created,
-            modified,
-            accessed,
-            permission,
-            link_target_type,
-            owner_uid,
-            owner_gid,
-            owner_user_name,
-            owner_group_name,
-            owner_user_sid,
-            owner_group_sid,
-            permission_mode,
-            xattrs,
-        } = self.metadata;
+        let metadata_chunks = metadata_facet_chunks(&self.metadata);
+        let raw_file_size = self.metadata.raw_file_size;
         let mut vec = Vec::new();
         vec.push(RawChunk::from_data(ChunkType::FHED, self.header.to_bytes()));
         vec.extend(self.extra.into_iter().map(Into::into));
@@ -940,73 +938,7 @@ where
                 skip_while(&raw_file_size.to_be_bytes(), |i| *i == 0),
             ));
         }
-
-        if let Some(c) = created {
-            vec.push(RawChunk::from_data(
-                ChunkType::cTIM,
-                c.whole_seconds().to_be_bytes(),
-            ));
-            if c.subsec_nanoseconds() != 0 {
-                vec.push(RawChunk::from_data(
-                    ChunkType::cTNS,
-                    c.subsec_nanoseconds().to_be_bytes(),
-                ));
-            }
-        }
-        if let Some(d) = modified {
-            vec.push(RawChunk::from_data(
-                ChunkType::mTIM,
-                d.whole_seconds().to_be_bytes(),
-            ));
-            if d.subsec_nanoseconds() != 0 {
-                vec.push(RawChunk::from_data(
-                    ChunkType::mTNS,
-                    d.subsec_nanoseconds().to_be_bytes(),
-                ));
-            }
-        }
-        if let Some(a) = accessed {
-            vec.push(RawChunk::from_data(
-                ChunkType::aTIM,
-                a.whole_seconds().to_be_bytes(),
-            ));
-            if a.subsec_nanoseconds() != 0 {
-                vec.push(RawChunk::from_data(
-                    ChunkType::aTNS,
-                    a.subsec_nanoseconds().to_be_bytes(),
-                ));
-            }
-        }
-        if let Some(p) = permission {
-            vec.push(RawChunk::from_data(ChunkType::fPRM, p.to_bytes()));
-        }
-        if let Some(v) = owner_uid {
-            vec.push(RawChunk::from_data(ChunkType::fUId, v.to_bytes()));
-        }
-        if let Some(v) = owner_gid {
-            vec.push(RawChunk::from_data(ChunkType::fGId, v.to_bytes()));
-        }
-        if let Some(v) = owner_user_name {
-            vec.push(RawChunk::from_data(ChunkType::fONm, v.to_bytes()));
-        }
-        if let Some(v) = owner_group_name {
-            vec.push(RawChunk::from_data(ChunkType::fGNm, v.to_bytes()));
-        }
-        if let Some(v) = owner_user_sid {
-            vec.push(RawChunk::from_data(ChunkType::fOSi, v.to_bytes()));
-        }
-        if let Some(v) = owner_group_sid {
-            vec.push(RawChunk::from_data(ChunkType::fGSi, v.to_bytes()));
-        }
-        if let Some(v) = permission_mode {
-            vec.push(RawChunk::from_data(ChunkType::fMOd, v.to_bytes()));
-        }
-        if let Some(ltp) = link_target_type {
-            vec.push(RawChunk::from_data(ChunkType::fLTP, ltp.to_bytes()));
-        }
-        for xattr in xattrs {
-            vec.push(RawChunk::from_data(ChunkType::xATR, xattr.to_bytes()));
-        }
+        vec.extend(metadata_chunks);
         if let Some(p) = self.phsf {
             vec.push(RawChunk::from_data(ChunkType::PHSF, p.into_bytes()));
         }

--- a/lib/src/entry/builder/solid.rs
+++ b/lib/src/entry/builder/solid.rs
@@ -1,12 +1,13 @@
 use super::prepend_data_prefix;
 use crate::{
-    archive::{InternalArchiveDataWriter, InternalDataWriter, write_file_entry},
+    archive::{InternalArchiveDataWriter, InternalDataWriter, write_stream_entry},
     chunk::{ChunkType, RawChunk},
     cipher::CipherWriter,
     compress::CompressionWriter,
     entry::{
-        Entry, EntryName, Metadata, NormalEntry, SolidEntry, SolidHeader, WriteCipher, WriteOption,
-        WriteOptions, get_writer, get_writer_context, private::SealedEntryExt,
+        DataKind, Entry, EntryName, EntryWriteAttributes, NormalEntry, SolidEntry, SolidHeader,
+        WriteCipher, WriteOption, WriteOptions, get_writer, get_writer_context,
+        private::SealedEntryExt,
     },
     io::{FlattenWriter, TryIntoInner},
 };
@@ -15,11 +16,11 @@ use std::{
     num::NonZeroU32,
 };
 
-/// A writer for adding data to a file within a [`SolidEntryBuilder`].
+/// A writer for adding an entry payload within a [`SolidEntryBuilder`].
 ///
-/// This struct provides a `Write` interface for adding content to a file that is
-/// being created within a solid entry. It is passed to the closure in the
-/// [`SolidEntryBuilder::write_file`] method.
+/// This struct provides a `Write` interface for adding content to an entry that
+/// is being created within a solid entry. It is passed to the closure in
+/// [`SolidEntryBuilder::write_file`] or [`SolidEntryBuilder::write_opaque`].
 pub struct SolidEntryDataWriter<'a>(
     InternalArchiveDataWriter<&'a mut InternalDataWriter<FlattenWriter>>,
 );
@@ -142,7 +143,9 @@ impl SolidEntryBuilder {
     /// # Errors
     ///
     /// Returns an error if an I/O error occurs while writing the entry,
-    /// or if the closure returns an error.
+    /// or if the closure returns an error. If this method returns an error, the
+    /// builder may contain a partial entry and must be discarded without
+    /// further use.
     ///
     /// # Examples
     ///
@@ -162,16 +165,61 @@ impl SolidEntryBuilder {
     /// # }
     /// ```
     #[inline]
-    pub fn write_file<F>(&mut self, name: EntryName, metadata: Metadata, mut f: F) -> io::Result<()>
+    pub fn write_file<F>(
+        &mut self,
+        name: EntryName,
+        attributes: impl Into<EntryWriteAttributes>,
+        f: F,
+    ) -> io::Result<()>
     where
-        F: FnMut(&mut SolidEntryDataWriter) -> io::Result<()>,
+        F: FnOnce(&mut SolidEntryDataWriter) -> io::Result<()>,
     {
         let option = WriteOptions::store();
-        write_file_entry(
+        write_stream_entry(
             &mut self.data,
             name,
-            metadata,
+            DataKind::FILE,
+            attributes.into(),
             option,
+            self.max_file_chunk_size,
+            |w| {
+                let mut writer = SolidEntryDataWriter(w);
+                f(&mut writer)?;
+                Ok(writer.0)
+            },
+        )
+    }
+
+    /// Writes an opaque entry payload to the solid entry.
+    ///
+    /// The inner entry always uses STORE; compression and encryption are
+    /// provided only by the outer solid stream. No validation is performed
+    /// between `kind` and the payload. Prefer kind-specific APIs for data kinds
+    /// defined by the PNA specification.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an I/O error occurs while writing the entry, or if
+    /// the closure returns an error. If this method returns an error, the
+    /// builder may contain a partial entry and must be discarded without
+    /// further use.
+    #[inline]
+    pub fn write_opaque<F>(
+        &mut self,
+        name: EntryName,
+        kind: DataKind,
+        attributes: impl Into<EntryWriteAttributes>,
+        f: F,
+    ) -> io::Result<()>
+    where
+        F: FnOnce(&mut SolidEntryDataWriter) -> io::Result<()>,
+    {
+        write_stream_entry(
+            &mut self.data,
+            name,
+            kind,
+            attributes.into(),
+            WriteOptions::store(),
             self.max_file_chunk_size,
             |w| {
                 let mut writer = SolidEntryDataWriter(w);
@@ -219,8 +267,9 @@ impl SolidEntryBuilder {
         self
     }
 
-    /// Sets the maximum chunk size for file data (FDAT) written via
-    /// [`write_file()`](SolidEntryBuilder::write_file).
+    /// Sets the maximum chunk size for entry data (FDAT) written via
+    /// [`write_file()`](SolidEntryBuilder::write_file) or
+    /// [`write_opaque()`](SolidEntryBuilder::write_opaque).
     ///
     /// This is independent of [`max_chunk_size()`](SolidEntryBuilder::max_chunk_size),
     /// which controls the outer data chunking.
@@ -275,7 +324,9 @@ impl SolidEntryBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ChunkType, CipherMode, Encryption, HashAlgorithm, ReadOptions};
+    use crate::{
+        ChunkType, CipherMode, Compression, Encryption, HashAlgorithm, Metadata, ReadOptions,
+    };
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
@@ -363,6 +414,35 @@ mod tests {
         reader.read_to_end(&mut buf).unwrap();
 
         assert_eq!("テストデータ".as_bytes(), &buf[..]);
+    }
+
+    #[test]
+    fn solid_entry_builder_write_opaque_uses_store() {
+        let kind = DataKind::new_private(202).unwrap();
+        let mut builder = SolidEntryBuilder::new(
+            WriteOptions::builder()
+                .compression(Compression::ZSTANDARD)
+                .build(),
+        )
+        .unwrap();
+        builder
+            .write_opaque("entry".into(), kind, Metadata::new(), |writer| {
+                writer.write_all(b"opaque")
+            })
+            .unwrap();
+        let solid_entry = builder.build_as_entry().unwrap();
+
+        let mut entries = solid_entry.entries(ReadOptions::builder().build()).unwrap();
+        let entry = entries.next().unwrap().unwrap();
+        assert_eq!(entry.header().data_kind(), kind);
+        assert_eq!(entry.header().compression(), Compression::NO);
+        let mut data = Vec::new();
+        entry
+            .reader(ReadOptions::builder().build())
+            .unwrap()
+            .read_to_end(&mut data)
+            .unwrap();
+        assert_eq!(data, b"opaque");
     }
 
     #[test]

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -1,8 +1,8 @@
 //! Metadata and permission types for archive entries.
 
-use crate::entry::ExtendedAttribute;
 use crate::util::bounded::{LengthExceeded, str::BoundedString};
 use crate::{Duration, UnknownValueError};
+use crate::{RawChunk, entry::ExtendedAttribute};
 use std::io::{self, Read};
 use std::ops::Deref;
 use std::str;
@@ -40,6 +40,55 @@ pub struct Metadata {
     pub(crate) owner_group_sid: Option<OwnerGroupSid>,
     pub(crate) permission_mode: Option<PermissionMode>,
     pub(crate) xattrs: Vec<ExtendedAttribute>,
+}
+
+/// Attributes known before streaming an entry payload.
+///
+/// This type combines structured [`Metadata`] with raw extra chunks. Extra
+/// chunks are written in insertion order immediately after the entry header,
+/// matching the placement used by entry builders. Extra chunk types are not
+/// validated; even structural or critical chunks are written as supplied.
+///
+/// Streaming entry methods do not generate an `fSIZ` chunk from [`Metadata`]
+/// size fields. A caller-supplied raw `fSIZ` extra chunk is still written like
+/// any other extra chunk.
+pub struct EntryWriteAttributes {
+    pub(crate) metadata: Metadata,
+    pub(crate) extra_chunks: Vec<RawChunk>,
+}
+
+impl EntryWriteAttributes {
+    /// Creates streaming entry attributes from structured metadata.
+    #[inline]
+    pub fn new(metadata: Metadata) -> Self {
+        Self {
+            metadata,
+            extra_chunks: Vec::new(),
+        }
+    }
+
+    /// Returns the structured metadata.
+    #[inline]
+    pub const fn metadata(&self) -> &Metadata {
+        &self.metadata
+    }
+
+    /// Adds a raw extra chunk, preserving insertion order.
+    #[inline]
+    pub fn add_extra_chunk<T>(&mut self, chunk: T) -> &mut Self
+    where
+        T: Into<RawChunk>,
+    {
+        self.extra_chunks.push(chunk.into());
+        self
+    }
+}
+
+impl From<Metadata> for EntryWriteAttributes {
+    #[inline]
+    fn from(metadata: Metadata) -> Self {
+        Self::new(metadata)
+    }
 }
 
 impl Metadata {

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -115,6 +115,7 @@
 //! - [`FileEntryBuilder`] / [`DirEntryBuilder`] / [`SymlinkEntryBuilder`] / [`HardLinkEntryBuilder`] - Kind-specific entry builders
 //! - [`OpaqueEntryBuilder`] - Escape-hatch builder for entry kinds without a dedicated builder
 //! - [`SolidEntryBuilder`] - Builder for creating solid (multi-file) entries
+//! - [`EntryWriteAttributes`] - Metadata and extra chunks for streaming entry writes
 //! - [`WriteOptions`] - Configuration for compression and encryption when writing
 //! - [`ReadOptions`] - Configuration (password) for reading encrypted entries
 //! - [`NormalEntry`] / [`SolidEntry`] / [`ReadEntry`] - Entry types for reading


### PR DESCRIPTION
## Summary

- introduce `EntryWriteAttributes` for structured metadata plus ordered raw extra chunks
- share metadata facet serialization between `NormalEntry` and streaming writes
- add `write_opaque` to normal archives, solid archives, and `SolidEntryBuilder`
- change streaming callbacks to `FnOnce` while preserving direct `Metadata` callers
- keep solid inner entries on STORE and avoid automatic `fSIZ` generation

## Why

The filesystem bridge planned for `pna` needs to stream payloads without buffering whole entries while retaining builder-equivalent metadata and extension chunks. The existing FILE-only streaming path could not express arbitrary `DataKind` values or extra chunks and had drifted from `NormalEntry` metadata serialization.

## Impact

Existing `write_file(..., Metadata, ...)` calls continue to compile through `From<Metadata>`. Advanced callers can now supply extra chunks or stream private and experimental entry kinds without adding filesystem concerns to `libpna`.

This is stack 1 of 2. The follow-up PR adds Unix filesystem owner/mode facets in `pna` and will target this branch.

## Validation

- `cargo test -p libpna --all-features`
- `cargo clippy -p libpna -p pna --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p libpna -p pna --no-deps --all-features`
- `cargo check --workspace --all-targets --all-features`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for writing opaque archive entries with custom data kinds.
  * Added entry attributes combining standard metadata with extra chunks.
  * File and solid-entry writing now supports richer metadata and configurable attributes.
  * Streaming output respects maximum chunk sizes across file and opaque entries.
  * Solid entries preserve outer compression and encryption while using uncompressed inner storage.

* **Documentation**
  * Clarified behavior when writing fails and when archives may remain partially written.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->