### PR TITLE
:recycle: Reuse signature validation in CLI

### DIFF
--- a/cli/src/utils/io.rs
+++ b/cli/src/utils/io.rs
@@ -2,9 +2,11 @@ use crate::ext::BufReadExt;
 use std::io;
 
 pub(crate) fn is_pna<R: io::Read>(mut reader: R) -> io::Result<bool> {
-    let mut buf = [0u8; pna::PNA_SIGNATURE.len()];
-    reader.read_exact(&mut buf)?;
-    Ok(buf == *pna::PNA_SIGNATURE)
+    match pna::io::read_signature(&mut reader) {
+        Ok(()) => Ok(true),
+        Err(error) if error.kind() == io::ErrorKind::InvalidData => Ok(false),
+        Err(error) => Err(error),
+    }
 }
 
 #[inline]
@@ -102,6 +104,22 @@ pub(crate) fn streams_equal<R1: io::Read, R2: io::Read>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn is_pna_uses_signature_validation() {
+        assert!(is_pna(&pna::PNA_SIGNATURE[..]).unwrap());
+
+        let mut invalid = *pna::PNA_SIGNATURE;
+        invalid[0] ^= 0xff;
+        assert!(!is_pna(&invalid[..]).unwrap());
+
+        assert_eq!(
+            is_pna(&pna::PNA_SIGNATURE[..pna::PNA_SIGNATURE.len() - 1])
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::UnexpectedEof
+        );
+    }
 
     #[test]
     fn read_to_nul_splits_on_nul_without_including_delimiters() {


### PR DESCRIPTION
## What changed

Delegate CLI archive signature probing to `pna::io::read_signature`, mapping only signature mismatches to `false` while retaining I/O and truncation errors.

## Why

The CLI duplicated the signature read and comparison logic after a validated low-level signature API became available.

## Impact

Signature validation rules now have one implementation. Tests cover valid, mismatched, and truncated inputs.

## Validation

- `cargo test -p portable-network-archive --lib --all-features is_pna_uses_signature_validation`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of PNA file signatures.
  * Invalid or truncated data is now handled safely, while other input errors are reported correctly.
  * Added coverage for valid, invalid, and incomplete signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->