### PR TITLE
:boom: Remove deprecated panicking MetadataTimeExt getters

### DIFF
--- a/pna/src/ext/metadata.rs
+++ b/pna/src/ext/metadata.rs
@@ -9,39 +9,6 @@ use std::{fs, io, path::Path, time::SystemTime};
 
 /// [`Metadata`] time-related extension methods.
 pub trait MetadataTimeExt: private::Sealed {
-    /// Returns the created time.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the stored duration is outside the platform's representable
-    /// `SystemTime` range.
-    #[deprecated(
-        since = "0.34.0",
-        note = "panics for archive timestamps outside the platform's SystemTime range; use try_created_time or saturating_created_time"
-    )]
-    fn created_time(&self) -> Option<SystemTime>;
-    /// Returns the modified time.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the stored duration is outside the platform's representable
-    /// `SystemTime` range.
-    #[deprecated(
-        since = "0.34.0",
-        note = "panics for archive timestamps outside the platform's SystemTime range; use try_modified_time or saturating_modified_time"
-    )]
-    fn modified_time(&self) -> Option<SystemTime>;
-    /// Returns the accessed time.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the stored duration is outside the platform's representable
-    /// `SystemTime` range.
-    #[deprecated(
-        since = "0.34.0",
-        note = "panics for archive timestamps outside the platform's SystemTime range; use try_accessed_time or saturating_accessed_time"
-    )]
-    fn accessed_time(&self) -> Option<SystemTime>;
     /// Returns the created time, or `Err` if the stored duration is outside
     /// the platform's representable [`SystemTime`] range.
     ///
@@ -84,69 +51,6 @@ pub trait MetadataTimeExt: private::Sealed {
 }
 
 impl MetadataTimeExt for Metadata {
-    /// Returns the created time.
-    ///
-    /// This is the same as [Metadata::created] + [SystemTime::UNIX_EPOCH].
-    /// ```
-    /// # #![allow(deprecated)]
-    /// use pna::{Duration, Metadata, prelude::*};
-    /// use std::time::UNIX_EPOCH;
-    ///
-    /// let metadata = Metadata::new().with_created(Some(Duration::seconds(1000)));
-    ///
-    /// assert_eq!(
-    ///     metadata.created().map(|d| UNIX_EPOCH + d),
-    ///     metadata.created_time(),
-    /// );
-    /// ```
-    #[allow(deprecated)]
-    #[inline]
-    fn created_time(&self) -> Option<SystemTime> {
-        self.created().map(|it| SystemTime::UNIX_EPOCH + it)
-    }
-
-    /// Returns the modified time.
-    ///
-    /// This is the same as [Metadata::modified] + [SystemTime::UNIX_EPOCH].
-    /// ```
-    /// # #![allow(deprecated)]
-    /// use pna::{Duration, Metadata, prelude::*};
-    /// use std::time::UNIX_EPOCH;
-    ///
-    /// let metadata = Metadata::new().with_modified(Some(Duration::seconds(1000)));
-    ///
-    /// assert_eq!(
-    ///     metadata.modified().map(|d| UNIX_EPOCH + d),
-    ///     metadata.modified_time(),
-    /// );
-    /// ```
-    #[allow(deprecated)]
-    #[inline]
-    fn modified_time(&self) -> Option<SystemTime> {
-        self.modified().map(|it| SystemTime::UNIX_EPOCH + it)
-    }
-
-    /// Returns the accessed time.
-    ///
-    /// This is the same as [Metadata::accessed] + [SystemTime::UNIX_EPOCH].
-    /// ```
-    /// # #![allow(deprecated)]
-    /// use pna::{Duration, Metadata, prelude::*};
-    /// use std::time::UNIX_EPOCH;
-    ///
-    /// let metadata = Metadata::new().with_accessed(Some(Duration::seconds(1000)));
-    ///
-    /// assert_eq!(
-    ///     metadata.accessed().map(|d| UNIX_EPOCH + d),
-    ///     metadata.accessed_time(),
-    /// );
-    /// ```
-    #[allow(deprecated)]
-    #[inline]
-    fn accessed_time(&self) -> Option<SystemTime> {
-        self.accessed().map(|it| SystemTime::UNIX_EPOCH + it)
-    }
-
     #[inline]
     fn try_created_time(&self) -> Result<Option<SystemTime>, SystemTimeOutOfRange> {
         self.created().map(duration_to_system_time).transpose()
@@ -181,7 +85,6 @@ impl MetadataTimeExt for Metadata {
     ///
     /// # Examples
     /// ```
-    /// # #![allow(deprecated)]
     /// use pna::{Metadata, prelude::*};
     /// use std::time::{Duration, SystemTime, UNIX_EPOCH};
     ///
@@ -189,13 +92,13 @@ impl MetadataTimeExt for Metadata {
     /// // Time after Unix epoch will be preserved
     /// let after_epoch = UNIX_EPOCH + Duration::from_secs(1000);
     /// let metadata = Metadata::new().with_created_time(Some(after_epoch));
-    /// assert_eq!(metadata.created_time(), Some(after_epoch));
+    /// assert_eq!(metadata.saturating_created_time(), Some(after_epoch));
     ///
     /// # #[cfg(target_family = "wasm")]
     /// # return;
     /// let before_epoch = UNIX_EPOCH - Duration::from_secs(1);
     /// let metadata = Metadata::new().with_created_time(Some(before_epoch));
-    /// assert_eq!(metadata.created_time(), Some(before_epoch));
+    /// assert_eq!(metadata.saturating_created_time(), Some(before_epoch));
     /// # }
     /// ```
     #[inline]
@@ -207,7 +110,6 @@ impl MetadataTimeExt for Metadata {
     ///
     /// # Examples
     /// ```
-    /// # #![allow(deprecated)]
     /// use pna::{Metadata, prelude::*};
     /// use std::time::{Duration, SystemTime, UNIX_EPOCH};
     ///
@@ -215,13 +117,13 @@ impl MetadataTimeExt for Metadata {
     /// // Time after Unix epoch will be preserved
     /// let after_epoch = UNIX_EPOCH + Duration::from_secs(1000);
     /// let metadata = Metadata::new().with_modified_time(Some(after_epoch));
-    /// assert_eq!(metadata.modified_time(), Some(after_epoch));
+    /// assert_eq!(metadata.saturating_modified_time(), Some(after_epoch));
     ///
     /// # #[cfg(target_family = "wasm")]
     /// # return;
     /// let before_epoch = UNIX_EPOCH - Duration::from_secs(1);
     /// let metadata = Metadata::new().with_modified_time(Some(before_epoch));
-    /// assert_eq!(metadata.modified_time(), Some(before_epoch));
+    /// assert_eq!(metadata.saturating_modified_time(), Some(before_epoch));
     /// # }
     /// ```
     #[inline]
@@ -233,7 +135,6 @@ impl MetadataTimeExt for Metadata {
     ///
     /// # Examples
     /// ```
-    /// # #![allow(deprecated)]
     /// use pna::{Metadata, prelude::*};
     /// use std::time::{Duration, SystemTime, UNIX_EPOCH};
     ///
@@ -241,13 +142,13 @@ impl MetadataTimeExt for Metadata {
     /// // Time after Unix epoch will be preserved
     /// let after_epoch = UNIX_EPOCH + Duration::from_secs(1000);
     /// let metadata = Metadata::new().with_accessed_time(Some(after_epoch));
-    /// assert_eq!(metadata.accessed_time(), Some(after_epoch));
+    /// assert_eq!(metadata.saturating_accessed_time(), Some(after_epoch));
     ///
     /// # #[cfg(target_family = "wasm")]
     /// # return;
     /// let before_epoch = UNIX_EPOCH - Duration::from_secs(1);
     /// let metadata = Metadata::new().with_accessed_time(Some(before_epoch));
-    /// assert_eq!(metadata.accessed_time(), Some(before_epoch));
+    /// assert_eq!(metadata.saturating_accessed_time(), Some(before_epoch));
     /// # }
     /// ```
     #[inline]


### PR DESCRIPTION
## Summary

Remove `MetadataTimeExt::{created_time, modified_time, accessed_time}`, which panic for archive timestamps outside the platform's `SystemTime` range. The `try_*` and `saturating_*` variants remain.

## Notes

The `with_*_time` doc examples now assert through `saturating_*_time`.

Resolves #3212


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the deprecated `created_time`, `modified_time`, and `accessed_time` metadata accessors.
  * Applications using these methods must migrate to the corresponding saturating accessors.
* **Documentation**
  * Updated metadata time examples to demonstrate the supported saturating accessor methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->