### PR TITLE
:recycle: Reuse chunk framing size in CLI

### DIFF
--- a/cli/src/command/chunk.rs
+++ b/cli/src/command/chunk.rs
@@ -96,7 +96,7 @@ fn list_archive_chunks(args: ListCommand) -> anyhow::Result<()> {
                 })),
             );
         }
-        offset += chunk.length() as usize + std::mem::size_of::<u32>() * 3;
+        offset += chunk.length() as usize + pna::MIN_CHUNK_BYTES_SIZE;
     }
     let mut table = builder.build();
     table.with(TableStyle::empty());


### PR DESCRIPTION
## What changed

Advance CLI chunk-list offsets with `MIN_CHUNK_BYTES_SIZE` instead of locally summing three `u32` field widths.

## Why

The low-level API now provides the canonical framing size, so retaining a second definition risks drift.

## Impact

Output remains unchanged while chunk framing knowledge stays centralized.

## Validation

- `cargo test -p portable-network-archive --test cli --all-features chunk::list::basic::`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`

