### PR TITLE
:wrench: Set cargo versioning-strategy to increase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 20
+    versioning-strategy: "increase"
     groups:
       rand-crates:
         patterns:


### PR DESCRIPTION
## Summary

Pin the cargo ecosystem to `versioning-strategy: increase`. Dependabot made `increase-if-necessary` the default for every Cargo crate on 2026-06-10 (dependabot/dependabot-core#14306, closing dependabot/dependabot-core#4009), after which bumps that already satisfied the existing requirement updated `Cargo.lock` alone and left the `Cargo.toml` requirements behind.

## Notes

The upstream default is motivated by manifest churn dragging the MSRV up. MSRV is verified by a separate CI job here, so keeping the requirements in step with the resolved versions stays safe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management to use an increase-only versioning strategy for Cargo dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->