### PR TITLE
:boom: Remove deprecated PNA_HEADER alias

### DIFF
--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -10,7 +10,7 @@ use crate::{
     compress::CompressionWriter,
 };
 use core::num::NonZeroU32;
-pub use header::*;
+pub(crate) use header::*;
 use std::io::prelude::*;
 pub(crate) use write::*;
 

--- a/lib/src/archive/header.rs
+++ b/lib/src/archive/header.rs
@@ -1,11 +1,6 @@
 //! Archive header constants and validation.
 
-use crate::PNA_SIGNATURE;
 use std::io;
-
-/// Alias of [`PNA_SIGNATURE`].
-#[deprecated(since = "0.37.0", note = "renamed to `PNA_SIGNATURE`")]
-pub const PNA_HEADER: &[u8; 8] = PNA_SIGNATURE;
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub(crate) struct ArchiveHeader {


### PR DESCRIPTION
## Summary

Remove the deprecated `PNA_HEADER` alias of `PNA_SIGNATURE`.

## Notes

Deprecated in `0.37.0`, so per the deprecation policy this is mergeable from `0.41.0` — draft until then.

`archive::header` no longer exports anything public, so its re-export in `archive` becomes `pub(crate)`.

Resolves #3406
