### PR TITLE
:sparkles: Stabilize update subcommand

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -10,7 +10,7 @@ use crate::{
         complete::CompleteCommand, concat::ConcatCommand, core::Umask, create::CreateCommand,
         delete::DeleteCommand, experimental::ExperimentalCommand, extract::ExtractCommand,
         list::ListCommand, migrate::MigrateCommand, sort::SortCommand, split::SplitCommand,
-        strip::StripCommand, xattr::XattrCommand,
+        strip::StripCommand, update::UpdateCommand, xattr::XattrCommand,
     },
     utils::{fs::current_umask, process::is_running_as_root},
 };
@@ -181,6 +181,8 @@ pub(crate) enum Commands {
     Create(CreateCommand),
     #[command(visible_alias = "a", about = "Append files to archive")]
     Append(AppendCommand),
+    #[command(about = "Update entries in archive")]
+    Update(UpdateCommand),
     #[command(visible_alias = "x", about = "Extract files from archive")]
     Extract(ExtractCommand),
     #[command(visible_aliases = &["l", "ls"], about = "List files in archive")]

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -123,6 +123,7 @@ impl Cli {
         match self.commands {
             Commands::Create(cmd) => cmd.execute(ctx),
             Commands::Append(cmd) => cmd.execute(ctx),
+            Commands::Update(cmd) => cmd.execute(ctx),
             Commands::Extract(cmd) => cmd.execute(ctx),
             Commands::List(cmd) => cmd.execute(ctx),
             Commands::Delete(cmd) => cmd.execute(ctx),

--- a/cli/src/command/experimental.rs
+++ b/cli/src/command/experimental.rs
@@ -12,7 +12,17 @@ impl Command for ExperimentalCommand {
     #[inline]
     fn execute(self, ctx: &crate::cli::GlobalContext) -> anyhow::Result<()> {
         match self.command {
-            ExperimentalCommands::Update(cmd) => cmd.execute(ctx),
+            ExperimentalCommands::Update(cmd) => {
+                log::warn!(
+                    "`{0} experimental update` subcommand was stabilized, use `{0} update` instead. this command will be removed in the future.",
+                    std::env::current_exe()
+                        .ok()
+                        .and_then(|it| it.file_name().map(|n| n.to_os_string()))
+                        .unwrap_or_default()
+                        .to_string_lossy()
+                );
+                cmd.execute(ctx)
+            }
             ExperimentalCommands::Chown(cmd) => cmd.execute(ctx),
             ExperimentalCommands::Chmod(cmd) => cmd.execute(ctx),
             ExperimentalCommands::Acl(cmd) => cmd.execute(ctx),
@@ -26,7 +36,9 @@ impl Command for ExperimentalCommand {
 #[derive(Subcommand, Clone, Debug)]
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum ExperimentalCommands {
-    #[command(about = "Update entries in archive")]
+    #[command(
+        about = "Update entries in archive (stabilized, use `pna update` command instead. this command will be removed in the future)"
+    )]
     Update(command::update::UpdateCommand),
     #[command(about = "Change owner")]
     Chown(command::chown::ChownCommand),


### PR DESCRIPTION
## Summary
Moves `update` out of `experimental` and makes it a stable top-level subcommand. `experimental update` stays as a deprecated alias that emits a stabilization warning, so the Deprecation Policy grace period applies before it is removed.

## Notes
Placed next to `create`/`append` in the subcommand list to match the `-c`/`-r`/`-u` grouping already exposed by `compat bsdtar`.

Closes #1547


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the stable `update` command for updating archive entries.

* **Bug Fixes**
  * The previous experimental update command now displays a deprecation warning and directs you to use `update` instead.

* **Documentation**
  * Updated command help text to indicate that the experimental form will be removed in a future release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->