### PR TITLE
Run zizmor on ubuntu-slim

### DIFF
--- a/.github/workflows/actions-lint.yml
+++ b/.github/workflows/actions-lint.yml
@@ -49,7 +49,7 @@ jobs:
     name: Run zizmor
     # Scans all workflows including auto-generated release.yml;
     # suppress false positives via zizmor.yml config if needed
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 60
     permissions:
       contents: read # checkout


### PR DESCRIPTION
## Summary
Switch the `zizmor` job in `actions-lint.yml` to `ubuntu-slim`. `zizmor-action` is a composite action, so it runs fine there.

## Notes
`actionlint` stays on `ubuntu-latest`: `reviewdog/action-actionlint` is a Docker-based action, and `ubuntu-slim` has no Docker daemon available.