### PR TITLE
:bug: Replace archives through an atomically renamed staged file

### DIFF
--- a/cli/src/command/core/safe_writer.rs
+++ b/cli/src/command/core/safe_writer.rs
@@ -20,7 +20,8 @@ pub(crate) struct SafeWriter {
 }
 
 impl SafeWriter {
-    /// Creates a new temp file with pattern `.pna.{random}` in the same directory as `final_path`.
+    /// Creates a new temp file with pattern `.pna.{random}` in the same directory as
+    /// `final_path`, which keeps [`persist()`](Self::persist)'s rename within one filesystem.
     ///
     /// # Errors
     ///

--- a/cli/src/command/core/staged_archive.rs
+++ b/cli/src/command/core/staged_archive.rs
@@ -1,33 +1,31 @@
-use crate::utils::{self, GlobPatterns};
-use std::{
-    borrow::Cow,
-    fs, io,
-    path::{Path, PathBuf},
-};
+use super::SafeWriter;
+use crate::utils::GlobPatterns;
+use std::{fs, io, path::PathBuf};
 
 /// An archive rewrite held in a temp file until the checks that must precede it have passed.
 ///
 /// The staged file takes the place of the original only through [`commit()`](Self::commit),
 /// so a run that fails its checks leaves the original as it was.
 pub(crate) struct StagedArchive {
-    temp: NamedTempFile,
-    output: PathBuf,
+    writer: SafeWriter,
 }
 
 impl StagedArchive {
-    /// Stages a rewrite of `output`.
-    ///
-    /// On platforms without a temp directory the staged file is created next to `output`.
+    /// Stages a rewrite of `output`, creating the directory it lives in if it is missing.
     #[inline]
     pub(crate) fn new(output: PathBuf) -> io::Result<Self> {
-        let temp = NamedTempFile::new(|| output.parent().unwrap_or_else(|| ".".as_ref()))?;
-        Ok(Self { temp, output })
+        if let Some(parent) = output.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        Ok(Self {
+            writer: SafeWriter::new(output)?,
+        })
     }
 
     /// Returns the file the rewritten archive is written to.
     #[inline]
     pub(crate) fn as_file_mut(&mut self) -> &mut fs::File {
-        self.temp.as_file_mut()
+        self.writer.as_file_mut()
     }
 
     /// Puts the staged archive in place of the original.
@@ -39,70 +37,98 @@ impl StagedArchive {
         if let Some(patterns) = patterns {
             patterns.ensure_all_matched()?;
         }
-        self.temp.persist(self.output)?;
+        self.writer.persist()?;
         Ok(())
     }
 }
 
-fn temp_dir_or_else<'p>(default: impl Fn() -> &'p Path) -> Cow<'p, Path> {
-    if cfg!(target_os = "wasi") {
-        default().into()
-    } else {
-        std::env::temp_dir().into()
-    }
-}
+#[cfg(test)]
+#[cfg(not(target_family = "wasm"))]
+mod tests {
+    use super::*;
+    use std::{io::Write, path::Path};
 
-/// Path of a staged file, removed when it goes out of scope.
-///
-/// Owning the path separately from the open file keeps [`NamedTempFile::persist`] able to
-/// close the file before the move while the abandoned path is still cleaned up.
-struct TempPath(PathBuf);
-
-impl Drop for TempPath {
-    fn drop(&mut self) {
-        match fs::remove_file(&self.0) {
-            Ok(()) => {}
-            // `persist` moved the file away, so nothing is left to remove.
-            Err(e) if e.kind() == io::ErrorKind::NotFound => {}
-            Err(e) => log::warn!("failed to remove staged file '{}': {e}", self.0.display()),
-        }
-    }
-}
-
-struct NamedTempFile {
-    file_path: TempPath,
-    file: fs::File,
-}
-
-impl NamedTempFile {
-    #[inline]
-    fn new<'p>(fallback_dir: impl Fn() -> &'p Path) -> io::Result<Self> {
-        let temp_dir = temp_dir_or_else(fallback_dir);
-        fs::create_dir_all(&temp_dir)?;
-        let random = rand::random::<usize>();
-        let file_path = temp_dir.join(format!("{random}.tmp"));
-        let file = fs::File::create(&file_path)?;
-        Ok(Self {
-            file,
-            file_path: TempPath(file_path),
-        })
+    fn test_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir()
+            .join("pna_staged_archive_test")
+            .join(name);
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
     }
 
-    #[inline]
-    fn as_file_mut(&mut self) -> &mut fs::File {
-        &mut self.file
+    fn entries_beside(dir: &Path, archive: &str) -> Vec<String> {
+        fs::read_dir(dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .filter(|name| name != archive)
+            .collect()
     }
 
-    #[inline]
-    fn persist(self, new_path: impl AsRef<Path>) -> io::Result<()> {
-        let Self { file, file_path } = self;
-        file.sync_all()?;
-        drop(file);
+    #[test]
+    fn staged_file_is_created_beside_the_archive() {
+        let dir = test_dir("beside");
+        let output = dir.join("archive.pna");
+        fs::write(&output, b"original").unwrap();
 
-        let new_path_ref = new_path.as_ref();
-        if let Some(parent) = new_path_ref.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        utils::fs::mv(&file_path.0, new_path_ref)
+        let staged = StagedArchive::new(output).unwrap();
+
+        assert_eq!(entries_beside(&dir, "archive.pna").len(), 1);
+        drop(staged);
+    }
+
+    #[test]
+    fn dropping_without_commit_keeps_the_archive_and_leaves_no_staged_file() {
+        let dir = test_dir("drop");
+        let output = dir.join("archive.pna");
+        fs::write(&output, b"original").unwrap();
+
+        let mut staged = StagedArchive::new(output.clone()).unwrap();
+        staged.as_file_mut().write_all(b"rewritten").unwrap();
+        drop(staged);
+
+        assert_eq!(fs::read(&output).unwrap(), b"original");
+        assert!(entries_beside(&dir, "archive.pna").is_empty());
+    }
+
+    #[test]
+    fn commit_replaces_the_archive_contents() {
+        let dir = test_dir("commit");
+        let output = dir.join("archive.pna");
+        fs::write(&output, b"original").unwrap();
+
+        let mut staged = StagedArchive::new(output.clone()).unwrap();
+        staged.as_file_mut().write_all(b"rewritten").unwrap();
+        staged.commit(None).unwrap();
+
+        assert_eq!(fs::read(&output).unwrap(), b"rewritten");
+        assert!(entries_beside(&dir, "archive.pna").is_empty());
+    }
+
+    #[test]
+    fn commit_is_refused_when_a_pattern_matched_nothing() {
+        let dir = test_dir("unmatched");
+        let output = dir.join("archive.pna");
+        fs::write(&output, b"original").unwrap();
+
+        let mut staged = StagedArchive::new(output.clone()).unwrap();
+        staged.as_file_mut().write_all(b"rewritten").unwrap();
+        let patterns = GlobPatterns::new(["absent"]).unwrap();
+
+        assert!(staged.commit(Some(&patterns)).is_err());
+        assert_eq!(fs::read(&output).unwrap(), b"original");
+        assert!(entries_beside(&dir, "archive.pna").is_empty());
+    }
+
+    #[test]
+    fn a_missing_directory_is_created_for_the_archive() {
+        let dir = test_dir("missing_parent");
+        let output = dir.join("nested").join("archive.pna");
+
+        let mut staged = StagedArchive::new(output.clone()).unwrap();
+        staged.as_file_mut().write_all(b"written").unwrap();
+        staged.commit(None).unwrap();
+
+        assert_eq!(fs::read(&output).unwrap(), b"written");
     }
 }

--- a/cli/src/utils/fs.rs
+++ b/cli/src/utils/fs.rs
@@ -46,36 +46,6 @@ pub(crate) fn is_pna<P: AsRef<Path>>(path: P) -> io::Result<bool> {
     super::io::is_pna(file)
 }
 
-#[inline]
-pub(crate) fn mv<Src: AsRef<Path>, Dest: AsRef<Path>>(src: Src, dest: Dest) -> io::Result<()> {
-    #[cfg(unix)]
-    fn inner(src: &Path, dest: &Path) -> io::Result<()> {
-        use std::os::unix::fs::MetadataExt;
-        let src_meta = fs::metadata(src)?;
-        if dest
-            .parent()
-            .and_then(|parent| fs::metadata(parent).ok())
-            .is_some_and(|dest_meta| src_meta.dev() == dest_meta.dev())
-        {
-            fs::rename(src, dest)
-        } else {
-            fs::copy(src, dest)?;
-            fs::remove_file(src)
-        }
-    }
-    #[cfg(windows)]
-    #[inline]
-    fn inner(src: &Path, dest: &Path) -> io::Result<()> {
-        move_file(src.as_os_str(), dest.as_os_str())
-    }
-    #[cfg(target_os = "wasi")]
-    fn inner(src: &Path, dest: &Path) -> io::Result<()> {
-        fs::copy(src, dest)?;
-        fs::remove_file(src)
-    }
-    inner(src.as_ref(), dest.as_ref())
-}
-
 #[cfg(any(windows, unix))]
 pub(crate) fn lchown<P: AsRef<Path>>(
     path: P,

--- a/cli/src/utils/os/windows/fs.rs
+++ b/cli/src/utils/os/windows/fs.rs
@@ -11,8 +11,7 @@ use windows::Win32::Storage::FileSystem::{
     FILE_BASIC_INFO, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
     FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
     FILE_WRITE_ATTRIBUTES, FileBasicInfo, GetFileInformationByHandle, GetFileInformationByHandleEx,
-    MOVEFILE_COPY_ALLOWED, MOVEFILE_REPLACE_EXISTING, MoveFileExW, OPEN_EXISTING, READ_CONTROL,
-    SetFileInformationByHandle, WRITE_DAC, WRITE_OWNER,
+    OPEN_EXISTING, READ_CONTROL, SetFileInformationByHandle, WRITE_DAC, WRITE_OWNER,
 };
 use windows::core::PCWSTR;
 
@@ -37,18 +36,6 @@ impl Drop for FileHandle {
     fn drop(&mut self) {
         let _ = unsafe { CloseHandle(self.0) };
     }
-}
-
-#[inline]
-pub(crate) fn move_file(src: &std::ffi::OsStr, dist: &std::ffi::OsStr) -> io::Result<()> {
-    unsafe {
-        MoveFileExW(
-            PCWSTR::from_raw(encode_wide(src)?.as_ptr()),
-            PCWSTR::from_raw(encode_wide(dist)?.as_ptr()),
-            MOVEFILE_REPLACE_EXISTING | MOVEFILE_COPY_ALLOWED,
-        )
-    }
-    .map_err(Into::into)
 }
 
 #[inline]


### PR DESCRIPTION
## Summary

Archive rewrites were staged in the system temp directory, so putting the staged file in place crossed filesystems whenever that directory sat on a different mount. The move then degraded into a copy that truncated the original archive before rewriting it, losing the archive if the run was interrupted.

## Notes

- Affects every command that rewrites an archive in place: `delete`, `update`, `sort`, `strip`, `migrate`, `chmod`, `chown`, `xattr`, `acl`, and `compat bsdtar -u`.
- On Windows the same degradation was requested explicitly through `MOVEFILE_COPY_ALLOWED`.
- `SafeWriter` already stages in the target's own directory, so it replaces the hand-rolled staging here. That leaves the cross-device move helpers (`utils::fs::mv` and the Windows `move_file` it wrapped) unused, and they are removed.
- A rewritten archive now comes out with `SafeWriter`'s staging mode instead of one derived from the umask. #3381 gives it the mode the archive actually had.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive staging reliability across platforms.
  * Output directories are now created automatically when needed.
  * Temporary files are kept on the same filesystem as final outputs, improving commit and rename operations.
  * Enhanced cleanup behavior for staged files, including unmatched patterns and missing parent directories.

* **Documentation**
  * Clarified temporary-file handling and persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->