### PR TITLE
:bug: Keep the mode of a rewritten archive

### DIFF
--- a/cli/src/command/acl.rs
+++ b/cli/src/command/acl.rs
@@ -7,7 +7,7 @@ use crate::{
         Command, ask_password,
         core::{
             SplitArchiveReader, StagedArchive, TransformStrategyKeepSolid,
-            TransformStrategyUnSolid, collect_split_archives,
+            TransformStrategyUnSolid, Umask, collect_split_archives,
         },
     },
     ext::{Acls, NormalEntryExt},
@@ -115,8 +115,8 @@ pub(crate) struct SetAclCommand {
 
 impl Command for SetAclCommand {
     #[inline]
-    fn execute(self, _ctx: &crate::cli::GlobalContext) -> anyhow::Result<()> {
-        archive_set_acl(self)
+    fn execute(self, ctx: &crate::cli::GlobalContext) -> anyhow::Result<()> {
+        archive_set_acl(self, ctx.umask())
     }
 }
 
@@ -327,7 +327,7 @@ fn archive_get_acl(args: GetAclCommand) -> anyhow::Result<()> {
 }
 
 #[hooq::hooq(anyhow)]
-fn archive_set_acl(args: SetAclCommand) -> anyhow::Result<()> {
+fn archive_set_acl(args: SetAclCommand, umask: Umask) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
     let files = args.file.files;
     let mut set_strategy = if let Some("-") = args.restore.as_deref() {
@@ -350,7 +350,7 @@ fn archive_set_acl(args: SetAclCommand) -> anyhow::Result<()> {
     let mut source = SplitArchiveReader::new(collect_split_archives(&args.file.archive)?)?;
 
     let output_path = args.file.archive.remove_part();
-    let mut staged = StagedArchive::new(output_path)?;
+    let mut staged = StagedArchive::new(output_path, umask)?;
 
     match args.transform_strategy.strategy() {
         SolidEntriesTransformStrategy::UnSolid => source.transform_entries(

--- a/cli/src/command/bsdtar.rs
+++ b/cli/src/command/bsdtar.rs
@@ -691,7 +691,7 @@ fn run_bsdtar(ctx: &GlobalContext, args: BsdtarCommand) -> anyhow::Result<()> {
     } else if args.append {
         run_append(args)
     } else if args.update {
-        run_update(args)
+        run_update(args, ctx.umask())
     } else {
         unreachable!()
     }
@@ -1403,7 +1403,7 @@ fn resolve_name_id(
     }
 }
 
-fn run_update(args: BsdtarCommand) -> anyhow::Result<()> {
+fn run_update(args: BsdtarCommand, umask: Umask) -> anyhow::Result<()> {
     let current_dir = env::current_dir()?;
     let password = ask_password(args.password)?;
     let password = password.as_deref();
@@ -1533,7 +1533,7 @@ fn run_update(args: BsdtarCommand) -> anyhow::Result<()> {
 
     let archives = collect_split_archives(&archive_path)?;
 
-    let mut staged = StagedArchive::new(archive_path.remove_part())?;
+    let mut staged = StagedArchive::new(archive_path.remove_part(), umask)?;
     let mut out_archive = Archive::write_header(staged.as_file_mut())?;
 
     let mut source = SplitArchiveReader::new(archives)?;

--- a/cli/src/command/chmod.rs
+++ b/cli/src/command/chmod.rs
@@ -4,7 +4,7 @@ use crate::{
         Command, ask_password,
         core::{
             SplitArchiveReader, StagedArchive, TransformStrategyKeepSolid,
-            TransformStrategyUnSolid, collect_split_archives,
+            TransformStrategyUnSolid, Umask, collect_split_archives,
         },
     },
     utils::{GlobPatterns, PathPartExt},
@@ -37,13 +37,13 @@ pub(crate) struct ChmodCommand {
 
 impl Command for ChmodCommand {
     #[inline]
-    fn execute(self, _ctx: &crate::cli::GlobalContext) -> anyhow::Result<()> {
-        archive_chmod(self)
+    fn execute(self, ctx: &crate::cli::GlobalContext) -> anyhow::Result<()> {
+        archive_chmod(self, ctx.umask())
     }
 }
 
 #[hooq::hooq(anyhow)]
-fn archive_chmod(args: ChmodCommand) -> anyhow::Result<()> {
+fn archive_chmod(args: ChmodCommand, umask: Umask) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
     if args.files.is_empty() {
         return Ok(());
@@ -53,7 +53,7 @@ fn archive_chmod(args: ChmodCommand) -> anyhow::Result<()> {
     let mut source = SplitArchiveReader::new(collect_split_archives(&args.archive)?)?;
 
     let output_path = args.archive.remove_part();
-    let mut staged = StagedArchive::new(output_path)?;
+    let mut staged = StagedArchive::new(output_path, umask)?;
 
     match args.transform_strategy.strategy() {
         SolidEntriesTransformStrategy::UnSolid => source.transform_entries(

--- a/cli/src/command/chown.rs
+++ b/cli/src/command/chown.rs
@@ -4,7 +4,7 @@ use crate::{
         Command, ask_password,
         core::{
             SplitArchiveReader, StagedArchive, TransformStrategyKeepSolid,
-            TransformStrategyUnSolid, collect_split_archives,
+            TransformStrategyUnSolid, Umask, collect_split_archives,
         },
     },
     utils::{
@@ -44,13 +44,13 @@ pub(crate) struct ChownCommand {
 
 impl Command for ChownCommand {
     #[inline]
-    fn execute(self, _ctx: &crate::cli::GlobalContext) -> anyhow::Result<()> {
-        archive_chown(self)
+    fn execute(self, ctx: &crate::cli::GlobalContext) -> anyhow::Result<()> {
+        archive_chown(self, ctx.umask())
     }
 }
 
 #[hooq::hooq(anyhow)]
-fn archive_chown(args: ChownCommand) -> anyhow::Result<()> {
+fn archive_chown(args: ChownCommand, umask: Umask) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
     if args.files.is_empty() {
         return Ok(());
@@ -64,7 +64,7 @@ fn archive_chown(args: ChownCommand) -> anyhow::Result<()> {
     let mut source = SplitArchiveReader::new(collect_split_archives(&args.archive)?)?;
 
     let output_path = args.archive.remove_part();
-    let mut staged = StagedArchive::new(output_path)?;
+    let mut staged = StagedArchive::new(output_path, umask)?;
 
     match args.transform_strategy.strategy() {
         SolidEntriesTransformStrategy::UnSolid => source.transform_entries(

--- a/cli/src/command/core/staged_archive.rs
+++ b/cli/src/command/core/staged_archive.rs
@@ -1,4 +1,4 @@
-use super::SafeWriter;
+use super::{SafeWriter, Umask};
 use crate::utils::GlobPatterns;
 use std::{fs, io, path::PathBuf};
 
@@ -8,17 +8,37 @@ use std::{fs, io, path::PathBuf};
 /// so a run that fails its checks leaves the original as it was.
 pub(crate) struct StagedArchive {
     writer: SafeWriter,
+    #[cfg(unix)]
+    mode: u32,
 }
 
 impl StagedArchive {
     /// Stages a rewrite of `output`, creating the directory it lives in if it is missing.
+    ///
+    /// On unix, the commit gives the archive the permission bits of the regular file it
+    /// replaces, or what `umask` leaves of `0666` when there is no such file.
     #[inline]
-    pub(crate) fn new(output: PathBuf) -> io::Result<Self> {
+    #[cfg_attr(not(unix), allow(unused_variables))]
+    pub(crate) fn new(output: PathBuf, umask: Umask) -> io::Result<Self> {
         if let Some(parent) = output.parent() {
             fs::create_dir_all(parent)?;
         }
+        #[cfg(unix)]
+        let mode = {
+            use std::os::unix::fs::PermissionsExt;
+            match fs::symlink_metadata(&output) {
+                Ok(meta) if meta.file_type().is_file() => meta.permissions().mode() & 0o777,
+                // A directory, symlink or fifo is replaced by a file the commit creates, so
+                // there is no mode being kept.
+                Ok(_) => umask.apply(0o666).into(),
+                Err(e) if e.kind() == io::ErrorKind::NotFound => umask.apply(0o666).into(),
+                Err(e) => return Err(e),
+            }
+        };
         Ok(Self {
             writer: SafeWriter::new(output)?,
+            #[cfg(unix)]
+            mode,
         })
     }
 
@@ -33,9 +53,17 @@ impl StagedArchive {
     /// `patterns` holds the patterns the run was asked to match, or is `None` for commands
     /// that take none. A pattern that matched nothing aborts the commit.
     #[inline]
-    pub(crate) fn commit(self, patterns: Option<&GlobPatterns>) -> anyhow::Result<()> {
+    #[cfg_attr(not(unix), allow(unused_mut))]
+    pub(crate) fn commit(mut self, patterns: Option<&GlobPatterns>) -> anyhow::Result<()> {
         if let Some(patterns) = patterns {
             patterns.ensure_all_matched()?;
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            self.writer
+                .as_file_mut()
+                .set_permissions(fs::Permissions::from_mode(self.mode))?;
         }
         self.writer.persist()?;
         Ok(())
@@ -71,7 +99,7 @@ mod tests {
         let output = dir.join("archive.pna");
         fs::write(&output, b"original").unwrap();
 
-        let staged = StagedArchive::new(output).unwrap();
+        let staged = StagedArchive::new(output, Umask::new(0o022)).unwrap();
 
         assert_eq!(entries_beside(&dir, "archive.pna").len(), 1);
         drop(staged);
@@ -83,7 +111,7 @@ mod tests {
         let output = dir.join("archive.pna");
         fs::write(&output, b"original").unwrap();
 
-        let mut staged = StagedArchive::new(output.clone()).unwrap();
+        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022)).unwrap();
         staged.as_file_mut().write_all(b"rewritten").unwrap();
         drop(staged);
 
@@ -97,7 +125,7 @@ mod tests {
         let output = dir.join("archive.pna");
         fs::write(&output, b"original").unwrap();
 
-        let mut staged = StagedArchive::new(output.clone()).unwrap();
+        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022)).unwrap();
         staged.as_file_mut().write_all(b"rewritten").unwrap();
         staged.commit(None).unwrap();
 
@@ -111,7 +139,7 @@ mod tests {
         let output = dir.join("archive.pna");
         fs::write(&output, b"original").unwrap();
 
-        let mut staged = StagedArchive::new(output.clone()).unwrap();
+        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022)).unwrap();
         staged.as_file_mut().write_all(b"rewritten").unwrap();
         let patterns = GlobPatterns::new(["absent"]).unwrap();
 
@@ -120,12 +148,111 @@ mod tests {
         assert!(entries_beside(&dir, "archive.pna").is_empty());
     }
 
+    #[cfg(unix)]
+    fn mode_of(path: &Path) -> u32 {
+        use std::os::unix::fs::PermissionsExt;
+        fs::metadata(path).unwrap().permissions().mode() & 0o7777
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn commit_keeps_the_mode_of_the_archive_it_replaced() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = test_dir("inherit_mode");
+        let output = dir.join("archive.pna");
+        fs::write(&output, b"original").unwrap();
+        fs::set_permissions(&output, fs::Permissions::from_mode(0o666)).unwrap();
+
+        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022)).unwrap();
+        staged.as_file_mut().write_all(b"rewritten").unwrap();
+        staged.commit(None).unwrap();
+
+        assert_eq!(mode_of(&output), 0o666);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn commit_drops_the_special_bits_of_the_archive_it_replaced() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = test_dir("special_bits");
+        let output = dir.join("archive.pna");
+        fs::write(&output, b"original").unwrap();
+        fs::set_permissions(&output, fs::Permissions::from_mode(0o4755)).unwrap();
+
+        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022)).unwrap();
+        staged.as_file_mut().write_all(b"rewritten").unwrap();
+        staged.commit(None).unwrap();
+
+        assert_eq!(mode_of(&output), 0o755);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn commit_gives_a_new_archive_what_the_umask_leaves_of_0666() {
+        let dir = test_dir("new_mode");
+        let output = dir.join("archive.pna");
+
+        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o007)).unwrap();
+        staged.as_file_mut().write_all(b"written").unwrap();
+        staged.commit(None).unwrap();
+
+        assert_eq!(mode_of(&output), 0o660);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn commit_does_not_take_the_mode_of_a_directory_it_replaces() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = test_dir("replaced_directory");
+        let output = dir.join("archive.pna");
+        fs::create_dir(&output).unwrap();
+        fs::set_permissions(&output, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022)).unwrap();
+        staged.as_file_mut().write_all(b"written").unwrap();
+        staged.commit(None).unwrap();
+
+        assert!(output.is_file());
+        assert_eq!(mode_of(&output), 0o644);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn commit_does_not_take_the_mode_through_a_symlink_it_replaces() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = test_dir("replaced_symlink");
+        let target = dir.join("target.bin");
+        let output = dir.join("archive.pna");
+        fs::write(&target, b"target").unwrap();
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o600)).unwrap();
+        std::os::unix::fs::symlink(&target, &output).unwrap();
+
+        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022)).unwrap();
+        staged.as_file_mut().write_all(b"written").unwrap();
+        staged.commit(None).unwrap();
+
+        assert_eq!(fs::read(&output).unwrap(), b"written");
+        assert_eq!(mode_of(&output), 0o644);
+        assert_eq!(fs::read(&target).unwrap(), b"target");
+        assert_eq!(mode_of(&target), 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn new_fails_when_the_mode_of_the_output_cannot_be_read() {
+        let dir = test_dir("unreadable_mode");
+        let output = dir.join("a".repeat(300));
+
+        assert!(StagedArchive::new(output, Umask::new(0o022)).is_err());
+        assert!(fs::read_dir(&dir).unwrap().next().is_none());
+    }
+
     #[test]
     fn a_missing_directory_is_created_for_the_archive() {
         let dir = test_dir("missing_parent");
         let output = dir.join("nested").join("archive.pna");
 
-        let mut staged = StagedArchive::new(output.clone()).unwrap();
+        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022)).unwrap();
         staged.as_file_mut().write_all(b"written").unwrap();
         staged.commit(None).unwrap();
 

--- a/cli/src/command/delete.rs
+++ b/cli/src/command/delete.rs
@@ -6,7 +6,7 @@ use crate::{
         Command, ask_password,
         core::{
             PathFilter, SplitArchiveReader, StagedArchive, TransformStrategyKeepSolid,
-            TransformStrategyUnSolid, collect_split_archives, read_paths, read_paths_stdin,
+            TransformStrategyUnSolid, Umask, collect_split_archives, read_paths, read_paths_stdin,
         },
     },
     utils::{GlobPatterns, PathPartExt, VCS_FILES},
@@ -92,13 +92,13 @@ pub(crate) struct DeleteCommand {
 
 impl Command for DeleteCommand {
     #[inline]
-    fn execute(self, _ctx: &crate::cli::GlobalContext) -> anyhow::Result<()> {
-        delete_file_from_archive(self)
+    fn execute(self, ctx: &crate::cli::GlobalContext) -> anyhow::Result<()> {
+        delete_file_from_archive(self, ctx.umask())
     }
 }
 
 #[hooq::hooq(anyhow)]
-fn delete_file_from_archive(args: DeleteCommand) -> anyhow::Result<()> {
+fn delete_file_from_archive(args: DeleteCommand, umask: Umask) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
     let mut files = args.file.files;
     if args.files_from_stdin {
@@ -127,7 +127,7 @@ fn delete_file_from_archive(args: DeleteCommand) -> anyhow::Result<()> {
     let output_path = args
         .output
         .unwrap_or_else(|| args.file.archive.remove_part());
-    let mut staged = StagedArchive::new(output_path)?;
+    let mut staged = StagedArchive::new(output_path, umask)?;
 
     match args.transform_strategy.strategy() {
         SolidEntriesTransformStrategy::UnSolid => source.transform_entries(

--- a/cli/src/command/migrate.rs
+++ b/cli/src/command/migrate.rs
@@ -4,7 +4,7 @@ use crate::{
         Command, ask_password,
         core::{
             SplitArchiveReader, StagedArchive, TransformStrategyKeepSolid,
-            TransformStrategyUnSolid, collect_split_archives,
+            TransformStrategyUnSolid, Umask, collect_split_archives,
         },
     },
     ext::*,
@@ -27,19 +27,19 @@ pub(crate) struct MigrateCommand {
 
 impl Command for MigrateCommand {
     #[inline]
-    fn execute(self, _ctx: &crate::cli::GlobalContext) -> anyhow::Result<()> {
-        migrate_metadata(self)
+    fn execute(self, ctx: &crate::cli::GlobalContext) -> anyhow::Result<()> {
+        migrate_metadata(self, ctx.umask())
     }
 }
 
 #[hooq::hooq(anyhow)]
-fn migrate_metadata(args: MigrateCommand) -> anyhow::Result<()> {
+fn migrate_metadata(args: MigrateCommand, umask: Umask) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
 
     let mut source = SplitArchiveReader::new(collect_split_archives(&args.archive)?)?;
 
     let output_path = args.output;
-    let mut staged = StagedArchive::new(output_path)?;
+    let mut staged = StagedArchive::new(output_path, umask)?;
 
     match args.transform_strategy.strategy() {
         SolidEntriesTransformStrategy::UnSolid => source.transform_entries(

--- a/cli/src/command/sort.rs
+++ b/cli/src/command/sort.rs
@@ -2,7 +2,7 @@ use crate::{
     cli::PasswordArgs,
     command::{
         Command, ask_password,
-        core::{SplitArchiveReader, StagedArchive, collect_split_archives},
+        core::{SplitArchiveReader, StagedArchive, Umask, collect_split_archives},
     },
     utils::PathPartExt,
 };
@@ -138,13 +138,13 @@ pub(crate) struct SortCommand {
 
 impl Command for SortCommand {
     #[inline]
-    fn execute(self, _ctx: &crate::cli::GlobalContext) -> anyhow::Result<()> {
-        sort_archive(self)
+    fn execute(self, ctx: &crate::cli::GlobalContext) -> anyhow::Result<()> {
+        sort_archive(self, ctx.umask())
     }
 }
 
 #[hooq::hooq(anyhow)]
-fn sort_archive(args: SortCommand) -> anyhow::Result<()> {
+fn sort_archive(args: SortCommand, umask: Umask) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
     let archives = collect_split_archives(&args.archive)?;
     let mut source = SplitArchiveReader::new(archives)?;
@@ -178,7 +178,7 @@ fn sort_archive(args: SortCommand) -> anyhow::Result<()> {
     });
 
     let output = args.output.unwrap_or_else(|| args.archive.remove_part());
-    let mut staged = StagedArchive::new(output)?;
+    let mut staged = StagedArchive::new(output, umask)?;
     let mut archive = Archive::write_header(staged.as_file_mut())?;
     for entry in entries {
         archive.add_entry(entry)?;

--- a/cli/src/command/strip.rs
+++ b/cli/src/command/strip.rs
@@ -7,7 +7,7 @@ use crate::{
         Command, ask_password,
         core::{
             SplitArchiveReader, StagedArchive, TransformStrategyKeepSolid,
-            TransformStrategyUnSolid, collect_split_archives,
+            TransformStrategyUnSolid, Umask, collect_split_archives,
         },
     },
     utils::PathPartExt,
@@ -62,19 +62,19 @@ pub(crate) struct StripCommand {
 
 impl Command for StripCommand {
     #[inline]
-    fn execute(self, _ctx: &crate::cli::GlobalContext) -> anyhow::Result<()> {
-        strip_metadata(self)
+    fn execute(self, ctx: &crate::cli::GlobalContext) -> anyhow::Result<()> {
+        strip_metadata(self, ctx.umask())
     }
 }
 
 #[hooq::hooq(anyhow)]
-fn strip_metadata(args: StripCommand) -> anyhow::Result<()> {
+fn strip_metadata(args: StripCommand, umask: Umask) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
     let archive = args.file.archive;
     let mut source = SplitArchiveReader::new(collect_split_archives(&archive)?)?;
 
     let output_path = args.output.unwrap_or_else(|| archive.remove_part());
-    let mut staged = StagedArchive::new(output_path)?;
+    let mut staged = StagedArchive::new(output_path, umask)?;
 
     match args.transform_strategy.strategy() {
         SolidEntriesTransformStrategy::UnSolid => source.transform_entries(

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -11,7 +11,7 @@ use crate::{
             KeepOptions, MacMetadataStrategy, PathFilter, PathTransformers, PathnameEditor,
             PermissionStrategyResolver, SplitArchiveReader, StagedArchive, TimeFilterResolver,
             TimestampStrategyResolver, TransformContext, TransformStrategy,
-            TransformStrategyKeepSolid, TransformStrategyUnSolid, XattrStrategy,
+            TransformStrategyKeepSolid, TransformStrategyUnSolid, Umask, XattrStrategy,
             cmp_at_stored_precision, collect_items_from_paths, collect_split_archives,
             create_entry, entry_option,
             iter::ReorderByIndex,
@@ -408,13 +408,13 @@ pub(crate) struct UpdateCommand {
 
 impl Command for UpdateCommand {
     #[inline]
-    fn execute(self, _ctx: &crate::cli::GlobalContext) -> anyhow::Result<()> {
-        update_archive(self)
+    fn execute(self, ctx: &crate::cli::GlobalContext) -> anyhow::Result<()> {
+        update_archive(self, ctx.umask())
     }
 }
 
 #[hooq::hooq(anyhow)]
-fn update_archive(args: UpdateCommand) -> anyhow::Result<()> {
+fn update_archive(args: UpdateCommand, umask: Umask) -> anyhow::Result<()> {
     let transform_strategy = args.transform_strategy.strategy();
     let sync = args.sync;
     let password = ask_password(args.password)?;
@@ -517,7 +517,7 @@ fn update_archive(args: UpdateCommand) -> anyhow::Result<()> {
     let target_items = collect_items_from_paths(&files, &collect_options, &mut resolver)?;
 
     let output_path = args.output.unwrap_or_else(|| archive_path.remove_part());
-    let mut staged = StagedArchive::new(output_path)?;
+    let mut staged = StagedArchive::new(output_path, umask)?;
     let mut out_archive = Archive::write_header(staged.as_file_mut())?;
 
     let mut source = SplitArchiveReader::new(archives)?;

--- a/cli/src/command/xattr.rs
+++ b/cli/src/command/xattr.rs
@@ -6,7 +6,7 @@ use crate::{
         Command, ask_password,
         core::{
             SplitArchiveReader, StagedArchive, TransformStrategyKeepSolid,
-            TransformStrategyUnSolid, collect_split_archives,
+            TransformStrategyUnSolid, Umask, collect_split_archives,
         },
     },
     utils::{GlobPatterns, PathPartExt},
@@ -114,8 +114,8 @@ pub(crate) struct SetXattrCommand {
 
 impl Command for SetXattrCommand {
     #[inline]
-    fn execute(self, _ctx: &crate::cli::GlobalContext) -> anyhow::Result<()> {
-        archive_set_xattr(self)
+    fn execute(self, ctx: &crate::cli::GlobalContext) -> anyhow::Result<()> {
+        archive_set_xattr(self, ctx.umask())
     }
 }
 
@@ -232,7 +232,7 @@ fn archive_get_xattr(args: GetXattrCommand) -> anyhow::Result<()> {
 }
 
 #[hooq::hooq(anyhow)]
-fn archive_set_xattr(args: SetXattrCommand) -> anyhow::Result<()> {
+fn archive_set_xattr(args: SetXattrCommand, umask: Umask) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
     let files = args.file.files;
     let mut set_strategy = if let Some("-") = args.restore.as_deref() {
@@ -255,7 +255,7 @@ fn archive_set_xattr(args: SetXattrCommand) -> anyhow::Result<()> {
     let mut source = SplitArchiveReader::new(collect_split_archives(&args.file.archive)?)?;
 
     let output_path = args.file.archive.remove_part();
-    let mut staged = StagedArchive::new(output_path)?;
+    let mut staged = StagedArchive::new(output_path, umask)?;
 
     match args.transform_strategy.strategy() {
         SolidEntriesTransformStrategy::UnSolid => source.transform_entries(


### PR DESCRIPTION
## Summary

Rewriting an archive in place gave the replacement the mode its staged file was created with rather than the mode the archive itself had, so an archive kept at 0640 came back widened to 0644.

## Notes

- The mode is taken only from a regular file being replaced. A directory, symlink or fifo standing at the path, or nothing at all, gives what the umask leaves of `0666`, as `create` does. This is the common case for `migrate --output`.
- The special bits (setuid, setgid, sticky) are not carried over.
- A path whose mode cannot be read fails before the archive is rewritten, rather than falling back to the umask.
- `Umask` is threaded from `GlobalContext` into the commands that stage a rewrite; they were already given the context and ignoring it.
- Unix only. Windows permissions carry just the read-only flag, and applying it to the staged file risks failing the rename that puts it in place.

## Verification

`delete` on an archive at 0640 leaves it at 0640, and at 0600 leaves it at 0600; on `main` both come back 0644. `migrate --output` to a path holding no archive produces 0644 under umask 022.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Archive operations now consistently respect configured file-creation permissions.
  * Existing archive permissions are preserved when archives are updated or staged.
  * Newly created archives apply the system umask, preventing overly permissive file access.
  * Improved permission consistency across archive updates, deletions, metadata changes, sorting, migration, ACL, and extended-attribute operations.
  * Archive updates now handle subsecond timestamps more accurately, ensuring entries refresh when changes cannot be reliably compared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
