### PR TITLE
:boom: Remove deprecated Permission::new

### DIFF
--- a/cli/src/ext.rs
+++ b/cli/src/ext.rs
@@ -202,17 +202,36 @@ impl<S: Display> Display for UserDisplay<S> {
 mod resolved_ownership_tests {
     use super::*;
 
+    /// Reads back a `Metadata` carrying the given `fPRM` values.
+    ///
+    /// `fPRM` can no longer be authored through the API, so the chunk is
+    /// written raw and the values come back off the wire.
+    #[allow(deprecated)]
+    fn fprm_metadata(uid: u64, uname: &str, gid: u64, gname: &str, mode: u16) -> pna::Metadata {
+        let mut body = uid.to_be_bytes().to_vec();
+        body.push(uname.len() as u8);
+        body.extend_from_slice(uname.as_bytes());
+        body.extend_from_slice(&gid.to_be_bytes());
+        body.push(gname.len() as u8);
+        body.extend_from_slice(gname.as_bytes());
+        body.extend_from_slice(&mode.to_be_bytes());
+
+        let mut buf = Vec::new();
+        {
+            let mut archive = pna::Archive::write_header(&mut buf).unwrap();
+            let mut builder = pna::FileEntryBuilder::new("f".into()).unwrap();
+            builder.add_extra_chunk(pna::RawChunk::from_data(pna::ChunkType::fPRM, body));
+            archive.add_entry(builder.build().unwrap()).unwrap();
+            archive.finalize().unwrap();
+        }
+        let mut archive = pna::Archive::read_header(&buf[..]).unwrap();
+        let entry = archive.entries().skip_solid().next().unwrap().unwrap();
+        entry.metadata().clone()
+    }
+
     #[test]
     fn owner_facet_overwrites_fprm_baseline() {
-        #[allow(deprecated)]
-        let m = pna::Metadata::new()
-            .with_permission(Some(pna::Permission::new(
-                7,
-                "legacy".into(),
-                8,
-                "grp".into(),
-                0o600,
-            )))
+        let m = fprm_metadata(7, "legacy", 8, "grp", 0o600)
             .with_owner_uid(Some(pna::OwnerUid::from(1)))
             .with_owner_user_name(Some(pna::OwnerUserName::new("new").unwrap()))
             .with_owner_user_sid(Some(pna::OwnerUserSid::new("S-1-1").unwrap()));
@@ -234,14 +253,7 @@ mod resolved_ownership_tests {
 
     #[test]
     fn fprm_only_is_rescued() {
-        #[allow(deprecated)]
-        let m = pna::Metadata::new().with_permission(Some(pna::Permission::new(
-            5,
-            "u".into(),
-            6,
-            "g".into(),
-            0o644,
-        )));
+        let m = fprm_metadata(5, "u", 6, "g", 0o644);
         let r = ResolvedOwnership::from_metadata(&m);
         assert_eq!((r.uid, r.gid, r.mode), (Some(5), Some(6), Some(0o644)));
         assert_eq!(r.uname.as_deref(), Some("u"));

--- a/cli/tests/cli/chmod.rs
+++ b/cli/tests/cli/chmod.rs
@@ -16,11 +16,9 @@ mod unsolid;
 
 use crate::utils::{archive, archive::FileEntryDef, setup};
 use clap::Parser;
-#[allow(deprecated)]
-use pna::Permission;
 use pna::{
-    Archive, DirEntryBuilder, EntryName, FileEntryBuilder, HardLinkEntryBuilder, Metadata,
-    SymlinkEntryBuilder,
+    Archive, ChunkType, DirEntryBuilder, EntryName, FileEntryBuilder, HardLinkEntryBuilder,
+    RawChunk, SymlinkEntryBuilder,
 };
 use portable_network_archive::cli;
 use std::fs::File;
@@ -86,13 +84,10 @@ fn archive_chmod_drops_legacy_fprm() {
         let mut archive = Archive::write_header(File::create(path).unwrap()).unwrap();
         let mut builder =
             FileEntryBuilder::new(EntryName::from_utf8_preserve_root(ENTRY_PATH)).unwrap();
-        builder.metadata(Metadata::new().with_permission(Some(Permission::new(
-            1000,
-            "user".to_string(),
-            1000,
-            "group".to_string(),
-            0o777,
-        ))));
+        builder.add_extra_chunk(RawChunk::from_data(
+            ChunkType::fPRM,
+            archive::legacy_fprm_body(1000, "user", 1000, "group", 0o777),
+        ));
         builder.write_all(ENTRY_CONTENT).unwrap();
         archive.add_entry(builder.build().unwrap()).unwrap();
         archive.finalize().unwrap();

--- a/cli/tests/cli/chown/user_only.rs
+++ b/cli/tests/cli/chown/user_only.rs
@@ -1,8 +1,6 @@
 use crate::utils::{archive, archive::FileEntryDef, setup};
 use clap::Parser;
-#[allow(deprecated)]
-use pna::Permission;
-use pna::{Archive, EntryName, FileEntryBuilder, Metadata};
+use pna::{Archive, ChunkType, EntryName, FileEntryBuilder, RawChunk};
 use portable_network_archive::cli;
 use std::fs::File;
 use std::io::Write;
@@ -95,13 +93,10 @@ fn chown_user_only_drops_legacy_fprm() {
         let mut archive = Archive::write_header(File::create(path).unwrap()).unwrap();
         let mut builder =
             FileEntryBuilder::new(EntryName::from_utf8_preserve_root("target.txt")).unwrap();
-        builder.metadata(Metadata::new().with_permission(Some(Permission::new(
-            1000,
-            "user".to_string(),
-            1000,
-            "group".to_string(),
-            0o644,
-        ))));
+        builder.add_extra_chunk(RawChunk::from_data(
+            ChunkType::fPRM,
+            archive::legacy_fprm_body(1000, "user", 1000, "group", 0o644),
+        ));
         builder.write_all(b"target").unwrap();
         archive.add_entry(builder.build().unwrap()).unwrap();
         archive.finalize().unwrap();

--- a/cli/tests/cli/utils/archive.rs
+++ b/cli/tests/cli/utils/archive.rs
@@ -24,6 +24,20 @@ pub fn xattr(name: &str, value: &[u8]) -> pna::ExtendedAttribute {
     )
 }
 
+/// Encodes a legacy `fPRM` chunk Body: uid, length-prefixed user name, gid,
+/// length-prefixed group name, mode. `fPRM` cannot be authored through the API,
+/// so tests that need one write the chunk raw.
+pub fn legacy_fprm_body(uid: u64, uname: &str, gid: u64, gname: &str, mode: u16) -> Vec<u8> {
+    let mut bytes = uid.to_be_bytes().to_vec();
+    bytes.push(uname.len() as u8);
+    bytes.extend_from_slice(uname.as_bytes());
+    bytes.extend_from_slice(&gid.to_be_bytes());
+    bytes.push(gname.len() as u8);
+    bytes.extend_from_slice(gname.as_bytes());
+    bytes.extend_from_slice(&mode.to_be_bytes());
+    bytes
+}
+
 /// Creates an archive with file entries having specific permissions.
 /// This bypasses filesystem permission requirements by constructing entries programmatically.
 pub fn create_archive_with_permissions(

--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -704,7 +704,6 @@ mod tests {
         assert!(entries.next().is_none());
     }
 
-    #[allow(deprecated)]
     #[test]
     fn metadata() {
         let original_entry = {
@@ -716,13 +715,11 @@ mod tests {
                     .with_created(Some(Duration::seconds(31)))
                     .with_modified(Some(Duration::seconds(32)))
                     .with_accessed(Some(Duration::seconds(33)))
-                    .with_permission(Some(Permission::new(
-                        1,
-                        "uname".into(),
-                        2,
-                        "gname".into(),
-                        0o775,
-                    ))),
+                    .with_owner_uid(Some(OwnerUid::from(1)))
+                    .with_owner_gid(Some(OwnerGid::from(2)))
+                    .with_owner_user_name(Some(OwnerUserName::new("uname").unwrap()))
+                    .with_owner_group_name(Some(OwnerGroupName::new("gname").unwrap()))
+                    .with_permission_mode(Some(PermissionMode::from(0o775))),
             );
             builder.write_all(b"entry data").unwrap();
             builder.build().unwrap()
@@ -751,8 +748,24 @@ mod tests {
             read_entry.metadata().accessed()
         );
         assert_eq!(
-            original_entry.metadata().permission(),
-            read_entry.metadata().permission()
+            original_entry.metadata().owner_uid(),
+            read_entry.metadata().owner_uid()
+        );
+        assert_eq!(
+            original_entry.metadata().owner_gid(),
+            read_entry.metadata().owner_gid()
+        );
+        assert_eq!(
+            original_entry.metadata().owner_user_name(),
+            read_entry.metadata().owner_user_name()
+        );
+        assert_eq!(
+            original_entry.metadata().owner_group_name(),
+            read_entry.metadata().owner_group_name()
+        );
+        assert_eq!(
+            original_entry.metadata().permission_mode(),
+            read_entry.metadata().permission_mode()
         );
         assert_eq!(
             original_entry.metadata().compressed_size(),

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -1005,6 +1005,14 @@ mod tests {
         assert!(out.chars().all(|c| c == two_byte_char));
     }
 
+    #[allow(deprecated)]
+    fn legacy_fprm(uid: u64, uname: &str, gid: u64, gname: &str, mode: u16) -> Permission {
+        Permission::try_from_bytes(&crate::entry::meta::legacy_fprm_body(
+            uid, uname, gid, gname, mode,
+        ))
+        .unwrap()
+    }
+
     #[test]
     #[allow(deprecated)]
     fn metadata_preserves_all_owner_facets() {
@@ -1034,13 +1042,9 @@ mod tests {
     #[allow(deprecated)]
     fn metadata_rescues_fprm_only_source() {
         let mut b = FileEntryBuilder::new("f".into()).unwrap();
-        b.metadata(Metadata::new().with_permission(Some(Permission::new(
-            7,
-            "legacy".to_string(),
-            8,
-            "grp".to_string(),
-            0o600,
-        ))));
+        b.metadata(
+            Metadata::new().with_permission(Some(legacy_fprm(7, "legacy", 8, "grp", 0o600))),
+        );
         let entry = b.build().unwrap();
         let m = entry.metadata();
         assert_eq!(m.owner_uid().map(|v| v.get()), Some(7));
@@ -1059,13 +1063,7 @@ mod tests {
             Metadata::new()
                 .with_owner_uid(Some(OwnerUid::from(1)))
                 .with_owner_user_name(Some(OwnerUserName::new("new").unwrap()))
-                .with_permission(Some(Permission::new(
-                    7,
-                    "legacy".to_string(),
-                    8,
-                    "grp".to_string(),
-                    0o600,
-                ))),
+                .with_permission(Some(legacy_fprm(7, "legacy", 8, "grp", 0o600))),
         );
         let entry = b.build().unwrap();
         let m = entry.metadata();
@@ -1078,29 +1076,6 @@ mod tests {
             m.permission().is_some(),
             "fPRM must coexist with a partially set owner facet"
         );
-    }
-
-    #[test]
-    #[allow(deprecated)]
-    fn metadata_truncates_overlong_fprm_name() {
-        let big_char = 'é';
-        assert_eq!(big_char.len_utf8(), 2);
-        let big = String::from(big_char).repeat(200); // 400 bytes
-        let mut b = FileEntryBuilder::new("f".into()).unwrap();
-        b.metadata(Metadata::new().with_permission(Some(Permission::new(
-            7,
-            big,
-            8,
-            "grp".to_string(),
-            0o600,
-        ))));
-        let entry = b.build().unwrap();
-        let m = entry.metadata();
-        let uname = m.owner_user_name().unwrap().as_str();
-        assert_eq!(uname.len(), 254);
-        assert_eq!(uname.chars().count(), 127);
-        assert!(uname.chars().all(|c| c == big_char));
-        assert_eq!(m.owner_uid().map(|v| v.get()), Some(7));
     }
 
     #[allow(deprecated)]

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -340,6 +340,9 @@ impl Default for Metadata {
 }
 
 /// Owner, group, and permission bits for an archive entry.
+///
+/// Instances only come from reading an entry that carries an `fPRM` chunk, via
+/// [`Metadata::permission`]; the `fPRM` chunk cannot be authored any more.
 #[deprecated(
     since = "0.34.0",
     note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching Metadata::with_* setters)"
@@ -355,44 +358,7 @@ pub struct Permission {
 
 #[allow(deprecated)]
 impl Permission {
-    /// Creates a new [`Permission`] with the given user, group, and permission bits.
-    ///
-    /// The `uid`/`gid` are numeric POSIX IDs, `uname`/`gname` are the
-    /// corresponding names, and `permission` holds the file mode bits (e.g. `0o755`).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #![allow(deprecated)]
-    /// use libpna::Permission;
-    ///
-    /// let perm = Permission::new(1000, "user".into(), 100, "group".into(), 0o755);
-    /// ```
-    #[deprecated(
-        since = "0.34.0",
-        note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching Metadata::with_* setters)"
-    )]
-    #[inline]
-    pub const fn new(uid: u64, uname: String, gid: u64, gname: String, permission: u16) -> Self {
-        Self {
-            uid,
-            uname,
-            gid,
-            gname,
-            permission,
-        }
-    }
     /// Returns the user ID associated with this permission.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #![allow(deprecated)]
-    /// use libpna::Permission;
-    ///
-    /// let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
-    /// assert_eq!(perm.uid(), 1000);
-    /// ```
     #[deprecated(
         since = "0.34.0",
         note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching Metadata::with_* setters)"
@@ -403,16 +369,6 @@ impl Permission {
     }
 
     /// Returns the user name associated with this permission.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #![allow(deprecated)]
-    /// use libpna::Permission;
-    ///
-    /// let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
-    /// assert_eq!(perm.uname(), "user1");
-    /// ```
     #[deprecated(
         since = "0.34.0",
         note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching Metadata::with_* setters)"
@@ -423,16 +379,6 @@ impl Permission {
     }
 
     /// Returns the group ID associated with this permission.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #![allow(deprecated)]
-    /// use libpna::Permission;
-    ///
-    /// let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
-    /// assert_eq!(perm.gid(), 100);
-    /// ```
     #[deprecated(
         since = "0.34.0",
         note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching Metadata::with_* setters)"
@@ -443,16 +389,6 @@ impl Permission {
     }
 
     /// Returns the group name associated with this permission.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #![allow(deprecated)]
-    /// use libpna::Permission;
-    ///
-    /// let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
-    /// assert_eq!(perm.gname(), "group1");
-    /// ```
     #[deprecated(
         since = "0.34.0",
         note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching Metadata::with_* setters)"
@@ -463,16 +399,6 @@ impl Permission {
     }
 
     /// Returns the permission bits associated with this permission.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #![allow(deprecated)]
-    /// use libpna::Permission;
-    ///
-    /// let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
-    /// assert_eq!(perm.permissions(), 0o644);
-    /// ```
     #[deprecated(
         since = "0.34.0",
         note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching Metadata::with_* setters)"
@@ -540,6 +466,20 @@ impl Permission {
             permission,
         })
     }
+}
+
+/// Builds an `fPRM` chunk Body: uid, length-prefixed user name, gid,
+/// length-prefixed group name, mode.
+#[cfg(test)]
+pub(crate) fn legacy_fprm_body(uid: u64, uname: &str, gid: u64, gname: &str, mode: u16) -> Vec<u8> {
+    let mut bytes = uid.to_be_bytes().to_vec();
+    bytes.push(uname.len() as u8);
+    bytes.extend_from_slice(uname.as_bytes());
+    bytes.extend_from_slice(&gid.to_be_bytes());
+    bytes.push(gname.len() as u8);
+    bytes.extend_from_slice(gname.as_bytes());
+    bytes.extend_from_slice(&mode.to_be_bytes());
+    bytes
 }
 
 /// Maximum owner-facet string byte length (the `fONm`/`fGNm`/`fOSi`/`fGSi`
@@ -976,8 +916,14 @@ mod tests {
     #[allow(deprecated)]
     #[test]
     fn permission() {
-        let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
-        assert_eq!(perm, Permission::try_from_bytes(&perm.to_bytes()).unwrap());
+        let body = legacy_fprm_body(1000, "user1", 100, "group1", 0o644);
+        let perm = Permission::try_from_bytes(&body).unwrap();
+        assert_eq!(perm.uid(), 1000);
+        assert_eq!(perm.uname(), "user1");
+        assert_eq!(perm.gid(), 100);
+        assert_eq!(perm.gname(), "group1");
+        assert_eq!(perm.permissions(), 0o644);
+        assert_eq!(perm.to_bytes(), body);
     }
 
     #[test]
@@ -1235,14 +1181,10 @@ mod tests {
             let mut b = FileEntryBuilder::new("f".into()).unwrap();
             b.metadata(
                 Metadata::new()
-                    // Legacy fPRM (Permission uses plain String uname/gname on this branch).
-                    .with_permission(Some(Permission::new(
-                        7,
-                        "legacy".to_string(),
-                        8,
-                        "grp".to_string(),
-                        0o600,
-                    )))
+                    .with_permission(Some(
+                        Permission::try_from_bytes(&legacy_fprm_body(7, "legacy", 8, "grp", 0o600))
+                            .unwrap(),
+                    ))
                     // All 7 new owner facets.
                     .with_owner_uid(Some(OwnerUid::from(1)))
                     .with_owner_gid(Some(OwnerGid::from(2)))

--- a/pna/src/ext/entry_builder.rs
+++ b/pna/src/ext/entry_builder.rs
@@ -210,7 +210,42 @@ mod tests {
 
     #[allow(deprecated)]
     use libpna::Permission;
-    use libpna::{Archive, OwnerGroupSid, OwnerUserSid, WriteOptions};
+    use libpna::{Archive, ChunkType, OwnerGroupSid, OwnerUserSid, RawChunk, WriteOptions};
+
+    /// Reads back a `Metadata` carrying the given `fPRM` values.
+    ///
+    /// `fPRM` can no longer be authored through the API, so the chunk is
+    /// written raw and the values come back off the wire.
+    #[allow(deprecated)]
+    fn fprm_metadata(uid: u64, uname: &str, gid: u64, gname: &str, mode: u16) -> Metadata {
+        let mut body = uid.to_be_bytes().to_vec();
+        body.push(uname.len() as u8);
+        body.extend_from_slice(uname.as_bytes());
+        body.extend_from_slice(&gid.to_be_bytes());
+        body.push(gname.len() as u8);
+        body.extend_from_slice(gname.as_bytes());
+        body.extend_from_slice(&mode.to_be_bytes());
+
+        let mut buf = Vec::new();
+        {
+            let mut a = Archive::write_header(&mut buf).unwrap();
+            let mut b = OpaqueEntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
+            b.add_extra_chunk(RawChunk::from_data(ChunkType::fPRM, body));
+            a.add_entry(b.build().unwrap()).unwrap();
+            a.finalize().unwrap();
+        }
+        let mut a = Archive::read_header(&buf[..]).unwrap();
+        let e = a.entries().skip_solid().next().unwrap().unwrap();
+        e.metadata().clone()
+    }
+
+    #[allow(deprecated)]
+    fn fprm(uid: u64, uname: &str, gid: u64, gname: &str, mode: u16) -> Permission {
+        fprm_metadata(uid, uname, gid, gname, mode)
+            .permission()
+            .cloned()
+            .expect("the raw fPRM chunk must decode")
+    }
 
     #[allow(deprecated)]
     fn roundtrip(src: &Metadata) -> Metadata {
@@ -266,13 +301,7 @@ mod tests {
     #[test]
     #[allow(deprecated)]
     fn add_metadata_translates_fprm_only_source() {
-        let src = Metadata::new().with_permission(Some(Permission::new(
-            7,
-            "legacy".to_string(),
-            8,
-            "grp".to_string(),
-            0o600,
-        )));
+        let src = Metadata::new().with_permission(Some(fprm(7, "legacy", 8, "grp", 0o600)));
         let m = roundtrip(&src);
         assert_eq!(m.owner_uid().map(|v| v.get()), Some(7));
         assert_eq!(m.owner_gid().map(|v| v.get()), Some(8));
@@ -288,13 +317,7 @@ mod tests {
         let src = Metadata::new()
             .with_owner_uid(Some(OwnerUid::from(1)))
             .with_owner_user_name(Some(OwnerUserName::new("new").unwrap()))
-            .with_permission(Some(Permission::new(
-                7,
-                "legacy".to_string(),
-                8,
-                "grp".to_string(),
-                0o600,
-            )));
+            .with_permission(Some(fprm(7, "legacy", 8, "grp", 0o600)));
         let m = roundtrip(&src);
         assert_eq!(m.owner_uid().map(|v| v.get()), Some(1));
         assert_eq!(m.owner_user_name().map(|v| v.as_str()), Some("new"));
@@ -306,42 +329,9 @@ mod tests {
 
     #[test]
     #[allow(deprecated)]
-    fn add_metadata_truncates_overlong_fprm_name() {
-        let big_char = 'é';
-        assert_eq!(big_char.len_utf8(), 2);
-        let big = String::from(big_char).repeat(200); // 400 bytes
-        let src = Metadata::new().with_permission(Some(Permission::new(
-            7,
-            big,
-            8,
-            "grp".to_string(),
-            0o600,
-        )));
-        let m = roundtrip(&src);
-        let uname = m.owner_user_name().unwrap().as_str();
-        assert_eq!(uname.len(), 254);
-        assert_eq!(uname.chars().count(), 127);
-        assert!(uname.chars().all(|c| c == big_char));
-        assert_eq!(m.owner_uid().map(|v| v.get()), Some(7));
-    }
-
-    #[test]
-    #[allow(deprecated)]
     fn add_metadata_preserves_explicit_builder_fprm_while_rescuing_metadata_fprm() {
-        let src = Metadata::new().with_permission(Some(Permission::new(
-            7,
-            "legacy".to_string(),
-            8,
-            "grp".to_string(),
-            0o600,
-        )));
-        let explicit = Permission::new(
-            1,
-            "explicit".to_string(),
-            2,
-            "explicit_group".to_string(),
-            0o700,
-        );
+        let src = Metadata::new().with_permission(Some(fprm(7, "legacy", 8, "grp", 0o600)));
+        let explicit = fprm(1, "explicit", 2, "explicit_group", 0o700);
         let m = roundtrip_with_builder_permission(&src, explicit);
         let p = m.permission().expect("explicit builder fPRM must remain");
         assert_eq!(p.uid(), 1);


### PR DESCRIPTION
## Summary

Remove `Permission::new`, the only way to originate `fPRM` data. Every remaining `Permission` value comes off the wire through `Metadata::permission`, so an entry read from an archive still round-trips its `fPRM` chunk — `libpna` just cannot author a new one.

## Notes

Bottom of a three-part stack: #3419 redirects the deprecated setters to the owner facets, #3417 rescues the chunk on read and removes the rest of the API. Part of #3210.

An `fPRM` name longer than the owner-facet bound is no longer constructible — the chunk Body length-prefixes each name with a single byte — so the tests that fed the write-side rescue an over-long name are gone. `owner_name_bounded` stays for now; it disappears with the rescue itself in #3417.

Tests that need an `fPRM`-bearing entry now write the chunk raw and read the values back.
