### PR TITLE
Add CLI test for single-part create --split

### DIFF
--- a/cli/tests/cli/create.rs
+++ b/cli/tests/cli/create.rs
@@ -28,6 +28,7 @@ mod option_one_file_system;
 mod option_password_from_file;
 mod option_password_from_file_raw;
 mod option_password_hash;
+mod option_split;
 mod option_strip_components;
 mod option_substitution;
 mod option_transform;

--- a/cli/tests/cli/create/option_split.rs
+++ b/cli/tests/cli/create/option_split.rs
@@ -1,0 +1,72 @@
+use crate::utils::{archive, setup};
+use clap::Parser;
+use portable_network_archive::cli;
+use std::{collections::HashSet, fs, io::prelude::*, path::Path};
+
+/// Precondition: The input files fit within a single part of the requested split size.
+/// Action: Run `pna create` with `--split`.
+/// Expectation: The archive is written to the requested path with no part-numbered
+/// file left behind, and its entries round-trip.
+#[test]
+fn create_with_split_fitting_in_single_part() {
+    setup();
+    if Path::new("create_split_single_part").exists() {
+        fs::remove_dir_all("create_split_single_part").unwrap();
+    }
+    fs::create_dir_all("create_split_single_part/in/").unwrap();
+    fs::write("create_split_single_part/in/first.txt", b"first").unwrap();
+    fs::write("create_split_single_part/in/second.txt", b"second").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "create_split_single_part/archive.pna",
+        "--overwrite",
+        "--unstable",
+        "--split",
+        "100kb",
+        "create_split_single_part/in/first.txt",
+        "create_split_single_part/in/second.txt",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    assert!(
+        Path::new("create_split_single_part/archive.pna").exists(),
+        "a single-part split should be written to the requested path"
+    );
+    assert!(
+        !Path::new("create_split_single_part/archive.part1.pna").exists(),
+        "a single-part split should not leave a part-numbered file behind"
+    );
+
+    let mut seen = HashSet::new();
+    archive::for_each_entry("create_split_single_part/archive.pna", |entry| {
+        let path = entry.header().path().to_string();
+        let mut contents = Vec::new();
+        entry
+            .reader(pna::ReadOptions::with_password::<&[u8]>(None))
+            .unwrap()
+            .read_to_end(&mut contents)
+            .unwrap();
+        seen.insert((path, contents));
+    })
+    .unwrap();
+
+    assert_eq!(
+        seen,
+        HashSet::from([
+            (
+                "create_split_single_part/in/first.txt".to_string(),
+                b"first".to_vec()
+            ),
+            (
+                "create_split_single_part/in/second.txt".to_string(),
+                b"second".to_vec()
+            ),
+        ])
+    );
+}


### PR DESCRIPTION
## Summary

Add a CLI integration test for `pna create --split` when the input fits in one part. `write_split_archive_path` renames `<name>.part1.pna` to `<name>` only in that case, and every existing `--split` test produces multiple parts, so the rename was untested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for the `pna create --split` command when all inputs fit in a single archive part.
  * Verified that entries and their contents are preserved and no unnecessary numbered part file is created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->