### PR TITLE
Remove or trim comments that no longer match the code

### DIFF
--- a/cli/src/chunk/acl.rs
+++ b/cli/src/chunk/acl.rs
@@ -720,7 +720,7 @@ bitflags! {
         /// CHANGE_OWNER permission for a file or directory.
         const CHOWN = 0b1000000000000;
 
-        /// SYNCHRONIZE permission (unsupported).
+        /// SYNCHRONIZE permission.
         const SYNC = 0b10000000000000;
 
         /// NFSv4 READ_DATA permission.

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -2074,7 +2074,6 @@ fn transform_normal_entry(
             },
     } = &keep_options.owner_strategy
     {
-        // Only apply if at least one override is specified
         let own = crate::ext::ResolvedOwnership::from_metadata(&metadata);
         if (uid.is_some() || gid.is_some() || uname.is_some() || gname.is_some()) && !own.is_empty()
         {

--- a/cli/src/command/core/path.rs
+++ b/cli/src/command/core/path.rs
@@ -910,7 +910,7 @@ mod tests {
         assert!(had_root);
     }
 
-    // --- B1: strip_absolute_path_bsdtar boundary values ---
+    // --- strip_absolute_path_bsdtar boundary values ---
 
     #[test]
     fn strip_absolute_path_bsdtar_empty_string() {
@@ -1017,7 +1017,7 @@ mod tests {
         assert!(had_root);
     }
 
-    // --- B2: device prefix (\\.\) tests ---
+    // --- device prefix (\\.\) tests ---
 
     #[test]
     fn strip_absolute_path_bsdtar_device_prefix_with_drive() {
@@ -1062,9 +1062,7 @@ mod tests {
         assert!(has_parent_dir_component(path));
     }
 
-    // --- B3+B4: is_unsafe_link equivalent (strip + has_parent_dir combined) ---
-    // is_unsafe_link is: had_root || has_parent_dir_component(rewritten)
-    // We test the same logic directly here.
+    // --- is_unsafe_link equivalent (strip + has_parent_dir combined) ---
 
     #[test]
     fn strip_then_parent_dir_detects_drive_dotdot_backslash() {

--- a/cli/src/command/core/time_filter.rs
+++ b/cli/src/command/core/time_filter.rs
@@ -39,8 +39,6 @@ mod range {
         /// - `newer = None`    becomes `start = Bound::Unbounded`
         /// - `older = Some(t)` becomes `end = Bound::Excluded(t)`
         /// - `older = None`    becomes `end = Bound::Unbounded`
-        ///
-        /// Matches the strict `>`/`<` semantics fixed in commit `befbdb86`.
         pub(crate) fn new_strict(newer: Option<SystemTime>, older: Option<SystemTime>) -> Self {
             Self {
                 start: newer.map_or(Bound::Unbounded, Bound::Excluded),
@@ -190,7 +188,6 @@ mod range {
 
         #[test]
         fn contains_both_included_accepts_both_bounds_and_between() {
-            // Closes the Included..Included coverage gap noted in Task 3 review.
             let r = TimeRange::from_bounds(Bound::Included(t1()), Bound::Included(t3()));
             assert!(r.contains(t1())); // lower bound accepted (inclusive)
             assert!(r.contains(t2())); // strictly inside

--- a/cli/src/utils/globs.rs
+++ b/cli/src/utils/globs.rs
@@ -56,8 +56,7 @@ impl<'s> GlobPatterns<'s> {
 /// Tar-compatible glob matcher that mirrors libarchive/bsdtar semantics.
 ///
 /// Unlike `GlobPatterns`, this uses the project's `BsdGlobPattern` (which is
-/// derived from libarchive's path matching) and also tracks which patterns
-/// matched so we can surface the same "not found in archive" diagnostics.
+/// derived from libarchive's path matching).
 #[derive(Clone, Debug)]
 pub(crate) struct BsdGlobMatcher<'s> {
     patterns: Vec<BsdGlobPattern<'s>>,
@@ -124,8 +123,6 @@ impl<'s> BsdGlobMatcher<'s> {
         matched_any
     }
 
-    /// Returns true if any pattern matches the given path, regardless of
-    /// whether the pattern has already been satisfied.
     #[inline]
     pub(crate) fn matches_any_pattern(&self, path: impl AsRef<str>) -> bool {
         let path = path.as_ref();

--- a/cli/src/utils/mmap.rs
+++ b/cli/src/utils/mmap.rs
@@ -10,7 +10,6 @@ impl Mmap {
     pub(crate) fn map_with_size(file: fs::File, len: usize) -> io::Result<Self> {
         // SAFETY:
         // - The file handle is kept alive for the lifetime of the map via `_file` field
-        // - `len` is obtained from file metadata, so it corresponds to a valid region
         // - The caller must ensure the file is not modified while the map is active;
         //   this is used for reading source files during archive creation where
         //   concurrent modification would cause data corruption regardless of mmap

--- a/lib/src/cipher.rs
+++ b/lib/src/cipher.rs
@@ -18,16 +18,8 @@ use cipher::block_padding::Pkcs7;
 use ctr::{CtrCore, flavors::Ctr128BE};
 use std::io::{self, Read, Write};
 
-/// A type alias for a CTR mode stream cipher reader.
-///
-/// This type represents a reader that decrypts data using CTR mode with a 128-bit block size
-/// and big-endian counter.
 type CtrReader<R, C, F> = stream::StreamCipherReader<R, CtrCore<C, F>>;
 
-/// A type alias for a CTR mode stream cipher writer.
-///
-/// This type represents a writer that encrypts data using CTR mode with a 128-bit block size
-/// and big-endian counter.
 type CtrWriter<W, C, F> = stream::StreamCipherWriter<W, CtrCore<C, F>>;
 
 /// A type alias for a CTR mode stream cipher reader with 128-bit block size and big-endian counter.

--- a/lib/src/cipher/stream/read.rs
+++ b/lib/src/cipher/stream/read.rs
@@ -62,7 +62,6 @@ mod tests {
             51, 87, 18, 30, 187, 90, 41, 70, 139, 216, 97, 70, 117, 150, 206, 61, 165, 155, 222,
             228, 45, 204, 6, 20, 222, 169, 85, 54, 141, 138, 93, 192, 202, 212,
         ];
-        // encrypt in-place
         let mut buf = [0u8; 34];
         let mut cipher = Aes128Ctr64LEReader::new(plaintext.as_slice(), &key, &iv).unwrap();
         cipher.read_exact(&mut buf).unwrap();

--- a/lib/src/cipher/stream/write.rs
+++ b/lib/src/cipher/stream/write.rs
@@ -81,7 +81,6 @@ mod tests {
             51, 87, 18, 30, 187, 90, 41, 70, 139, 216, 97, 70, 117, 150, 206, 61, 165, 155, 222,
             228, 45, 204, 6, 20, 222, 169, 85, 54, 141, 138, 93, 192, 202, 212,
         ];
-        // encrypt in-place
         let mut buf = [0u8; 34];
         let mut cipher = Aes128Ctr64LEWriter::new(buf.as_mut_slice(), &key, &iv).unwrap();
         cipher.write_all(&plaintext).unwrap();

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -435,8 +435,6 @@ impl Iterator for EntryIterator<'_> {
 type BytesCursor = io::Cursor<Vec<u8>>;
 
 /// An iterator that moves out of a solid entry.
-///
-/// This struct is created by the `into_entries` method on [`SolidEntry`].
 pub(crate) struct SolidIntoEntries(
     EntryReader<ChainReader<std::vec::IntoIter<BytesCursor>, BytesCursor>>,
 );


### PR DESCRIPTION
## Summary
An AI-slop comment audit (Opus/Fable cross-review, findings verified against source) surfaced several comments that contradict the current code. This PR fixes the subset where the fix is a pure deletion (or trimming a single incorrect clause) with no information loss:

- `lib/src/cipher.rs`: dropped the `CtrReader`/`CtrWriter` type-alias docs — they claimed a fixed 128-bit block size / big-endian counter, but those aliases are generic over the flavor `F`; the claim only holds for the `Ctr128BE*` specializations, which already document it correctly.
- `lib/src/cipher/stream/{read,write}.rs`: removed `// encrypt in-place` from two tests — the code writes into a separate buffer, not in place (leftover from a copied RustCrypto example).
- `lib/src/entry.rs`: removed a doc line pointing to a nonexistent `into_entries` method (the actual constructor is `into_entries_with_options`).
- `cli/src/chunk/acl.rs`: dropped `(unsupported)` from the `SYNCHRONIZE permission` doc — `Permission::SYNC` is actually mapped on both Unix and Windows.
- `cli/src/command/core.rs`: removed a comment describing only part of the guard condition it sits above.
- `cli/src/utils/mmap.rs`: removed a SAFETY bullet asserting `len` comes from file metadata — it's a caller-supplied argument, so the function can't know that.
- `cli/src/utils/globs.rs`: removed a false differentiator between `BsdGlobMatcher` and `GlobPatterns` (both track matched patterns; the real difference is the matching engine) and a `matches_any_pattern` doc making the same false claim.
- `cli/src/command/core/{path,time_filter}.rs`: dropped internal-only references with no referent in the repo (a review-round label, a commit hash, and internal task IDs in test section banners).

Remaining findings from the audit need a rewrite rather than a deletion (e.g. `bsdtar.rs`'s stdin/stdout mislabeling, `chunk/types.rs`'s Ancillary/Auxiliary terminology mismatch) and are left for a follow-up.

## Verification
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p libpna -p portable-network-archive --all-features`
- `cargo fmt --all -- --check`