### PR TITLE
:recycle: Use chunk parser in corruption tests

### DIFF
--- a/cli/tests/cli/utils/archive.rs
+++ b/cli/tests/cli/utils/archive.rs
@@ -3,6 +3,7 @@ use pna::prelude::*;
 use std::{
     fs::File,
     io::{self, Read, Write},
+    mem,
     path::Path,
 };
 
@@ -354,31 +355,35 @@ pub fn get_archive_entry_names(path: impl AsRef<Path>) -> Vec<String> {
 /// Returns whether a matching non-empty chunk was found and corrupted.
 pub fn corrupt_first_chunk(
     path: impl AsRef<Path>,
-    target: [u8; 4],
+    target: pna::ChunkType,
     recompute_crc: bool,
 ) -> io::Result<bool> {
     let mut bytes = std::fs::read(&path)?;
-    let mut pos = 8; // skip PNA signature
-    while pos + 12 <= bytes.len() {
-        let len = u32::from_be_bytes(bytes[pos..pos + 4].try_into().unwrap()) as usize;
-        let ty: [u8; 4] = bytes[pos + 4..pos + 8].try_into().unwrap();
-        if ty == target && len > 0 {
-            let data_start = pos + 8;
-            bytes[data_start] ^= 0xFF;
-            if recompute_crc {
-                // SAFETY: `ty` was read from a valid archive, so it is a valid chunk type.
-                let chunk_type = unsafe { pna::ChunkType::from_unchecked(ty) };
-                let chunk = pna::RawChunk::from_data(
-                    chunk_type,
-                    bytes[data_start..data_start + len].to_vec(),
-                );
-                let crc_pos = data_start + len;
-                bytes[crc_pos..crc_pos + 4].copy_from_slice(&chunk.crc().to_be_bytes());
+    let target_data = {
+        let mut chunk_start = pna::PNA_SIGNATURE.len();
+        let mut target_data = None;
+        for chunk in pna::read_chunks_from_slice(&bytes)? {
+            let chunk = chunk?;
+            let data_len = chunk.data().len();
+            if chunk.ty() == target && data_len > 0 {
+                let data_start = chunk_start + mem::size_of::<u32>() + target.len();
+                target_data = Some((data_start, data_len));
+                break;
             }
-            std::fs::write(&path, bytes)?;
-            return Ok(true);
+            chunk_start += pna::MIN_CHUNK_BYTES_SIZE + data_len;
         }
-        pos += 12 + len; // always advances at least 12 bytes per iteration
+        target_data
+    };
+
+    let Some((data_start, data_len)) = target_data else {
+        return Ok(false);
+    };
+    bytes[data_start] ^= 0xFF;
+    if recompute_crc {
+        let crc = (target, &bytes[data_start..data_start + data_len]).crc();
+        let crc_pos = data_start + data_len;
+        bytes[crc_pos..crc_pos + mem::size_of::<u32>()].copy_from_slice(&crc.to_be_bytes());
     }
-    Ok(false)
+    std::fs::write(&path, bytes)?;
+    Ok(true)
 }

--- a/cli/tests/cli/verify.rs
+++ b/cli/tests/cli/verify.rs
@@ -53,7 +53,7 @@ fn verify_with_crc_mismatch() {
     .unwrap()
     .execute()
     .unwrap();
-    assert!(corrupt_first_chunk("verify_crc/verify_crc.pna", *b"FDAT", false).unwrap());
+    assert!(corrupt_first_chunk("verify_crc/verify_crc.pna", pna::ChunkType::FDAT, false).unwrap());
 
     cargo_bin_cmd!("pna")
         .args(["experimental", "verify", "-f", "verify_crc/verify_crc.pna"])
@@ -87,7 +87,14 @@ fn verify_with_stream_corruption() {
     .unwrap()
     .execute()
     .unwrap();
-    assert!(corrupt_first_chunk("verify_stream/verify_stream.pna", *b"FDAT", true).unwrap());
+    assert!(
+        corrupt_first_chunk(
+            "verify_stream/verify_stream.pna",
+            pna::ChunkType::FDAT,
+            true,
+        )
+        .unwrap()
+    );
 
     cargo_bin_cmd!("pna")
         .args([
@@ -122,7 +129,9 @@ fn verify_with_fast_on_stream_corruption() {
     .unwrap()
     .execute()
     .unwrap();
-    assert!(corrupt_first_chunk("verify_fast/verify_fast.pna", *b"FDAT", true).unwrap());
+    assert!(
+        corrupt_first_chunk("verify_fast/verify_fast.pna", pna::ChunkType::FDAT, true,).unwrap()
+    );
 
     cargo_bin_cmd!("pna")
         .args([
@@ -158,7 +167,14 @@ fn verify_with_fast_on_crc_mismatch() {
     .unwrap()
     .execute()
     .unwrap();
-    assert!(corrupt_first_chunk("verify_fast_crc/verify_fast_crc.pna", *b"FDAT", false).unwrap());
+    assert!(
+        corrupt_first_chunk(
+            "verify_fast_crc/verify_fast_crc.pna",
+            pna::ChunkType::FDAT,
+            false,
+        )
+        .unwrap()
+    );
 
     cargo_bin_cmd!("pna")
         .args([
@@ -463,7 +479,7 @@ fn verify_with_solid_stream_corruption() {
     assert!(
         corrupt_first_chunk(
             "verify_solid_stream/verify_solid_stream.pna",
-            *b"SDAT",
+            pna::ChunkType::SDAT,
             true
         )
         .unwrap()
@@ -505,7 +521,12 @@ fn verify_with_fast_on_solid_stream_corruption() {
     .execute()
     .unwrap();
     assert!(
-        corrupt_first_chunk("verify_fast_solid/verify_fast_solid.pna", *b"SDAT", true).unwrap()
+        corrupt_first_chunk(
+            "verify_fast_solid/verify_fast_solid.pna",
+            pna::ChunkType::SDAT,
+            true,
+        )
+        .unwrap()
     );
 
     cargo_bin_cmd!("pna")
@@ -546,7 +567,7 @@ fn verify_with_fast_on_solid_crc_mismatch() {
     assert!(
         corrupt_first_chunk(
             "verify_fast_solid_crc/verify_fast_solid_crc.pna",
-            *b"SDAT",
+            pna::ChunkType::SDAT,
             false
         )
         .unwrap()
@@ -754,7 +775,9 @@ fn verify_with_size_hint_mismatch() {
     .unwrap()
     .execute()
     .unwrap();
-    assert!(corrupt_first_chunk("verify_fsiz/verify_fsiz.pna", *b"fSIZ", true).unwrap());
+    assert!(
+        corrupt_first_chunk("verify_fsiz/verify_fsiz.pna", pna::ChunkType::fSIZ, true,).unwrap()
+    );
 
     cargo_bin_cmd!("pna")
         .args([


### PR DESCRIPTION
## What changed

Use `read_chunks_from_slice`, `ChunkType`, `MIN_CHUNK_BYTES_SIZE`, and the `Chunk` CRC implementation in CLI corruption tests.

## Why

The test helper duplicated chunk framing and parsing, reconstructed `RawChunk` only to obtain a CRC, and used `ChunkType::from_unchecked` as an escape hatch.

## Impact

Corruption tests now exercise the public low-level primitives and contain no unsafe chunk-type conversion or local parser implementation.

## Validation

- `cargo test -p portable-network-archive --test cli verify:: --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`

