### PR TITLE
:bug: Compare update mtime at the archive's stored precision

### DIFF
--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -19,7 +19,7 @@ pub(crate) use self::path::PathnameEditor;
 pub(crate) use self::permission::{ModeStrategy, OwnerOptions, OwnerStrategy, Umask};
 pub(crate) use self::safe_writer::SafeWriter;
 pub(crate) use self::staged_archive::StagedArchive;
-pub(crate) use self::timestamp::{TimeSource, TimestampStrategy};
+pub(crate) use self::timestamp::{TimeSource, TimestampStrategy, cmp_at_stored_precision};
 use crate::{
     cli::{CipherAlgorithmArgs, CompressionAlgorithmArgs, HashAlgorithmArgs, MissingTimePolicy},
     utils::{self, PathPartExt, fs::HardlinkResolver},

--- a/cli/src/command/core/timestamp.rs
+++ b/cli/src/command/core/timestamp.rs
@@ -1,4 +1,26 @@
-use std::time::SystemTime;
+use pna::Duration;
+use std::{cmp::Ordering, time::SystemTime};
+
+/// Compares two timestamps at the precision `archived` was stored with, so that an
+/// entry carrying no sub-second precision compares by whole seconds only.
+pub(crate) fn cmp_at_stored_precision(archived: Duration, fs: Duration) -> Ordering {
+    if archived.subsec_nanoseconds() == 0 {
+        floor_seconds(archived).cmp(&floor_seconds(fs))
+    } else {
+        archived.cmp(&fs)
+    }
+}
+
+/// A whole second denotes the interval starting at it on both sides of the epoch;
+/// [`Duration::whole_seconds`] alone truncates towards zero.
+fn floor_seconds(duration: Duration) -> i64 {
+    let seconds = duration.whole_seconds();
+    if duration.subsec_nanoseconds() < 0 {
+        seconds - 1
+    } else {
+        seconds
+    }
+}
 
 /// How to determine a single timestamp value.
 ///
@@ -54,10 +76,10 @@ impl TimestampStrategy {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::Duration;
+    use std::time::Duration as StdDuration;
 
     fn time(secs: u64) -> SystemTime {
-        SystemTime::UNIX_EPOCH + Duration::from_secs(secs)
+        SystemTime::UNIX_EPOCH + StdDuration::from_secs(secs)
     }
 
     #[test]
@@ -83,5 +105,124 @@ mod tests {
         assert_eq!(source.resolve(Some(time(30))), Some(time(30)));
         // No source -> None
         assert_eq!(source.resolve(None), None);
+    }
+
+    #[test]
+    fn cmp_at_stored_precision_whole_second_archive_ignores_filesystem_subsecond() {
+        assert_eq!(
+            cmp_at_stored_precision(Duration::seconds(100), Duration::new(100, 500_000_000)),
+            Ordering::Equal,
+        );
+    }
+
+    #[test]
+    fn cmp_at_stored_precision_whole_second_archive_ignores_end_of_second() {
+        assert_eq!(
+            cmp_at_stored_precision(Duration::seconds(100), Duration::new(100, 999_999_999)),
+            Ordering::Equal,
+        );
+    }
+
+    #[test]
+    fn cmp_at_stored_precision_whole_second_archive_is_older_at_next_second() {
+        assert_eq!(
+            cmp_at_stored_precision(Duration::seconds(100), Duration::seconds(101)),
+            Ordering::Less,
+        );
+    }
+
+    #[test]
+    fn cmp_at_stored_precision_whole_second_archive_is_newer_at_previous_second() {
+        assert_eq!(
+            cmp_at_stored_precision(Duration::seconds(100), Duration::new(99, 999_999_999)),
+            Ordering::Greater,
+        );
+    }
+
+    #[test]
+    fn cmp_at_stored_precision_whole_second_archive_ignores_filesystem_subsecond_before_epoch() {
+        assert_eq!(
+            cmp_at_stored_precision(Duration::seconds(-100), Duration::new(-99, -500_000_000)),
+            Ordering::Equal,
+        );
+    }
+
+    #[test]
+    fn cmp_at_stored_precision_whole_second_archive_is_newer_below_its_own_second_before_epoch() {
+        assert_eq!(
+            cmp_at_stored_precision(Duration::seconds(-100), Duration::new(-100, -1)),
+            Ordering::Greater,
+        );
+    }
+
+    #[test]
+    fn cmp_at_stored_precision_whole_second_archive_is_older_at_next_second_before_epoch() {
+        assert_eq!(
+            cmp_at_stored_precision(Duration::seconds(-100), Duration::seconds(-99)),
+            Ordering::Less,
+        );
+    }
+
+    #[test]
+    fn cmp_at_stored_precision_whole_second_archive_accepts_exact_match_before_epoch() {
+        assert_eq!(
+            cmp_at_stored_precision(Duration::seconds(-100), Duration::seconds(-100)),
+            Ordering::Equal,
+        );
+    }
+
+    #[test]
+    fn cmp_at_stored_precision_subsecond_archive_accepts_exact_match() {
+        assert_eq!(
+            cmp_at_stored_precision(
+                Duration::new(100, 500_000_000),
+                Duration::new(100, 500_000_000),
+            ),
+            Ordering::Equal,
+        );
+    }
+
+    #[test]
+    fn cmp_at_stored_precision_subsecond_archive_is_newer_within_same_second() {
+        assert_eq!(
+            cmp_at_stored_precision(
+                Duration::new(100, 500_000_000),
+                Duration::new(100, 250_000_000),
+            ),
+            Ordering::Greater,
+        );
+    }
+
+    #[test]
+    fn cmp_at_stored_precision_subsecond_archive_is_older_within_same_second() {
+        assert_eq!(
+            cmp_at_stored_precision(
+                Duration::new(100, 500_000_000),
+                Duration::new(100, 750_000_000),
+            ),
+            Ordering::Less,
+        );
+    }
+
+    #[test]
+    fn cmp_at_stored_precision_subsecond_archive_accepts_exact_match_before_epoch() {
+        assert_eq!(
+            cmp_at_stored_precision(
+                Duration::new(-1, -500_000_000),
+                Duration::new(-1, -500_000_000),
+            ),
+            Ordering::Equal,
+        );
+    }
+
+    #[test]
+    fn cmp_at_stored_precision_subsecond_archive_is_older_within_same_second_before_epoch() {
+        assert_eq!(
+            cmp_at_stored_precision(
+                Duration::new(-1, -500_000_000),
+                Duration::new(-1, -400_000_000),
+            ),
+            Ordering::Less,
+        );
     }
 }

--- a/cli/src/command/diff.rs
+++ b/cli/src/command/diff.rs
@@ -7,11 +7,15 @@ use crate::{
     utils::{BsdGlobMatcher, io::streams_equal},
 };
 
+#[cfg(unix)]
+use crate::command::core::cmp_at_stored_precision;
 use clap::{Parser, ValueEnum};
 #[cfg(unix)]
 use pna::prelude::SystemTimeDurationExt;
 use pna::{DataKind, EntryContent, NormalEntry, ReadOptions};
 use same_file::is_same_file;
+#[cfg(unix)]
+use std::cmp::Ordering;
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
 #[cfg(unix)]
@@ -222,30 +226,10 @@ struct CompareOptions {
     format: Format,
 }
 
-/// Compare an archived timestamp against a filesystem timestamp at the archive's stored precision:
-/// whole-second storage compares by whole seconds, sub-second storage requires exact equality.
 #[cfg(unix)]
 fn matches_at_stored_precision(archived: pna::Duration, fs: SystemTime) -> bool {
-    let Ok(fs) = fs.try_duration_since_unix_epoch_signed() else {
-        return false;
-    };
-    if archived.subsec_nanoseconds() == 0 {
-        floor_seconds(fs) == floor_seconds(archived)
-    } else {
-        fs == archived
-    }
-}
-
-/// A whole second denotes the interval starting at it on both sides of the epoch;
-/// [`pna::Duration::whole_seconds`] alone truncates towards zero.
-#[cfg(unix)]
-fn floor_seconds(duration: pna::Duration) -> i64 {
-    let seconds = duration.whole_seconds();
-    if duration.subsec_nanoseconds() < 0 {
-        seconds - 1
-    } else {
-        seconds
-    }
+    fs.try_duration_since_unix_epoch_signed()
+        .is_ok_and(|fs| cmp_at_stored_precision(archived, fs) == Ordering::Equal)
 }
 
 /// Compare file metadata and return list of differences.
@@ -434,63 +418,4 @@ fn compare_entry<T: AsRef<[u8]>>(
         }
     }
     Ok(diff_count)
-}
-
-#[cfg(all(test, unix))]
-mod tests {
-    use super::*;
-    use std::time::Duration as StdDuration;
-
-    fn after_epoch(millis: u64) -> SystemTime {
-        SystemTime::UNIX_EPOCH + StdDuration::from_millis(millis)
-    }
-
-    fn before_epoch(millis: u64) -> SystemTime {
-        SystemTime::UNIX_EPOCH - StdDuration::from_millis(millis)
-    }
-
-    #[test]
-    fn whole_second_archive_matches_subsecond_filesystem_time_within_the_same_second() {
-        assert!(matches_at_stored_precision(
-            pna::Duration::seconds(1),
-            after_epoch(1_500),
-        ));
-    }
-
-    #[test]
-    fn whole_second_archive_matches_subsecond_filesystem_time_within_the_same_second_before_epoch()
-    {
-        assert!(matches_at_stored_precision(
-            pna::Duration::seconds(-2),
-            before_epoch(1_500),
-        ));
-    }
-
-    #[test]
-    fn whole_second_archive_differs_from_filesystem_time_in_the_next_second_before_epoch() {
-        assert!(!matches_at_stored_precision(
-            pna::Duration::seconds(-1),
-            before_epoch(1_500),
-        ));
-    }
-
-    #[test]
-    fn whole_second_archive_matches_the_second_boundary_before_epoch() {
-        assert!(matches_at_stored_precision(
-            pna::Duration::seconds(-2),
-            before_epoch(2_000),
-        ));
-    }
-
-    #[test]
-    fn subsecond_archive_requires_exact_filesystem_time_before_epoch() {
-        assert!(matches_at_stored_precision(
-            pna::Duration::milliseconds(-1_500),
-            before_epoch(1_500),
-        ));
-        assert!(!matches_at_stored_precision(
-            pna::Duration::milliseconds(-1_500),
-            before_epoch(1_400),
-        ));
-    }
 }

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -12,7 +12,8 @@ use crate::{
             PermissionStrategyResolver, SplitArchiveReader, StagedArchive, TimeFilterResolver,
             TimestampStrategyResolver, TransformContext, TransformStrategy,
             TransformStrategyKeepSolid, TransformStrategyUnSolid, XattrStrategy,
-            collect_items_from_paths, collect_split_archives, create_entry, entry_option,
+            cmp_at_stored_precision, collect_items_from_paths, collect_split_archives,
+            create_entry, entry_option,
             iter::ReorderByIndex,
             re::{bsd::SubstitutionRule, gnu::TransformRule},
             read_paths, read_paths_stdin,
@@ -22,8 +23,10 @@ use crate::{
 };
 use clap::{ArgAction, ArgGroup, Parser, ValueHint, builder::ArgPredicate};
 use indexmap::IndexMap;
-use pna::{Archive, EntryName, Metadata, prelude::*};
+use pna::prelude::SystemTimeDurationExt;
+use pna::{Archive, EntryName, Metadata};
 use std::{
+    cmp::Ordering,
     fs, io,
     path::{Path, PathBuf},
 };
@@ -690,7 +693,8 @@ fn exists_on_disk(path: &Path) -> bool {
 
 // The missing-time policy applies to whichever side lacks an mtime: the
 // filesystem side (unreadable metadata) as well as the archive side (no mTIM
-// chunk). With `Assume(t)` and both sides missing, `t < t` never updates.
+// chunk). With `Assume(t)` and both sides missing, the two compare equal and
+// never update.
 #[inline]
 fn is_newer_than_archive(
     missing_time: MissingTimePolicy,
@@ -703,27 +707,47 @@ fn is_newer_than_archive(
         (Err(_), MissingTimePolicy::Exclude) => return false,
         (Err(_), MissingTimePolicy::Assume(t)) => t,
     };
-    let archive_mtime = match (metadata.saturating_modified_time(), missing_time) {
-        (Some(t), _) => t,
+    let archive_mtime = match (metadata.modified(), missing_time) {
+        (Some(d), _) => Some(d),
         (None, MissingTimePolicy::Include) => return true,
         (None, MissingTimePolicy::Exclude) => return false,
-        (None, MissingTimePolicy::Assume(t)) => t,
+        (None, MissingTimePolicy::Assume(t)) => t.try_duration_since_unix_epoch_signed().ok(),
     };
-    archive_mtime < fs_mtime
+    // A time outside the representable range cannot be compared, so the entry is
+    // refreshed rather than silently kept.
+    match (
+        archive_mtime,
+        fs_mtime.try_duration_since_unix_epoch_signed().ok(),
+    ) {
+        (Some(archived), Some(fs)) => cmp_at_stored_precision(archived, fs) == Ordering::Less,
+        _ => true,
+    }
 }
 
 #[cfg(test)]
 #[cfg(not(target_family = "wasm"))]
 mod tests {
     use super::*;
+    use pna::Duration;
+    use std::time::{Duration as StdDuration, SystemTime};
 
     fn test_dir(name: &str) -> PathBuf {
-        let dir = std::env::temp_dir()
-            .join("pna_update_exists_on_disk")
-            .join(name);
+        let dir = std::env::temp_dir().join("pna_update").join(name);
         let _ = fs::remove_dir_all(&dir);
         fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    /// Returns [`None`] when the filesystem cannot hold the requested precision.
+    fn file_with_mtime(name: &str, mtime: SystemTime) -> Option<PathBuf> {
+        let file = test_dir(name).join("file.txt");
+        fs::write(&file, "content").unwrap();
+        filetime::set_file_mtime(&file, filetime::FileTime::from_system_time(mtime)).unwrap();
+        (fs::metadata(&file).unwrap().modified().unwrap() == mtime).then_some(file)
+    }
+
+    fn archived(mtime: Duration) -> Metadata {
+        Metadata::new().with_modified(Some(mtime))
     }
 
     #[test]
@@ -752,6 +776,37 @@ mod tests {
         let file = dir.join("file.txt");
         fs::write(&file, "content").unwrap();
         assert!(!exists_on_disk(&file.join("child")));
+    }
+
+    #[test]
+    fn is_newer_than_archive_ignores_subsecond_when_archive_has_whole_second_mtime() {
+        let whole_second = SystemTime::UNIX_EPOCH + StdDuration::from_secs(86400);
+        let Some(file) = file_with_mtime(
+            "mtime_whole_second_entry",
+            whole_second + StdDuration::from_nanos(123_456_700),
+        ) else {
+            return;
+        };
+
+        assert!(!is_newer_than_archive(
+            MissingTimePolicy::Include,
+            &fs::metadata(&file).unwrap(),
+            &archived(Duration::seconds(86400)),
+        ));
+    }
+
+    #[test]
+    fn is_newer_than_archive_updates_when_filesystem_reaches_next_second() {
+        let next_second = SystemTime::UNIX_EPOCH + StdDuration::from_secs(86401);
+        let Some(file) = file_with_mtime("mtime_next_second", next_second) else {
+            return;
+        };
+
+        assert!(is_newer_than_archive(
+            MissingTimePolicy::Include,
+            &fs::metadata(&file).unwrap(),
+            &archived(Duration::seconds(86400)),
+        ));
     }
 
     #[cfg(unix)]

--- a/cli/tests/cli/update.rs
+++ b/cli/tests/cli/update.rs
@@ -3,6 +3,8 @@ mod duplicate_targets;
 mod encryption;
 mod entry_order;
 mod error;
+#[cfg(not(target_family = "wasm"))]
+mod mtime_stored_precision;
 mod multipart;
 mod no_timestamp_archive;
 mod option_atime;

--- a/cli/tests/cli/update/mtime_stored_precision.rs
+++ b/cli/tests/cli/update/mtime_stored_precision.rs
@@ -1,0 +1,74 @@
+use crate::utils::{archive, setup};
+use clap::Parser;
+use portable_network_archive::cli;
+use std::{
+    fs,
+    time::{Duration, SystemTime},
+};
+
+fn archived_mtimes(path: &str) -> Vec<Option<pna::Duration>> {
+    let mut mtimes = Vec::new();
+    archive::for_each_entry(path, |entry| mtimes.push(entry.metadata().modified())).unwrap();
+    mtimes
+}
+
+/// Precondition: Archive stores a file mtime with zero sub-second precision.
+/// Action: Filesystem mtime moves to the same whole second with nonzero nanoseconds, then update runs.
+/// Expectation: The entry is left untouched and no second entry is appended.
+/// Returns early on filesystems without nanosecond timestamp support.
+#[test]
+fn update_keeps_entry_when_only_subsecond_differs() {
+    setup();
+    let dir = "update_mtime_keeps_entry";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let file_path = format!("{dir}/file.txt");
+    fs::write(&file_path, "content").unwrap();
+    let whole_second = SystemTime::UNIX_EPOCH + Duration::from_secs(86400);
+    filetime::set_file_mtime(
+        &file_path,
+        filetime::FileTime::from_system_time(whole_second),
+    )
+    .unwrap();
+
+    let archive_path = format!("{dir}/archive.pna");
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        &archive_path,
+        "--overwrite",
+        "--keep-timestamp",
+        &file_path,
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let with_nanos = whole_second + Duration::from_nanos(123_456_700);
+    filetime::set_file_mtime(&file_path, filetime::FileTime::from_system_time(with_nanos)).unwrap();
+    if fs::metadata(&file_path).unwrap().modified().unwrap() != with_nanos {
+        return;
+    }
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "-f",
+        &archive_path,
+        "--keep-timestamp",
+        &file_path,
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    assert_eq!(
+        archived_mtimes(&archive_path),
+        [Some(pna::Duration::seconds(86400))],
+    );
+}


### PR DESCRIPTION
## Summary

`update` compared mtimes exactly while `diff` compared them at the precision the entry was stored with. An archive holding whole-second mtimes therefore re-stored every file whose filesystem mtime carried nanoseconds, even though `diff` reported no difference.

## Notes

- `compat bsdtar -u` shares `run_update_archive` and picks up the same comparison.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved timestamp comparisons during archive updates to respect the precision stored in the archive.
  - Prevented unnecessary updates or duplicate entries when only unsupported subsecond timestamp differences exist.
  - Corrected handling of timestamps before the Unix epoch and missing timestamp values.

- **Tests**
  - Added coverage for whole-second and subsecond timestamp precision, including filesystem and pre-epoch scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->