### PR TITLE
:memo: Drop comments that restate the code below them

### DIFF
--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -76,9 +76,6 @@ pub(crate) enum ProcessAction {
 }
 
 /// Options controlling how filesystem items are collected for archiving.
-///
-/// This struct groups all traversal and filtering options that were previously
-/// passed as individual parameters.
 #[derive(Clone, Debug)]
 pub(crate) struct CollectOptions<'a> {
     pub(crate) recursive: bool,
@@ -613,9 +610,9 @@ pub(crate) fn collect_items_from_paths<P: AsRef<Path>>(
 ///
 /// When link-following is disabled and the operand resolves to a symlink,
 /// returns the path with trailing separators (and curdir components such as
-/// `link/.`) normalized away via `Path::components()`. Without this, POSIX
+/// `link/.`) normalized away via `Path::components()`, because POSIX
 /// `lstat("link/")` silently dereferences the symlink-to-directory and
-/// walkdir misclassifies the root. For ordinary directories the original
+/// walkdir would misclassify the root. For ordinary directories the original
 /// path is preserved so the trailing slash propagates into descendants — on
 /// Windows `Path::push` only inserts `\` when the parent does not already
 /// end in a separator, and substitution/transform/`--exclude` rules match
@@ -1044,7 +1041,6 @@ pub(crate) fn build_entry_metadata(
         use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
         let mode = meta.permissions().mode() as u16;
-        // Get owner info: use overrides from OwnerStrategy if Preserve, else use filesystem values
         let uid = options.uid.unwrap_or(meta.uid());
         let gid = options.gid.unwrap_or(meta.gid());
         let uname = match &options.uname {
@@ -1083,7 +1079,6 @@ pub(crate) fn build_entry_metadata(
         let mode = mode_from_file_information(path, &info, meta.file_type().is_symlink());
         let user = sd.owner_sid()?;
         let group = sd.group_sid()?;
-        // Get owner info: use overrides from OwnerStrategy
         let uid = options.uid.map_or(u64::MAX, Into::into);
         let gid = options.gid.map_or(u64::MAX, Into::into);
         let uname = options.uname.clone().unwrap_or(user.name);
@@ -2153,7 +2148,6 @@ fn transform_normal_entry(
         }
     }
 
-    // Apply ownership overrides from owner_strategy
     if let OwnerStrategy::Preserve {
         options:
             OwnerOptions {

--- a/cli/src/command/diff.rs
+++ b/cli/src/command/diff.rs
@@ -241,7 +241,6 @@ fn compare_file_metadata<T: AsRef<[u8]>>(
     let mut diffs = Vec::new();
     let ownership = crate::ext::ResolvedOwnership::from_metadata(entry.metadata());
 
-    // Compare mode
     if let Some(mode) = ownership.mode {
         let archive_mode = mode & 0o7777;
         let fs_mode = (fs_meta.permissions().mode() & 0o7777) as u16;
@@ -250,7 +249,6 @@ fn compare_file_metadata<T: AsRef<[u8]>>(
         }
     }
 
-    // Compare mtime
     if let Some(archive_mtime) = entry.metadata().saturating_modified_time()
         && let Ok(fs_mtime) = fs_meta.modified()
         && !times_equal(archive_mtime, fs_mtime)
@@ -258,7 +256,6 @@ fn compare_file_metadata<T: AsRef<[u8]>>(
         diffs.push(DiffKind::MtimeDiffers);
     }
 
-    // Compare uid/gid
     if let Some(uid) = ownership.uid
         && uid != fs_meta.uid() as u64
     {
@@ -354,14 +351,12 @@ fn compare_entry<T: AsRef<[u8]>>(
     let mut diff_count = 0usize;
     match data_kind {
         DataKind::FILE if meta.is_file() => {
-            // Compare metadata first
             let meta_diffs = compare_file_metadata(&entry, &meta, options);
             diff_count += meta_diffs.len();
             for diff in &meta_diffs {
                 report(diff, path_str, options.format);
             }
 
-            // Compare size first, then content
             let fs_size = meta.len();
             let archive_size = entry.metadata().raw_file_size();
             if archive_size.is_some_and(|s| s != fs_size as u128) {

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -1138,7 +1138,6 @@ where
         Err(err) => return Err(err),
     };
 
-    // Check overwrite strategy
     if let Some(existing) = &metadata {
         match overwrite_strategy {
             OverwriteStrategy::Never if !unlink_first => {
@@ -1190,12 +1189,10 @@ where
         OverwriteStrategy::Always | OverwriteStrategy::KeepNewer
     ) && had_existing;
 
-    // Remove existing if unlink_first mode
     if unlink_existing {
         utils::io::ignore_not_found(utils::fs::remove_path(path))?;
     }
 
-    // Create parent directories
     if let Some(parent) = path.parent() {
         ensure_directory_components(parent, unlink_first, secure_symlinks)?;
     }
@@ -1604,9 +1601,7 @@ where
             ModeStrategy::Never => {}
         }
     }
-    // On macOS, when mac_metadata_strategy is Always and the entry has mac_metadata,
-    // AppleDouble restoration via copyfile() will include xattrs and ACLs.
-    // Skip separate handling to avoid duplication.
+    // On macOS, AppleDouble restoration via copyfile() already carries the xattrs and ACLs.
     #[cfg(target_os = "macos")]
     let skip_xattr_acl = matches!(
         keep_options.mac_metadata_strategy,

--- a/cli/src/utils/os/unix/fs.rs
+++ b/cli/src/utils/os/unix/fs.rs
@@ -272,7 +272,7 @@ pub(crate) fn set_flags(path: &Path, flags: &[String]) -> io::Result<()> {
         Err(e) => return Err(e.into()),
     };
 
-    // Get current flags to preserve flags we're not setting
+    // Preserve the flags this call does not set
     let mut current_flags: libc::c_int = 0;
     match unsafe { fs_ioc_getflags(fd.as_raw_fd(), &mut current_flags) } {
         Ok(_) => {}
@@ -285,7 +285,6 @@ pub(crate) fn set_flags(path: &Path, flags: &[String]) -> io::Result<()> {
         Err(e) => return Err(e.into()),
     }
 
-    // Build new flags bitmap
     let mut new_flags = current_flags;
     for flag in flags {
         match flag.as_str() {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -104,7 +104,6 @@ fn mangen(args: MangenArgs) -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = &args.output;
     fs::create_dir_all(out_dir)?;
 
-    // Get the CLI command and rename to match the binary name
     let cmd = portable_network_archive::cli::Cli::command().name("pna");
 
     // Use clap_mangen::generate_to which properly handles subcommands
@@ -118,13 +117,10 @@ fn mangen(args: MangenArgs) -> Result<(), Box<dyn std::error::Error>> {
 fn docgen(args: DocgenArgs) -> Result<(), Box<dyn std::error::Error>> {
     let out_path = &args.output;
 
-    // Get the CLI command and rename to match the binary name
     let cmd = portable_network_archive::cli::Cli::command().name("pna");
 
-    // Generate markdown documentation
     let markdown = clap_markdown::help_markdown_command(&cmd);
 
-    // Create a parent directory if it doesn't exist
     if let Some(parent) = out_path.parent() {
         fs::create_dir_all(parent)?;
     }


### PR DESCRIPTION
## Summary

Comments that regenerate from the statement they precede are removed, and the two that carried more than a label keep only that part. No code changes.

## Notes

- The removed `extract` comment named `unlink_first` while the branch it labels tests `unlink_existing`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified internal documentation for symlink-root normalization and Linux file-flag handling.
  * Removed redundant or outdated explanatory comments across command, extraction, and documentation-generation workflows.
* **Refactor**
  * Simplified code comments without changing runtime behavior or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->