### PR TITLE
:boom: Remove deprecated SystemTimeExt trait

### DIFF
--- a/lib/src/ext/time.rs
+++ b/lib/src/ext/time.rs
@@ -1,47 +1,6 @@
 //! Extension traits for time types.
 
 use crate::Duration;
-use std::time::SystemTime;
-
-/// [`SystemTime`] extension trait.
-///
-/// The result is positive for times after the epoch and negative for times
-/// before it.
-///
-/// # Examples
-///
-/// ```
-/// # #![allow(deprecated)]
-/// use std::time::{Duration, SystemTime};
-/// use libpna::prelude::SystemTimeExt;
-///
-/// let epoch = SystemTime::UNIX_EPOCH;
-/// assert!(epoch.duration_since_unix_epoch_signed().is_zero());
-///
-/// let after = SystemTime::UNIX_EPOCH + Duration::from_secs(100);
-/// assert!(after.duration_since_unix_epoch_signed().is_positive());
-/// ```
-#[deprecated(
-    since = "0.34.0",
-    note = "moved to the pna crate; use pna::prelude::SystemTimeDurationExt::try_duration_since_unix_epoch_signed or saturating_duration_since_unix_epoch_signed"
-)]
-pub trait SystemTimeExt {
-    /// Returns the duration since the Unix epoch as a signed [`Duration`].
-    ///
-    /// # Panics
-    ///
-    /// Panics if `*self` is outside `OffsetDateTime`'s representable
-    /// ±9999-year range (unreachable for filesystem timestamps).
-    fn duration_since_unix_epoch_signed(&self) -> Duration;
-}
-
-#[allow(deprecated)]
-impl SystemTimeExt for SystemTime {
-    #[inline]
-    fn duration_since_unix_epoch_signed(&self) -> Duration {
-        time::OffsetDateTime::from(*self) - time::OffsetDateTime::UNIX_EPOCH
-    }
-}
 
 /// [`Duration`] extension trait for the `<x>TIM` + `<x>TNS` / 1e9 timestamp
 /// representation.
@@ -86,16 +45,6 @@ mod tests {
     use super::*;
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
-
-    #[allow(deprecated)]
-    #[test]
-    fn unix_epoch_returns_zero() {
-        assert!(
-            SystemTime::UNIX_EPOCH
-                .duration_since_unix_epoch_signed()
-                .is_zero()
-        );
-    }
 
     fn assert_splits_and_rebuilds(duration: Duration, expected: (i64, u32)) {
         assert_eq!(duration.to_seconds_nanos(), expected);

--- a/lib/src/prelude.rs
+++ b/lib/src/prelude.rs
@@ -7,4 +7,4 @@
 //! # #![allow(unused_imports)]
 //! use libpna::prelude::*;
 //! ```
-pub use crate::{Chunk, Entry, ext::time::*};
+pub use crate::{Chunk, Entry};


### PR DESCRIPTION
## Summary

Remove the deprecated `SystemTimeExt` trait, superseded by `pna::prelude::SystemTimeDurationExt`.

## Notes

`libpna::prelude` no longer re-exports `ext::time`, whose remaining item is crate-internal.

Resolves #3211
