### PR TITLE
:sparkles: Add streaming archive entry cursors

### DIFF
--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -1,8 +1,10 @@
 //! Archive reading and writing for PNA files.
 
 mod header;
+mod part;
 mod read;
 mod split_parts;
+mod stream;
 mod write;
 
 use crate::{
@@ -14,8 +16,10 @@ use crate::{
 };
 use core::num::NonZeroU32;
 pub use header::*;
+pub use part::*;
 pub use split_parts::{MIN_SPLIT_PART_BYTES, SplitParts};
 use std::io::{self, Write};
+pub use stream::*;
 pub(crate) use write::*;
 
 fn write_archive_framing<W: Write>(writer: &mut W, header: &ArchiveHeader) -> io::Result<()> {

--- a/lib/src/archive/part.rs
+++ b/lib/src/archive/part.rs
@@ -1,0 +1,40 @@
+//! Continuation across the parts of a multipart archive.
+//!
+//! A PNA archive may be split across several parts, each self-framed and, when
+//! it is not the last, closed by `ANXT` followed by `AEND`. Reading past that
+//! boundary means obtaining the next part from somewhere the archive itself
+//! cannot know about - a file next to the current one, a network range request,
+//! a buffer already in memory. [`PartProvider`] is that seam.
+use std::io::{self, Read};
+
+/// Supplies the next physical part of a multipart archive.
+pub trait PartProvider<R: Read> {
+    /// Opens the part whose AHED archive number is expected to equal `expected`.
+    ///
+    /// Returning `Ok(None)` reports that the required part is unavailable and
+    /// fails the current cursor rather than implicitly retrying it.
+    ///
+    /// # Errors
+    ///
+    /// Returns any error encountered while locating or opening the part.
+    fn next_part(&mut self, expected: u32) -> io::Result<Option<R>>;
+}
+
+/// Marker provider used internally for a single physical archive.
+///
+/// Values of this type cannot be constructed outside this crate.
+#[derive(Clone, Copy, Debug)]
+pub struct NoParts {
+    _private: (),
+}
+
+impl NoParts {
+    pub(crate) const NEW: Self = Self { _private: () };
+}
+
+impl<R: Read> PartProvider<R> for NoParts {
+    #[inline]
+    fn next_part(&mut self, _expected: u32) -> io::Result<Option<R>> {
+        Ok(None)
+    }
+}

--- a/lib/src/archive/part.rs
+++ b/lib/src/archive/part.rs
@@ -11,6 +11,10 @@ use std::io::{self, Read};
 pub trait PartProvider<R: Read> {
     /// Opens the part whose AHED archive number is expected to equal `expected`.
     ///
+    /// `expected` counts archives from 0, so it is one less than the `.partN.pna`
+    /// suffix conventionally given to the same part on disk. The first part is
+    /// supplied by the caller, so `expected` is always at least 1.
+    ///
     /// Returning `Ok(None)` reports that the required part is unavailable and
     /// fails the current cursor rather than implicitly retrying it.
     ///
@@ -18,6 +22,14 @@ pub trait PartProvider<R: Read> {
     ///
     /// Returns any error encountered while locating or opening the part.
     fn next_part(&mut self, expected: u32) -> io::Result<Option<R>>;
+}
+
+/// Any closure of the same shape is a provider.
+impl<R: Read, F: FnMut(u32) -> io::Result<Option<R>>> PartProvider<R> for F {
+    #[inline]
+    fn next_part(&mut self, expected: u32) -> io::Result<Option<R>> {
+        self(expected)
+    }
 }
 
 /// Marker provider used internally for a single physical archive.

--- a/lib/src/archive/stream.rs
+++ b/lib/src/archive/stream.rs
@@ -12,6 +12,7 @@ use crate::{
 use std::{
     collections::VecDeque,
     io::{self, BufRead, BufReader, Read},
+    marker::PhantomData,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -98,11 +99,7 @@ impl EntryCompletion {
 ///
 /// Dropping an unfinished entry poisons the cursor. Consume the session through
 /// one of its terminal operations before requesting another entry.
-pub struct StreamingEntries<R, P = NoParts>
-where
-    R: Read,
-    P: PartProvider<R>,
-{
+pub struct StreamingEntries<R, P = NoParts> {
     source: StreamingSource<R, P>,
     state: CursorState,
 }
@@ -140,8 +137,8 @@ impl<R: Read, P: PartProvider<R>> StreamingEntries<R, P> {
 
     /// Reads enough input to expose the next physical entry header.
     ///
-    /// This is a lending operation. The returned entry must be decoded, skipped,
-    /// or explicitly discarded before the next call.
+    /// This is a lending operation: the returned entry must be consumed before
+    /// the next call. Dropping it instead poisons the cursor.
     ///
     /// # Errors
     ///
@@ -312,7 +309,8 @@ impl<R: Read> Archive<R> {
 }
 
 /// A physical entry yielded by [`StreamingEntries`].
-pub enum StreamingReadEntry<'a, R: Read, P: PartProvider<R> = NoParts> {
+#[must_use = "decode or skip the entry; dropping it poisons the cursor"]
+pub enum StreamingReadEntry<'a, R, P = NoParts> {
     /// An independently encoded normal entry.
     Normal(NormalEntrySession<'a, R, P>),
     /// A solid block containing a nested entry stream.
@@ -335,8 +333,8 @@ impl<R: Read, P: PartProvider<R>> ChunkCursor for StreamingSource<R, P> {
 }
 
 /// A header-first session for one normal entry.
-#[must_use = "decode, skip, or explicitly discard the entry"]
-pub struct NormalEntrySession<'a, R: Read, P: PartProvider<R> = NoParts> {
+#[must_use = "decode or skip the entry"]
+pub struct NormalEntrySession<'a, R, P = NoParts> {
     inner: NormalEntrySessionCore<'a, StreamingSource<R, P>>,
 }
 
@@ -356,13 +354,15 @@ impl<'a, C: ChunkCursor> NormalEntrySessionCore<'a, C> {
 
     /// Opens a decoded streaming reader for the entry payload.
     ///
-    /// Each physical `FDAT` body is released only after its CRC has been
-    /// validated. The entry as a whole is not complete until the reader reaches
-    /// EOF or [`DecodedEntryReader::finish`] succeeds.
+    /// Bytes returned before EOF are provisional; an integrity failure can
+    /// still surface at any point up to completion.
     ///
-    /// Data returned before EOF is provisional: a later codec, padding, AEAD,
-    /// or terminator error can still invalidate the entry. Filesystem extractors
-    /// should publish a temporary output only after successful completion.
+    /// Completion does not guarantee that the payload is as long as the
+    /// producer wrote it, since not every compression method can detect a
+    /// truncated payload. Compare the bytes read against
+    /// [`Metadata::raw_file_size`] where a length guarantee is required.
+    ///
+    /// [`Metadata::raw_file_size`]: crate::Metadata::raw_file_size
     ///
     /// # Errors
     ///
@@ -453,8 +453,16 @@ impl<'a, R: Read, P: PartProvider<R>> NormalEntrySession<'a, R, P> {
 
     /// Opens a decoded streaming reader for the entry payload.
     ///
-    /// Data returned before EOF is provisional: a later codec, padding, AEAD,
-    /// or terminator error can still invalidate the entry.
+    /// Bytes returned before EOF are provisional; an integrity failure can
+    /// still surface at any point up to completion. The entry is complete once
+    /// the reader reaches EOF or [`DecodedEntryReader::finish`] returns `Ok`.
+    ///
+    /// Completion does not guarantee that the payload is as long as the
+    /// producer wrote it, since not every compression method can detect a
+    /// truncated payload. Compare the bytes read against
+    /// [`Metadata::raw_file_size`] where a length guarantee is required.
+    ///
+    /// [`Metadata::raw_file_size`]: crate::Metadata::raw_file_size
     ///
     /// # Errors
     ///
@@ -480,7 +488,7 @@ impl<'a, R: Read, P: PartProvider<R>> NormalEntrySession<'a, R, P> {
 
 /// A header-first session for one solid block.
 #[must_use = "skip or enter the solid block"]
-pub struct SolidEntrySession<'a, R: Read, P: PartProvider<R> = NoParts> {
+pub struct SolidEntrySession<'a, R, P = NoParts> {
     source: &'a mut StreamingSource<R, P>,
     header: SolidHeader,
     chunks: Vec<RawChunk>,
@@ -494,7 +502,10 @@ impl<'a, R: Read, P: PartProvider<R>> SolidEntrySession<'a, R, P> {
         &self.header
     }
 
-    /// Skips the encoded solid block while validating framing and CRC values.
+    /// Skips the solid block without decrypting or decompressing it.
+    ///
+    /// The block is validated as [`Self::entries`] validates it, so both accept
+    /// and reject the same archives.
     ///
     /// # Errors
     ///
@@ -502,9 +513,13 @@ impl<'a, R: Read, P: PartProvider<R>> SolidEntrySession<'a, R, P> {
     #[inline]
     pub fn skip(self) -> io::Result<()> {
         let Self {
-            source, mut lease, ..
+            source,
+            chunks,
+            mut lease,
+            ..
         } = self;
-        let result = skip_solid_chunks(source);
+        let mut encoded = EncodedSolidReader::new(source, chunks);
+        let result = encoded.finish_physical().and_then(|()| encoded.finish());
         match result {
             Ok(()) => {
                 lease.complete();
@@ -586,7 +601,7 @@ pub struct StreamingSolidEntries<'a, R: Read, P: PartProvider<R> = NoParts> {
 }
 
 /// A header-first session for one normal entry inside a solid block.
-#[must_use = "decode, skip, or explicitly discard the entry"]
+#[must_use = "decode or skip the entry"]
 pub struct SolidNormalEntrySession<'entry, 'archive, R: Read, P: PartProvider<R> = NoParts> {
     inner: NormalEntrySessionCore<'entry, SolidStreamingSource<'archive, R, P>>,
 }
@@ -601,6 +616,19 @@ impl<'entry, 'archive, R: Read, P: PartProvider<R>>
     }
 
     /// Opens a decoded streaming reader for the entry payload.
+    ///
+    /// Bytes returned before EOF are provisional; an integrity failure can
+    /// still surface at any point up to completion. The entry is complete once
+    /// the reader reaches EOF or [`SolidDecodedEntryReader::finish`] returns
+    /// `Ok`; the enclosing block is validated by
+    /// [`StreamingSolidEntries::finish`].
+    ///
+    /// Completion does not guarantee that the payload is as long as the
+    /// producer wrote it, since not every compression method can detect a
+    /// truncated payload. Compare the bytes read against
+    /// [`Metadata::raw_file_size`] where a length guarantee is required.
+    ///
+    /// [`Metadata::raw_file_size`]: crate::Metadata::raw_file_size
     ///
     /// # Errors
     ///
@@ -948,7 +976,38 @@ impl<R: Read, P: PartProvider<R>> Read for SolidDecodedEntryReader<'_, '_, R, P>
     }
 }
 
-struct EncodedEntryReader<'a, C> {
+/// Describes the chunk frame an encoded stream is built from.
+///
+/// Normal entries and solid blocks share one grammar and differ only in the
+/// chunk types that carry and terminate their payload.
+trait EncodedFrame {
+    /// Chunk type carrying payload bytes.
+    const DATA: ChunkType;
+    /// Chunk type terminating the stream.
+    const END: ChunkType;
+    /// Subject used in grammar errors.
+    const SUBJECT: &'static str;
+}
+
+struct NormalFrame;
+
+impl EncodedFrame for NormalFrame {
+    const DATA: ChunkType = ChunkType::FDAT;
+    const END: ChunkType = ChunkType::FEND;
+    const SUBJECT: &'static str = "normal entry";
+}
+
+struct SolidFrame;
+
+impl EncodedFrame for SolidFrame {
+    const DATA: ChunkType = ChunkType::SDAT;
+    const END: ChunkType = ChunkType::SEND;
+    const SUBJECT: &'static str = "solid entry";
+}
+
+/// Reads one encoded stream out of its chunk frame, retaining the chunks that
+/// are not payload so the entry can be reconstructed on completion.
+struct EncodedReader<'a, C, F> {
     source: &'a mut C,
     chunks: Vec<RawChunk>,
     current: io::Cursor<Vec<u8>>,
@@ -956,9 +1015,13 @@ struct EncodedEntryReader<'a, C> {
     encoded_size: u64,
     sequence: EntryChunkSequence,
     done: bool,
+    frame: PhantomData<F>,
 }
 
-impl<'a, C: ChunkCursor> EncodedEntryReader<'a, C> {
+type EncodedEntryReader<'a, C> = EncodedReader<'a, C, NormalFrame>;
+type EncodedSolidReader<'a, C> = EncodedReader<'a, C, SolidFrame>;
+
+impl<'a, C: ChunkCursor, F: EncodedFrame> EncodedReader<'a, C, F> {
     fn new(source: &'a mut C, chunks: Vec<RawChunk>) -> Self {
         Self {
             source,
@@ -968,6 +1031,7 @@ impl<'a, C: ChunkCursor> EncodedEntryReader<'a, C> {
             encoded_size: 0,
             sequence: EntryChunkSequence::default(),
             done: false,
+            frame: PhantomData,
         }
     }
 
@@ -987,43 +1051,42 @@ impl<'a, C: ChunkCursor> EncodedEntryReader<'a, C> {
 
     fn load_next(&mut self) -> io::Result<()> {
         let chunk = self.source.read_stream_chunk()?;
-        match chunk.ty() {
-            ChunkType::FDAT => {
-                self.sequence.observe_data(ChunkType::FDAT)?;
-                self.encoded_size = self
-                    .encoded_size
-                    .checked_add(chunk.data().len() as u64)
-                    .ok_or_else(|| {
-                        io::Error::new(io::ErrorKind::InvalidData, "entry encoded size overflow")
-                    })?;
-                self.current = io::Cursor::new(chunk.data);
-            }
-            ChunkType::FEND => {
-                self.chunks.push(chunk);
-                self.done = true;
-            }
-            ChunkType::PHSF => {
-                self.sequence.observe_phsf()?;
-                self.phsf = Some(
-                    String::from_utf8(chunk.data.clone())
-                        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?,
-                );
-                self.chunks.push(chunk);
-            }
-            ty if ty.is_critical() => {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("unexpected critical chunk `{ty}` in normal entry"),
-                ));
-            }
-            _ => {
-                self.sequence.observe_ancillary();
-                self.chunks.push(chunk);
-            }
+        let ty = chunk.ty();
+        if ty == F::DATA {
+            self.sequence.observe_data(F::DATA)?;
+            self.encoded_size = self
+                .encoded_size
+                .checked_add(chunk.data().len() as u64)
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidData, "entry encoded size overflow")
+                })?;
+            self.current = io::Cursor::new(chunk.data);
+        } else if ty == F::END {
+            self.chunks.push(chunk);
+            self.done = true;
+        } else if ty == ChunkType::PHSF {
+            self.sequence.observe_phsf()?;
+            self.phsf = Some(
+                String::from_utf8(chunk.data.clone())
+                    .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?,
+            );
+            self.chunks.push(chunk);
+        } else if ty.is_critical() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "unexpected critical chunk `{ty}` in {subject}",
+                    subject = F::SUBJECT
+                ),
+            ));
+        } else {
+            self.sequence.observe_ancillary();
+            self.chunks.push(chunk);
         }
         Ok(())
     }
 
+    /// Walks the remaining physical chunks without exposing their bodies.
     fn finish_physical(&mut self) -> io::Result<()> {
         self.current
             .set_position(self.current.get_ref().len() as u64);
@@ -1034,7 +1097,9 @@ impl<'a, C: ChunkCursor> EncodedEntryReader<'a, C> {
         }
         Ok(())
     }
+}
 
+impl<C: ChunkCursor> EncodedReader<'_, C, NormalFrame> {
     fn into_completion(self) -> io::Result<EntryCompletion> {
         if !self.done {
             return Err(io::Error::new(
@@ -1057,92 +1122,7 @@ impl<'a, C: ChunkCursor> EncodedEntryReader<'a, C> {
     }
 }
 
-impl<C: ChunkCursor> Read for EncodedEntryReader<'_, C> {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        if buf.is_empty() {
-            return Ok(0);
-        }
-        loop {
-            let read = self.current.read(buf)?;
-            if read != 0 {
-                return Ok(read);
-            }
-            if self.done {
-                return Ok(0);
-            }
-            self.load_next()?;
-        }
-    }
-}
-
-struct EncodedSolidReader<'a, R: Read, P: PartProvider<R>> {
-    source: &'a mut StreamingSource<R, P>,
-    chunks: Vec<RawChunk>,
-    current: io::Cursor<Vec<u8>>,
-    phsf: Option<String>,
-    sequence: EntryChunkSequence,
-    done: bool,
-}
-
-impl<'a, R: Read, P: PartProvider<R>> EncodedSolidReader<'a, R, P> {
-    fn new(source: &'a mut StreamingSource<R, P>, chunks: Vec<RawChunk>) -> Self {
-        Self {
-            source,
-            chunks,
-            current: io::Cursor::new(Vec::new()),
-            phsf: None,
-            sequence: EntryChunkSequence::default(),
-            done: false,
-        }
-    }
-
-    fn phsf(&self) -> Option<&str> {
-        self.phsf.as_deref()
-    }
-
-    fn prepare(&mut self) -> io::Result<()> {
-        while !self.done && self.current.position() == self.current.get_ref().len() as u64 {
-            self.load_next()?;
-            if !self.current.get_ref().is_empty() {
-                break;
-            }
-        }
-        Ok(())
-    }
-
-    fn load_next(&mut self) -> io::Result<()> {
-        let chunk = self.source.read_logical_chunk()?;
-        match chunk.ty() {
-            ChunkType::SDAT => {
-                self.sequence.observe_data(ChunkType::SDAT)?;
-                self.current = io::Cursor::new(chunk.data);
-            }
-            ChunkType::SEND => {
-                self.chunks.push(chunk);
-                self.done = true;
-            }
-            ChunkType::PHSF => {
-                self.sequence.observe_phsf()?;
-                self.phsf = Some(
-                    String::from_utf8(chunk.data.clone())
-                        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?,
-                );
-                self.chunks.push(chunk);
-            }
-            ty if ty.is_critical() => {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("unexpected critical chunk `{ty}` in solid entry"),
-                ));
-            }
-            _ => {
-                self.sequence.observe_ancillary();
-                self.chunks.push(chunk);
-            }
-        }
-        Ok(())
-    }
-
+impl<C: ChunkCursor> EncodedReader<'_, C, SolidFrame> {
     fn finish(self) -> io::Result<()> {
         if !self.done {
             return Err(io::Error::new(
@@ -1154,7 +1134,7 @@ impl<'a, R: Read, P: PartProvider<R>> EncodedSolidReader<'a, R, P> {
     }
 }
 
-impl<R: Read, P: PartProvider<R>> Read for EncodedSolidReader<'_, R, P> {
+impl<C: ChunkCursor, F: EncodedFrame> Read for EncodedReader<'_, C, F> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if buf.is_empty() {
             return Ok(0);
@@ -1172,7 +1152,8 @@ impl<R: Read, P: PartProvider<R>> Read for EncodedSolidReader<'_, R, P> {
     }
 }
 
-type SolidPipeline<'a, R, P> = DecompressReader<DecryptReader<EncodedSolidReader<'a, R, P>>>;
+type SolidPipeline<'a, R, P> =
+    DecompressReader<DecryptReader<EncodedSolidReader<'a, StreamingSource<R, P>>>>;
 
 struct SolidDecodedReader<'a, R: Read, P: PartProvider<R>> {
     pipeline: Option<SolidPipeline<'a, R, P>>,
@@ -1249,27 +1230,6 @@ impl<R: Read, P: PartProvider<R>> Read for SolidDecodedReader<'_, R, P> {
                 self.stopped = Some((error.kind(), error.to_string()));
                 Err(error)
             }
-        }
-    }
-}
-
-fn skip_solid_chunks<R: Read, P: PartProvider<R>>(
-    source: &mut StreamingSource<R, P>,
-) -> io::Result<()> {
-    let mut sequence = EntryChunkSequence::default();
-    loop {
-        let chunk = source.read_logical_chunk()?;
-        match chunk.ty() {
-            ChunkType::SDAT => sequence.observe_data(ChunkType::SDAT)?,
-            ChunkType::SEND => return Ok(()),
-            ChunkType::PHSF => sequence.observe_phsf()?,
-            ty if ty.is_critical() => {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("unexpected critical chunk `{ty}` in solid entry"),
-                ));
-            }
-            _ => sequence.observe_ancillary(),
         }
     }
 }

--- a/lib/src/archive/stream.rs
+++ b/lib/src/archive/stream.rs
@@ -1,0 +1,1303 @@
+//! Sequential archive entry reading.
+
+use super::{Archive, ArchiveHeader};
+use crate::{
+    Chunk, ChunkType, EntryHeader, Metadata, NormalEntry, RawChunk, ReadOptions, SolidHeader,
+    archive::part::{NoParts, PartProvider},
+    cipher::DecryptReader,
+    compress::DecompressReader,
+    entry::{RawEntry, decompress_reader, decrypt_reader},
+    util::io::TryIntoInner,
+};
+use std::{
+    collections::VecDeque,
+    io::{self, BufRead, BufReader, Read},
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CursorState {
+    Ready,
+    Stopped(StopReason),
+}
+
+/// Why a cursor will not produce further entries.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum StopReason {
+    Poisoned,
+    Finished,
+    Failed,
+}
+
+struct EntryLease<'a> {
+    state: &'a mut CursorState,
+    armed: bool,
+}
+
+impl<'a> EntryLease<'a> {
+    fn new(state: &'a mut CursorState) -> Self {
+        Self { state, armed: true }
+    }
+
+    fn complete(mut self) {
+        *self.state = CursorState::Ready;
+        self.armed = false;
+    }
+
+    fn fail(&mut self) {
+        *self.state = CursorState::Stopped(StopReason::Failed);
+        self.armed = false;
+    }
+}
+
+impl Drop for EntryLease<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            *self.state = CursorState::Stopped(StopReason::Poisoned);
+        }
+    }
+}
+
+fn cursor_state_error(reason: StopReason) -> io::Error {
+    let message = match reason {
+        StopReason::Poisoned => "a streaming entry was dropped before completion",
+        StopReason::Finished => "the streaming archive has already finished",
+        StopReason::Failed => "the streaming archive is in a failed state",
+    };
+    io::Error::new(io::ErrorKind::InvalidInput, message)
+}
+
+/// Final information produced after an entry reaches `FEND`.
+#[derive(Clone, Debug)]
+pub struct EntryCompletion {
+    header: EntryHeader,
+    metadata: Metadata,
+    extra_chunks: Vec<RawChunk>,
+}
+
+impl EntryCompletion {
+    /// Returns the entry header.
+    #[inline]
+    pub const fn header(&self) -> &EntryHeader {
+        &self.header
+    }
+
+    /// Returns metadata finalized after reading through `FEND`.
+    #[inline]
+    pub const fn metadata(&self) -> &Metadata {
+        &self.metadata
+    }
+
+    /// Returns retained unknown ancillary chunks.
+    #[inline]
+    pub fn extra_chunks(&self) -> &[RawChunk] {
+        &self.extra_chunks
+    }
+}
+
+/// An owned lending cursor over physical archive entries.
+///
+/// Dropping an unfinished entry poisons the cursor. Consume the session through
+/// one of its terminal operations before requesting another entry.
+pub struct StreamingEntries<R, P = NoParts>
+where
+    R: Read,
+    P: PartProvider<R>,
+{
+    source: StreamingSource<R, P>,
+    state: CursorState,
+}
+
+struct StreamingSource<R, P> {
+    reader: R,
+    provider: P,
+    header: ArchiveHeader,
+    pending: VecDeque<RawChunk>,
+    options: ReadOptions,
+    max_chunk_data_len: u32,
+}
+
+impl<R: Read, P: PartProvider<R>> StreamingEntries<R, P> {
+    fn from_parts(
+        reader: R,
+        provider: P,
+        header: ArchiveHeader,
+        pending: VecDeque<RawChunk>,
+        options: ReadOptions,
+        max_chunk_data_len: u32,
+    ) -> Self {
+        Self {
+            source: StreamingSource {
+                reader,
+                provider,
+                header,
+                pending,
+                options,
+                max_chunk_data_len,
+            },
+            state: CursorState::Ready,
+        }
+    }
+
+    /// Reads enough input to expose the next physical entry header.
+    ///
+    /// This is a lending operation. The returned entry must be decoded, skipped,
+    /// or explicitly discarded before the next call.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for invalid archive grammar, a missing multipart
+    /// continuation, an unfinished prior entry, or underlying I/O.
+    #[inline]
+    pub fn next_entry(&mut self) -> io::Result<Option<StreamingReadEntry<'_, R, P>>> {
+        match self.state {
+            CursorState::Ready => {}
+            CursorState::Stopped(StopReason::Finished) => return Ok(None),
+            CursorState::Stopped(reason) => return Err(cursor_state_error(reason)),
+        }
+
+        let chunk = match self.source.read_logical_chunk() {
+            Ok(chunk) => chunk,
+            Err(error) => {
+                self.state = CursorState::Stopped(StopReason::Failed);
+                return Err(error);
+            }
+        };
+        match chunk.ty() {
+            ChunkType::AEND => {
+                self.state = CursorState::Stopped(StopReason::Finished);
+                Ok(None)
+            }
+            ChunkType::FHED => {
+                let header = match parse_entry_header(&chunk) {
+                    Ok(header) => header,
+                    Err(error) => {
+                        self.state = CursorState::Stopped(StopReason::Failed);
+                        return Err(error);
+                    }
+                };
+                let lease = EntryLease::new(&mut self.state);
+                Ok(Some(StreamingReadEntry::Normal(NormalEntrySession {
+                    inner: NormalEntrySessionCore {
+                        source: &mut self.source,
+                        header,
+                        chunks: vec![chunk],
+                        lease,
+                    },
+                })))
+            }
+            ChunkType::SHED => {
+                let header = match parse_solid_header(&chunk) {
+                    Ok(header) => header,
+                    Err(error) => {
+                        self.state = CursorState::Stopped(StopReason::Failed);
+                        return Err(error);
+                    }
+                };
+                let lease = EntryLease::new(&mut self.state);
+                Ok(Some(StreamingReadEntry::Solid(SolidEntrySession {
+                    source: &mut self.source,
+                    header,
+                    chunks: vec![chunk],
+                    lease,
+                })))
+            }
+            ty => {
+                self.state = CursorState::Stopped(StopReason::Failed);
+                Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("unexpected archive chunk `{ty}`"),
+                ))
+            }
+        }
+    }
+}
+
+impl<R: Read, P: PartProvider<R>> StreamingSource<R, P> {
+    fn read_physical_chunk(&mut self) -> io::Result<RawChunk> {
+        if let Some(chunk) = self.pending.pop_front() {
+            return Ok(chunk);
+        }
+        crate::io::read_chunk(&mut self.reader, self.max_chunk_data_len)
+    }
+
+    fn read_logical_chunk(&mut self) -> io::Result<RawChunk> {
+        loop {
+            let chunk = self.read_physical_chunk()?;
+            if chunk.ty() != ChunkType::ANXT {
+                return Ok(chunk);
+            }
+            let end = self.read_physical_chunk()?;
+            if end.ty() != ChunkType::AEND {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "expected `{}` after `{}`, got `{}`",
+                        ChunkType::AEND,
+                        ChunkType::ANXT,
+                        end.ty()
+                    ),
+                ));
+            }
+            self.open_next_part()?;
+        }
+    }
+
+    fn open_next_part(&mut self) -> io::Result<()> {
+        let expected =
+            self.header.archive_number.checked_add(1).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "archive number overflow")
+            })?;
+        let next = self.provider.next_part(expected)?.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("archive part {expected} is required"),
+            )
+        })?;
+        self.reader = next;
+        crate::io::read_signature(&mut self.reader)?;
+        let chunk = crate::io::read_chunk(&mut self.reader, self.max_chunk_data_len)?;
+        if chunk.ty() != ChunkType::AHED {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("expected `{}`, got `{}`", ChunkType::AHED, chunk.ty()),
+            ));
+        }
+        let header = ArchiveHeader::try_from_bytes(chunk.data())?;
+        if header.archive_number != expected {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "next archive number must be {expected}, got {}",
+                    header.archive_number
+                ),
+            ));
+        }
+        self.header = header;
+        Ok(())
+    }
+}
+
+impl<R: Read> Archive<R> {
+    /// Converts this archive into an owned streaming entry cursor.
+    #[inline]
+    pub fn into_streaming_entries(self, options: ReadOptions) -> StreamingEntries<R> {
+        let max_chunk_data_len = self.max_chunk_size.map_or(u32::MAX, |max| max.get());
+        StreamingEntries::from_parts(
+            self.inner,
+            NoParts::NEW,
+            self.header,
+            self.buf.into(),
+            options,
+            max_chunk_data_len,
+        )
+    }
+
+    /// Converts this archive into a multipart streaming cursor.
+    #[inline]
+    pub fn into_streaming_entries_with_parts<P: PartProvider<R>>(
+        self,
+        options: ReadOptions,
+        provider: P,
+    ) -> StreamingEntries<R, P> {
+        let max_chunk_data_len = self.max_chunk_size.map_or(u32::MAX, |max| max.get());
+        StreamingEntries::from_parts(
+            self.inner,
+            provider,
+            self.header,
+            self.buf.into(),
+            options,
+            max_chunk_data_len,
+        )
+    }
+}
+
+/// A physical entry yielded by [`StreamingEntries`].
+pub enum StreamingReadEntry<'a, R: Read, P: PartProvider<R> = NoParts> {
+    /// An independently encoded normal entry.
+    Normal(NormalEntrySession<'a, R, P>),
+    /// A solid block containing a nested entry stream.
+    Solid(SolidEntrySession<'a, R, P>),
+}
+
+trait ChunkCursor {
+    fn read_stream_chunk(&mut self) -> io::Result<RawChunk>;
+    fn options(&self) -> &ReadOptions;
+}
+
+impl<R: Read, P: PartProvider<R>> ChunkCursor for StreamingSource<R, P> {
+    fn read_stream_chunk(&mut self) -> io::Result<RawChunk> {
+        self.read_logical_chunk()
+    }
+
+    fn options(&self) -> &ReadOptions {
+        &self.options
+    }
+}
+
+/// A header-first session for one normal entry.
+#[must_use = "decode, skip, or explicitly discard the entry"]
+pub struct NormalEntrySession<'a, R: Read, P: PartProvider<R> = NoParts> {
+    inner: NormalEntrySessionCore<'a, StreamingSource<R, P>>,
+}
+
+struct NormalEntrySessionCore<'a, C> {
+    source: &'a mut C,
+    header: EntryHeader,
+    chunks: Vec<RawChunk>,
+    lease: EntryLease<'a>,
+}
+
+impl<'a, C: ChunkCursor> NormalEntrySessionCore<'a, C> {
+    /// Returns the entry header without reading its payload.
+    #[inline]
+    const fn header(&self) -> &EntryHeader {
+        &self.header
+    }
+
+    /// Opens a decoded streaming reader for the entry payload.
+    ///
+    /// Each physical `FDAT` body is released only after its CRC has been
+    /// validated. The entry as a whole is not complete until the reader reaches
+    /// EOF or [`DecodedEntryReader::finish`] succeeds.
+    ///
+    /// Data returned before EOF is provisional: a later codec, padding, AEAD,
+    /// or terminator error can still invalidate the entry. Filesystem extractors
+    /// should publish a temporary output only after successful completion.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for invalid entry grammar, an unsupported codec or
+    /// cipher, password/KDF failure, or underlying I/O.
+    #[inline]
+    fn decoded(self) -> io::Result<DecodedEntryReaderCore<'a, C>> {
+        let Self {
+            source,
+            header,
+            chunks,
+            mut lease,
+        } = self;
+        let options = source.options().clone();
+        let mut encoded = EncodedEntryReader::new(source, chunks);
+        if let Err(error) = encoded.prepare() {
+            lease.fail();
+            return Err(error);
+        }
+        let phsf = encoded.phsf().map(str::to_owned);
+        let header_bytes = header.to_bytes();
+        let decrypt = match decrypt_reader(
+            encoded,
+            header.encryption(),
+            header.cipher_mode(),
+            phsf.as_deref(),
+            &options,
+            ChunkType::FHED,
+            &header_bytes,
+        ) {
+            Ok(reader) => reader,
+            Err(error) => {
+                lease.fail();
+                return Err(error);
+            }
+        };
+        let pipeline = match decompress_reader(decrypt, header.compression()) {
+            Ok(reader) => reader,
+            Err(error) => {
+                lease.fail();
+                return Err(error);
+            }
+        };
+        Ok(DecodedEntryReaderCore {
+            pipeline: Some(pipeline),
+            lease: Some(lease),
+            completion: None,
+            stopped: None,
+        })
+    }
+
+    /// Reads and validates the entry framing without decrypting or decompressing.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for invalid chunk CRC, grammar, or I/O.
+    #[inline]
+    fn skip(self) -> io::Result<EntryCompletion> {
+        let Self {
+            source,
+            chunks,
+            mut lease,
+            ..
+        } = self;
+        let mut encoded = EncodedEntryReader::new(source, chunks);
+        let result = encoded
+            .finish_physical()
+            .and_then(|()| encoded.into_completion());
+        match result {
+            Ok(completion) => {
+                lease.complete();
+                Ok(completion)
+            }
+            Err(error) => {
+                lease.fail();
+                Err(error)
+            }
+        }
+    }
+}
+
+impl<'a, R: Read, P: PartProvider<R>> NormalEntrySession<'a, R, P> {
+    /// Returns the entry header without reading its payload.
+    #[inline]
+    pub const fn header(&self) -> &EntryHeader {
+        self.inner.header()
+    }
+
+    /// Opens a decoded streaming reader for the entry payload.
+    ///
+    /// Data returned before EOF is provisional: a later codec, padding, AEAD,
+    /// or terminator error can still invalidate the entry.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for invalid entry grammar, an unsupported codec or
+    /// cipher, password/KDF failure, or underlying I/O.
+    #[inline]
+    pub fn decoded(self) -> io::Result<DecodedEntryReader<'a, R, P>> {
+        self.inner
+            .decoded()
+            .map(|inner| DecodedEntryReader { inner })
+    }
+
+    /// Reads and validates the entry framing without decrypting or decompressing.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for invalid chunk CRC, grammar, or I/O.
+    #[inline]
+    pub fn skip(self) -> io::Result<EntryCompletion> {
+        self.inner.skip()
+    }
+}
+
+/// A header-first session for one solid block.
+#[must_use = "skip or enter the solid block"]
+pub struct SolidEntrySession<'a, R: Read, P: PartProvider<R> = NoParts> {
+    source: &'a mut StreamingSource<R, P>,
+    header: SolidHeader,
+    chunks: Vec<RawChunk>,
+    lease: EntryLease<'a>,
+}
+
+impl<'a, R: Read, P: PartProvider<R>> SolidEntrySession<'a, R, P> {
+    /// Returns the solid header without reading its payload.
+    #[inline]
+    pub const fn header(&self) -> &SolidHeader {
+        &self.header
+    }
+
+    /// Skips the encoded solid block while validating framing and CRC values.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for invalid grammar, CRC, or I/O.
+    #[inline]
+    pub fn skip(self) -> io::Result<()> {
+        let Self {
+            source, mut lease, ..
+        } = self;
+        let result = skip_solid_chunks(source);
+        match result {
+            Ok(()) => {
+                lease.complete();
+                Ok(())
+            }
+            Err(error) => {
+                lease.fail();
+                Err(error)
+            }
+        }
+    }
+
+    /// Opens the decoded inner entry cursor.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for unsupported codecs, password/KDF failure, invalid
+    /// grammar, or I/O.
+    #[inline]
+    pub fn entries(self) -> io::Result<StreamingSolidEntries<'a, R, P>> {
+        let Self {
+            source,
+            header,
+            chunks,
+            mut lease,
+        } = self;
+        let options = source.options.clone();
+        let max_chunk_data_len = source.max_chunk_data_len;
+        let mut encoded = EncodedSolidReader::new(source, chunks);
+        if let Err(error) = encoded.prepare() {
+            lease.fail();
+            return Err(error);
+        }
+        let phsf = encoded.phsf().map(str::to_owned);
+        let header_bytes = header.to_bytes();
+        let decrypt = match decrypt_reader(
+            encoded,
+            header.encryption(),
+            header.cipher_mode(),
+            phsf.as_deref(),
+            &options,
+            ChunkType::SHED,
+            &header_bytes,
+        ) {
+            Ok(reader) => reader,
+            Err(error) => {
+                lease.fail();
+                return Err(error);
+            }
+        };
+        let pipeline = match decompress_reader(decrypt, header.compression()) {
+            Ok(reader) => reader,
+            Err(error) => {
+                lease.fail();
+                return Err(error);
+            }
+        };
+        Ok(StreamingSolidEntries {
+            source: SolidStreamingSource {
+                reader: BufReader::new(SolidDecodedReader {
+                    pipeline: Some(pipeline),
+                    lease: Some(lease),
+                    complete: false,
+                    stopped: None,
+                }),
+                options,
+                max_chunk_data_len,
+            },
+            state: CursorState::Ready,
+        })
+    }
+}
+
+/// Lending cursor over entries decoded from one solid block.
+#[must_use = "finish the solid cursor to validate its outer stream"]
+pub struct StreamingSolidEntries<'a, R: Read, P: PartProvider<R> = NoParts> {
+    source: SolidStreamingSource<'a, R, P>,
+    state: CursorState,
+}
+
+/// A header-first session for one normal entry inside a solid block.
+#[must_use = "decode, skip, or explicitly discard the entry"]
+pub struct SolidNormalEntrySession<'entry, 'archive, R: Read, P: PartProvider<R> = NoParts> {
+    inner: NormalEntrySessionCore<'entry, SolidStreamingSource<'archive, R, P>>,
+}
+
+impl<'entry, 'archive, R: Read, P: PartProvider<R>>
+    SolidNormalEntrySession<'entry, 'archive, R, P>
+{
+    /// Returns the entry header without reading its payload.
+    #[inline]
+    pub const fn header(&self) -> &EntryHeader {
+        self.inner.header()
+    }
+
+    /// Opens a decoded streaming reader for the entry payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for invalid entry grammar, an unsupported codec or
+    /// cipher, password/KDF failure, or underlying I/O.
+    #[inline]
+    pub fn decoded(self) -> io::Result<SolidDecodedEntryReader<'entry, 'archive, R, P>> {
+        self.inner
+            .decoded()
+            .map(|inner| SolidDecodedEntryReader { inner })
+    }
+
+    /// Reads and validates the entry framing without decrypting or decompressing.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for invalid chunk CRC, grammar, or I/O.
+    #[inline]
+    pub fn skip(self) -> io::Result<EntryCompletion> {
+        self.inner.skip()
+    }
+}
+
+struct SolidStreamingSource<'a, R: Read, P: PartProvider<R>> {
+    reader: BufReader<SolidDecodedReader<'a, R, P>>,
+    options: ReadOptions,
+    max_chunk_data_len: u32,
+}
+
+impl<'archive, R: Read, P: PartProvider<R>> StreamingSolidEntries<'archive, R, P> {
+    /// Reads enough inner data to expose the next normal entry header.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for invalid inner grammar, codec termination,
+    /// cipher authentication, or I/O.
+    #[inline]
+    pub fn next_entry(
+        &mut self,
+    ) -> io::Result<Option<SolidNormalEntrySession<'_, 'archive, R, P>>> {
+        match self.state {
+            CursorState::Ready => {}
+            CursorState::Stopped(StopReason::Finished) => return Ok(None),
+            CursorState::Stopped(reason) => return Err(cursor_state_error(reason)),
+        }
+        let empty = match self.source.reader.fill_buf() {
+            Ok(bytes) => bytes.is_empty(),
+            Err(error) => {
+                self.state = CursorState::Stopped(StopReason::Failed);
+                return Err(error);
+            }
+        };
+        if empty {
+            self.state = CursorState::Stopped(StopReason::Finished);
+            return Ok(None);
+        }
+        let chunk =
+            match crate::io::read_chunk(&mut self.source.reader, self.source.max_chunk_data_len) {
+                Ok(chunk) => chunk,
+                Err(error) => {
+                    self.state = CursorState::Stopped(StopReason::Failed);
+                    return Err(error);
+                }
+            };
+        if chunk.ty() != ChunkType::FHED {
+            self.state = CursorState::Stopped(StopReason::Failed);
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("expected inner `{}`, got `{}`", ChunkType::FHED, chunk.ty()),
+            ));
+        }
+        let header = match parse_entry_header(&chunk) {
+            Ok(header) => header,
+            Err(error) => {
+                self.state = CursorState::Stopped(StopReason::Failed);
+                return Err(error);
+            }
+        };
+        let lease = EntryLease::new(&mut self.state);
+        Ok(Some(SolidNormalEntrySession {
+            inner: NormalEntrySessionCore {
+                source: &mut self.source,
+                header,
+                chunks: vec![chunk],
+                lease,
+            },
+        }))
+    }
+
+    /// Drains the remaining inner entries and validates the outer `SEND`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for invalid inner or outer grammar, codec
+    /// termination, cipher authentication, or I/O.
+    #[inline]
+    pub fn finish(mut self) -> io::Result<()> {
+        while let Some(entry) = self.next_entry()? {
+            entry.skip()?;
+        }
+        self.source.reader.into_inner().finish()
+    }
+}
+
+impl<R: Read, P: PartProvider<R>> ChunkCursor for SolidStreamingSource<'_, R, P> {
+    fn read_stream_chunk(&mut self) -> io::Result<RawChunk> {
+        crate::io::read_chunk(&mut self.reader, self.max_chunk_data_len)
+    }
+
+    fn options(&self) -> &ReadOptions {
+        &self.options
+    }
+}
+
+type EntryPipeline<'a, C> = DecompressReader<DecryptReader<EncodedEntryReader<'a, C>>>;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum EntryDataPhase {
+    #[default]
+    Prelude,
+    Datastream,
+    Trailing,
+}
+
+#[derive(Debug, Default)]
+struct EntryChunkSequence {
+    phase: EntryDataPhase,
+    phsf_seen: bool,
+    ancillary_seen: bool,
+}
+
+impl EntryChunkSequence {
+    fn observe_phsf(&mut self) -> io::Result<()> {
+        if self.phsf_seen {
+            return Err(chunk_order_error("`PHSF` must not appear more than once"));
+        }
+        if self.phase != EntryDataPhase::Prelude || self.ancillary_seen {
+            return Err(chunk_order_error(
+                "`PHSF` must precede ancillary chunks and the data stream",
+            ));
+        }
+        self.phsf_seen = true;
+        Ok(())
+    }
+
+    fn observe_data(&mut self, ty: ChunkType) -> io::Result<()> {
+        if self.phase == EntryDataPhase::Trailing {
+            return Err(chunk_order_error(format!(
+                "`{ty}` chunks must form one consecutive data stream"
+            )));
+        }
+        self.phase = EntryDataPhase::Datastream;
+        Ok(())
+    }
+
+    fn observe_ancillary(&mut self) {
+        self.ancillary_seen = true;
+        if self.phase == EntryDataPhase::Datastream {
+            self.phase = EntryDataPhase::Trailing;
+        }
+    }
+}
+
+fn chunk_order_error(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
+}
+
+/// Decoded payload reader for one normal entry.
+///
+/// Successfully returned bytes precede whole-entry verification. Treat them as
+/// provisional until EOF or [`Self::finish`] succeeds.
+#[must_use = "read to EOF, finish, or explicitly discard the remaining entry"]
+struct DecodedEntryReaderCore<'a, C: ChunkCursor> {
+    pipeline: Option<EntryPipeline<'a, C>>,
+    lease: Option<EntryLease<'a>>,
+    completion: Option<EntryCompletion>,
+    stopped: Option<(io::ErrorKind, String)>,
+}
+
+impl<C: ChunkCursor> DecodedEntryReaderCore<'_, C> {
+    /// Drains unread decoded bytes and validates the complete entry.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for codec, cipher, CRC, grammar, or I/O failure.
+    #[inline]
+    fn finish(mut self) -> io::Result<EntryCompletion> {
+        io::copy(&mut self, &mut io::sink())?;
+        Ok(self
+            .completion
+            .take()
+            .expect("a drained reader always holds its completion"))
+    }
+
+    /// Abandons decoded validation and drains to the next physical entry boundary.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the remaining physical chunks cannot be validated or
+    /// the boundary can no longer be recovered.
+    #[inline]
+    fn discard_remaining(self) -> io::Result<()> {
+        let mut this = self;
+        if this.completion.is_some() {
+            return Ok(());
+        }
+        let pipeline = this.pipeline.take().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "the physical entry boundary is no longer recoverable",
+            )
+        })?;
+        let decrypt = pipeline.into_inner_unchecked();
+        let mut encoded = decrypt.into_inner_unchecked();
+        if let Err(error) = encoded.finish_physical() {
+            if let Some(lease) = this.lease.as_mut() {
+                lease.fail();
+            }
+            return Err(error);
+        }
+        if let Some(lease) = this.lease.take() {
+            lease.complete();
+        }
+        Ok(())
+    }
+}
+
+impl<C: ChunkCursor> Read for DecodedEntryReaderCore<'_, C> {
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if buf.is_empty() || self.completion.is_some() {
+            return Ok(0);
+        }
+        if let Some((kind, message)) = &self.stopped {
+            return Err(io::Error::new(*kind, message.clone()));
+        }
+
+        let result = self
+            .pipeline
+            .as_mut()
+            .expect("incomplete reader always retains its pipeline")
+            .read(buf);
+        match result {
+            Ok(0) => {
+                let pipeline = self.pipeline.take().expect("pipeline checked above");
+                let finalized = pipeline
+                    .try_into_inner()
+                    .and_then(TryIntoInner::try_into_inner)
+                    .and_then(EncodedEntryReader::into_completion);
+                match finalized {
+                    Ok(completion) => {
+                        if let Some(lease) = self.lease.take() {
+                            lease.complete();
+                        }
+                        self.completion = Some(completion);
+                        Ok(0)
+                    }
+                    Err(error) => {
+                        if let Some(lease) = self.lease.as_mut() {
+                            lease.fail();
+                        }
+                        self.stopped = Some((error.kind(), error.to_string()));
+                        Err(error)
+                    }
+                }
+            }
+            Ok(read) => Ok(read),
+            Err(error) => {
+                self.stopped = Some((error.kind(), error.to_string()));
+                Err(error)
+            }
+        }
+    }
+}
+
+/// Decoded payload reader for one normal archive entry.
+#[must_use = "read to EOF, finish, or explicitly discard the remaining entry"]
+pub struct DecodedEntryReader<'a, R: Read, P: PartProvider<R> = NoParts> {
+    inner: DecodedEntryReaderCore<'a, StreamingSource<R, P>>,
+}
+
+impl<R: Read, P: PartProvider<R>> DecodedEntryReader<'_, R, P> {
+    /// Drains unread decoded bytes and validates the complete entry.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for codec, cipher, CRC, grammar, or I/O failure.
+    #[inline]
+    pub fn finish(self) -> io::Result<EntryCompletion> {
+        self.inner.finish()
+    }
+
+    /// Abandons decoded validation and drains to the next physical entry boundary.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the remaining physical chunks cannot be validated or
+    /// the boundary can no longer be recovered.
+    #[inline]
+    pub fn discard_remaining(self) -> io::Result<()> {
+        self.inner.discard_remaining()
+    }
+}
+
+impl<R: Read, P: PartProvider<R>> Read for DecodedEntryReader<'_, R, P> {
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+/// Decoded payload reader for a normal entry inside a solid block.
+#[must_use = "read to EOF, finish, or explicitly discard the remaining entry"]
+pub struct SolidDecodedEntryReader<'entry, 'archive, R: Read, P: PartProvider<R> = NoParts> {
+    inner: DecodedEntryReaderCore<'entry, SolidStreamingSource<'archive, R, P>>,
+}
+
+impl<R: Read, P: PartProvider<R>> SolidDecodedEntryReader<'_, '_, R, P> {
+    /// Drains unread decoded bytes and validates the complete entry.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for codec, cipher, CRC, grammar, or I/O failure.
+    #[inline]
+    pub fn finish(self) -> io::Result<EntryCompletion> {
+        self.inner.finish()
+    }
+
+    /// Abandons decoded validation and drains to the next inner entry boundary.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the remaining chunks cannot be validated or the
+    /// boundary can no longer be recovered.
+    #[inline]
+    pub fn discard_remaining(self) -> io::Result<()> {
+        self.inner.discard_remaining()
+    }
+}
+
+impl<R: Read, P: PartProvider<R>> Read for SolidDecodedEntryReader<'_, '_, R, P> {
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+struct EncodedEntryReader<'a, C> {
+    source: &'a mut C,
+    chunks: Vec<RawChunk>,
+    current: io::Cursor<Vec<u8>>,
+    phsf: Option<String>,
+    encoded_size: u64,
+    sequence: EntryChunkSequence,
+    done: bool,
+}
+
+impl<'a, C: ChunkCursor> EncodedEntryReader<'a, C> {
+    fn new(source: &'a mut C, chunks: Vec<RawChunk>) -> Self {
+        Self {
+            source,
+            chunks,
+            current: io::Cursor::new(Vec::new()),
+            phsf: None,
+            encoded_size: 0,
+            sequence: EntryChunkSequence::default(),
+            done: false,
+        }
+    }
+
+    fn phsf(&self) -> Option<&str> {
+        self.phsf.as_deref()
+    }
+
+    fn prepare(&mut self) -> io::Result<()> {
+        while !self.done && self.current.position() == self.current.get_ref().len() as u64 {
+            self.load_next()?;
+            if !self.current.get_ref().is_empty() {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    fn load_next(&mut self) -> io::Result<()> {
+        let chunk = self.source.read_stream_chunk()?;
+        match chunk.ty() {
+            ChunkType::FDAT => {
+                self.sequence.observe_data(ChunkType::FDAT)?;
+                self.encoded_size = self
+                    .encoded_size
+                    .checked_add(chunk.data().len() as u64)
+                    .ok_or_else(|| {
+                        io::Error::new(io::ErrorKind::InvalidData, "entry encoded size overflow")
+                    })?;
+                self.current = io::Cursor::new(chunk.data);
+            }
+            ChunkType::FEND => {
+                self.chunks.push(chunk);
+                self.done = true;
+            }
+            ChunkType::PHSF => {
+                self.sequence.observe_phsf()?;
+                self.phsf = Some(
+                    String::from_utf8(chunk.data.clone())
+                        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?,
+                );
+                self.chunks.push(chunk);
+            }
+            ty if ty.is_critical() => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("unexpected critical chunk `{ty}` in normal entry"),
+                ));
+            }
+            _ => {
+                self.sequence.observe_ancillary();
+                self.chunks.push(chunk);
+            }
+        }
+        Ok(())
+    }
+
+    fn finish_physical(&mut self) -> io::Result<()> {
+        self.current
+            .set_position(self.current.get_ref().len() as u64);
+        while !self.done {
+            self.load_next()?;
+            self.current
+                .set_position(self.current.get_ref().len() as u64);
+        }
+        Ok(())
+    }
+
+    fn into_completion(self) -> io::Result<EntryCompletion> {
+        if !self.done {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "entry did not reach `FEND`",
+            ));
+        }
+        let mut entry: NormalEntry = RawEntry(self.chunks).try_into()?;
+        entry.metadata.compressed_size = self.encoded_size.try_into().map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "encoded entry size cannot be represented on this platform",
+            )
+        })?;
+        Ok(EntryCompletion {
+            header: entry.header,
+            metadata: entry.metadata,
+            extra_chunks: entry.extra,
+        })
+    }
+}
+
+impl<C: ChunkCursor> Read for EncodedEntryReader<'_, C> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        loop {
+            let read = self.current.read(buf)?;
+            if read != 0 {
+                return Ok(read);
+            }
+            if self.done {
+                return Ok(0);
+            }
+            self.load_next()?;
+        }
+    }
+}
+
+struct EncodedSolidReader<'a, R: Read, P: PartProvider<R>> {
+    source: &'a mut StreamingSource<R, P>,
+    chunks: Vec<RawChunk>,
+    current: io::Cursor<Vec<u8>>,
+    phsf: Option<String>,
+    sequence: EntryChunkSequence,
+    done: bool,
+}
+
+impl<'a, R: Read, P: PartProvider<R>> EncodedSolidReader<'a, R, P> {
+    fn new(source: &'a mut StreamingSource<R, P>, chunks: Vec<RawChunk>) -> Self {
+        Self {
+            source,
+            chunks,
+            current: io::Cursor::new(Vec::new()),
+            phsf: None,
+            sequence: EntryChunkSequence::default(),
+            done: false,
+        }
+    }
+
+    fn phsf(&self) -> Option<&str> {
+        self.phsf.as_deref()
+    }
+
+    fn prepare(&mut self) -> io::Result<()> {
+        while !self.done && self.current.position() == self.current.get_ref().len() as u64 {
+            self.load_next()?;
+            if !self.current.get_ref().is_empty() {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    fn load_next(&mut self) -> io::Result<()> {
+        let chunk = self.source.read_logical_chunk()?;
+        match chunk.ty() {
+            ChunkType::SDAT => {
+                self.sequence.observe_data(ChunkType::SDAT)?;
+                self.current = io::Cursor::new(chunk.data);
+            }
+            ChunkType::SEND => {
+                self.chunks.push(chunk);
+                self.done = true;
+            }
+            ChunkType::PHSF => {
+                self.sequence.observe_phsf()?;
+                self.phsf = Some(
+                    String::from_utf8(chunk.data.clone())
+                        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?,
+                );
+                self.chunks.push(chunk);
+            }
+            ty if ty.is_critical() => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("unexpected critical chunk `{ty}` in solid entry"),
+                ));
+            }
+            _ => {
+                self.sequence.observe_ancillary();
+                self.chunks.push(chunk);
+            }
+        }
+        Ok(())
+    }
+
+    fn finish(self) -> io::Result<()> {
+        if !self.done {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "solid entry did not reach `SEND`",
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl<R: Read, P: PartProvider<R>> Read for EncodedSolidReader<'_, R, P> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        loop {
+            let read = self.current.read(buf)?;
+            if read != 0 {
+                return Ok(read);
+            }
+            if self.done {
+                return Ok(0);
+            }
+            self.load_next()?;
+        }
+    }
+}
+
+type SolidPipeline<'a, R, P> = DecompressReader<DecryptReader<EncodedSolidReader<'a, R, P>>>;
+
+struct SolidDecodedReader<'a, R: Read, P: PartProvider<R>> {
+    pipeline: Option<SolidPipeline<'a, R, P>>,
+    lease: Option<EntryLease<'a>>,
+    complete: bool,
+    stopped: Option<(io::ErrorKind, String)>,
+}
+
+impl<R: Read, P: PartProvider<R>> SolidDecodedReader<'_, R, P> {
+    fn finish(mut self) -> io::Result<()> {
+        if !self.complete {
+            let mut byte = [0u8; 1];
+            if self.read(&mut byte)? != 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "solid stream contains an unfinished inner entry",
+                ));
+            }
+        }
+        if self.complete {
+            Ok(())
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "solid block did not reach completion",
+            ))
+        }
+    }
+}
+
+impl<R: Read, P: PartProvider<R>> Read for SolidDecodedReader<'_, R, P> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if buf.is_empty() || self.complete {
+            return Ok(0);
+        }
+        if let Some((kind, message)) = &self.stopped {
+            return Err(io::Error::new(*kind, message.clone()));
+        }
+
+        match self
+            .pipeline
+            .as_mut()
+            .expect("incomplete solid reader always retains its pipeline")
+            .read(buf)
+        {
+            Ok(0) => {
+                let pipeline = self.pipeline.take().expect("pipeline checked above");
+                let finalized = pipeline
+                    .try_into_inner()
+                    .and_then(TryIntoInner::try_into_inner)
+                    .and_then(EncodedSolidReader::finish);
+                match finalized {
+                    Ok(()) => {
+                        if let Some(lease) = self.lease.take() {
+                            lease.complete();
+                        }
+                        self.complete = true;
+                        Ok(0)
+                    }
+                    Err(error) => {
+                        if let Some(lease) = self.lease.as_mut() {
+                            lease.fail();
+                        }
+                        self.stopped = Some((error.kind(), error.to_string()));
+                        Err(error)
+                    }
+                }
+            }
+            Ok(read) => Ok(read),
+            Err(error) => {
+                if let Some(lease) = self.lease.as_mut() {
+                    lease.fail();
+                }
+                self.stopped = Some((error.kind(), error.to_string()));
+                Err(error)
+            }
+        }
+    }
+}
+
+fn skip_solid_chunks<R: Read, P: PartProvider<R>>(
+    source: &mut StreamingSource<R, P>,
+) -> io::Result<()> {
+    let mut sequence = EntryChunkSequence::default();
+    loop {
+        let chunk = source.read_logical_chunk()?;
+        match chunk.ty() {
+            ChunkType::SDAT => sequence.observe_data(ChunkType::SDAT)?,
+            ChunkType::SEND => return Ok(()),
+            ChunkType::PHSF => sequence.observe_phsf()?,
+            ty if ty.is_critical() => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("unexpected critical chunk `{ty}` in solid entry"),
+                ));
+            }
+            _ => sequence.observe_ancillary(),
+        }
+    }
+}
+
+fn parse_entry_header(chunk: &RawChunk) -> io::Result<EntryHeader> {
+    let header = EntryHeader::try_from_bytes(chunk.data())?;
+    if header.major != 0 || header.minor != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            format!(
+                "entry version {}.{} is not supported",
+                header.major, header.minor
+            ),
+        ));
+    }
+    Ok(header)
+}
+
+fn parse_solid_header(chunk: &RawChunk) -> io::Result<SolidHeader> {
+    let header = SolidHeader::try_from_bytes(chunk.data())?;
+    if header.major != 0 || header.minor != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            format!(
+                "solid entry version {}.{} is not supported",
+                header.major, header.minor
+            ),
+        ));
+    }
+    Ok(header)
+}

--- a/lib/src/cipher.rs
+++ b/lib/src/cipher.rs
@@ -172,6 +172,51 @@ impl<R: Read> Read for DecryptReader<R> {
     }
 }
 
+impl<R: Read> DecryptReader<R> {
+    /// Discards cipher state and returns the encoded source without verifying
+    /// padding or authentication.
+    pub(crate) fn into_inner_unchecked(self) -> R {
+        match self {
+            Self::No(r) => r,
+            Self::CbcAes(r) => r.into_inner(),
+            Self::CbcCamellia(r) => r.into_inner(),
+            Self::CtrAes(r) => r.into_inner(),
+            Self::CtrCamellia(r) => r.into_inner(),
+            Self::GcmAes(r) => r.into_inner(),
+            Self::GcmCamellia(r) => r.into_inner(),
+        }
+    }
+}
+
+impl<R: Read> TryIntoInner<R> for DecryptReader<R> {
+    fn try_into_inner(mut self) -> io::Result<R> {
+        let mut byte = [0u8; 1];
+        loop {
+            match self.read(&mut byte) {
+                Ok(0) => break,
+                Ok(_) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "decryption reader still contains unread data",
+                    ));
+                }
+                Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                Err(e) => return Err(e),
+            }
+        }
+
+        Ok(match self {
+            Self::No(r) => r,
+            Self::CbcAes(r) => r.into_inner(),
+            Self::CbcCamellia(r) => r.into_inner(),
+            Self::CtrAes(r) => r.into_inner(),
+            Self::CtrCamellia(r) => r.into_inner(),
+            Self::GcmAes(r) => r.into_inner(),
+            Self::GcmCamellia(r) => r.into_inner(),
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -307,5 +352,20 @@ mod tests {
         if let Ok(recovered) = decrypt_camellia256_cbc(&wrong_key, &ct) {
             assert_ne!(recovered.as_slice(), KAT_PLAINTEXT.as_slice())
         }
+    }
+
+    #[test]
+    fn decrypt_reader_try_into_inner_recovers_reader_after_eof() {
+        let encrypted = encrypt_aes256_cbc(&KAT_KEY, &KAT_IV, KAT_PLAINTEXT).unwrap();
+        let ciphertext = encrypted[KAT_IV.len()..].to_vec();
+        let mut reader = DecryptReader::CbcAes(
+            DecryptCbcAes256Reader::new(io::Cursor::new(ciphertext), &KAT_KEY, &KAT_IV).unwrap(),
+        );
+        let mut plain = Vec::new();
+        reader.read_to_end(&mut plain).unwrap();
+        assert_eq!(plain, KAT_PLAINTEXT);
+
+        let inner = reader.try_into_inner().unwrap();
+        assert_eq!(inner.position(), inner.get_ref().len() as u64);
     }
 }

--- a/lib/src/cipher/block/read.rs
+++ b/lib/src/cipher/block/read.rs
@@ -44,6 +44,11 @@ where
             eof: false,
         })
     }
+
+    #[inline]
+    pub(crate) fn into_inner(self) -> R {
+        self.r
+    }
 }
 
 impl<R, C, P> Read for CbcBlockCipherDecryptReader<R, C, P>

--- a/lib/src/cipher/gcm.rs
+++ b/lib/src/cipher/gcm.rs
@@ -159,6 +159,11 @@ where
         }
     }
 
+    #[inline]
+    pub(crate) fn into_inner(self) -> R {
+        self.r
+    }
+
     fn fail(&mut self, e: AeadError) -> io::Error {
         self.fuse = Some(Stopped::Aead(e.clone()));
         e.into()

--- a/lib/src/cipher/stream/read.rs
+++ b/lib/src/cipher/stream/read.rs
@@ -27,6 +27,11 @@ where
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?,
         })
     }
+
+    #[inline]
+    pub(crate) fn into_inner(self) -> R {
+        self.r
+    }
 }
 
 impl<R, T> Read for StreamCipherReader<R, T>

--- a/lib/src/compress.rs
+++ b/lib/src/compress.rs
@@ -3,7 +3,7 @@
 use crate::util::io::TryIntoInner;
 use flate2::{bufread::ZlibDecoder, write::ZlibEncoder};
 use liblzma::{bufread::XzDecoder, write::XzEncoder};
-use std::io::{BufReader, Read, Result, Write};
+use std::io::{BufRead, BufReader, Read, Result, Write};
 use zstd::stream::{read::Decoder as ZStdDecoder, write::Encoder as ZstdEncoder};
 
 pub(crate) mod deflate;
@@ -103,5 +103,144 @@ impl<R: Read> Read for DecompressReader<R> {
             Self::ZStd(r) => r.read(buf),
             Self::Xz(r) => r.read(buf),
         }
+    }
+}
+
+impl<R: Read> DecompressReader<R> {
+    /// Discards codec state and buffered encoded bytes, returning the source.
+    ///
+    /// This is only used to recover the next physical chunk boundary after a
+    /// caller deliberately abandons decoded validation.
+    pub(crate) fn into_inner_unchecked(self) -> R {
+        match self {
+            Self::No(r) => r.into_inner(),
+            Self::Deflate(r) => r.into_inner().into_inner(),
+            Self::ZStd(r) => r.finish().into_inner(),
+            Self::Xz(r) => r.into_inner().into_inner(),
+        }
+    }
+}
+
+impl<R: Read> TryIntoInner<R> for DecompressReader<R> {
+    fn try_into_inner(mut self) -> Result<R> {
+        let mut byte = [0u8; 1];
+        loop {
+            match self.read(&mut byte) {
+                Ok(0) => break,
+                Ok(_) => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "decompression reader still contains unread data",
+                    ));
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(e) => return Err(e),
+            }
+        }
+
+        let mut reader = match self {
+            Self::No(r) => r,
+            Self::Deflate(r) => r.into_inner(),
+            Self::ZStd(r) => r.finish(),
+            Self::Xz(r) => r.into_inner(),
+        };
+        if !reader.fill_buf()?.is_empty() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "compressed stream contains trailing data",
+            ));
+        }
+        Ok(reader.into_inner())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Cursor, ErrorKind};
+    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    use wasm_bindgen_test::wasm_bindgen_test as test;
+
+    const PLAIN: &[u8] = b"streaming decompression finalization";
+
+    fn deflate(plain: &[u8]) -> Vec<u8> {
+        let mut encoder = ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+        encoder.write_all(plain).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    fn zstd(plain: &[u8]) -> Vec<u8> {
+        let mut encoder = ZstdEncoder::new(Vec::new(), 0).unwrap();
+        encoder.write_all(plain).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    fn xz(plain: &[u8]) -> Vec<u8> {
+        let mut encoder = XzEncoder::new(Vec::new(), 6);
+        encoder.write_all(plain).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    fn readers() -> Vec<(&'static str, DecompressReader<Cursor<Vec<u8>>>)> {
+        vec![
+            (
+                "store",
+                DecompressReader::No(BufReader::new(Cursor::new(PLAIN.to_vec()))),
+            ),
+            (
+                "deflate",
+                DecompressReader::Deflate(ZlibDecoder::new(BufReader::new(Cursor::new(deflate(
+                    PLAIN,
+                ))))),
+            ),
+            (
+                "zstd",
+                DecompressReader::ZStd(
+                    ZStdDecoder::with_buffer(BufReader::new(Cursor::new(zstd(PLAIN)))).unwrap(),
+                ),
+            ),
+            (
+                "xz",
+                DecompressReader::Xz(XzDecoder::new(BufReader::new(Cursor::new(xz(PLAIN))))),
+            ),
+        ]
+    }
+
+    #[test]
+    fn try_into_inner_recovers_source_after_eof_for_every_codec() {
+        for (label, mut reader) in readers() {
+            let mut plain = Vec::new();
+            reader.read_to_end(&mut plain).unwrap();
+            assert_eq!(plain, PLAIN, "{label} decoded payload");
+
+            let inner = reader.try_into_inner().unwrap();
+            assert_eq!(
+                inner.position(),
+                inner.get_ref().len() as u64,
+                "{label} consumed its whole source"
+            );
+        }
+    }
+
+    #[test]
+    fn try_into_inner_rejects_unread_decompressed_data() {
+        let reader = DecompressReader::No(BufReader::new(Cursor::new(PLAIN.to_vec())));
+        let error = reader.try_into_inner().unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn try_into_inner_rejects_trailing_compressed_data() {
+        let mut encoder = ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+        encoder.write_all(PLAIN).unwrap();
+        let mut encoded = encoder.finish().unwrap();
+        encoded.extend_from_slice(b"trailing");
+        let mut reader =
+            DecompressReader::Deflate(ZlibDecoder::new(BufReader::new(Cursor::new(encoded))));
+        let mut plain = Vec::new();
+        reader.read_to_end(&mut plain).unwrap();
+
+        let error = reader.try_into_inner().unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::InvalidData);
     }
 }

--- a/lib/src/util/io/finish.rs
+++ b/lib/src/util/io/finish.rs
@@ -1,4 +1,4 @@
-//! Trait for extracting the inner writer from layered I/O types.
+//! Trait for finishing layered I/O types and extracting their inner value.
 
 use std::io;
 

--- a/lib/tests/streaming_entries.rs
+++ b/lib/tests/streaming_entries.rs
@@ -1,0 +1,398 @@
+use libpna::{
+    Archive, Chunk, ChunkType, CipherMode, Compression, Encryption, HashAlgorithm, Metadata,
+    PNA_SIGNATURE, PartProvider, ReadOptions, StreamingReadEntry, WriteOptions,
+};
+use std::{
+    cell::Cell,
+    collections::VecDeque,
+    io::{self, Cursor, Read, Write},
+    rc::Rc,
+};
+
+fn rewrite_archive(
+    bytes: &[u8],
+    mut rewrite: impl FnMut(ChunkType, &[u8]) -> Vec<(ChunkType, Vec<u8>)>,
+) -> Vec<u8> {
+    let mut output = PNA_SIGNATURE.to_vec();
+    let mut remaining = libpna::bytes::read_signature(bytes).unwrap();
+    while !remaining.is_empty() {
+        let (chunk, rest) = libpna::bytes::read_chunk(remaining, u32::MAX).unwrap();
+        for chunk in rewrite(chunk.ty(), chunk.data()) {
+            libpna::io::write_chunk(&mut output, chunk).unwrap();
+        }
+        remaining = rest;
+    }
+    output
+}
+
+fn assert_normal_skip_fails(bytes: Vec<u8>) {
+    let archive = Archive::read_header(bytes.as_slice()).unwrap();
+    let mut entries = archive.into_streaming_entries(ReadOptions::builder().build());
+    let StreamingReadEntry::Normal(entry) = entries.next_entry().unwrap().unwrap() else {
+        panic!("expected normal entry");
+    };
+    assert_eq!(entry.skip().unwrap_err().kind(), io::ErrorKind::InvalidData);
+    let error = match entries.next_entry() {
+        Err(error) => error,
+        Ok(_) => panic!("failed cursor unexpectedly advanced"),
+    };
+    assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+}
+
+fn normal_archive(data: &[u8], compression: Compression) -> Vec<u8> {
+    let mut archive = Archive::write_header(Vec::new()).unwrap();
+    archive
+        .write_file(
+            "file.txt".into(),
+            Metadata::new(),
+            WriteOptions::builder().compression(compression).build(),
+            |writer| writer.write_all(data),
+        )
+        .unwrap();
+    archive.finalize().unwrap()
+}
+
+fn solid_archive(data: &[u8], compression: Compression) -> Vec<u8> {
+    let mut solid = Archive::write_solid_header(
+        Vec::new(),
+        WriteOptions::builder().compression(compression).build(),
+    )
+    .unwrap();
+    solid
+        .write_file("solid.txt".into(), Metadata::new(), |writer| {
+            writer.write_all(data)
+        })
+        .unwrap();
+    solid.finalize().unwrap()
+}
+
+fn read_normal_data(archive: Vec<u8>) -> (Vec<u8>, libpna::EntryCompletion) {
+    let archive = Archive::read_header(Cursor::new(archive)).unwrap();
+    let mut entries = archive.into_streaming_entries(ReadOptions::builder().build());
+    let StreamingReadEntry::Normal(entry) = entries.next_entry().unwrap().unwrap() else {
+        panic!("expected normal entry");
+    };
+    let mut reader = entry.decoded().unwrap();
+    let mut data = Vec::new();
+    reader.read_to_end(&mut data).unwrap();
+    let completion = reader.finish().unwrap();
+    assert!(entries.next_entry().unwrap().is_none());
+    (data, completion)
+}
+
+#[test]
+fn streams_normal_entry_and_finalizes_metadata() {
+    let expected = b"decoded payload".repeat(4096);
+    let (actual, completion) = read_normal_data(normal_archive(&expected, Compression::DEFLATE));
+
+    assert_eq!(actual, expected);
+    assert_eq!(completion.header().path().to_string(), "file.txt");
+}
+
+#[test]
+fn streams_an_authenticated_encrypted_entry() {
+    let expected = b"authenticated streaming payload".repeat(1024);
+    let options = WriteOptions::builder()
+        .compression(Compression::ZSTANDARD)
+        .encryption(Encryption::AES)
+        .cipher_mode(CipherMode::GCM)
+        .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(10_000)))
+        .password(Some("password"))
+        .try_build()
+        .unwrap();
+    let mut archive = Archive::write_header(Vec::new()).unwrap();
+    archive
+        .write_file("secret".into(), Metadata::new(), options, |writer| {
+            writer.write_all(&expected)
+        })
+        .unwrap();
+    let bytes = archive.finalize().unwrap();
+    let archive = Archive::read_header(bytes.as_slice()).unwrap();
+    let mut entries = archive.into_streaming_entries(ReadOptions::with_password(Some("password")));
+    let StreamingReadEntry::Normal(entry) = entries.next_entry().unwrap().unwrap() else {
+        panic!("expected normal entry");
+    };
+    let mut reader = entry.decoded().unwrap();
+    let mut actual = Vec::new();
+    reader.read_to_end(&mut actual).unwrap();
+    reader.finish().unwrap();
+
+    assert_eq!(actual, expected);
+}
+
+struct CountingReader {
+    inner: Cursor<Vec<u8>>,
+    consumed: Rc<Cell<usize>>,
+}
+
+impl Read for CountingReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let read = self.inner.read(buf)?;
+        self.consumed.set(self.consumed.get() + read);
+        Ok(read)
+    }
+}
+
+#[test]
+fn exposes_header_before_reading_payload() {
+    let payload = vec![0x5a; 1024 * 1024];
+    let bytes = normal_archive(&payload, Compression::NO);
+    let consumed = Rc::new(Cell::new(0));
+    let reader = CountingReader {
+        inner: Cursor::new(bytes.clone()),
+        consumed: Rc::clone(&consumed),
+    };
+    let archive = Archive::read_header(reader).unwrap();
+    let after_header = consumed.get();
+    let mut entries = archive.into_streaming_entries(ReadOptions::builder().build());
+    let StreamingReadEntry::Normal(entry) = entries.next_entry().unwrap().unwrap() else {
+        panic!("expected normal entry");
+    };
+
+    assert_eq!(entry.header().path().to_string(), "file.txt");
+    assert!(consumed.get() - after_header < payload.len());
+    entry.skip().unwrap();
+}
+
+#[test]
+fn skip_validates_framing_and_allows_the_next_entry() {
+    let mut archive = Archive::write_header(Vec::new()).unwrap();
+    for (name, body) in [("one", b"first".as_slice()), ("two", b"second".as_slice())] {
+        archive
+            .write_file(
+                name.into(),
+                Metadata::new(),
+                WriteOptions::store(),
+                |writer| writer.write_all(body),
+            )
+            .unwrap();
+    }
+    let bytes = archive.finalize().unwrap();
+    let archive = Archive::read_header(bytes.as_slice()).unwrap();
+    let mut entries = archive.into_streaming_entries(ReadOptions::builder().build());
+
+    let StreamingReadEntry::Normal(first) = entries.next_entry().unwrap().unwrap() else {
+        panic!("expected normal entry");
+    };
+    first.skip().unwrap();
+    let StreamingReadEntry::Normal(second) = entries.next_entry().unwrap().unwrap() else {
+        panic!("expected normal entry");
+    };
+    assert_eq!(second.header().path().to_string(), "two");
+    second.skip().unwrap();
+    assert!(entries.next_entry().unwrap().is_none());
+}
+
+#[test]
+fn dropping_an_entry_session_poison_the_cursor() {
+    let bytes = normal_archive(b"body", Compression::NO);
+    let archive = Archive::read_header(bytes.as_slice()).unwrap();
+    let mut entries = archive.into_streaming_entries(ReadOptions::builder().build());
+    drop(entries.next_entry().unwrap().unwrap());
+
+    let error = match entries.next_entry() {
+        Err(error) => error,
+        Ok(_) => panic!("poisoned cursor unexpectedly advanced"),
+    };
+    assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+}
+
+#[test]
+fn rejects_invalid_normal_chunk_ordering() {
+    let original = normal_archive(b"payload", Compression::NO);
+    let ancillary = ChunkType::private(*b"raWw").unwrap();
+
+    let nonconsecutive_data = rewrite_archive(&original, |ty, data| {
+        if ty == ChunkType::FDAT {
+            let middle = data.len() / 2;
+            vec![
+                (ty, data[..middle].to_vec()),
+                (ancillary, Vec::new()),
+                (ty, data[middle..].to_vec()),
+            ]
+        } else {
+            vec![(ty, data.to_vec())]
+        }
+    });
+    assert_normal_skip_fails(nonconsecutive_data);
+
+    let duplicate_phsf = rewrite_archive(&original, |ty, data| {
+        if ty == ChunkType::FDAT {
+            vec![
+                (ChunkType::PHSF, b"first".to_vec()),
+                (ChunkType::PHSF, b"second".to_vec()),
+                (ty, data.to_vec()),
+            ]
+        } else {
+            vec![(ty, data.to_vec())]
+        }
+    });
+    assert_normal_skip_fails(duplicate_phsf);
+
+    let late_phsf = rewrite_archive(&original, |ty, data| {
+        if ty == ChunkType::FDAT {
+            vec![(ty, data.to_vec()), (ChunkType::PHSF, b"late".to_vec())]
+        } else {
+            vec![(ty, data.to_vec())]
+        }
+    });
+    assert_normal_skip_fails(late_phsf);
+
+    let phsf_after_metadata = rewrite_archive(&original, |ty, data| {
+        if ty == ChunkType::FDAT {
+            vec![
+                (ChunkType::cTIM, 1i64.to_be_bytes().to_vec()),
+                (ChunkType::PHSF, b"late".to_vec()),
+                (ty, data.to_vec()),
+            ]
+        } else {
+            vec![(ty, data.to_vec())]
+        }
+    });
+    assert_normal_skip_fails(phsf_after_metadata);
+}
+
+#[test]
+fn discard_remaining_recovers_after_partial_decoding() {
+    let bytes = normal_archive(&vec![42; 128 * 1024], Compression::DEFLATE);
+    let archive = Archive::read_header(bytes.as_slice()).unwrap();
+    let mut entries = archive.into_streaming_entries(ReadOptions::builder().build());
+    let StreamingReadEntry::Normal(entry) = entries.next_entry().unwrap().unwrap() else {
+        panic!("expected normal entry");
+    };
+    let mut reader = entry.decoded().unwrap();
+    let mut prefix = [0; 17];
+    reader.read_exact(&mut prefix).unwrap();
+
+    reader.discard_remaining().unwrap();
+    assert!(entries.next_entry().unwrap().is_none());
+}
+
+#[test]
+fn corrupted_fdat_is_not_released_as_plaintext() {
+    let mut bytes = normal_archive(b"trusted bytes", Compression::NO);
+    let type_offset = bytes
+        .windows(4)
+        .position(|window| window == b"FDAT")
+        .unwrap();
+    bytes[type_offset + 4] ^= 1;
+    let archive = Archive::read_header(bytes.as_slice()).unwrap();
+    let mut entries = archive.into_streaming_entries(ReadOptions::builder().build());
+    let StreamingReadEntry::Normal(entry) = entries.next_entry().unwrap().unwrap() else {
+        panic!("expected normal entry");
+    };
+
+    let error = match entry.decoded() {
+        Err(error) => error,
+        Ok(_) => panic!("corrupted chunk unexpectedly decoded"),
+    };
+    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+}
+
+#[test]
+fn streams_solid_entries_without_flattening_the_outer_entry() {
+    let expected = b"inside solid".repeat(2048);
+    let bytes = solid_archive(&expected, Compression::DEFLATE);
+    let archive = Archive::read_header(bytes.as_slice()).unwrap();
+    let mut outer = archive.into_streaming_entries(ReadOptions::builder().build());
+    let StreamingReadEntry::Solid(solid) = outer.next_entry().unwrap().unwrap() else {
+        panic!("expected solid entry");
+    };
+    let mut inner = solid.entries().unwrap();
+    let entry = inner.next_entry().unwrap().unwrap();
+    let mut reader = entry.decoded().unwrap();
+    let mut actual = Vec::new();
+    reader.read_to_end(&mut actual).unwrap();
+    reader.finish().unwrap();
+    assert_eq!(actual, expected);
+    inner.finish().unwrap();
+    assert!(outer.next_entry().unwrap().is_none());
+}
+
+#[test]
+fn rejects_nonconsecutive_solid_data() {
+    let ancillary = ChunkType::private(*b"raWw").unwrap();
+    let bytes = rewrite_archive(&solid_archive(b"payload", Compression::NO), |ty, data| {
+        if ty == ChunkType::SDAT {
+            let middle = data.len() / 2;
+            vec![
+                (ty, data[..middle].to_vec()),
+                (ancillary, Vec::new()),
+                (ty, data[middle..].to_vec()),
+            ]
+        } else {
+            vec![(ty, data.to_vec())]
+        }
+    });
+    let archive = Archive::read_header(bytes.as_slice()).unwrap();
+    let mut entries = archive.into_streaming_entries(ReadOptions::builder().build());
+    let StreamingReadEntry::Solid(solid) = entries.next_entry().unwrap().unwrap() else {
+        panic!("expected solid entry");
+    };
+
+    assert_eq!(solid.skip().unwrap_err().kind(), io::ErrorKind::InvalidData);
+    let error = match entries.next_entry() {
+        Err(error) => error,
+        Ok(_) => panic!("failed cursor unexpectedly advanced"),
+    };
+    assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+}
+
+#[test]
+fn malformed_inner_entry_remains_failed_during_finish() {
+    let bytes = rewrite_archive(&solid_archive(b"payload", Compression::NO), |ty, data| {
+        if ty == ChunkType::SDAT {
+            vec![(ty, vec![0, 0, 0])]
+        } else {
+            vec![(ty, data.to_vec())]
+        }
+    });
+    let archive = Archive::read_header(bytes.as_slice()).unwrap();
+    let mut outer = archive.into_streaming_entries(ReadOptions::builder().build());
+    let StreamingReadEntry::Solid(solid) = outer.next_entry().unwrap().unwrap() else {
+        panic!("expected solid entry");
+    };
+    let mut inner = solid.entries().unwrap();
+
+    let error = match inner.next_entry() {
+        Err(error) => error,
+        Ok(_) => panic!("truncated inner chunk unexpectedly parsed"),
+    };
+    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    assert_eq!(
+        inner.finish().unwrap_err().kind(),
+        io::ErrorKind::InvalidInput
+    );
+}
+
+struct Parts(VecDeque<Cursor<&'static [u8]>>);
+
+impl PartProvider<Cursor<&'static [u8]>> for Parts {
+    fn next_part(&mut self, _expected: u32) -> io::Result<Option<Cursor<&'static [u8]>>> {
+        Ok(self.0.pop_front())
+    }
+}
+
+#[test]
+fn follows_a_multipart_entry_through_the_provider() {
+    let first = include_bytes!("../../resources/test/multipart.part1.pna");
+    let second = include_bytes!("../../resources/test/multipart.part2.pna");
+    let archive = Archive::read_header(Cursor::new(first.as_slice())).unwrap();
+    let mut entries = archive.into_streaming_entries_with_parts(
+        ReadOptions::builder().build(),
+        Parts(VecDeque::from([Cursor::new(second.as_slice())])),
+    );
+    let StreamingReadEntry::Normal(entry) = entries.next_entry().unwrap().unwrap() else {
+        panic!("expected normal entry");
+    };
+    let mut reader = entry.decoded().unwrap();
+    let mut actual = Vec::new();
+    reader.read_to_end(&mut actual).unwrap();
+    reader.finish().unwrap();
+
+    assert_eq!(
+        actual,
+        include_bytes!("../../resources/test/multipart_test.txt")
+    );
+    assert!(entries.next_entry().unwrap().is_none());
+}

--- a/lib/tests/streaming_entries.rs
+++ b/lib/tests/streaming_entries.rs
@@ -254,7 +254,23 @@ fn rejects_invalid_normal_chunk_ordering() {
 
 #[test]
 fn discard_remaining_recovers_after_partial_decoding() {
-    let bytes = normal_archive(&vec![42; 128 * 1024], Compression::DEFLATE);
+    let mut archive = Archive::write_header(Vec::new()).unwrap();
+    for (name, body) in [
+        ("one", vec![42u8; 128 * 1024]),
+        ("two", b"second entry".to_vec()),
+    ] {
+        archive
+            .write_file(
+                name.into(),
+                Metadata::new(),
+                WriteOptions::builder()
+                    .compression(Compression::DEFLATE)
+                    .build(),
+                |writer| writer.write_all(&body),
+            )
+            .unwrap();
+    }
+    let bytes = archive.finalize().unwrap();
     let archive = Archive::read_header(bytes.as_slice()).unwrap();
     let mut entries = archive.into_streaming_entries(ReadOptions::builder().build());
     let StreamingReadEntry::Normal(entry) = entries.next_entry().unwrap().unwrap() else {
@@ -265,7 +281,71 @@ fn discard_remaining_recovers_after_partial_decoding() {
     reader.read_exact(&mut prefix).unwrap();
 
     reader.discard_remaining().unwrap();
+
+    // The cursor is left usable and positioned on the next physical entry.
+    let StreamingReadEntry::Normal(second) = entries.next_entry().unwrap().unwrap() else {
+        panic!("expected normal entry");
+    };
+    assert_eq!(second.header().path().to_string(), "two");
+    let mut reader = second.decoded().unwrap();
+    let mut payload = Vec::new();
+    reader.read_to_end(&mut payload).unwrap();
+    reader.finish().unwrap();
+    assert_eq!(payload, b"second entry");
     assert!(entries.next_entry().unwrap().is_none());
+}
+
+#[test]
+fn discard_remaining_without_reading_anything_still_recovers() {
+    let bytes = normal_archive(&vec![7; 64 * 1024], Compression::ZSTANDARD);
+    let archive = Archive::read_header(bytes.as_slice()).unwrap();
+    let mut entries = archive.into_streaming_entries(ReadOptions::builder().build());
+    let StreamingReadEntry::Normal(entry) = entries.next_entry().unwrap().unwrap() else {
+        panic!("expected normal entry");
+    };
+
+    entry.decoded().unwrap().discard_remaining().unwrap();
+    assert!(entries.next_entry().unwrap().is_none());
+}
+
+#[test]
+fn discarding_an_inner_solid_entry_recovers_the_inner_cursor() {
+    let mut solid = Archive::write_solid_header(
+        Vec::new(),
+        WriteOptions::builder()
+            .compression(Compression::DEFLATE)
+            .build(),
+    )
+    .unwrap();
+    for (name, body) in [
+        ("one", vec![9u8; 32 * 1024]),
+        ("two", b"inner two".to_vec()),
+    ] {
+        solid
+            .write_file(name.into(), Metadata::new(), |writer| {
+                writer.write_all(&body)
+            })
+            .unwrap();
+    }
+    let bytes = solid.finalize().unwrap();
+    let archive = Archive::read_header(bytes.as_slice()).unwrap();
+    let mut outer = archive.into_streaming_entries(ReadOptions::builder().build());
+    let StreamingReadEntry::Solid(solid) = outer.next_entry().unwrap().unwrap() else {
+        panic!("expected solid entry");
+    };
+    let mut inner = solid.entries().unwrap();
+
+    let first = inner.next_entry().unwrap().unwrap();
+    let mut reader = first.decoded().unwrap();
+    let mut prefix = [0; 11];
+    reader.read_exact(&mut prefix).unwrap();
+    reader.discard_remaining().unwrap();
+
+    let second = inner.next_entry().unwrap().unwrap();
+    assert_eq!(second.header().path().to_string(), "two");
+    second.skip().unwrap();
+    inner.finish().unwrap();
+    assert!(outer.next_entry().unwrap().is_none());
 }
 
 #[test]
@@ -395,4 +475,501 @@ fn follows_a_multipart_entry_through_the_provider() {
         include_bytes!("../../resources/test/multipart_test.txt")
     );
     assert!(entries.next_entry().unwrap().is_none());
+}
+
+#[test]
+fn a_closure_serves_as_a_part_provider() {
+    let first = include_bytes!("../../resources/test/multipart.part1.pna");
+    let second = include_bytes!("../../resources/test/multipart.part2.pna");
+    let archive = Archive::read_header(Cursor::new(first.as_slice())).unwrap();
+    let mut requested = Vec::new();
+    let actual = {
+        let mut entries = archive.into_streaming_entries_with_parts(
+            ReadOptions::builder().build(),
+            |expected: u32| -> io::Result<Option<Cursor<&'static [u8]>>> {
+                requested.push(expected);
+                Ok(Some(Cursor::new(second.as_slice())))
+            },
+        );
+        let StreamingReadEntry::Normal(entry) = entries.next_entry().unwrap().unwrap() else {
+            panic!("expected normal entry");
+        };
+        let mut reader = entry.decoded().unwrap();
+        let mut actual = Vec::new();
+        reader.read_to_end(&mut actual).unwrap();
+        reader.finish().unwrap();
+        assert!(entries.next_entry().unwrap().is_none());
+        actual
+    };
+
+    assert_eq!(
+        actual,
+        include_bytes!("../../resources/test/multipart_test.txt")
+    );
+    assert_eq!(requested, [1], "`expected` numbers archives from 0");
+}
+
+// --- equivalence with the pre-existing reader -------------------------------
+
+/// One entry as observed by either reader, for cross-implementation comparison.
+type Observed = (String, Metadata, Vec<u8>, usize);
+
+fn read_all_classic(archive: &[u8], options: &ReadOptions) -> Vec<Observed> {
+    let mut archive = Archive::read_header(archive).unwrap();
+    archive
+        .entries_with_options(options)
+        .map(|entry| {
+            let entry = entry.unwrap();
+            let mut data = Vec::new();
+            entry
+                .reader(options.clone())
+                .unwrap()
+                .read_to_end(&mut data)
+                .unwrap();
+            (
+                entry.header().path().to_string(),
+                entry.metadata().clone(),
+                data,
+                entry.extra_chunks().len(),
+            )
+        })
+        .collect()
+}
+
+fn read_all_streaming(archive: &[u8], options: &ReadOptions) -> Vec<Observed> {
+    fn drain(reader: &mut impl Read) -> Vec<u8> {
+        let mut data = Vec::new();
+        reader.read_to_end(&mut data).unwrap();
+        data
+    }
+    let mut observed = Vec::new();
+    let handle = Archive::read_header(archive).unwrap();
+    let mut entries = handle.into_streaming_entries(options.clone());
+    while let Some(entry) = entries.next_entry().unwrap() {
+        match entry {
+            StreamingReadEntry::Normal(entry) => {
+                let mut reader = entry.decoded().unwrap();
+                let data = drain(&mut reader);
+                let completion = reader.finish().unwrap();
+                observed.push((
+                    completion.header().path().to_string(),
+                    completion.metadata().clone(),
+                    data,
+                    completion.extra_chunks().len(),
+                ));
+            }
+            StreamingReadEntry::Solid(solid) => {
+                let mut inner = solid.entries().unwrap();
+                while let Some(entry) = inner.next_entry().unwrap() {
+                    let mut reader = entry.decoded().unwrap();
+                    let data = drain(&mut reader);
+                    let completion = reader.finish().unwrap();
+                    observed.push((
+                        completion.header().path().to_string(),
+                        completion.metadata().clone(),
+                        data,
+                        completion.extra_chunks().len(),
+                    ));
+                }
+                inner.finish().unwrap();
+            }
+        }
+    }
+    observed
+}
+
+#[test]
+fn streaming_matches_the_classic_reader() {
+    let plain = ReadOptions::builder().build();
+    let secret = ReadOptions::with_password(Some("password"));
+
+    let encrypted = |compression: Compression, cipher_mode: CipherMode| {
+        let options = WriteOptions::builder()
+            .compression(compression)
+            .encryption(Encryption::AES)
+            .cipher_mode(cipher_mode)
+            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
+            .password(Some("password"))
+            .try_build()
+            .unwrap();
+        let mut archive = Archive::write_header(Vec::new()).unwrap();
+        archive
+            .write_file("secret.bin".into(), Metadata::new(), options, |writer| {
+                writer.write_all(&b"equivalence".repeat(512))
+            })
+            .unwrap();
+        archive.finalize().unwrap()
+    };
+
+    let cases: Vec<(&str, Vec<u8>, &ReadOptions)> = vec![
+        (
+            "store",
+            normal_archive(b"equivalence", Compression::NO),
+            &plain,
+        ),
+        (
+            "deflate",
+            normal_archive(&b"equivalence".repeat(500), Compression::DEFLATE),
+            &plain,
+        ),
+        (
+            "zstd",
+            normal_archive(&b"equivalence".repeat(500), Compression::ZSTANDARD),
+            &plain,
+        ),
+        (
+            "xz",
+            normal_archive(&b"equivalence".repeat(500), Compression::XZ),
+            &plain,
+        ),
+        ("empty", normal_archive(b"", Compression::DEFLATE), &plain),
+        (
+            "solid",
+            solid_archive(&b"equivalence".repeat(300), Compression::ZSTANDARD),
+            &plain,
+        ),
+        (
+            "gcm",
+            encrypted(Compression::ZSTANDARD, CipherMode::GCM),
+            &secret,
+        ),
+        (
+            "cbc",
+            encrypted(Compression::DEFLATE, CipherMode::CBC),
+            &secret,
+        ),
+        ("ctr", encrypted(Compression::NO, CipherMode::CTR), &secret),
+    ];
+
+    for (label, bytes, options) in cases {
+        let classic = read_all_classic(&bytes, options);
+        let streaming = read_all_streaming(&bytes, options);
+        assert!(!classic.is_empty(), "{label} produced no entries");
+        assert_eq!(classic, streaming, "{label} readers disagree");
+    }
+}
+
+#[test]
+fn skip_reports_the_same_completion_as_a_full_decode() {
+    let bytes = normal_archive(&b"completion".repeat(400), Compression::DEFLATE);
+    let (_, decoded) = read_normal_data(bytes.clone());
+
+    let archive = Archive::read_header(bytes.as_slice()).unwrap();
+    let mut entries = archive.into_streaming_entries(ReadOptions::builder().build());
+    let StreamingReadEntry::Normal(entry) = entries.next_entry().unwrap().unwrap() else {
+        panic!("expected normal entry");
+    };
+    let skipped = entry.skip().unwrap();
+
+    assert_eq!(skipped.header().path(), decoded.header().path());
+    assert_eq!(skipped.metadata(), decoded.metadata());
+    assert_eq!(
+        skipped.metadata().compressed_size(),
+        decoded.metadata().compressed_size()
+    );
+}
+
+// --- encryption failure modes ----------------------------------------------
+
+fn encrypted_archive(payload: &[u8], cipher_mode: CipherMode) -> Vec<u8> {
+    let options = WriteOptions::builder()
+        .compression(Compression::NO)
+        .encryption(Encryption::AES)
+        .cipher_mode(cipher_mode)
+        .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
+        .password(Some("password"))
+        .try_build()
+        .unwrap();
+    let mut archive = Archive::write_header(Vec::new()).unwrap();
+    archive
+        .write_file("secret.bin".into(), Metadata::new(), options, |writer| {
+            writer.write_all(payload)
+        })
+        .unwrap();
+    archive.finalize().unwrap()
+}
+
+fn first_normal_entry(
+    bytes: &[u8],
+    options: ReadOptions,
+) -> io::Result<(Vec<u8>, libpna::EntryCompletion)> {
+    let archive = Archive::read_header(bytes)?;
+    let mut entries = archive.into_streaming_entries(options);
+    let StreamingReadEntry::Normal(entry) = entries.next_entry()?.unwrap() else {
+        panic!("expected normal entry");
+    };
+    let mut reader = entry.decoded()?;
+    let mut data = Vec::new();
+    reader.read_to_end(&mut data)?;
+    let completion = reader.finish()?;
+    Ok((data, completion))
+}
+
+#[test]
+fn rejects_a_missing_password_in_every_cipher_mode() {
+    for cipher_mode in [CipherMode::GCM, CipherMode::CBC, CipherMode::CTR] {
+        let bytes = encrypted_archive(b"top secret", cipher_mode);
+        let error = first_normal_entry(&bytes, ReadOptions::builder().build())
+            .expect_err("a missing password unexpectedly decoded");
+        assert_eq!(
+            error.kind(),
+            io::ErrorKind::InvalidInput,
+            "{cipher_mode:?} missing password"
+        );
+
+        let (data, _) =
+            first_normal_entry(&bytes, ReadOptions::with_password(Some("password"))).unwrap();
+        assert_eq!(data, b"top secret", "{cipher_mode:?} round trip");
+    }
+}
+
+#[test]
+fn a_wrong_password_is_only_detected_by_authenticated_modes() {
+    // GCM confirms the derived key against the stream header before any segment
+    // is released, so a wrong password fails outright.
+    let gcm = encrypted_archive(b"top secret", CipherMode::GCM);
+    let error = first_normal_entry(&gcm, ReadOptions::with_password(Some("nope")))
+        .expect_err("GCM accepted a wrong password");
+    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+
+    // CBC has no key confirmation, but the padding check at EOF usually rejects
+    // a key that does not decrypt to a valid final block.
+    let cbc = encrypted_archive(b"top secret", CipherMode::CBC);
+    assert!(
+        first_normal_entry(&cbc, ReadOptions::with_password(Some("nope"))).is_err(),
+        "CBC accepted a wrong password"
+    );
+
+    // CTR is an unauthenticated stream cipher with no padding and no key
+    // confirmation, so a wrong password yields garbage rather than an error.
+    // Callers needing detection must use an authenticated mode.
+    let ctr = encrypted_archive(b"top secret", CipherMode::CTR);
+    let (data, _) = first_normal_entry(&ctr, ReadOptions::with_password(Some("nope")))
+        .expect("CTR reports no integrity error");
+    assert_ne!(data, b"top secret", "CTR must not decode with a wrong key");
+}
+
+#[test]
+fn tampered_gcm_ciphertext_fails_before_completion() {
+    let payload = b"authenticated".repeat(512);
+    let bytes = encrypted_archive(&payload, CipherMode::GCM);
+    let tampered = rewrite_archive(&bytes, |ty, data| {
+        if ty == ChunkType::FDAT {
+            let mut data = data.to_vec();
+            // Flip a byte well inside the datastream so the failure surfaces as
+            // an authentication error rather than a stream-header mismatch.
+            let middle = data.len() / 2;
+            data[middle] ^= 0x01;
+            vec![(ty, data)]
+        } else {
+            vec![(ty, data.to_vec())]
+        }
+    });
+
+    let error = first_normal_entry(&tampered, ReadOptions::with_password(Some("password")))
+        .expect_err("tampered ciphertext unexpectedly completed");
+    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+}
+
+// --- multipart failure modes ----------------------------------------------
+
+#[test]
+fn a_missing_continuation_part_is_reported_as_such() {
+    let first = include_bytes!("../../resources/test/multipart.part1.pna");
+    let archive = Archive::read_header(Cursor::new(first.as_slice())).unwrap();
+    // No provider at all: `NoParts` reports every continuation as unavailable.
+    let mut entries = archive.into_streaming_entries(ReadOptions::builder().build());
+
+    let StreamingReadEntry::Normal(entry) = entries.next_entry().unwrap().unwrap() else {
+        panic!("expected normal entry");
+    };
+    let mut reader = entry.decoded().unwrap();
+    let error = io::copy(&mut reader, &mut io::sink()).unwrap_err();
+
+    assert_eq!(error.kind(), io::ErrorKind::NotFound);
+    assert!(
+        error.to_string().contains("archive part 1 is required"),
+        "unexpected message: {error}"
+    );
+}
+
+#[test]
+fn a_provider_error_is_not_reported_as_a_short_read() {
+    let first = include_bytes!("../../resources/test/multipart.part1.pna");
+    let archive = Archive::read_header(Cursor::new(first.as_slice())).unwrap();
+    let mut entries = archive.into_streaming_entries_with_parts(
+        ReadOptions::builder().build(),
+        |_: u32| -> io::Result<Option<Cursor<&'static [u8]>>> {
+            Err(io::Error::new(io::ErrorKind::PermissionDenied, "no access"))
+        },
+    );
+
+    let StreamingReadEntry::Normal(entry) = entries.next_entry().unwrap().unwrap() else {
+        panic!("expected normal entry");
+    };
+    let mut reader = entry.decoded().unwrap();
+    let error = io::copy(&mut reader, &mut io::sink()).unwrap_err();
+
+    assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+}
+
+#[test]
+fn a_provider_serving_the_wrong_part_is_rejected() {
+    let first = include_bytes!("../../resources/test/multipart.part1.pna");
+    let archive = Archive::read_header(Cursor::new(first.as_slice())).unwrap();
+    let mut entries = archive.into_streaming_entries_with_parts(
+        ReadOptions::builder().build(),
+        // Hands back part 1 again instead of part 2.
+        |_: u32| -> io::Result<Option<Cursor<&'static [u8]>>> {
+            Ok(Some(Cursor::new(first.as_slice())))
+        },
+    );
+
+    let StreamingReadEntry::Normal(entry) = entries.next_entry().unwrap().unwrap() else {
+        panic!("expected normal entry");
+    };
+    let mut reader = entry.decoded().unwrap();
+    let error = io::copy(&mut reader, &mut io::sink()).unwrap_err();
+
+    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    assert!(
+        error.to_string().contains("next archive number must be 1"),
+        "unexpected message: {error}"
+    );
+}
+
+// --- solid: `skip` and `entries` must agree on the same bytes ---------------
+
+/// Runs both solid traversal paths over `bytes` and returns each outcome.
+fn solid_skip_and_entries(bytes: &[u8]) -> (io::Result<()>, io::Result<()>) {
+    let skipped = (|| {
+        let archive = Archive::read_header(bytes)?;
+        let mut entries = archive.into_streaming_entries(ReadOptions::builder().build());
+        let StreamingReadEntry::Solid(solid) = entries.next_entry()?.unwrap() else {
+            panic!("expected solid entry");
+        };
+        solid.skip()
+    })();
+
+    let entered = (|| {
+        let archive = Archive::read_header(bytes)?;
+        let mut entries = archive.into_streaming_entries(ReadOptions::builder().build());
+        let StreamingReadEntry::Solid(solid) = entries.next_entry()?.unwrap() else {
+            panic!("expected solid entry");
+        };
+        let mut inner = solid.entries()?;
+        while let Some(entry) = inner.next_entry()? {
+            entry.skip()?;
+        }
+        inner.finish()
+    })();
+
+    (skipped, entered)
+}
+
+#[test]
+fn solid_skip_and_entries_agree_on_grammar_violations() {
+    let original = solid_archive(b"payload", Compression::NO);
+    let ancillary = ChunkType::private(*b"raWw").unwrap();
+
+    let inject = |chunks: Vec<(ChunkType, Vec<u8>)>| {
+        rewrite_archive(&original, move |ty, data| {
+            if ty == ChunkType::SDAT {
+                let mut out = chunks.clone();
+                out.push((ty, data.to_vec()));
+                out
+            } else {
+                vec![(ty, data.to_vec())]
+            }
+        })
+    };
+
+    let cases = [
+        (
+            "non-utf8 phsf",
+            inject(vec![(ChunkType::PHSF, vec![0xff, 0xfe])]),
+        ),
+        (
+            "duplicate phsf",
+            inject(vec![
+                (ChunkType::PHSF, b"first".to_vec()),
+                (ChunkType::PHSF, b"second".to_vec()),
+            ]),
+        ),
+        (
+            "critical chunk in solid entry",
+            inject(vec![(ChunkType::FHED, Vec::new())]),
+        ),
+        (
+            "non-consecutive solid data",
+            rewrite_archive(&original, |ty, data| {
+                if ty == ChunkType::SDAT {
+                    let middle = data.len() / 2;
+                    vec![
+                        (ty, data[..middle].to_vec()),
+                        (ancillary, Vec::new()),
+                        (ty, data[middle..].to_vec()),
+                    ]
+                } else {
+                    vec![(ty, data.to_vec())]
+                }
+            }),
+        ),
+    ];
+
+    for (label, bytes) in cases {
+        let (skipped, entered) = solid_skip_and_entries(&bytes);
+        let skipped = skipped.expect_err(&format!("{label}: skip accepted invalid grammar"));
+        let entered = entered.expect_err(&format!("{label}: entries accepted invalid grammar"));
+        assert_eq!(skipped.kind(), io::ErrorKind::InvalidData, "{label} skip");
+        assert_eq!(
+            entered.kind(),
+            io::ErrorKind::InvalidData,
+            "{label} entries"
+        );
+    }
+
+    // A well-formed block still succeeds through both paths.
+    let (skipped, entered) = solid_skip_and_entries(&original);
+    skipped.unwrap();
+    entered.unwrap();
+}
+
+// --- truncation detection is codec dependent -------------------------------
+
+#[test]
+fn truncation_detection_matches_the_documented_guarantee() {
+    // `decoded()` documents that completion does not establish payload length,
+    // and that detection depends on the codec's own framing. This pins that
+    // split so a change in either direction is deliberate.
+    for (compression, detected) in [
+        (Compression::ZSTANDARD, true),
+        (Compression::XZ, true),
+        (Compression::DEFLATE, false),
+        (Compression::NO, false),
+    ] {
+        let payload = vec![b'a'; 100_000];
+        let archive = normal_archive(&payload, compression);
+        let truncated = rewrite_archive(&archive, |ty, data| {
+            // Halve the payload while leaving every chunk CRC and `FEND` valid.
+            if ty == ChunkType::FDAT {
+                vec![(ty, data[..data.len() / 2].to_vec())]
+            } else {
+                vec![(ty, data.to_vec())]
+            }
+        });
+
+        let result = first_normal_entry(&truncated, ReadOptions::builder().build());
+        if detected {
+            let error = result.expect_err("truncation unexpectedly accepted");
+            assert_eq!(error.kind(), io::ErrorKind::UnexpectedEof);
+        } else {
+            let (data, _) = result.expect("codec has no framing to detect truncation");
+            assert!(
+                data.len() < payload.len(),
+                "expected a short payload, got {}",
+                data.len()
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Add owned lending cursors that expose normal and solid entry headers before payload consumption.
- Stream decoded payloads while validating each buffered data chunk before release.
- Make completion, skipping, recovery, multipart continuation, and solid-entry traversal explicit.
- Enforce entry grammar ordering and keep cursor failures sticky.
- Accept a bare closure as the multipart part provider, mirroring the closure `Archive::write_split_header` takes on the write side.

## Why

The existing abstract reader materializes an entry before decoding it. This API bounds payload buffering to one chunk, supports early entry selection, and preserves integrity checks without flattening solid blocks.

## Usage

### Select entries by header, decode only what you need

`next_entry` stops at the entry header. `skip` walks the framing and CRCs of an unwanted entry without decrypting or decompressing it, so the cost of passing over an entry does not depend on its codec or on holding its password.

```rust
use libpna::{Archive, ReadOptions, StreamingReadEntry};
use std::{fs::File, io, io::Read};

fn extract_one(path: &str) -> io::Result<()> {
    let archive = Archive::read_header(File::open(path)?)?;
    let mut entries = archive.into_streaming_entries(ReadOptions::with_password(Some("password")));

    while let Some(entry) = entries.next_entry()? {
        match entry {
            StreamingReadEntry::Normal(entry) => {
                // The header is available before a single payload byte is decoded.
                if entry.header().path().as_str() != "wanted.txt" {
                    entry.skip()?;
                    continue;
                }
                let mut reader = entry.decoded()?;
                let mut payload = Vec::new();
                reader.read_to_end(&mut payload)?;
                // Metadata is only final once the entry has been read through FEND.
                let completion = reader.finish()?;
                println!("{:?}", completion.metadata().modified());
            }
            StreamingReadEntry::Solid(entry) => entry.skip()?,
        }
    }
    Ok(())
}
```

### Traverse a solid block without flattening it

The solid block stays addressable as one physical entry. Its inner entries are read through a nested cursor, and `finish` drains whatever is left and validates the block's own `SEND`.

```rust
use libpna::{Archive, ReadOptions, StreamingReadEntry};
use std::{fs::File, io};

fn walk_solid(path: &str) -> io::Result<()> {
    let archive = Archive::read_header(File::open(path)?)?;
    let mut entries = archive.into_streaming_entries(ReadOptions::builder().build());

    while let Some(entry) = entries.next_entry()? {
        let StreamingReadEntry::Solid(solid) = entry else {
            continue;
        };
        println!("solid block: {:?}", solid.header().compression());

        let mut inner = solid.entries()?;
        while let Some(entry) = inner.next_entry()? {
            println!("  {}", entry.header().path());
            let mut reader = entry.decoded()?;
            io::copy(&mut reader, &mut io::sink())?;
            reader.finish()?;
        }
        inner.finish()?;
    }
    Ok(())
}
```

### Read a split archive across its parts

`PartProvider` supplies the next physical part on demand, so a payload that straddles a part boundary is rejoined without the caller concatenating files first. Any `FnMut(u32) -> io::Result<Option<R>>` is a provider, matching the closure `Archive::write_split_header` takes on the write side. Note the numbering: `expected` is the AHED archive number and starts at 0, while the `.partN.pna` suffix written by `pna create --split` starts at 1.

```rust
use libpna::{Archive, ReadOptions, StreamingReadEntry};
use std::{fs::File, io, io::Read, path::Path};

fn read_multipart(dir: &Path, stem: &str) -> io::Result<()> {
    let archive = Archive::read_header(File::open(dir.join(format!("{stem}.part1.pna")))?)?;
    let mut entries = archive.into_streaming_entries_with_parts(
        ReadOptions::builder().build(),
        |expected: u32| -> io::Result<Option<File>> {
            match File::open(dir.join(format!("{stem}.part{}.pna", expected + 1))) {
                Ok(file) => Ok(Some(file)),
                // Reporting the part as unavailable fails the cursor instead of
                // silently truncating the entry that spans the boundary.
                Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
                Err(error) => Err(error),
            }
        },
    );

    while let Some(entry) = entries.next_entry()? {
        let StreamingReadEntry::Normal(entry) = entry else {
            continue;
        };
        let mut reader = entry.decoded()?;
        let mut payload = Vec::new();
        // A payload split across a part boundary is rejoined here.
        reader.read_to_end(&mut payload)?;
        let completion = reader.finish()?;
        println!("{} ({} bytes)", completion.header().path(), payload.len());
    }
    Ok(())
}
```

If a part is missing, `next_part` returns `Ok(None)` and the cursor fails with `archive part N is required`; if it hands back the wrong file, the AHED check fails with `next archive number must be N, got M`. Neither case is reported as a short read.

### Stop mid-payload and resynchronize

Dropping an unfinished entry poisons the cursor. `discard_remaining` is the explicit way out: it abandons decoded validation and walks to the next physical entry boundary, leaving the cursor usable.

```rust
use libpna::{Archive, ReadOptions, StreamingReadEntry};
use std::{fs::File, io, io::Read};

fn sniff(path: &str) -> io::Result<()> {
    let archive = Archive::read_header(File::open(path)?)?;
    let mut entries = archive.into_streaming_entries(ReadOptions::builder().build());

    while let Some(entry) = entries.next_entry()? {
        let StreamingReadEntry::Normal(entry) = entry else {
            continue;
        };
        let mut reader = entry.decoded()?;
        let mut head = Vec::new();
        reader.by_ref().take(64).read_to_end(&mut head)?;
        reader.discard_remaining()?;
        println!("{head:?}");
    }
    Ok(())
}
```

## Validation

- `cargo test -p libpna --test streaming_entries --all-features`
- `cargo test -p libpna --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added streaming access to normal, solid, encrypted, and multipart archive entries.
  * Added support for reading, skipping, discarding, and finalizing entries while preserving metadata and extra chunks.
  * Added completion details and multipart continuation support for streamed processing.

* **Bug Fixes**
  * Improved reader finalization to detect unread or trailing data before returning underlying streams.
  * Strengthened validation for malformed chunks, corrupted data, authentication failures, and incomplete streams.
  * Improved recovery after fully reading encrypted or compressed streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->