### PR TITLE
:recycle: Read chunks through shared primitives

### DIFF
--- a/lib/src/archive/read.rs
+++ b/lib/src/archive/read.rs
@@ -4,7 +4,7 @@ mod slice;
 
 use crate::{
     archive::{Archive, ArchiveHeader},
-    chunk::{Chunk, ChunkReader, ChunkType, RawChunk, read_chunk},
+    chunk::{Chunk, ChunkReader, ChunkType, RawChunk},
     entry::{Entry, NormalEntry, RawEntry, ReadEntry, ReadOptions},
 };
 use std::{
@@ -46,8 +46,9 @@ impl<R: Read> Archive<R> {
     fn next_raw_item(&mut self) -> io::Result<Option<RawEntry>> {
         let mut chunks = Vec::new();
         swap(&mut self.buf, &mut chunks);
+        let max_chunk_size = self.max_chunk_size.map_or(u32::MAX, |max| max.get());
         loop {
-            let chunk = read_chunk(&mut self.inner, self.max_chunk_size)?;
+            let chunk = crate::io::read_chunk(&mut self.inner, max_chunk_size)?;
             match chunk.ty {
                 ChunkType::FEND | ChunkType::SEND => {
                     chunks.push(chunk);
@@ -407,7 +408,7 @@ impl<R: Read + Seek> Archive<R> {
     /// ```
     #[inline]
     pub fn seek_to_end(&mut self) -> io::Result<()> {
-        let mut reader = ChunkReader::new(&mut self.inner, self.max_chunk_size);
+        let mut reader = ChunkReader::new(&mut self.inner);
         let byte = loop {
             let (ty, byte_length) = reader.skip_chunk()?;
             if ty == ChunkType::AEND {

--- a/lib/src/archive/read.rs
+++ b/lib/src/archive/read.rs
@@ -25,8 +25,7 @@ impl<R: Read> Archive<R> {
 
     fn read_header_with_buffer(mut reader: R, buf: Vec<RawChunk>) -> io::Result<Self> {
         crate::io::read_signature(&mut reader)?;
-        let mut chunk_reader = ChunkReader::new(&mut reader, None);
-        let chunk = chunk_reader.read_chunk()?;
+        let chunk = crate::io::read_chunk(&mut reader, u32::MAX)?;
         if chunk.ty != ChunkType::AHED {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,

--- a/lib/src/archive/read/slice.rs
+++ b/lib/src/archive/read/slice.rs
@@ -21,7 +21,7 @@ impl<'d> Archive<&'d [u8]> {
     #[inline]
     fn read_header_from_slice_with_buffer(bytes: &'d [u8], buf: Vec<RawChunk>) -> io::Result<Self> {
         let bytes = crate::bytes::read_signature(bytes)?;
-        let (chunk, r) = read_chunk_from_slice(bytes)?;
+        let (chunk, r) = crate::bytes::read_chunk(bytes, u32::MAX)?;
         if chunk.ty != ChunkType::AHED {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,

--- a/lib/src/archive/read/slice.rs
+++ b/lib/src/archive/read/slice.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     Archive, Chunk, ChunkType, Entry, NormalEntry, RawChunk, ReadEntry, ReadOptions,
-    archive::ArchiveHeader, chunk::read_chunk_from_slice, entry::RawEntry,
+    archive::ArchiveHeader, entry::RawEntry,
 };
 use std::borrow::Cow;
 use std::io;
@@ -44,7 +44,7 @@ impl<'d> Archive<&'d [u8]> {
         std::mem::swap(&mut self.buf, &mut chunks);
         let mut chunks = chunks.into_iter().map(Into::into).collect::<Vec<_>>();
         loop {
-            let (chunk, r) = read_chunk_from_slice(self.inner)?;
+            let (chunk, r) = crate::bytes::read_chunk(self.inner, u32::MAX)?;
             self.inner = r;
             match chunk.ty {
                 ChunkType::FEND | ChunkType::SEND => {

--- a/lib/src/chunk.rs
+++ b/lib/src/chunk.rs
@@ -386,7 +386,7 @@ pub fn read_as_chunks<R: Read>(
     mut archive: R,
 ) -> io::Result<impl Iterator<Item = io::Result<impl Chunk>>> {
     struct Chunks<R> {
-        reader: ChunkReader<R>,
+        reader: R,
         eoa: bool,
     }
     impl<R: Read> Iterator for Chunks<R> {
@@ -396,15 +396,17 @@ pub fn read_as_chunks<R: Read>(
             if self.eoa {
                 return None;
             }
-            Some(self.reader.read_chunk().inspect(|chunk| {
-                self.eoa = chunk.ty() == ChunkType::AEND;
-            }))
+            Some(
+                crate::io::read_chunk(&mut self.reader, u32::MAX).inspect(|chunk| {
+                    self.eoa = chunk.ty() == ChunkType::AEND;
+                }),
+            )
         }
     }
     crate::io::read_signature(&mut archive)?;
 
     Ok(Chunks {
-        reader: ChunkReader::new(archive, None),
+        reader: archive,
         eoa: false,
     })
 }
@@ -451,11 +453,13 @@ pub fn read_chunks_from_slice<'a>(
             if self.eoa {
                 return None;
             }
-            Some(read_chunk_from_slice(self.reader).map(|(chunk, bytes)| {
-                self.eoa = chunk.ty() == ChunkType::AEND;
-                self.reader = bytes;
-                chunk
-            }))
+            Some(
+                crate::bytes::read_chunk(self.reader, u32::MAX).map(|(chunk, bytes)| {
+                    self.eoa = chunk.ty() == ChunkType::AEND;
+                    self.reader = bytes;
+                    chunk
+                }),
+            )
         }
     }
     let archive = crate::bytes::read_signature(archive)?;

--- a/lib/src/chunk/read.rs
+++ b/lib/src/chunk/read.rs
@@ -1,7 +1,6 @@
 //! Chunk reading and deserialization from byte streams and slices.
 
-use crate::chunk::{ChunkType, MIN_CHUNK_BYTES_SIZE, RawChunk};
-use core::num::NonZeroU32;
+use crate::chunk::{ChunkType, MIN_CHUNK_BYTES_SIZE};
 use std::{
     io::{self, Read, Seek, SeekFrom},
     mem,
@@ -9,22 +8,11 @@ use std::{
 
 pub(crate) struct ChunkReader<R> {
     pub(crate) r: R,
-    max_chunk_size: Option<NonZeroU32>,
 }
 
 impl<R> ChunkReader<R> {
-    pub(crate) fn new(reader: R, max_chunk_size: Option<NonZeroU32>) -> Self {
-        Self {
-            r: reader,
-            max_chunk_size,
-        }
-    }
-}
-
-impl<R: Read> ChunkReader<R> {
-    #[inline]
-    pub(crate) fn read_chunk(&mut self) -> io::Result<RawChunk> {
-        read_chunk(&mut self.r, self.max_chunk_size)
+    pub(crate) fn new(reader: R) -> Self {
+        Self { r: reader }
     }
 }
 
@@ -52,93 +40,5 @@ impl<R: Read + Seek> ChunkReader<R> {
                 .checked_add(length as usize)
                 .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "chunk size overflow"))?,
         ))
-    }
-}
-
-pub(crate) fn read_chunk<R: Read>(
-    mut r: R,
-    max_chunk_size: Option<NonZeroU32>,
-) -> io::Result<RawChunk> {
-    crate::io::read_chunk(&mut r, max_chunk_size.map_or(u32::MAX, NonZeroU32::get))
-}
-
-pub(crate) fn read_chunk_from_slice(bytes: &[u8]) -> io::Result<(RawChunk<&[u8]>, &[u8])> {
-    crate::bytes::read_chunk(bytes, u32::MAX)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::chunk::ChunkExt;
-    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
-    use wasm_bindgen_test::wasm_bindgen_test as test;
-
-    fn valid_chunk_bytes() -> Vec<u8> {
-        RawChunk::from_data(ChunkType::FDAT, vec![0xAA, 0xBB, 0xCC, 0xDD]).to_bytes()
-    }
-
-    #[test]
-    fn read_from_slice_roundtrips_valid_chunk() {
-        let bytes = valid_chunk_bytes();
-        let (chunk, rest) = read_chunk_from_slice(&bytes).unwrap();
-        assert_eq!(chunk.ty, ChunkType::FDAT);
-        assert_eq!(chunk.data, &[0xAA, 0xBB, 0xCC, 0xDD]);
-        assert!(rest.is_empty());
-    }
-
-    #[test]
-    fn read_from_slice_rejects_crc_mismatch() {
-        let mut bytes = valid_chunk_bytes();
-        *bytes.last_mut().unwrap() ^= 0xFF;
-        let err = read_chunk_from_slice(&bytes).unwrap_err();
-        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
-    }
-
-    #[test]
-    fn read_from_slice_rejects_data_corruption_with_intact_crc() {
-        let mut bytes = valid_chunk_bytes();
-        bytes[8] ^= 0xFF;
-        let err = read_chunk_from_slice(&bytes).unwrap_err();
-        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
-    }
-
-    #[test]
-    fn read_from_slice_rejects_truncated_crc() {
-        let bytes = valid_chunk_bytes();
-        let truncated = &bytes[..bytes.len() - 2];
-        let err = read_chunk_from_slice(truncated).unwrap_err();
-        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
-    }
-
-    #[test]
-    fn read_from_slice_rejects_length_exceeding_input() {
-        let mut bytes = valid_chunk_bytes();
-        bytes[3] = 0xFF;
-        let err = read_chunk_from_slice(&bytes).unwrap_err();
-        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
-    }
-
-    #[test]
-    fn read_from_reader_roundtrips_valid_chunk() {
-        let bytes = valid_chunk_bytes();
-        let chunk = read_chunk(io::Cursor::new(bytes), None).unwrap();
-        assert_eq!(chunk.ty, ChunkType::FDAT);
-        assert_eq!(chunk.data, vec![0xAA, 0xBB, 0xCC, 0xDD]);
-    }
-
-    #[test]
-    fn read_from_reader_rejects_crc_mismatch() {
-        let mut bytes = valid_chunk_bytes();
-        *bytes.last_mut().unwrap() ^= 0xFF;
-        let err = read_chunk(io::Cursor::new(bytes), None).unwrap_err();
-        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
-    }
-
-    #[test]
-    fn read_from_reader_rejects_length_exceeding_input() {
-        let mut bytes = valid_chunk_bytes();
-        bytes[3] = 0xFF;
-        let err = read_chunk(io::Cursor::new(bytes), None).unwrap_err();
-        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
     }
 }

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -28,9 +28,7 @@ pub use self::{
 pub(crate) use self::{private::*, read::*, write::*};
 use crate::{
     Duration,
-    chunk::{
-        Chunk, ChunkExt, ChunkReader, ChunkType, MIN_CHUNK_BYTES_SIZE, RawChunk, chunk_data_split,
-    },
+    chunk::{Chunk, ChunkExt, ChunkType, MIN_CHUNK_BYTES_SIZE, RawChunk, chunk_data_split},
     util::io::ChainReader,
     util::slice::skip_while,
 };
@@ -380,10 +378,9 @@ pub(crate) struct EntryIterator<'s>(EntryReader<EncodedDataReader<'s>>);
 
 #[inline]
 fn read_next_normal_entry_from_stream<R: Read>(reader: &mut R) -> Option<io::Result<NormalEntry>> {
-    let mut chunk_reader = ChunkReader::new(reader, None);
     let mut chunks = Vec::new();
     loop {
-        let chunk = chunk_reader.read_chunk();
+        let chunk = crate::io::read_chunk(reader, u32::MAX);
         match chunk {
             Ok(chunk) => match chunk.ty {
                 ChunkType::FEND => {


### PR DESCRIPTION
## Summary

- route raw chunk iterators through the new low-level parsing APIs
- route archive headers, archive entries, and solid inner entries through the same primitives
- remove the duplicate synchronous and slice parser implementations

## Why

The public API should be the implementation's canonical framing path. Sharing it keeps size-limit, type, CRC, and truncation behavior aligned across callers.

## Validation

- `cargo test --workspace --all-features`
- `cargo clippy -p libpna --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

Stacked on the low-level chunk parsing API PR.
