### PR TITLE
:bug: Preserve chunk fields through references

### DIFF
--- a/lib/src/chunk.rs
+++ b/lib/src/chunk.rs
@@ -292,7 +292,12 @@ impl<T: AsRef<[u8]>> Chunk for (ChunkType, T) {
     }
 }
 
-impl<T: Chunk> Chunk for &T {
+impl<T: Chunk + ?Sized> Chunk for &T {
+    #[inline]
+    fn length(&self) -> u32 {
+        T::length(*self)
+    }
+
     #[inline]
     fn ty(&self) -> ChunkType {
         T::ty(*self)
@@ -301,10 +306,20 @@ impl<T: Chunk> Chunk for &T {
     #[inline]
     fn data(&self) -> &[u8] {
         T::data(*self)
+    }
+
+    #[inline]
+    fn crc(&self) -> u32 {
+        T::crc(*self)
     }
 }
 
-impl<T: Chunk> Chunk for &mut T {
+impl<T: Chunk + ?Sized> Chunk for &mut T {
+    #[inline]
+    fn length(&self) -> u32 {
+        T::length(*self)
+    }
+
     #[inline]
     fn ty(&self) -> ChunkType {
         T::ty(*self)
@@ -313,6 +328,11 @@ impl<T: Chunk> Chunk for &mut T {
     #[inline]
     fn data(&self) -> &[u8] {
         T::data(*self)
+    }
+
+    #[inline]
+    fn crc(&self) -> u32 {
+        T::crc(*self)
     }
 }
 
@@ -453,6 +473,40 @@ mod tests {
     use super::*;
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
+
+    #[test]
+    fn chunk_references_preserve_fields() {
+        struct StoredChunk;
+
+        impl Chunk for StoredChunk {
+            fn length(&self) -> u32 {
+                1
+            }
+
+            fn ty(&self) -> ChunkType {
+                ChunkType::FDAT
+            }
+
+            fn data(&self) -> &[u8] {
+                b"abc"
+            }
+
+            fn crc(&self) -> u32 {
+                0x0102_0304
+            }
+        }
+
+        fn assert_fields(chunk: impl Chunk) {
+            assert_eq!(chunk.length(), 1);
+            assert_eq!(chunk.ty(), ChunkType::FDAT);
+            assert_eq!(chunk.data(), b"abc");
+            assert_eq!(chunk.crc(), 0x0102_0304);
+        }
+
+        let mut chunk = StoredChunk;
+        assert_fields(&chunk);
+        assert_fields(&mut chunk);
+    }
 
     #[test]
     fn chunk_trait_bounds() {

--- a/lib/src/chunk/traits.rs
+++ b/lib/src/chunk/traits.rs
@@ -24,10 +24,11 @@ use super::{ChunkType, Crc32};
 /// assert_eq!(chunk.crc(), 2776590148);
 /// ```
 pub trait Chunk {
-    /// Returns the length of the chunk's data payload in bytes.
+    /// Returns the chunk's represented data length.
     ///
-    /// This value corresponds to the `length` field stored in the chunk structure
-    /// and indicates the size of the data returned by the `data()` method.
+    /// The default implementation derives the length from [`Chunk::data`].
+    /// Implementations that preserve an encoded chunk may override this method to
+    /// return its stored `length` field.
     #[inline]
     fn length(&self) -> u32 {
         self.data().len() as u32
@@ -39,7 +40,11 @@ pub trait Chunk {
     /// Returns the data of the chunk.
     fn data(&self) -> &[u8];
 
-    /// Returns the CRC32 checksum calculated over the chunk's type and data fields.
+    /// Returns the chunk's represented CRC32 checksum.
+    ///
+    /// The default implementation calculates the checksum over [`Chunk::ty`] and
+    /// [`Chunk::data`]. Implementations that preserve an encoded chunk may override
+    /// this method to return its stored `crc` field.
     #[inline]
     fn crc(&self) -> u32 {
         let mut crc = Crc32::new();


### PR DESCRIPTION
## Summary

- forward `length`, `ty`, `data`, and `crc` through `Chunk` implementations for `&T` and `&mut T`
- allow those reference implementations to wrap `Chunk + ?Sized`
- clarify that the default length and CRC accessors derive canonical values while implementations may preserve encoded fields
- add a focused regression test for shared and mutable references

## Why

The reference implementations previously forwarded only the chunk type and data. Their length and CRC therefore fell back to the trait defaults and were recalculated. Wrapping a custom chunk in a reference could silently change its represented wire fields.

References now preserve the same four-field representation as the underlying chunk, making `Chunk` reference-transparent independently of any future writing API.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p libpna chunk_references_preserve_fields --all-features`
- `cargo test -p libpna --all-features`
- `cargo clippy -p libpna --all-targets --all-features -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chunk functionality now works consistently with both shared and mutable references.
  * Unsized chunk types are supported when accessed through references.
  * Chunk fields and checksum values are preserved when using references.

* **Documentation**
  * Clarified how chunk lengths and checksums are calculated, including behavior for encoded chunks and stored checksums.

* **Tests**
  * Added coverage confirming reference-based chunks preserve their values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->