### PR TITLE
:sparkles: Add low-level chunk parsing APIs

### DIFF
--- a/lib/src/archive/read.rs
+++ b/lib/src/archive/read.rs
@@ -182,8 +182,7 @@ impl<R: futures_io::AsyncRead + Unpin> Archive<R> {
 
     async fn read_header_with_buffer_async(mut reader: R, buf: Vec<RawChunk>) -> io::Result<Self> {
         crate::async_io::read_signature(&mut reader).await?;
-        let mut chunk_reader = ChunkReader::new(&mut reader, None);
-        let chunk = chunk_reader.read_chunk_async().await?;
+        let chunk = crate::async_io::read_chunk(&mut reader, u32::MAX).await?;
         if chunk.ty != ChunkType::AHED {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -197,9 +196,9 @@ impl<R: futures_io::AsyncRead + Unpin> Archive<R> {
     async fn next_raw_item_async(&mut self) -> io::Result<Option<RawEntry>> {
         let mut chunks = Vec::new();
         swap(&mut self.buf, &mut chunks);
-        let mut reader = ChunkReader::new(&mut self.inner, self.max_chunk_size);
+        let max_chunk_size = self.max_chunk_size.map_or(u32::MAX, |max| max.get());
         loop {
-            let chunk = reader.read_chunk_async().await?;
+            let chunk = crate::async_io::read_chunk(&mut self.inner, max_chunk_size).await?;
             match chunk.ty {
                 ChunkType::FEND | ChunkType::SEND => {
                     chunks.push(chunk);

--- a/lib/src/async_io.rs
+++ b/lib/src/async_io.rs
@@ -1,9 +1,9 @@
 //! Asynchronous I/O primitives for reading and writing PNA archives.
 
-use crate::PNA_SIGNATURE;
+use crate::{ChunkType, PNA_SIGNATURE, RawChunk, util::io::try_zeroed_vec};
 use futures_io::AsyncRead;
 use futures_util::AsyncReadExt;
-use std::io;
+use std::{io, mem};
 
 /// Reads and validates the PNA archive signature asynchronously.
 ///
@@ -23,9 +23,65 @@ pub async fn read_signature<R: AsyncRead + Unpin + ?Sized>(reader: &mut R) -> io
     crate::format::validate_signature(&signature)
 }
 
+/// Reads and validates one PNA chunk from `reader` asynchronously.
+///
+/// The reader must be positioned at the chunk length field. On success, this
+/// function consumes exactly one complete chunk and does not read any bytes
+/// following its CRC. This function does not read the archive signature or
+/// interpret archive-level chunk ordering.
+///
+/// `max_data_len` is an inclusive upper bound for the chunk data length. Pass
+/// [`u32::MAX`] to allow the full range representable by the PNA format.
+///
+/// On failure, an unspecified number of bytes may have been consumed and the
+/// reader is not guaranteed to remain at a chunk boundary.
+///
+/// # Errors
+///
+/// Returns [`io::ErrorKind::UnexpectedEof`] when any chunk field is incomplete,
+/// [`io::ErrorKind::InvalidData`] when the declared data length exceeds
+/// `max_data_len`, the chunk type is invalid, or the stored CRC-32 does not
+/// match the chunk type and data, [`io::ErrorKind::OutOfMemory`] when the chunk
+/// data buffer cannot be allocated, and any other error produced by `reader`.
+#[inline]
+pub async fn read_chunk<R: AsyncRead + Unpin + ?Sized>(
+    reader: &mut R,
+    max_data_len: u32,
+) -> io::Result<RawChunk<Vec<u8>>> {
+    let mut length = [0u8; mem::size_of::<u32>()];
+    reader.read_exact(&mut length).await?;
+    let length = u32::from_be_bytes(length);
+    if length > max_data_len {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("chunk data length {length} exceeds limit {max_data_len}"),
+        ));
+    }
+
+    let mut ty = [0u8; mem::size_of::<ChunkType>()];
+    reader.read_exact(&mut ty).await?;
+    let chunk_type = ChunkType::new(ty)?;
+
+    let mut data = try_zeroed_vec(length as usize)?;
+    reader.read_exact(&mut data).await?;
+
+    let mut crc = [0u8; mem::size_of::<u32>()];
+    reader.read_exact(&mut crc).await?;
+    let crc = u32::from_be_bytes(crc);
+    crate::format::validate_chunk_crc(&ty, &data, crc)?;
+
+    Ok(RawChunk {
+        length,
+        ty: chunk_type,
+        data,
+        crc,
+    })
+}
+
 #[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use super::*;
+    use crate::Chunk;
     use futures_util::io::Cursor;
 
     #[tokio::test]
@@ -50,6 +106,103 @@ mod tests {
         let mut reader = Cursor::new(b"xxxxxxxx");
         assert_eq!(
             read_signature(&mut reader).await.unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    fn valid_chunk_bytes() -> Vec<u8> {
+        vec![
+            0x00, 0x00, 0x00, 0x04, // chunk length
+            b'F', b'D', b'A', b'T', // chunk type
+            0xAA, 0xBB, 0xCC, 0xDD, // chunk data
+            0x47, 0xF3, 0x2B, 0x10, // CRC-32
+        ]
+    }
+
+    fn raw_chunk_bytes(ty: [u8; 4], data: &[u8]) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(data.len() + 12);
+        bytes.extend_from_slice(&(data.len() as u32).to_be_bytes());
+        bytes.extend_from_slice(&ty);
+        bytes.extend_from_slice(data);
+        bytes.extend_from_slice(&crate::format::chunk_crc(&ty, data).to_be_bytes());
+        bytes
+    }
+
+    #[tokio::test]
+    async fn read_chunk_returns_owned_chunk_and_stops_at_its_crc() {
+        let mut input = valid_chunk_bytes();
+        let chunk_len = input.len();
+        input.extend_from_slice(b"following");
+        let mut reader = Cursor::new(input);
+
+        let chunk = read_chunk(&mut reader, u32::MAX).await.unwrap();
+
+        assert_eq!(chunk.ty(), ChunkType::FDAT);
+        assert_eq!(chunk.data(), [0xAA, 0xBB, 0xCC, 0xDD]);
+        assert_eq!(reader.position(), chunk_len as u64);
+    }
+
+    #[tokio::test]
+    async fn read_chunk_enforces_inclusive_data_length_limit() {
+        let mut reader = Cursor::new(raw_chunk_bytes(*b"AEND", &[]));
+        let chunk = read_chunk(&mut reader, 0).await.unwrap();
+        assert_eq!(chunk.ty(), ChunkType::AEND);
+        assert!(chunk.data().is_empty());
+
+        let mut reader = Cursor::new(valid_chunk_bytes());
+        assert_eq!(read_chunk(&mut reader, 4).await.unwrap().length(), 4);
+
+        let mut reader = Cursor::new(valid_chunk_bytes());
+        assert_eq!(
+            read_chunk(&mut reader, 3).await.unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    #[tokio::test]
+    async fn read_chunk_checks_limit_before_requiring_the_remaining_fields() {
+        let mut reader = Cursor::new(u32::MAX.to_be_bytes());
+        assert_eq!(
+            read_chunk(&mut reader, 1024).await.unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    #[tokio::test]
+    async fn read_chunk_rejects_every_truncation_boundary() {
+        let bytes = valid_chunk_bytes();
+        for end in 0..bytes.len() {
+            let mut reader = Cursor::new(&bytes[..end]);
+            assert_eq!(
+                read_chunk(&mut reader, u32::MAX).await.unwrap_err().kind(),
+                io::ErrorKind::UnexpectedEof,
+                "truncation at byte {end}",
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn read_chunk_applies_chunk_type_validation_rules() {
+        let mut reader = Cursor::new(raw_chunk_bytes(*b"FD1T", b"data"));
+        assert_eq!(
+            read_chunk(&mut reader, u32::MAX).await.unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+
+        let mut reader = Cursor::new(raw_chunk_bytes(*b"ABcD", b"data"));
+        assert_eq!(
+            read_chunk(&mut reader, u32::MAX).await.unwrap().data(),
+            b"data"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_chunk_rejects_crc_mismatch() {
+        let mut bytes = valid_chunk_bytes();
+        *bytes.last_mut().unwrap() ^= 0xFF;
+        let mut reader = Cursor::new(bytes);
+        assert_eq!(
+            read_chunk(&mut reader, u32::MAX).await.unwrap_err().kind(),
             io::ErrorKind::InvalidData
         );
     }

--- a/lib/src/bytes.rs
+++ b/lib/src/bytes.rs
@@ -1,7 +1,7 @@
 //! Byte-slice primitives for parsing PNA archives.
 
-use crate::PNA_SIGNATURE;
-use std::io;
+use crate::{ChunkType, PNA_SIGNATURE, RawChunk};
+use std::{io, mem};
 
 /// Reads and validates the PNA archive signature from `bytes`.
 ///
@@ -20,9 +20,64 @@ pub fn read_signature(bytes: &[u8]) -> io::Result<&[u8]> {
     Ok(rest)
 }
 
+/// Reads and validates one PNA chunk from the beginning of `bytes`.
+///
+/// Returns the zero-copy chunk and the bytes following it. The input must start
+/// at the chunk length field; this function does not read the archive signature
+/// or interpret archive-level chunk ordering.
+///
+/// `max_data_len` is an inclusive upper bound for the chunk data length. Pass
+/// [`u32::MAX`] to allow the full range representable by the PNA format.
+///
+/// # Errors
+///
+/// Returns [`io::ErrorKind::UnexpectedEof`] when any chunk field is incomplete,
+/// or [`io::ErrorKind::InvalidData`] when the declared data length exceeds
+/// `max_data_len`, the chunk type is invalid, or the stored CRC-32 does not
+/// match the chunk type and data.
+#[inline]
+pub fn read_chunk(bytes: &[u8], max_data_len: u32) -> io::Result<(RawChunk<&[u8]>, &[u8])> {
+    let (length, bytes) = bytes
+        .split_first_chunk::<{ mem::size_of::<u32>() }>()
+        .ok_or(io::ErrorKind::UnexpectedEof)?;
+    let length = u32::from_be_bytes(*length);
+    if length > max_data_len {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("chunk data length {length} exceeds limit {max_data_len}"),
+        ));
+    }
+
+    let (ty, bytes) = bytes
+        .split_first_chunk::<{ mem::size_of::<ChunkType>() }>()
+        .ok_or(io::ErrorKind::UnexpectedEof)?;
+    let chunk_type = ChunkType::new(*ty)?;
+
+    let (data, bytes) = bytes
+        .split_at_checked(length as usize)
+        .ok_or(io::ErrorKind::UnexpectedEof)?;
+
+    let (crc, bytes) = bytes
+        .split_first_chunk::<{ mem::size_of::<u32>() }>()
+        .ok_or(io::ErrorKind::UnexpectedEof)?;
+    let crc = u32::from_be_bytes(*crc);
+    crate::format::validate_chunk_crc(ty, data, crc)?;
+
+    Ok((
+        RawChunk {
+            length,
+            ty: chunk_type,
+            data,
+            crc,
+        },
+        bytes,
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Chunk;
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
@@ -45,6 +100,99 @@ mod tests {
     fn read_signature_rejects_mismatched_signature() {
         assert_eq!(
             read_signature(b"xxxxxxxx").unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    fn valid_chunk_bytes() -> Vec<u8> {
+        vec![
+            0x00, 0x00, 0x00, 0x04, // chunk length
+            b'F', b'D', b'A', b'T', // chunk type
+            0xAA, 0xBB, 0xCC, 0xDD, // chunk data
+            0x47, 0xF3, 0x2B, 0x10, // CRC-32
+        ]
+    }
+
+    fn raw_chunk_bytes(ty: [u8; 4], data: &[u8]) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(data.len() + 12);
+        bytes.extend_from_slice(&(data.len() as u32).to_be_bytes());
+        bytes.extend_from_slice(&ty);
+        bytes.extend_from_slice(data);
+        bytes.extend_from_slice(&crate::format::chunk_crc(&ty, data).to_be_bytes());
+        bytes
+    }
+
+    #[test]
+    fn read_chunk_returns_borrowed_chunk_and_remainder() {
+        let mut input = valid_chunk_bytes();
+        input.extend_from_slice(b"following");
+
+        let (chunk, rest) = read_chunk(&input, u32::MAX).unwrap();
+
+        assert_eq!(chunk.ty(), ChunkType::FDAT);
+        assert_eq!(chunk.data(), [0xAA, 0xBB, 0xCC, 0xDD]);
+        assert_eq!(chunk.data().as_ptr(), input[8..].as_ptr());
+        assert_eq!(rest, b"following");
+    }
+
+    #[test]
+    fn read_chunk_enforces_inclusive_data_length_limit() {
+        let bytes = raw_chunk_bytes(*b"AEND", &[]);
+        let (chunk, rest) = read_chunk(&bytes, 0).unwrap();
+        assert_eq!(chunk.ty(), ChunkType::AEND);
+        assert!(chunk.data().is_empty());
+        assert!(rest.is_empty());
+
+        let bytes = valid_chunk_bytes();
+        assert_eq!(read_chunk(&bytes, 4).unwrap().0.length(), 4);
+
+        let bytes = valid_chunk_bytes();
+        assert_eq!(
+            read_chunk(&bytes, 3).unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    #[test]
+    fn read_chunk_checks_limit_before_requiring_the_remaining_fields() {
+        assert_eq!(
+            read_chunk(&u32::MAX.to_be_bytes(), 1024)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    #[test]
+    fn read_chunk_rejects_every_truncation_boundary() {
+        let bytes = valid_chunk_bytes();
+        for end in 0..bytes.len() {
+            assert_eq!(
+                read_chunk(&bytes[..end], u32::MAX).unwrap_err().kind(),
+                io::ErrorKind::UnexpectedEof,
+                "truncation at byte {end}",
+            );
+        }
+    }
+
+    #[test]
+    fn read_chunk_applies_chunk_type_validation_rules() {
+        let bytes = raw_chunk_bytes(*b"FD1T", b"data");
+        assert_eq!(
+            read_chunk(&bytes, u32::MAX).unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+
+        let bytes = raw_chunk_bytes(*b"ABcD", b"data");
+        assert_eq!(read_chunk(&bytes, u32::MAX).unwrap().0.data(), b"data");
+    }
+
+    #[test]
+    fn read_chunk_rejects_crc_mismatch() {
+        let mut bytes = valid_chunk_bytes();
+        *bytes.last_mut().unwrap() ^= 0xFF;
+        assert_eq!(
+            read_chunk(&bytes, u32::MAX).unwrap_err().kind(),
             io::ErrorKind::InvalidData
         );
     }

--- a/lib/src/chunk.rs
+++ b/lib/src/chunk.rs
@@ -4,13 +4,11 @@
 //! chunk types, reading/writing utilities, and CRC calculation needed to parse
 //! and emit well-formed streams. Higher-level modules (archive/entry) build on
 //! these primitives.
-mod crc;
 mod read;
 mod traits;
 mod types;
 mod write;
 
-use self::crc::Crc32;
 pub(crate) use self::{read::*, write::*};
 pub use self::{traits::*, types::*};
 use std::{

--- a/lib/src/chunk/crc.rs
+++ b/lib/src/chunk/crc.rs
@@ -1,3 +1,0 @@
-//! CRC-32 hasher re-export for chunk integrity verification.
-
-pub(super) use crc32fast::Hasher as Crc32;

--- a/lib/src/chunk/read.rs
+++ b/lib/src/chunk/read.rs
@@ -1,41 +1,11 @@
 //! Chunk reading and deserialization from byte streams and slices.
 
-use crate::{
-    chunk::{ChunkType, MIN_CHUNK_BYTES_SIZE, RawChunk},
-    format::validate_chunk_crc,
-};
+use crate::chunk::{ChunkType, MIN_CHUNK_BYTES_SIZE, RawChunk};
 use core::num::NonZeroU32;
-#[cfg(feature = "unstable-async")]
-use futures_io::AsyncRead;
-#[cfg(feature = "unstable-async")]
-use futures_util::AsyncReadExt;
 use std::{
     io::{self, Read, Seek, SeekFrom},
     mem,
 };
-
-/// Allocate chunk data buffer with graceful OOM handling and optional size limit.
-fn allocate_chunk_data(length: u32, max_size: Option<NonZeroU32>) -> io::Result<Vec<u8>> {
-    if let Some(max) = max_size
-        && length > max.get()
-    {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("chunk size {} exceeds limit {}", length, max),
-        ));
-    }
-
-    let len = length as usize;
-    let mut data = Vec::new();
-    data.try_reserve_exact(len).map_err(|_| {
-        io::Error::new(
-            io::ErrorKind::OutOfMemory,
-            format!("failed to allocate {} bytes for chunk", len),
-        )
-    })?;
-    data.resize(len, 0);
-    Ok(data)
-}
 
 pub(crate) struct ChunkReader<R> {
     pub(crate) r: R,
@@ -55,38 +25,6 @@ impl<R: Read> ChunkReader<R> {
     #[inline]
     pub(crate) fn read_chunk(&mut self) -> io::Result<RawChunk> {
         read_chunk(&mut self.r, self.max_chunk_size)
-    }
-}
-
-#[cfg(feature = "unstable-async")]
-impl<R: AsyncRead + Unpin> ChunkReader<R> {
-    pub(crate) async fn read_chunk_async(&mut self) -> io::Result<RawChunk> {
-        // read chunk length
-        let mut length = [0u8; mem::size_of::<u32>()];
-        self.r.read_exact(&mut length).await?;
-        let length = u32::from_be_bytes(length);
-
-        // read a chunk type
-        let mut ty = [0u8; mem::size_of::<ChunkType>()];
-        self.r.read_exact(&mut ty).await?;
-
-        // read chunk data
-        let mut data = allocate_chunk_data(length, self.max_chunk_size)?;
-        self.r.read_exact(&mut data).await?;
-
-        // read crc sum
-        let mut crc = [0u8; mem::size_of::<u32>()];
-        self.r.read_exact(&mut crc).await?;
-        let crc = u32::from_be_bytes(crc);
-
-        validate_chunk_crc(&ty, &data, crc)?;
-        let ty = ChunkType::new(ty)?;
-        Ok(RawChunk {
-            length,
-            ty,
-            data,
-            crc,
-        })
     }
 }
 
@@ -121,66 +59,11 @@ pub(crate) fn read_chunk<R: Read>(
     mut r: R,
     max_chunk_size: Option<NonZeroU32>,
 ) -> io::Result<RawChunk> {
-    // read chunk length
-    let mut length = [0u8; mem::size_of::<u32>()];
-    r.read_exact(&mut length)?;
-    let length = u32::from_be_bytes(length);
-
-    // read a chunk type
-    let mut ty = [0u8; mem::size_of::<ChunkType>()];
-    r.read_exact(&mut ty)?;
-
-    // read chunk data
-    let mut data = allocate_chunk_data(length, max_chunk_size)?;
-    r.read_exact(&mut data)?;
-
-    // read crc sum
-    let mut crc = [0u8; mem::size_of::<u32>()];
-    r.read_exact(&mut crc)?;
-    let crc = u32::from_be_bytes(crc);
-
-    validate_chunk_crc(&ty, &data, crc)?;
-    let ty = ChunkType::new(ty)?;
-    Ok(RawChunk {
-        length,
-        ty,
-        data,
-        crc,
-    })
+    crate::io::read_chunk(&mut r, max_chunk_size.map_or(u32::MAX, NonZeroU32::get))
 }
 
 pub(crate) fn read_chunk_from_slice(bytes: &[u8]) -> io::Result<(RawChunk<&[u8]>, &[u8])> {
-    // read chunk length
-    let (length, r) = bytes
-        .split_first_chunk::<{ mem::size_of::<u32>() }>()
-        .ok_or(io::ErrorKind::UnexpectedEof)?;
-    let length = u32::from_be_bytes(*length);
-
-    // read a chunk type
-    let (ty, r) = r
-        .split_first_chunk::<{ mem::size_of::<ChunkType>() }>()
-        .ok_or(io::ErrorKind::UnexpectedEof)?;
-    // read chunk data
-    let (data, r) = r
-        .split_at_checked(length as usize)
-        .ok_or(io::ErrorKind::UnexpectedEof)?;
-    // read crc sum
-    let (crc, r) = r
-        .split_first_chunk::<{ mem::size_of::<u32>() }>()
-        .ok_or(io::ErrorKind::UnexpectedEof)?;
-    let crc = u32::from_be_bytes(*crc);
-
-    validate_chunk_crc(ty, data, crc)?;
-    let ty = ChunkType::new(*ty)?;
-    Ok((
-        RawChunk {
-            length,
-            ty,
-            data,
-            crc,
-        },
-        r,
-    ))
+    crate::bytes::read_chunk(bytes, u32::MAX)
 }
 
 #[cfg(test)]

--- a/lib/src/chunk/read.rs
+++ b/lib/src/chunk/read.rs
@@ -1,6 +1,9 @@
 //! Chunk reading and deserialization from byte streams and slices.
 
-use crate::chunk::{ChunkType, MIN_CHUNK_BYTES_SIZE, RawChunk, crc::Crc32};
+use crate::{
+    chunk::{ChunkType, MIN_CHUNK_BYTES_SIZE, RawChunk},
+    format::validate_chunk_crc,
+};
 use core::num::NonZeroU32;
 #[cfg(feature = "unstable-async")]
 use futures_io::AsyncRead;
@@ -58,8 +61,6 @@ impl<R: Read> ChunkReader<R> {
 #[cfg(feature = "unstable-async")]
 impl<R: AsyncRead + Unpin> ChunkReader<R> {
     pub(crate) async fn read_chunk_async(&mut self) -> io::Result<RawChunk> {
-        let mut crc_hasher = Crc32::new();
-
         // read chunk length
         let mut length = [0u8; mem::size_of::<u32>()];
         self.r.read_exact(&mut length).await?;
@@ -69,22 +70,16 @@ impl<R: AsyncRead + Unpin> ChunkReader<R> {
         let mut ty = [0u8; mem::size_of::<ChunkType>()];
         self.r.read_exact(&mut ty).await?;
 
-        crc_hasher.update(&ty);
-
         // read chunk data
         let mut data = allocate_chunk_data(length, self.max_chunk_size)?;
         self.r.read_exact(&mut data).await?;
-
-        crc_hasher.update(&data);
 
         // read crc sum
         let mut crc = [0u8; mem::size_of::<u32>()];
         self.r.read_exact(&mut crc).await?;
         let crc = u32::from_be_bytes(crc);
 
-        if crc != crc_hasher.finalize() {
-            return Err(io::Error::new(io::ErrorKind::InvalidData, "broken chunk"));
-        }
+        validate_chunk_crc(&ty, &data, crc)?;
         let ty = ChunkType::new(ty)?;
         Ok(RawChunk {
             length,
@@ -126,8 +121,6 @@ pub(crate) fn read_chunk<R: Read>(
     mut r: R,
     max_chunk_size: Option<NonZeroU32>,
 ) -> io::Result<RawChunk> {
-    let mut crc_hasher = Crc32::new();
-
     // read chunk length
     let mut length = [0u8; mem::size_of::<u32>()];
     r.read_exact(&mut length)?;
@@ -137,22 +130,16 @@ pub(crate) fn read_chunk<R: Read>(
     let mut ty = [0u8; mem::size_of::<ChunkType>()];
     r.read_exact(&mut ty)?;
 
-    crc_hasher.update(&ty);
-
     // read chunk data
     let mut data = allocate_chunk_data(length, max_chunk_size)?;
     r.read_exact(&mut data)?;
-
-    crc_hasher.update(&data);
 
     // read crc sum
     let mut crc = [0u8; mem::size_of::<u32>()];
     r.read_exact(&mut crc)?;
     let crc = u32::from_be_bytes(crc);
 
-    if crc != crc_hasher.finalize() {
-        return Err(io::Error::new(io::ErrorKind::InvalidData, "broken chunk"));
-    }
+    validate_chunk_crc(&ty, &data, crc)?;
     let ty = ChunkType::new(ty)?;
     Ok(RawChunk {
         length,
@@ -163,8 +150,6 @@ pub(crate) fn read_chunk<R: Read>(
 }
 
 pub(crate) fn read_chunk_from_slice(bytes: &[u8]) -> io::Result<(RawChunk<&[u8]>, &[u8])> {
-    let mut crc_hasher = Crc32::new();
-
     // read chunk length
     let (length, r) = bytes
         .split_first_chunk::<{ mem::size_of::<u32>() }>()
@@ -175,23 +160,17 @@ pub(crate) fn read_chunk_from_slice(bytes: &[u8]) -> io::Result<(RawChunk<&[u8]>
     let (ty, r) = r
         .split_first_chunk::<{ mem::size_of::<ChunkType>() }>()
         .ok_or(io::ErrorKind::UnexpectedEof)?;
-    crc_hasher.update(&ty[..]);
-
     // read chunk data
     let (data, r) = r
         .split_at_checked(length as usize)
         .ok_or(io::ErrorKind::UnexpectedEof)?;
-    crc_hasher.update(data);
-
     // read crc sum
     let (crc, r) = r
         .split_first_chunk::<{ mem::size_of::<u32>() }>()
         .ok_or(io::ErrorKind::UnexpectedEof)?;
     let crc = u32::from_be_bytes(*crc);
 
-    if crc != crc_hasher.finalize() {
-        return Err(io::Error::new(io::ErrorKind::InvalidData, "broken chunk"));
-    }
+    validate_chunk_crc(ty, data, crc)?;
     let ty = ChunkType::new(*ty)?;
     Ok((
         RawChunk {

--- a/lib/src/chunk/traits.rs
+++ b/lib/src/chunk/traits.rs
@@ -1,6 +1,6 @@
 //! Chunk trait defining the interface for PNA archive chunks.
 
-use super::{ChunkType, Crc32};
+use super::ChunkType;
 
 /// A trait representing a chunk in a PNA archive.
 ///
@@ -47,9 +47,6 @@ pub trait Chunk {
     /// this method to return its stored `crc` field.
     #[inline]
     fn crc(&self) -> u32 {
-        let mut crc = Crc32::new();
-        crc.update(self.ty().as_bytes());
-        crc.update(self.data());
-        crc.finalize()
+        crate::format::chunk_crc(self.ty().as_bytes(), self.data())
     }
 }

--- a/lib/src/format.rs
+++ b/lib/src/format.rs
@@ -1,6 +1,8 @@
 //! Core definitions for the PNA file format.
 
+mod chunk;
 mod signature;
 
+pub(crate) use chunk::{chunk_crc, validate_chunk_crc};
 pub use signature::PNA_SIGNATURE;
 pub(crate) use signature::validate_signature;

--- a/lib/src/format/chunk.rs
+++ b/lib/src/format/chunk.rs
@@ -1,0 +1,48 @@
+//! PNA chunk integrity calculation and validation.
+
+use std::io;
+
+/// Calculates the CRC-32 checksum of a chunk type and data field.
+#[inline]
+pub(crate) fn chunk_crc(ty: &[u8; 4], data: &[u8]) -> u32 {
+    let mut crc = crc32fast::Hasher::new();
+    crc.update(ty);
+    crc.update(data);
+    crc.finalize()
+}
+
+/// Validates a stored chunk CRC-32 checksum.
+#[inline]
+pub(crate) fn validate_chunk_crc(ty: &[u8; 4], data: &[u8], stored: u32) -> io::Result<()> {
+    if stored != chunk_crc(ty, data) {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "broken chunk"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    use wasm_bindgen_test::wasm_bindgen_test as test;
+
+    #[test]
+    fn calculates_known_chunk_crc() {
+        assert_eq!(chunk_crc(b"FDAT", &[0xAA, 0xBB, 0xCC, 0xDD]), 0x47F3_2B10);
+    }
+
+    #[test]
+    fn validates_matching_chunk_crc() {
+        validate_chunk_crc(b"FDAT", &[0xAA, 0xBB, 0xCC, 0xDD], 0x47F3_2B10).unwrap();
+    }
+
+    #[test]
+    fn rejects_mismatched_chunk_crc() {
+        assert_eq!(
+            validate_chunk_crc(b"FDAT", &[0xAA, 0xBB, 0xCC, 0xDD], 0)
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+}

--- a/lib/src/io.rs
+++ b/lib/src/io.rs
@@ -1,7 +1,7 @@
 //! I/O primitives for reading and writing PNA archives.
 
-use crate::PNA_SIGNATURE;
-use std::io;
+use crate::{ChunkType, PNA_SIGNATURE, RawChunk, util::io::try_zeroed_vec};
+use std::{io, mem};
 
 /// Reads and validates the PNA archive signature.
 ///
@@ -21,10 +21,65 @@ pub fn read_signature<R: io::Read + ?Sized>(reader: &mut R) -> io::Result<()> {
     crate::format::validate_signature(&signature)
 }
 
+/// Reads and validates one PNA chunk from `reader`.
+///
+/// The reader must be positioned at the chunk length field. On success, this
+/// function consumes exactly one complete chunk and does not read any bytes
+/// following its CRC. This function does not read the archive signature or
+/// interpret archive-level chunk ordering.
+///
+/// `max_data_len` is an inclusive upper bound for the chunk data length. Pass
+/// [`u32::MAX`] to allow the full range representable by the PNA format.
+///
+/// On failure, an unspecified number of bytes may have been consumed and the
+/// reader is not guaranteed to remain at a chunk boundary.
+///
+/// # Errors
+///
+/// Returns [`io::ErrorKind::UnexpectedEof`] when any chunk field is incomplete,
+/// [`io::ErrorKind::InvalidData`] when the declared data length exceeds
+/// `max_data_len`, the chunk type is invalid, or the stored CRC-32 does not
+/// match the chunk type and data, [`io::ErrorKind::OutOfMemory`] when the chunk
+/// data buffer cannot be allocated, and any other error produced by `reader`.
+#[inline]
+pub fn read_chunk<R: io::Read + ?Sized>(
+    reader: &mut R,
+    max_data_len: u32,
+) -> io::Result<RawChunk<Vec<u8>>> {
+    let mut length = [0u8; mem::size_of::<u32>()];
+    reader.read_exact(&mut length)?;
+    let length = u32::from_be_bytes(length);
+    if length > max_data_len {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("chunk data length {length} exceeds limit {max_data_len}"),
+        ));
+    }
+
+    let mut ty = [0u8; mem::size_of::<ChunkType>()];
+    reader.read_exact(&mut ty)?;
+    let chunk_type = ChunkType::new(ty)?;
+
+    let mut data = try_zeroed_vec(length as usize)?;
+    reader.read_exact(&mut data)?;
+
+    let mut crc = [0u8; mem::size_of::<u32>()];
+    reader.read_exact(&mut crc)?;
+    let crc = u32::from_be_bytes(crc);
+    crate::format::validate_chunk_crc(&ty, &data, crc)?;
+
+    Ok(RawChunk {
+        length,
+        ty: chunk_type,
+        data,
+        crc,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::util::io::tests::PartialReader;
+    use crate::{Chunk, util::io::tests::PartialReader};
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
@@ -57,6 +112,107 @@ mod tests {
         let mut reader = io::Cursor::new(b"xxxxxxxx");
         assert_eq!(
             read_signature(&mut reader).unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    fn valid_chunk_bytes() -> Vec<u8> {
+        vec![
+            0x00, 0x00, 0x00, 0x04, // chunk length
+            b'F', b'D', b'A', b'T', // chunk type
+            0xAA, 0xBB, 0xCC, 0xDD, // chunk data
+            0x47, 0xF3, 0x2B, 0x10, // CRC-32
+        ]
+    }
+
+    fn raw_chunk_bytes(ty: [u8; 4], data: &[u8]) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(data.len() + 12);
+        bytes.extend_from_slice(&(data.len() as u32).to_be_bytes());
+        bytes.extend_from_slice(&ty);
+        bytes.extend_from_slice(data);
+        bytes.extend_from_slice(&crate::format::chunk_crc(&ty, data).to_be_bytes());
+        bytes
+    }
+
+    #[test]
+    fn read_chunk_returns_owned_chunk_and_stops_at_its_crc() {
+        let mut input = valid_chunk_bytes();
+        let chunk_len = input.len();
+        input.extend_from_slice(b"following");
+        let mut reader = io::Cursor::new(input);
+
+        let chunk = read_chunk(&mut reader, u32::MAX).unwrap();
+
+        assert_eq!(chunk.ty(), ChunkType::FDAT);
+        assert_eq!(chunk.data(), [0xAA, 0xBB, 0xCC, 0xDD]);
+        assert_eq!(reader.position(), chunk_len as u64);
+    }
+
+    #[test]
+    fn read_chunk_accepts_fields_split_across_reads() {
+        let bytes = valid_chunk_bytes();
+        let mut reader = PartialReader::new(bytes, [1u8; 32]);
+        assert_eq!(read_chunk(&mut reader, u32::MAX).unwrap().length(), 4);
+    }
+
+    #[test]
+    fn read_chunk_enforces_inclusive_data_length_limit() {
+        let mut reader = io::Cursor::new(raw_chunk_bytes(*b"AEND", &[]));
+        let chunk = read_chunk(&mut reader, 0).unwrap();
+        assert_eq!(chunk.ty(), ChunkType::AEND);
+        assert!(chunk.data().is_empty());
+
+        let mut reader = io::Cursor::new(valid_chunk_bytes());
+        assert_eq!(read_chunk(&mut reader, 4).unwrap().length(), 4);
+
+        let mut reader = io::Cursor::new(valid_chunk_bytes());
+        assert_eq!(
+            read_chunk(&mut reader, 3).unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    #[test]
+    fn read_chunk_checks_limit_before_requiring_the_remaining_fields() {
+        let mut reader = io::Cursor::new(u32::MAX.to_be_bytes());
+        assert_eq!(
+            read_chunk(&mut reader, 1024).unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    #[test]
+    fn read_chunk_rejects_every_truncation_boundary() {
+        let bytes = valid_chunk_bytes();
+        for end in 0..bytes.len() {
+            let mut reader = io::Cursor::new(&bytes[..end]);
+            assert_eq!(
+                read_chunk(&mut reader, u32::MAX).unwrap_err().kind(),
+                io::ErrorKind::UnexpectedEof,
+                "truncation at byte {end}",
+            );
+        }
+    }
+
+    #[test]
+    fn read_chunk_applies_chunk_type_validation_rules() {
+        let mut reader = io::Cursor::new(raw_chunk_bytes(*b"FD1T", b"data"));
+        assert_eq!(
+            read_chunk(&mut reader, u32::MAX).unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+
+        let mut reader = io::Cursor::new(raw_chunk_bytes(*b"ABcD", b"data"));
+        assert_eq!(read_chunk(&mut reader, u32::MAX).unwrap().data(), b"data");
+    }
+
+    #[test]
+    fn read_chunk_rejects_crc_mismatch() {
+        let mut bytes = valid_chunk_bytes();
+        *bytes.last_mut().unwrap() ^= 0xFF;
+        let mut reader = io::Cursor::new(bytes);
+        assert_eq!(
+            read_chunk(&mut reader, u32::MAX).unwrap_err().kind(),
             io::ErrorKind::InvalidData
         );
     }

--- a/lib/src/util/io.rs
+++ b/lib/src/util/io.rs
@@ -6,6 +6,21 @@ pub(crate) use self::finish::TryIntoInner;
 use crate::chunk::MAX_CHUNK_DATA_LENGTH;
 use std::io;
 
+/// Allocates a zeroed buffer of `len` bytes, reporting allocation failure
+/// instead of aborting the process as `vec![0; len]` would.
+///
+/// # Errors
+///
+/// Returns [`io::ErrorKind::OutOfMemory`] when the allocation fails.
+#[inline]
+pub(crate) fn try_zeroed_vec(len: usize) -> io::Result<Vec<u8>> {
+    let mut buf = Vec::new();
+    buf.try_reserve_exact(len)
+        .map_err(|_| io::Error::from(io::ErrorKind::OutOfMemory))?;
+    buf.resize(len, 0);
+    Ok(buf)
+}
+
 const MIN_CHUNK_BODY_SIZE: usize = 1;
 
 #[inline]


### PR DESCRIPTION
## Summary

- add symmetric `bytes::read_chunk` and `io::read_chunk` low-level APIs
- require an inclusive payload limit before allocation
- always validate chunk type and CRC-32 while returning concrete `RawChunk` values
- centralize chunk CRC calculation and validation under `format::chunk`

## Why

Single-chunk framing was only available through crate-private readers or archive-level iterators. This adds a small validated primitive without mixing in the PNA signature, AEND handling, or archive ordering.

## Validation

- `cargo test --workspace --all-features`
- `cargo clippy -p libpna --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

Stacked on #3333.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent chunk reading for synchronous and asynchronous archive processing.
  * Added validation for chunk types, lengths, and CRC checksums.
  * Added safeguards for oversized chunks, truncated data, malformed input, and memory allocation failures.

* **Bug Fixes**
  * Improved archive-read reliability by ensuring invalid or corrupted chunks are rejected with clear I/O errors.
  * Preserved existing asynchronous entry-processing behavior while applying the new validation consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->