### PR TITLE
:recycle: Share low-level chunk writing primitives

### DIFF
--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -756,7 +756,7 @@ mod tests {
 
     mod gcm_roundtrip {
         use super::*;
-        use crate::chunk::{Chunk, ChunkExt, ChunkType, RawChunk, read_as_chunks};
+        use crate::chunk::{Chunk, ChunkType, read_as_chunks};
         use std::num::NonZeroU32;
         #[cfg(all(target_family = "wasm", target_os = "unknown"))]
         use wasm_bindgen_test::wasm_bindgen_test as test;
@@ -828,17 +828,13 @@ mod tests {
                 if chunk.ty() == ChunkType::FDAT {
                     if !emitted {
                         for segment in &segments {
-                            RawChunk::from_data(ChunkType::FDAT, segment.to_vec())
-                                .write_chunk_in(&mut out)
-                                .unwrap();
+                            crate::io::write_chunk(&mut out, (ChunkType::FDAT, *segment)).unwrap();
                         }
                         emitted = true;
                     }
                     continue;
                 }
-                RawChunk::from_data(chunk.ty(), chunk.data().to_vec())
-                    .write_chunk_in(&mut out)
-                    .unwrap();
+                crate::io::write_chunk(&mut out, chunk).unwrap();
             }
             out
         }
@@ -1112,7 +1108,7 @@ mod tests {
 
     mod gcm_negative {
         use super::*;
-        use crate::chunk::{Chunk, ChunkExt, ChunkType, RawChunk, read_as_chunks};
+        use crate::chunk::{Chunk, ChunkType, read_as_chunks};
         use crate::error::AeadError;
         #[cfg(all(target_family = "wasm", target_os = "unknown"))]
         use wasm_bindgen_test::wasm_bindgen_test as test;
@@ -1199,9 +1195,7 @@ mod tests {
                     }
                     seen += 1;
                 }
-                RawChunk::from_data(chunk.ty(), data)
-                    .write_chunk_in(&mut out)
-                    .unwrap();
+                crate::io::write_chunk(&mut out, (chunk.ty(), data)).unwrap();
             }
             assert!(f.is_none(), "target chunk was found and tampered");
             out
@@ -1245,13 +1239,9 @@ mod tests {
                 }
                 if let Some(mut data) = stream.take() {
                     (f.take().expect("target datastream is tampered once"))(&mut data);
-                    RawChunk::from_data(ChunkType::FDAT, data)
-                        .write_chunk_in(&mut out)
-                        .unwrap();
+                    crate::io::write_chunk(&mut out, (ChunkType::FDAT, data)).unwrap();
                 }
-                RawChunk::from_data(ty, chunk.data().to_vec())
-                    .write_chunk_in(&mut out)
-                    .unwrap();
+                crate::io::write_chunk(&mut out, chunk).unwrap();
             }
             assert!(f.is_none(), "target datastream was found and tampered");
             out
@@ -1289,13 +1279,9 @@ mod tests {
                 }
                 if let Some(mut data) = stream.take() {
                     (f.take().expect("target datastream is tampered once"))(&mut data);
-                    RawChunk::from_data(ChunkType::SDAT, data)
-                        .write_chunk_in(&mut out)
-                        .unwrap();
+                    crate::io::write_chunk(&mut out, (ChunkType::SDAT, data)).unwrap();
                 }
-                RawChunk::from_data(ty, chunk.data().to_vec())
-                    .write_chunk_in(&mut out)
-                    .unwrap();
+                crate::io::write_chunk(&mut out, chunk).unwrap();
             }
             assert!(f.is_none(), "target datastream was found and tampered");
             out

--- a/lib/src/archive/read.rs
+++ b/lib/src/archive/read.rs
@@ -427,9 +427,14 @@ impl<R: Read + Seek> Archive<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::chunk::ChunkExt;
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
+
+    fn chunk_bytes(chunk: impl Chunk) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        crate::io::write_chunk(&mut bytes, chunk).unwrap();
+        bytes
+    }
 
     #[test]
     fn decode() {
@@ -457,17 +462,15 @@ mod tests {
     #[test]
     fn read_header_rejects_non_ahed_first_chunk() {
         let mut bytes = crate::PNA_SIGNATURE.to_vec();
-        bytes.extend_from_slice(&RawChunk::from_data(ChunkType::FEND, Vec::new()).to_bytes());
+        bytes.extend_from_slice(&chunk_bytes((ChunkType::FEND, [])));
         let err = Archive::read_header(&bytes[..]).err().unwrap();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 
     fn archive_bytes(header: ArchiveHeader) -> Vec<u8> {
         let mut bytes = crate::PNA_SIGNATURE.to_vec();
-        bytes.extend_from_slice(
-            &RawChunk::from_data(ChunkType::AHED, header.to_bytes().to_vec()).to_bytes(),
-        );
-        bytes.extend_from_slice(&RawChunk::from_data(ChunkType::AEND, Vec::new()).to_bytes());
+        bytes.extend_from_slice(&chunk_bytes((ChunkType::AHED, header.to_bytes())));
+        bytes.extend_from_slice(&chunk_bytes((ChunkType::AEND, [])));
         bytes
     }
 

--- a/lib/src/archive/write.rs
+++ b/lib/src/archive/write.rs
@@ -3,7 +3,7 @@
 use crate::{
     PNA_SIGNATURE,
     archive::{Archive, ArchiveHeader, SolidArchive},
-    chunk::{Chunk, ChunkExt, ChunkStreamWriter, ChunkType, RawChunk},
+    chunk::{Chunk, ChunkStreamWriter, ChunkType, RawChunk},
     cipher::CipherWriter,
     compress::CompressionWriter,
     entry::{
@@ -93,7 +93,7 @@ impl<W: Write> Archive<W> {
     #[inline]
     fn write_header_with(mut write: W, header: ArchiveHeader) -> io::Result<Self> {
         write.write_all(PNA_SIGNATURE)?;
-        (ChunkType::AHED, header.to_bytes()).write_chunk_in(&mut write)?;
+        crate::io::write_chunk(&mut write, (ChunkType::AHED, header.to_bytes()))?;
         Ok(Self::new(write, header))
     }
 
@@ -254,14 +254,14 @@ impl<W: Write> Archive<W> {
     {
         let mut written_len = 0;
         for chunk in entry_part.0 {
-            written_len += chunk.write_chunk_in(&mut self.inner)?;
+            written_len += crate::io::write_chunk(&mut self.inner, chunk)?;
         }
         Ok(written_len)
     }
 
     #[inline]
     fn add_next_archive_marker(&mut self) -> io::Result<usize> {
-        (ChunkType::ANXT, []).write_chunk_in(&mut self.inner)
+        crate::io::write_chunk(&mut self.inner, (ChunkType::ANXT, []))
     }
 
     /// Splits to the next archive.
@@ -328,7 +328,7 @@ impl<W: Write> Archive<W> {
     #[inline]
     #[must_use = "archive is not complete until finalize succeeds"]
     pub fn finalize(mut self) -> io::Result<W> {
-        (ChunkType::AEND, []).write_chunk_in(&mut self.inner)?;
+        crate::io::write_chunk(&mut self.inner, (ChunkType::AEND, []))?;
         Ok(self.inner)
     }
 }
@@ -350,10 +350,7 @@ impl<W: AsyncWrite + Unpin> Archive<W> {
     #[inline]
     async fn write_header_with_async(mut write: W, header: ArchiveHeader) -> io::Result<Self> {
         write.write_all(PNA_SIGNATURE).await?;
-        let mut chunk_writer = crate::chunk::ChunkWriter::new(&mut write);
-        chunk_writer
-            .write_chunk_async((ChunkType::AHED, header.to_bytes()))
-            .await?;
+        crate::async_io::write_chunk(&mut write, (ChunkType::AHED, header.to_bytes())).await?;
         Ok(Self::new(write, header))
     }
 
@@ -379,10 +376,7 @@ impl<W: AsyncWrite + Unpin> Archive<W> {
     /// Returns an error if writing the end-of-archive marker fails.
     #[inline]
     pub async fn finalize_async(mut self) -> io::Result<W> {
-        let mut chunk_writer = crate::chunk::ChunkWriter::new(&mut self.inner);
-        chunk_writer
-            .write_chunk_async((ChunkType::AEND, []))
-            .await?;
+        crate::async_io::write_chunk(&mut self.inner, (ChunkType::AEND, [])).await?;
         Ok(self.inner)
     }
 }
@@ -425,9 +419,9 @@ impl<W: Write> Archive<W> {
         );
         let context = get_writer_context(option, ChunkType::SHED, &header.to_bytes())?;
 
-        (ChunkType::SHED, header.to_bytes()).write_chunk_in(&mut self.inner)?;
+        crate::io::write_chunk(&mut self.inner, (ChunkType::SHED, header.to_bytes()))?;
         if let Some(WriteCipher { context: c, .. }) = &context.cipher {
-            (ChunkType::PHSF, c.phsf.as_bytes()).write_chunk_in(&mut self.inner)?;
+            crate::io::write_chunk(&mut self.inner, (ChunkType::PHSF, c.phsf.as_bytes()))?;
         }
         self.inner.flush()?;
         let max_chunk_size = self.max_chunk_size;
@@ -619,7 +613,7 @@ impl<W: Write> SolidArchive<W> {
     fn finalize_solid_entry(mut self) -> io::Result<Archive<W>> {
         self.inner.flush()?;
         let mut inner = self.inner.try_into_inner()?.try_into_inner()?.into_inner();
-        (ChunkType::SEND, []).write_chunk_in(&mut inner)?;
+        crate::io::write_chunk(&mut inner, (ChunkType::SEND, []))?;
         Ok(Archive::new(inner, self.archive_header))
     }
 }
@@ -649,14 +643,14 @@ where
         name,
     );
     let header_bytes = header.to_bytes();
-    (ChunkType::FHED, &header_bytes).write_chunk_in(inner)?;
+    crate::io::write_chunk(inner, (ChunkType::FHED, &header_bytes))?;
     for chunk in extra_chunks {
-        chunk.write_chunk_in(inner)?;
+        crate::io::write_chunk(inner, chunk)?;
     }
     write_metadata_facets(inner, &metadata)?;
     let context = get_writer_context(option, ChunkType::FHED, &header_bytes)?;
     if let Some(WriteCipher { context: c, .. }) = &context.cipher {
-        (ChunkType::PHSF, c.phsf.as_bytes()).write_chunk_in(inner)?;
+        crate::io::write_chunk(inner, (ChunkType::PHSF, c.phsf.as_bytes()))?;
     }
     let inner = {
         let mut writer = ChunkStreamWriter::new(ChunkType::FDAT, inner, max_chunk_size);
@@ -668,7 +662,7 @@ where
         writer.flush()?;
         writer.try_into_inner()?.try_into_inner()?.into_inner()
     };
-    (ChunkType::FEND, Vec::<u8>::new()).write_chunk_in(inner)?;
+    crate::io::write_chunk(inner, (ChunkType::FEND, Vec::<u8>::new()))?;
     Ok(())
 }
 

--- a/lib/src/chunk.rs
+++ b/lib/src/chunk.rs
@@ -12,7 +12,7 @@ pub(crate) use self::write::*;
 pub use self::{traits::*, types::*};
 use std::{
     borrow::Cow,
-    io::{self, prelude::*},
+    io::{self, Read},
     mem,
 };
 
@@ -30,9 +30,7 @@ pub(crate) const MAX_CHUNK_DATA_LENGTH: usize = u32::MAX as usize;
 /// An extension trait for [`Chunk`] that provides common operations.
 ///
 /// This trait is automatically implemented for any type that implements [`Chunk`],
-/// offering a set of convenient methods for working with chunks, such as
-/// calculating their total byte length, writing them to a writer, and converting
-/// them to a byte vector.
+/// offering convenient methods for inspecting chunk properties.
 pub(crate) trait ChunkExt: Chunk {
     /// Calculates the total size of the chunk in bytes.
     ///
@@ -50,38 +48,6 @@ pub(crate) trait ChunkExt: Chunk {
     #[inline]
     fn is_stream_chunk(&self) -> bool {
         self.ty() == ChunkType::FDAT || self.ty() == ChunkType::SDAT
-    }
-
-    /// Writes the entire chunk to a given writer.
-    ///
-    /// This method serializes the chunk, including its length, type, data, and
-    /// CRC, and writes the resulting bytes to the specified writer.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if any part of the write operation fails.
-    #[inline]
-    fn write_chunk_in<W: Write>(&self, writer: &mut W) -> io::Result<usize> {
-        writer.write_all(&self.length().to_be_bytes())?;
-        writer.write_all(self.ty().as_bytes())?;
-        writer.write_all(self.data())?;
-        writer.write_all(&self.crc().to_be_bytes())?;
-        Ok(self.bytes_len())
-    }
-
-    /// Converts the chunk into a `Vec<u8>`.
-    ///
-    /// This method serializes the entire chunk into a byte vector, which can be
-    /// useful for buffering or network transmission.
-    #[allow(dead_code)]
-    #[inline]
-    fn to_bytes(&self) -> Vec<u8> {
-        let mut vec = Vec::with_capacity(self.bytes_len());
-        vec.extend_from_slice(&self.length().to_be_bytes());
-        vec.extend_from_slice(self.ty().as_bytes());
-        vec.extend_from_slice(self.data());
-        vec.extend_from_slice(&self.crc().to_be_bytes());
-        vec
     }
 }
 
@@ -528,24 +494,6 @@ mod tests {
     }
 
     #[test]
-    fn to_bytes() {
-        let data = vec![0xAA, 0xBB, 0xCC, 0xDD];
-        let chunk = RawChunk::from_data(ChunkType::FDAT, data);
-
-        let bytes = chunk.to_bytes();
-
-        assert_eq!(
-            bytes,
-            vec![
-                0x00, 0x00, 0x00, 0x04, // chunk length (4)
-                0x46, 0x44, 0x41, 0x54, // chunk type ("FDAT")
-                0xAA, 0xBB, 0xCC, 0xDD, // data bytes
-                0x47, 0xf3, 0x2b, 0x10, // CRC32 (calculated from chunk type and data)
-            ]
-        );
-    }
-
-    #[test]
     fn data_split_at_zero() {
         let data = vec![0xAA, 0xBB, 0xCC, 0xDD];
         let chunk = RawChunk::from_data(ChunkType::FDAT, data);
@@ -602,7 +550,8 @@ mod tests {
 
     fn archive_with_broken_chunk() -> Vec<u8> {
         let mut archive = crate::PNA_SIGNATURE.to_vec();
-        let mut chunk = RawChunk::from_data(ChunkType::FDAT, b"data").to_bytes();
+        let mut chunk = Vec::new();
+        crate::io::write_chunk(&mut chunk, (ChunkType::FDAT, b"data")).unwrap();
         *chunk.last_mut().unwrap() ^= 0xFF;
         archive.extend_from_slice(&chunk);
         archive

--- a/lib/src/chunk/write.rs
+++ b/lib/src/chunk/write.rs
@@ -1,53 +1,12 @@
 //! Chunk writing and serialization to byte streams.
 
-use crate::chunk::{Chunk, ChunkExt, ChunkType};
+use crate::chunk::ChunkType;
 use core::num::NonZeroU32;
-#[cfg(feature = "unstable-async")]
-use futures_io::AsyncWrite;
-#[cfg(feature = "unstable-async")]
-use futures_util::AsyncWriteExt;
 use std::io::{self, Write};
-
-pub(crate) struct ChunkWriter<W> {
-    w: W,
-}
-
-impl<W> ChunkWriter<W> {
-    #[inline]
-    pub(crate) const fn new(writer: W) -> Self {
-        Self { w: writer }
-    }
-}
-
-impl<W: Write> ChunkWriter<W> {
-    #[inline]
-    pub(crate) fn write_chunk(&mut self, chunk: impl Chunk) -> io::Result<usize> {
-        chunk.write_chunk_in(&mut self.w)
-    }
-}
-
-#[cfg(feature = "unstable-async")]
-impl<W: AsyncWrite + Unpin> ChunkWriter<W> {
-    pub(crate) async fn write_chunk_async(&mut self, chunk: impl Chunk) -> io::Result<usize> {
-        // write length
-        let length = chunk.length();
-        self.w.write_all(&length.to_be_bytes()).await?;
-
-        // write a chunk type
-        self.w.write_all(chunk.ty().as_bytes()).await?;
-
-        // write data
-        self.w.write_all(chunk.data()).await?;
-
-        // write crc32
-        self.w.write_all(&chunk.crc().to_be_bytes()).await?;
-        Ok(chunk.bytes_len())
-    }
-}
 
 pub(crate) struct ChunkStreamWriter<W> {
     ty: ChunkType,
-    w: ChunkWriter<W>,
+    w: W,
     max_chunk_size: usize,
 }
 
@@ -56,7 +15,7 @@ impl<W> ChunkStreamWriter<W> {
     pub(crate) const fn new(ty: ChunkType, inner: W, max_chunk_size: Option<NonZeroU32>) -> Self {
         Self {
             ty,
-            w: ChunkWriter::new(inner),
+            w: inner,
             max_chunk_size: match max_chunk_size {
                 Some(n) => n.get() as usize,
                 None => u32::MAX as usize,
@@ -66,7 +25,7 @@ impl<W> ChunkStreamWriter<W> {
 
     #[inline]
     pub(crate) fn into_inner(self) -> W {
-        self.w.w
+        self.w
     }
 }
 
@@ -77,13 +36,13 @@ impl<W: Write> Write for ChunkStreamWriter<W> {
             return Ok(0);
         }
         let chunk = &buf[..buf.len().min(self.max_chunk_size)];
-        self.w.write_chunk((self.ty, chunk))?;
+        crate::io::write_chunk(&mut self.w, (self.ty, chunk))?;
         Ok(chunk.len())
     }
 
     #[inline]
     fn flush(&mut self) -> io::Result<()> {
-        self.w.w.flush()
+        self.w.flush()
     }
 }
 
@@ -92,35 +51,6 @@ mod tests {
     use super::*;
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
-
-    #[test]
-    fn write_aend_chunk() {
-        let mut chunk_writer = ChunkWriter::new(Vec::new());
-        assert_eq!(chunk_writer.write_chunk((ChunkType::AEND, [])).unwrap(), 12);
-        assert_eq!(
-            chunk_writer.w,
-            [0, 0, 0, 0, 65, 69, 78, 68, 107, 246, 72, 109]
-        );
-    }
-
-    #[test]
-    fn write_fdat_chunk() {
-        let mut chunk_writer = ChunkWriter::new(Vec::new());
-        assert_eq!(
-            chunk_writer
-                .write_chunk((ChunkType::FDAT, b"text data"))
-                .unwrap(),
-            21,
-        );
-
-        assert_eq!(
-            chunk_writer.w,
-            [
-                0, 0, 0, 9, 70, 68, 65, 84, 116, 101, 120, 116, 32, 100, 97, 116, 97, 177, 70, 138,
-                128
-            ]
-        );
-    }
 
     #[test]
     fn stream_writer_no_limit_writes_single_chunk() {
@@ -168,28 +98,5 @@ mod tests {
         assert_eq!(n, 0);
         let out = writer.into_inner();
         assert_eq!(out.len(), 0);
-    }
-
-    #[test]
-    fn stream_writer_exact_max_produces_single_chunk() {
-        let mut writer = ChunkStreamWriter::new(ChunkType::FDAT, Vec::new(), NonZeroU32::new(4));
-        let n = writer.write(b"abcd").unwrap();
-        assert_eq!(n, 4);
-        let out = writer.into_inner();
-        assert_eq!(&out[0..4], &4u32.to_be_bytes());
-        assert_eq!(&out[8..12], b"abcd");
-        assert_eq!(out.len(), 16);
-    }
-
-    #[test]
-    fn stream_writer_one_over_max_produces_two_chunks() {
-        let mut writer = ChunkStreamWriter::new(ChunkType::FDAT, Vec::new(), NonZeroU32::new(4));
-        writer.write_all(b"abcde").unwrap();
-        let out = writer.into_inner();
-        assert_eq!(&out[0..4], &4u32.to_be_bytes());
-        assert_eq!(&out[8..12], b"abcd");
-        assert_eq!(&out[16..20], &1u32.to_be_bytes());
-        assert_eq!(&out[24..25], b"e");
-        assert_eq!(out.len(), 16 + 13);
     }
 }

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -61,7 +61,7 @@ fn chunks_write_in<W: Write>(
 ) -> io::Result<usize> {
     let mut total = 0;
     for chunk in chunks {
-        total += chunk.write_chunk_in(writer)?;
+        total += crate::io::write_chunk(writer, chunk)?;
     }
     Ok(total)
 }
@@ -154,7 +154,7 @@ pub(crate) fn write_metadata_facets<W: Write>(
 ) -> io::Result<usize> {
     let mut total = 0;
     try_for_each_metadata_facet(metadata, |chunk| {
-        total += chunk.write_chunk_in(writer)?;
+        total += crate::io::write_chunk(writer, chunk)?;
         Ok::<(), io::Error>(())
     })?;
     Ok(total)
@@ -451,17 +451,17 @@ where
     #[inline]
     fn chunks_write_in<W: Write>(&self, writer: &mut W) -> io::Result<usize> {
         let mut total = 0;
-        total += (ChunkType::SHED, self.header.to_bytes()).write_chunk_in(writer)?;
+        total += crate::io::write_chunk(writer, (ChunkType::SHED, self.header.to_bytes()))?;
         for extra_chunk in &self.extra {
-            total += extra_chunk.write_chunk_in(writer)?;
+            total += crate::io::write_chunk(writer, extra_chunk)?;
         }
         if let Some(phsf) = &self.phsf {
-            total += (ChunkType::PHSF, phsf.as_bytes()).write_chunk_in(writer)?;
+            total += crate::io::write_chunk(writer, (ChunkType::PHSF, phsf.as_bytes()))?;
         }
         for data in &self.data {
-            total += (ChunkType::SDAT, data).write_chunk_in(writer)?;
+            total += crate::io::write_chunk(writer, (ChunkType::SDAT, data))?;
         }
-        total += (ChunkType::SEND, []).write_chunk_in(writer)?;
+        total += crate::io::write_chunk(writer, (ChunkType::SEND, []))?;
         Ok(total)
     }
 }
@@ -907,25 +907,27 @@ where
     fn chunks_write_in<W: Write>(&self, writer: &mut W) -> io::Result<usize> {
         let mut total = 0;
 
-        total += (ChunkType::FHED, self.header.to_bytes()).write_chunk_in(writer)?;
+        total += crate::io::write_chunk(writer, (ChunkType::FHED, self.header.to_bytes()))?;
         for ex in &self.extra {
-            total += ex.write_chunk_in(writer)?;
+            total += crate::io::write_chunk(writer, ex)?;
         }
         if let Some(raw_file_size) = self.metadata.raw_file_size {
-            total += (
-                ChunkType::fSIZ,
-                skip_while(&raw_file_size.to_be_bytes(), |i| *i == 0),
-            )
-                .write_chunk_in(writer)?;
+            total += crate::io::write_chunk(
+                writer,
+                (
+                    ChunkType::fSIZ,
+                    skip_while(&raw_file_size.to_be_bytes(), |i| *i == 0),
+                ),
+            )?;
         }
         total += write_metadata_facets(writer, &self.metadata)?;
         if let Some(p) = &self.phsf {
-            total += (ChunkType::PHSF, p.as_bytes()).write_chunk_in(writer)?;
+            total += crate::io::write_chunk(writer, (ChunkType::PHSF, p.as_bytes()))?;
         }
         for data_chunk in &self.data {
-            total += (ChunkType::FDAT, data_chunk).write_chunk_in(writer)?;
+            total += crate::io::write_chunk(writer, (ChunkType::FDAT, data_chunk))?;
         }
-        total += (ChunkType::FEND, []).write_chunk_in(writer)?;
+        total += crate::io::write_chunk(writer, (ChunkType::FEND, []))?;
         Ok(total)
     }
 }


### PR DESCRIPTION
## Summary

- route synchronous and asynchronous archive framing through the public low-level chunk writer
- route entry serialization and test fixture generation through the same primitive
- remove the redundant `ChunkWriter` wrapper and `ChunkExt` serialization helpers
- keep stream-writer tests focused on segmentation rather than re-testing field emission

## Stack

- stacked on #3351
- #3350 must merge before this writer stack so `Chunk` references preserve all four reported fields
- the existing #3342–#3341 branches were intentionally left unchanged; this PR is added only at the top of that stack

## Validation

- `cargo fmt --all`
- `cargo test -p libpna --all-features`
- `cargo clippy -p libpna --all-targets --all-features -- -D warnings`