### PR TITLE
Scope VM tests to each-feature over lib/pna/cli only

### DIFF
--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -61,7 +61,7 @@ jobs:
             chown -R $(whoami):$(id -gn) ./
             chmod -R a+rw ./
             cargo install -f cargo-hack@0.6.33 --locked
-            cargo hack test --locked --release --feature-powerset --exclude-features wasm
+            cargo hack test --locked --release --each-feature --exclude-features wasm -p libpna -p pna -p portable-network-archive
 
   NetBSD-test:
     runs-on: ubuntu-latest
@@ -91,7 +91,7 @@ jobs:
             chown -R $(whoami):$(id -gn) ./
             chmod -R a+rw ./
             cargo install -f cargo-hack --locked
-            cargo hack test --locked --release --feature-powerset --exclude-features wasm
+            cargo hack test --locked --release --each-feature --exclude-features wasm -p libpna -p pna -p portable-network-archive
 
   FreeBSD-test:
     runs-on: ubuntu-latest
@@ -153,7 +153,7 @@ jobs:
             chown -R $(whoami):$(id -gn) ./
             chmod -R a+rw ./
             cargo install -f cargo-hack --locked
-            cargo hack test --locked --release --feature-powerset --exclude-features wasm
+            cargo hack test --locked --release --each-feature --exclude-features wasm -p libpna -p pna -p portable-network-archive
 
   OpenBSD-test:
     runs-on: ubuntu-latest
@@ -182,7 +182,7 @@ jobs:
             chmod -R a+rw ./
             cargo install -f cargo-hack --locked
             ulimit -n 2048
-            cargo hack test --locked --release --feature-powerset --exclude-features wasm
+            cargo hack test --locked --release --each-feature --exclude-features wasm -p libpna -p pna -p portable-network-archive
 
 #  DragonflyBSD-test:
 #    runs-on: ubuntu-latest
@@ -207,7 +207,7 @@ jobs:
 #            chown -R $(whoami):$(id -gn) ./
 #            chmod -R a+rw ./
 #            cargo install -f cargo-hack --locked
-#            cargo hack test --locked --release --feature-powerset --exclude-features wasm
+#            cargo hack test --locked --release --each-feature --exclude-features wasm -p libpna -p pna -p portable-network-archive
 
   OmniOS-test:
     runs-on: ubuntu-latest
@@ -236,4 +236,4 @@ jobs:
             chown -R $(whoami):$(id -gn) ./
             chmod -R a+rw ./
             cargo install -f cargo-hack --locked
-            cargo hack test --locked --release --feature-powerset --exclude-features wasm,zlib-ng
+            cargo hack test --locked --release --each-feature --exclude-features wasm,zlib-ng -p libpna -p pna -p portable-network-archive


### PR DESCRIPTION
## Summary
Replace `--feature-powerset` with `--each-feature` in `.github/workflows/vm.yml`, and restrict the tested crates to `libpna`/`pna`/`portable-network-archive` (`-p` flags) instead of the whole workspace (which also ran against `fuzz`/`xtask`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated BSD, Solaris, OmniOS, and DragonFlyBSD VM test configurations to run tests across each supported feature.
  * Explicitly targets the `libpna`, `pna`, and `portable-network-archive` features.
  * Preserves platform-specific exclusions for unsupported features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->