### PR TITLE
:bug: Reject non-empty terminator chunks

### DIFF
--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -8,7 +8,7 @@ mod write;
 
 use crate::{
     PNA_SIGNATURE,
-    chunk::{ChunkStreamWriter, ChunkType, RawChunk},
+    chunk::{Chunk, ChunkStreamWriter, ChunkType, MIN_CHUNK_BYTES_SIZE, RawChunk},
     cipher::CipherWriter,
     compress::CompressionWriter,
     io::WriteChunk,
@@ -24,6 +24,29 @@ fn write_archive_framing<W: Write>(writer: &mut W, header: &ArchiveHeader) -> io
     writer.write_all(PNA_SIGNATURE)?;
     crate::io::write_chunk(writer, (ChunkType::AHED, header.to_bytes()))?;
     Ok(())
+}
+
+fn require_empty_chunk(chunk: &(impl Chunk + ?Sized)) -> io::Result<()> {
+    if chunk.data().is_empty() {
+        Ok(())
+    } else {
+        empty_chunk_error(chunk.ty())
+    }
+}
+
+fn require_empty_chunk_size(ty: ChunkType, bytes: u64) -> io::Result<()> {
+    if bytes == MIN_CHUNK_BYTES_SIZE as u64 {
+        Ok(())
+    } else {
+        empty_chunk_error(ty)
+    }
+}
+
+fn empty_chunk_error(ty: ChunkType) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("`{ty}` chunk must be empty"),
+    ))
 }
 
 /// Provides read and write access to a PNA file.

--- a/lib/src/archive/read.rs
+++ b/lib/src/archive/read.rs
@@ -3,7 +3,7 @@
 mod slice;
 
 use crate::{
-    archive::{Archive, ArchiveHeader},
+    archive::{Archive, ArchiveHeader, require_empty_chunk, require_empty_chunk_size},
     chunk::{Chunk, ChunkType, RawChunk},
     entry::{Entry, NormalEntry, RawEntry, ReadEntry, ReadOptions, SolidIntoEntries},
 };
@@ -51,11 +51,16 @@ impl<R: Read> Archive<R> {
             let chunk = crate::io::read_chunk(&mut self.inner, max_chunk_size)?;
             match chunk.ty {
                 ChunkType::FEND | ChunkType::SEND => {
+                    require_empty_chunk(&chunk)?;
                     chunks.push(chunk);
                     break;
                 }
-                ChunkType::ANXT => self.next_archive = true,
+                ChunkType::ANXT => {
+                    require_empty_chunk(&chunk)?;
+                    self.next_archive = true;
+                }
                 ChunkType::AEND => {
+                    require_empty_chunk(&chunk)?;
                     self.buf = chunks;
                     return Ok(None);
                 }
@@ -201,11 +206,16 @@ impl<R: futures_io::AsyncRead + Unpin> Archive<R> {
             let chunk = crate::async_io::read_chunk(&mut self.inner, max_chunk_size).await?;
             match chunk.ty {
                 ChunkType::FEND | ChunkType::SEND => {
+                    require_empty_chunk(&chunk)?;
                     chunks.push(chunk);
                     break;
                 }
-                ChunkType::ANXT => self.next_archive = true,
+                ChunkType::ANXT => {
+                    require_empty_chunk(&chunk)?;
+                    self.next_archive = true;
+                }
                 ChunkType::AEND => {
+                    require_empty_chunk(&chunk)?;
                     self.buf = chunks;
                     return Ok(None);
                 }
@@ -436,8 +446,10 @@ impl<R: Read + Seek> Archive<R> {
         let consumed = loop {
             let (ty, consumed) = crate::io::skip_chunk(&mut self.inner)?;
             if ty == ChunkType::AEND {
+                require_empty_chunk_size(ty, consumed)?;
                 break consumed;
             } else if ty == ChunkType::ANXT {
+                require_empty_chunk_size(ty, consumed)?;
                 self.next_archive = true;
             }
         };
@@ -495,6 +507,27 @@ mod tests {
         bytes.extend_from_slice(&chunk_bytes((ChunkType::AHED, header.to_bytes())));
         bytes.extend_from_slice(&chunk_bytes((ChunkType::AEND, [])));
         bytes
+    }
+
+    fn archive_with_terminator(ty: ChunkType, data: &[u8]) -> Vec<u8> {
+        let mut bytes = crate::PNA_SIGNATURE.to_vec();
+        bytes.extend_from_slice(&chunk_bytes((
+            ChunkType::AHED,
+            ArchiveHeader::new(0, 0, 0).to_bytes(),
+        )));
+        bytes.extend_from_slice(&chunk_bytes((ty, data)));
+        bytes
+    }
+
+    #[test]
+    fn raw_entries_reject_nonempty_entry_terminator() {
+        let bytes = archive_with_terminator(ChunkType::FEND, &[1]);
+        let mut archive = Archive::read_header(bytes.as_slice()).unwrap();
+        let error = match archive.raw_entries().next().unwrap() {
+            Err(error) => error,
+            Ok(_) => panic!("non-empty FEND unexpectedly succeeded"),
+        };
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
     }
 
     #[test]
@@ -568,6 +601,19 @@ mod tests {
 
     #[cfg(feature = "unstable-async")]
     #[tokio::test]
+    async fn async_entries_reject_nonempty_entry_terminator() {
+        use tokio_util::compat::TokioAsyncReadCompatExt;
+
+        let bytes = archive_with_terminator(ChunkType::FEND, &[1]);
+        let mut archive = Archive::read_header_async(io::Cursor::new(bytes).compat())
+            .await
+            .unwrap();
+        let error = archive.read_entry_async().await.unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[cfg(feature = "unstable-async")]
+    #[tokio::test]
     async fn extract_async() -> io::Result<()> {
         use tokio_util::compat::{FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt};
 
@@ -604,6 +650,16 @@ mod tests {
         let mut archive = Archive::read_header(io::Cursor::new(part1)).unwrap();
         archive.seek_to_end().unwrap();
         assert!(archive.has_next_archive());
+    }
+
+    #[test]
+    fn seek_to_end_rejects_nonempty_archive_terminator() {
+        let bytes = archive_with_terminator(ChunkType::AEND, &[1]);
+        let mut archive = Archive::read_header(io::Cursor::new(bytes)).unwrap();
+        assert_eq!(
+            archive.seek_to_end().unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
     }
 
     #[test]

--- a/lib/src/archive/read/slice.rs
+++ b/lib/src/archive/read/slice.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     Archive, Chunk, ChunkType, Entry, NormalEntry, RawChunk, ReadEntry, ReadOptions,
-    archive::{ArchiveHeader, read::ExtractSolidEntries},
+    archive::{ArchiveHeader, read::ExtractSolidEntries, require_empty_chunk},
     entry::RawEntry,
 };
 use std::borrow::Cow;
@@ -50,11 +50,16 @@ impl<'d> Archive<&'d [u8]> {
             self.inner = r;
             match chunk.ty {
                 ChunkType::FEND | ChunkType::SEND => {
+                    require_empty_chunk(&chunk)?;
                     chunks.push(chunk.into());
                     break;
                 }
-                ChunkType::ANXT => self.next_archive = true,
+                ChunkType::ANXT => {
+                    require_empty_chunk(&chunk)?;
+                    self.next_archive = true;
+                }
                 ChunkType::AEND => {
+                    require_empty_chunk(&chunk)?;
                     self.buf = chunks.into_iter().map(Into::into).collect::<Vec<_>>();
                     return Ok(None);
                 }
@@ -231,6 +236,17 @@ mod tests {
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
+    fn archive_with_terminator(ty: ChunkType, data: &[u8]) -> Vec<u8> {
+        let mut bytes = crate::PNA_SIGNATURE.to_vec();
+        crate::io::write_chunk(
+            &mut bytes,
+            (ChunkType::AHED, ArchiveHeader::new(0, 0, 0).to_bytes()),
+        )
+        .unwrap();
+        crate::io::write_chunk(&mut bytes, (ty, data)).unwrap();
+        bytes
+    }
+
     #[test]
     fn decode() {
         let bytes = include_bytes!("../../../../resources/test/zstd.pna");
@@ -403,5 +419,16 @@ mod tests {
             second.entries_slice().next().unwrap().unwrap_err().kind(),
             io::ErrorKind::InvalidData
         );
+    }
+
+    #[test]
+    fn entries_slice_reject_nonempty_entry_terminator() {
+        let bytes = archive_with_terminator(ChunkType::FEND, &[1]);
+        let mut archive = Archive::read_header_from_slice(&bytes).unwrap();
+        let error = match archive.raw_entries_slice().next().unwrap() {
+            Err(error) => error,
+            Ok(_) => panic!("non-empty FEND unexpectedly succeeded"),
+        };
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
     }
 }

--- a/lib/src/archive/stream.rs
+++ b/lib/src/archive/stream.rs
@@ -1,6 +1,6 @@
 //! Sequential archive entry reading.
 
-use super::{Archive, ArchiveHeader};
+use super::{Archive, ArchiveHeader, require_empty_chunk};
 use crate::{
     Chunk, ChunkType, EntryHeader, Metadata, NormalEntry, RawChunk, ReadOptions, SolidEntry,
     SolidHeader,
@@ -203,6 +203,10 @@ impl<R: Read, P: PartProvider<R>> StreamingEntries<R, P> {
         };
         match chunk.ty() {
             ChunkType::AEND => {
+                if let Err(error) = require_empty_chunk(&chunk) {
+                    self.state = CursorState::Failed;
+                    return Err(error);
+                }
                 self.state = CursorState::Finished;
                 Ok(None)
             }
@@ -265,6 +269,7 @@ impl<R: Read, P: PartProvider<R>> StreamingSource<R, P> {
             if chunk.ty() != ChunkType::ANXT {
                 return Ok(chunk);
             }
+            require_empty_chunk(&chunk)?;
             let end = self.read_physical_chunk()?;
             if end.ty() != ChunkType::AEND {
                 return Err(io::Error::new(
@@ -277,6 +282,7 @@ impl<R: Read, P: PartProvider<R>> StreamingSource<R, P> {
                     ),
                 ));
             }
+            require_empty_chunk(&end)?;
             self.open_next_part()?;
         }
     }
@@ -1056,6 +1062,7 @@ impl<'a, C: ChunkCursor> EncodedEntryReader<'a, C> {
                 self.current = io::Cursor::new(chunk.data);
             }
             ChunkType::FEND => {
+                require_empty_chunk(&chunk)?;
                 self.chunks.push(chunk);
                 self.done = true;
             }
@@ -1175,6 +1182,7 @@ impl<'a, R: Read, P: PartProvider<R>> EncodedSolidReader<'a, R, P> {
                 self.current = io::Cursor::new(chunk.data);
             }
             ChunkType::SEND => {
+                require_empty_chunk(&chunk)?;
                 self.chunks.push(chunk);
                 self.done = true;
             }
@@ -1319,7 +1327,10 @@ fn skip_solid_chunks<R: Read, P: PartProvider<R>>(
         let chunk = source.read_logical_chunk()?;
         match chunk.ty() {
             ChunkType::SDAT => sequence.observe_data(ChunkType::SDAT)?,
-            ChunkType::SEND => return Ok(()),
+            ChunkType::SEND => {
+                require_empty_chunk(&chunk)?;
+                return Ok(());
+            }
             ChunkType::PHSF => sequence.observe_phsf()?,
             ty if ty.is_critical() => {
                 return Err(io::Error::new(

--- a/lib/tests/streaming_entries.rs
+++ b/lib/tests/streaming_entries.rs
@@ -198,6 +198,42 @@ fn dropping_an_entry_session_poison_the_cursor() {
 }
 
 #[test]
+fn rejects_nonempty_entry_and_archive_terminators() {
+    let bytes = rewrite_archive(&normal_archive(b"body", Compression::NO), |ty, data| {
+        if ty == ChunkType::FEND {
+            vec![(ty, vec![1])]
+        } else {
+            vec![(ty, data.to_vec())]
+        }
+    });
+    let archive = Archive::read_header(bytes.as_slice()).unwrap();
+    let mut entries = archive.into_streaming_entries(ReadOptions::builder().build());
+    let StreamingReadEntry::Normal(entry) = entries.next_entry().unwrap().unwrap() else {
+        panic!("expected normal entry");
+    };
+    assert_eq!(entry.skip().unwrap_err().kind(), io::ErrorKind::InvalidData);
+
+    let bytes = rewrite_archive(&normal_archive(b"body", Compression::NO), |ty, data| {
+        if ty == ChunkType::AEND {
+            vec![(ty, vec![1])]
+        } else {
+            vec![(ty, data.to_vec())]
+        }
+    });
+    let archive = Archive::read_header(bytes.as_slice()).unwrap();
+    let mut entries = archive.into_streaming_entries(ReadOptions::builder().build());
+    let StreamingReadEntry::Normal(entry) = entries.next_entry().unwrap().unwrap() else {
+        panic!("expected normal entry");
+    };
+    entry.skip().unwrap();
+    let error = match entries.next_entry() {
+        Err(error) => error,
+        Ok(_) => panic!("non-empty AEND unexpectedly succeeded"),
+    };
+    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+}
+
+#[test]
 fn rejects_invalid_normal_chunk_ordering() {
     let original = normal_archive(b"payload", Compression::NO);
     let ancillary = ChunkType::private(*b"raWw").unwrap();


### PR DESCRIPTION
Apply the format requirement consistently across synchronous, asynchronous, slice, seek, and streaming archive readers. Keep the validation independent from the streaming cursor feature.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>