### PR TITLE
:bug: Pass CLI benchmark archives through --file

### DIFF
--- a/cli/benches/create.rs
+++ b/cli/benches/create.rs
@@ -9,6 +9,7 @@ fn bench_store(c: &mut Criterion) {
                 "pna",
                 "--quiet",
                 "c",
+                "--file",
                 concat!(env!("CARGO_TARGET_TMPDIR"), "/bench/store.pna"),
                 "--store",
                 "--overwrite",
@@ -27,6 +28,7 @@ fn bench_zstd(c: &mut Criterion) {
                 "pna",
                 "--quiet",
                 "c",
+                "--file",
                 concat!(env!("CARGO_TARGET_TMPDIR"), "/bench/zstd.pna"),
                 "--zstd",
                 "--overwrite",
@@ -45,6 +47,7 @@ fn bench_deflate(c: &mut Criterion) {
                 "pna",
                 "--quiet",
                 "c",
+                "--file",
                 concat!(env!("CARGO_TARGET_TMPDIR"), "/bench/deflate.pna"),
                 "--deflate",
                 "--overwrite",
@@ -63,6 +66,7 @@ fn bench_xz(c: &mut Criterion) {
                 "pna",
                 "--quiet",
                 "c",
+                "--file",
                 concat!(env!("CARGO_TARGET_TMPDIR"), "/bench/xz.pna"),
                 "--xz",
                 "--overwrite",
@@ -81,6 +85,7 @@ fn bench_zstd_keep_timestamp(c: &mut Criterion) {
                 "pna",
                 "--quiet",
                 "c",
+                "--file",
                 concat!(
                     env!("CARGO_TARGET_TMPDIR"),
                     "/bench/zstd_keep_timestamp.pna"
@@ -103,6 +108,7 @@ fn bench_zstd_keep_permission(c: &mut Criterion) {
                 "pna",
                 "--quiet",
                 "c",
+                "--file",
                 concat!(
                     env!("CARGO_TARGET_TMPDIR"),
                     "/bench/zstd_keep_permission.pna"

--- a/cli/benches/extract.rs
+++ b/cli/benches/extract.rs
@@ -9,6 +9,7 @@ fn bench_store(c: &mut Criterion) {
                 "pna",
                 "--quiet",
                 "x",
+                "--file",
                 concat!(env!("CARGO_MANIFEST_DIR"), "/../resources/test/store.pna"),
                 "--overwrite",
                 "--out-dir",
@@ -27,6 +28,7 @@ fn bench_zstd(c: &mut Criterion) {
                 "pna",
                 "--quiet",
                 "x",
+                "--file",
                 concat!(env!("CARGO_MANIFEST_DIR"), "/../resources/test/zstd.pna"),
                 "--overwrite",
                 "--out-dir",
@@ -45,6 +47,7 @@ fn bench_deflate(c: &mut Criterion) {
                 "pna",
                 "--quiet",
                 "x",
+                "--file",
                 concat!(env!("CARGO_MANIFEST_DIR"), "/../resources/test/deflate.pna"),
                 "--overwrite",
                 "--out-dir",
@@ -63,6 +66,7 @@ fn bench_xz(c: &mut Criterion) {
                 "pna",
                 "--quiet",
                 "x",
+                "--file",
                 concat!(env!("CARGO_MANIFEST_DIR"), "/../resources/test/xz.pna"),
                 "--overwrite",
                 "--out-dir",
@@ -81,6 +85,7 @@ fn bench_zstd_keep_timestamp(c: &mut Criterion) {
                 "pna",
                 "--quiet",
                 "x",
+                "--file",
                 concat!(
                     env!("CARGO_MANIFEST_DIR"),
                     "/../resources/test/zstd_keep_timestamp.pna"
@@ -102,6 +107,7 @@ fn bench_zstd_keep_permission(c: &mut Criterion) {
                 "pna",
                 "--quiet",
                 "x",
+                "--file",
                 concat!(
                     env!("CARGO_MANIFEST_DIR"),
                     "/../resources/test/zstd_keep_permission.pna"
@@ -124,6 +130,7 @@ fn bench_zstd_keep_xattr(c: &mut Criterion) {
                 "pna",
                 "--quiet",
                 "x",
+                "--file",
                 concat!(
                     env!("CARGO_MANIFEST_DIR"),
                     "/../resources/test/zstd_keep_xattr.pna"

--- a/cli/benches/list.rs
+++ b/cli/benches/list.rs
@@ -9,6 +9,7 @@ fn bench_list_normal(c: &mut Criterion) {
                 "pna",
                 "--quiet",
                 "ls",
+                "--file",
                 concat!(
                     env!("CARGO_MANIFEST_DIR"),
                     "/../resources/test/zstd_keep_dir.pna"
@@ -28,6 +29,7 @@ fn bench_list_normal_classify(c: &mut Criterion) {
                 "--quiet",
                 "ls",
                 "--classify",
+                "--file",
                 concat!(
                     env!("CARGO_MANIFEST_DIR"),
                     "/../resources/test/zstd_keep_dir.pna"
@@ -47,6 +49,7 @@ fn bench_list_normal_hide_control_chars(c: &mut Criterion) {
                 "--quiet",
                 "ls",
                 "-q",
+                "--file",
                 concat!(
                     env!("CARGO_MANIFEST_DIR"),
                     "/../resources/test/zstd_keep_dir.pna"
@@ -66,6 +69,7 @@ fn bench_list_normal_table(c: &mut Criterion) {
                 "--quiet",
                 "ls",
                 "-l",
+                "--file",
                 concat!(
                     env!("CARGO_MANIFEST_DIR"),
                     "/../resources/test/zstd_keep_dir.pna"
@@ -87,6 +91,7 @@ fn bench_list_normal_jsonl(c: &mut Criterion) {
                 "--format",
                 "jsonl",
                 "--unstable",
+                "--file",
                 concat!(
                     env!("CARGO_MANIFEST_DIR"),
                     "/../resources/test/zstd_keep_dir.pna"
@@ -108,6 +113,7 @@ fn bench_list_normal_tree(c: &mut Criterion) {
                 "--format",
                 "tree",
                 "--unstable",
+                "--file",
                 concat!(
                     env!("CARGO_MANIFEST_DIR"),
                     "/../resources/test/zstd_keep_dir.pna"
@@ -127,6 +133,7 @@ fn bench_list_solid(c: &mut Criterion) {
                 "--quiet",
                 "ls",
                 "--solid",
+                "--file",
                 concat!(
                     env!("CARGO_MANIFEST_DIR"),
                     "/../resources/test/solid_zstd.pna"

--- a/cli/benches/split.rs
+++ b/cli/benches/split.rs
@@ -9,6 +9,7 @@ fn bench_create_with_split(c: &mut Criterion) {
                 "pna",
                 "--quiet",
                 "c",
+                "--file",
                 concat!(
                     env!("CARGO_TARGET_TMPDIR"),
                     "/bench/create_with_split/store.pna"
@@ -32,6 +33,7 @@ fn bench_split(c: &mut Criterion) {
                 "pna",
                 "--quiet",
                 "split",
+                "--file",
                 concat!(env!("CARGO_MANIFEST_DIR"), "/../resources/test/store.pna"),
                 "--overwrite",
                 "--max-size",
@@ -52,6 +54,7 @@ fn bench_extract_multipart(c: &mut Criterion) {
                 "pna",
                 "--quiet",
                 "x",
+                "--file",
                 concat!(
                     env!("CARGO_MANIFEST_DIR"),
                     "/../resources/test/multipart.part1.pna"


### PR DESCRIPTION
## Summary

- pass archive paths through the required --file option in the create, extract, list, and split Criterion benchmarks
- allow all 23 CLI benchmark cases to reach their measured workloads again

## Context

Positional archive arguments were removed in [#2993](https://github.com/ChanTsune/Portable-Network-Archive/pull/2993) after five minor releases of deprecation, making -f/--file <ARCHIVE> required for these commands.

## Validation

- cargo fmt --all -- --check
- cargo bench -p portable-network-archive --bench create -- --test
- cargo bench -p portable-network-archive --bench extract -- --test
- cargo bench -p portable-network-archive --bench list -- --test
- cargo bench -p portable-network-archive --bench split -- --test