### PR TITLE
:memo: Drop comments that repeat what already documents them

### DIFF
--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -676,14 +676,8 @@ where
     Ok(())
 }
 
-// `--sync` realigns the archive to the disk state: an entry is pruned only
-// when its name (resolved against the current directory, the same base as
-// collection) no longer exists on disk. Entries merely filtered out of the
-// collected set (e.g. by --exclude or time filters) are kept. Ambiguous
-// errors such as PermissionDenied count as existing so pruning never risks
-// data loss. `--sync` is rejected together with -s/--transform/
-// --strip-components (see `sync`'s `conflicts_with_all` above), since those
-// options make the stored name diverge from a filesystem path.
+// Ambiguous errors such as PermissionDenied count as existing, so pruning
+// never risks data loss.
 fn exists_on_disk(path: &Path) -> bool {
     match fs::symlink_metadata(path) {
         Ok(_) => true,

--- a/cli/src/command/verify.rs
+++ b/cli/src/command/verify.rs
@@ -60,15 +60,14 @@ fn verify_archive(args: VerifyCommand) -> anyhow::Result<()> {
     let result = run_read_entries(
         archives,
         |entry| {
+            // A chunk that fails its CRC32 arrives as `Err(InvalidData)`, so an `Ok`
+            // entry has passed every chunk's CRC32.
             match entry {
                 Err(err) if err.kind() == io::ErrorKind::InvalidData => {
-                    // A broken chunk aborts the current entry's assembly, and
-                    // the remainder of that entry surfaces as one or more
-                    // InvalidData errors before the iterator resyncs on the
-                    // next entry header. Count the corrupted entry once;
-                    // adjacent corrupted entries with no healthy entry in
-                    // between collapse into a single failure (accepted
-                    // approximation).
+                    // One broken entry surfaces as several of these before the
+                    // iterator resyncs on the next entry header, so only the
+                    // first is counted; adjacent corrupted entries collapse
+                    // into a single failure (accepted approximation).
                     if !resyncing {
                         println!("<corrupted entry>: FAILED ({err})");
                         report.failed += 1;
@@ -80,10 +79,6 @@ fn verify_archive(args: VerifyCommand) -> anyhow::Result<()> {
                 Ok(read_entry) => {
                     resyncing = false;
                     if fast {
-                        // Assembling the entry already validated every chunk's
-                        // CRC32, which is all `--fast` checks: no entry data is
-                        // decoded, so the entries inside a solid block are not
-                        // verified either.
                         report.ok += 1;
                         return Ok(());
                     }

--- a/cli/src/command/xattr.rs
+++ b/cli/src/command/xattr.rs
@@ -405,11 +405,6 @@ fn transform_xattr(
     xattrs
         .into_iter()
         .map(|(key, value)| -> io::Result<pna::ExtendedAttribute> {
-            // CLI-supplied --name was validated by clap value_parser; existing
-            // entry xattrs are already bounded by their newtype invariants. The
-            // CLI-supplied --value's argv-bounded size cannot reach u32::MAX,
-            // so this conversion is provably safe here, but propagating any
-            // future bound violation as InvalidData costs nothing.
             let name = pna::XattrName::try_from(key)
                 .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
             let value = pna::XattrValue::try_from(value)


### PR DESCRIPTION
## Summary

Three comments restated a contract that is documented elsewhere, so each is cut back to what its own site owns.

- `verify.rs`: `--fast`'s `long_help` already states that only chunk structure and CRC32 are checked, that no entry data is decoded, and that solid-block members therefore go unverified. What is left is the one fact it does not carry — that a failed CRC32 arrives as an error, so an `Ok` entry has already passed — and that governs both arms, so it moves above the match.
- `update.rs`: `--sync`'s help covers the pruning rule, and the comment above its declaration already explains the `conflicts_with_all`. `exists_on_disk` keeps only its own contract, that ambiguous errors count as existing.
- `xattr.rs`: removed. `XattrName::try_from` returns a `Result`, so handling the error is obligatory and needs no justification.

## Notes

Comments only; no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified internal comments describing update pruning, archive verification, CRC32 validation, and corrupted-entry handling.
  * Removed redundant implementation commentary without changing command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->