### PR TITLE
:recycle: Move the stream chunk check onto ChunkType

### DIFF
--- a/lib/src/chunk.rs
+++ b/lib/src/chunk.rs
@@ -40,15 +40,6 @@ pub(crate) trait ChunkExt: Chunk {
     fn bytes_len(&self) -> usize {
         MIN_CHUNK_BYTES_SIZE + self.data().len()
     }
-
-    /// Checks if the chunk is a stream chunk.
-    ///
-    /// Stream chunks, such as `FDAT` (File Data) and `SDAT` (Solid Data),
-    /// contain file content data.
-    #[inline]
-    fn is_stream_chunk(&self) -> bool {
-        self.ty() == ChunkType::FDAT || self.ty() == ChunkType::SDAT
-    }
 }
 
 impl<T> ChunkExt for T where T: Chunk {}

--- a/lib/src/chunk/types.rs
+++ b/lib/src/chunk/types.rs
@@ -311,6 +311,13 @@ impl ChunkType {
     pub const fn is_safe_to_copy(&self) -> bool {
         self.0[3] & 32 != 0
     }
+
+    /// Returns `true` if consecutive chunks of this type form a single
+    /// datastream, making their boundaries arbitrary and re-chunkable.
+    #[inline]
+    pub(crate) fn is_stream(&self) -> bool {
+        *self == Self::FDAT || *self == Self::SDAT
+    }
 }
 
 impl Debug for ChunkType {

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -1254,7 +1254,7 @@ impl EntryPart<&[u8]> {
         while let Some(chunk) = remaining.pop_front() {
             // NOTE: If over max size, restore to the remaining chunk
             if max_bytes_len < total_size + chunk.bytes_len() {
-                if chunk.is_stream_chunk() && total_size + MIN_CHUNK_BYTES_SIZE < max_bytes_len {
+                if chunk.ty.is_stream() && total_size + MIN_CHUNK_BYTES_SIZE < max_bytes_len {
                     let available_bytes_len = max_bytes_len - total_size;
                     let chunk_split_index = available_bytes_len - MIN_CHUNK_BYTES_SIZE;
                     let (x, y) = chunk_data_split(chunk.ty, chunk.data, chunk_split_index);


### PR DESCRIPTION
## Summary

Replace `ChunkExt::is_stream_chunk` with `ChunkType::is_stream`, so the check is reachable where only a chunk type is at hand and no chunk value exists yet. Both items are crate-internal, so the public API is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of contiguous data stream chunks.
  * Preserved existing chunk-splitting behavior while simplifying the underlying classification logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->