### PR TITLE
:boom: Write owner facets from the deprecated permission setters

### DIFF
--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -28,6 +28,7 @@ use crate::{
 use futures_io::AsyncWrite;
 use std::{
     io::{self, prelude::*},
+    mem,
     num::NonZeroU32,
 };
 #[cfg(feature = "unstable-async")]
@@ -441,7 +442,10 @@ impl OpaqueEntryBuilder {
         self
     }
 
-    /// Sets the permission of the entry to the given owner, group, and permissions.
+    /// Sets the permission of the entry, recording it as owner facets.
+    ///
+    /// Like [`Metadata::with_permission`], the values land in the owner facet
+    /// chunks rather than in `fPRM`.
     #[deprecated(
         since = "0.34.0",
         note = "the fPRM chunk is superseded by the owner facet chunks; use `OpaqueEntryBuilder::metadata` with `Metadata::with_owner_uid`/`with_owner_gid`/`with_owner_user_name`/`with_owner_group_name`/`with_permission_mode`"
@@ -449,7 +453,8 @@ impl OpaqueEntryBuilder {
     #[allow(deprecated)]
     #[inline]
     pub fn permission(&mut self, permission: impl Into<Option<Permission>>) -> &mut Self {
-        self.core.metadata.permission = permission.into();
+        let metadata = mem::take(&mut self.core.metadata);
+        self.core.metadata = metadata.with_permission(permission.into());
         self
     }
 
@@ -1005,12 +1010,25 @@ mod tests {
         assert!(out.chars().all(|c| c == two_byte_char));
     }
 
+    /// A `Metadata` carrying only the given `fPRM` values, as reading a
+    /// pre-`0.34.0` archive produces. The deprecated setters record owner
+    /// facets instead, so the field is set directly.
     #[allow(deprecated)]
-    fn legacy_fprm(uid: u64, uname: &str, gid: u64, gname: &str, mode: u16) -> Permission {
-        Permission::try_from_bytes(&crate::entry::meta::legacy_fprm_body(
-            uid, uname, gid, gname, mode,
-        ))
-        .unwrap()
+    fn metadata_with_legacy_fprm(
+        uid: u64,
+        uname: &str,
+        gid: u64,
+        gname: &str,
+        mode: u16,
+    ) -> Metadata {
+        let mut metadata = Metadata::new();
+        metadata.permission = Some(
+            Permission::try_from_bytes(&crate::entry::meta::legacy_fprm_body(
+                uid, uname, gid, gname, mode,
+            ))
+            .unwrap(),
+        );
+        metadata
     }
 
     #[test]
@@ -1042,9 +1060,7 @@ mod tests {
     #[allow(deprecated)]
     fn metadata_rescues_fprm_only_source() {
         let mut b = FileEntryBuilder::new("f".into()).unwrap();
-        b.metadata(
-            Metadata::new().with_permission(Some(legacy_fprm(7, "legacy", 8, "grp", 0o600))),
-        );
+        b.metadata(metadata_with_legacy_fprm(7, "legacy", 8, "grp", 0o600));
         let entry = b.build().unwrap();
         let m = entry.metadata();
         assert_eq!(m.owner_uid().map(|v| v.get()), Some(7));
@@ -1060,10 +1076,9 @@ mod tests {
     fn metadata_partial_owner_facet_skips_rescue() {
         let mut b = FileEntryBuilder::new("f".into()).unwrap();
         b.metadata(
-            Metadata::new()
+            metadata_with_legacy_fprm(7, "legacy", 8, "grp", 0o600)
                 .with_owner_uid(Some(OwnerUid::from(1)))
-                .with_owner_user_name(Some(OwnerUserName::new("new").unwrap()))
-                .with_permission(Some(legacy_fprm(7, "legacy", 8, "grp", 0o600))),
+                .with_owner_user_name(Some(OwnerUserName::new("new").unwrap())),
         );
         let entry = b.build().unwrap();
         let m = entry.metadata();

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -171,7 +171,18 @@ impl Metadata {
         self
     }
 
-    /// Sets the permission of the entry.
+    /// Sets the permission of the entry, recording it as owner facets.
+    ///
+    /// The values land in `fUId`/`fGId`/`fONm`/`fGNm`/`fMOd`, and any `fPRM`
+    /// read from an archive is dropped, so this no longer writes an `fPRM`
+    /// chunk. [`Metadata::permission`] therefore keeps reporting only what an
+    /// archive carried, not what was set here.
+    ///
+    /// # Panics
+    ///
+    /// Panics if an owner name exceeds the 255-byte owner-facet bound. A
+    /// [`Permission`] can only come off the wire, where `fPRM` length-prefixes
+    /// each name with a single byte, so no reachable value can trip this.
     #[deprecated(
         since = "0.34.0",
         note = "the fPRM chunk is superseded by the owner facet chunks; use Metadata::with_owner_uid/with_owner_gid/with_owner_user_name/with_owner_group_name/with_owner_user_sid/with_owner_group_sid/with_permission_mode"
@@ -179,8 +190,16 @@ impl Metadata {
     #[allow(deprecated)]
     #[inline]
     pub fn with_permission(mut self, permission: Option<Permission>) -> Self {
-        self.permission = permission;
-        self
+        self.permission = None;
+        match permission {
+            None => self,
+            Some(p) => self
+                .with_owner_uid(Some(OwnerUid::from(p.uid())))
+                .with_owner_gid(Some(OwnerGid::from(p.gid())))
+                .with_owner_user_name(Some(OwnerUserName::new(p.uname()).expect(NAME_FITS)))
+                .with_owner_group_name(Some(OwnerGroupName::new(p.gname()).expect(NAME_FITS)))
+                .with_permission_mode(Some(PermissionMode::from(p.permissions()))),
+        }
     }
 
     /// Sets the owner user id facet (`fUId`).
@@ -485,6 +504,11 @@ pub(crate) fn legacy_fprm_body(uid: u64, uname: &str, gid: u64, gname: &str, mod
 /// Maximum owner-facet string byte length (the `fONm`/`fGNm`/`fOSi`/`fGSi`
 /// chunk Body uses a 1-byte length prefix).
 const OWNER_STR_MAX: usize = u8::MAX as usize;
+
+/// A [`Permission`] can only come off the wire, where `fPRM` length-prefixes
+/// each name with a single byte — the same bound the owner-facet names carry.
+#[allow(deprecated)]
+const NAME_FITS: &str = "an fPRM name cannot exceed the owner-facet bound";
 
 /// Owner user name (`fONm`).
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
@@ -1174,17 +1198,17 @@ mod tests {
             OwnerGid, OwnerGroupName, OwnerGroupSid, OwnerUid, OwnerUserName, OwnerUserSid,
             PermissionMode,
         };
-        use crate::{Archive, FileEntryBuilder};
+        use crate::{Archive, ChunkType, FileEntryBuilder, RawChunk};
         let mut buf = Vec::new();
         {
             let mut archive = Archive::write_header(&mut buf).unwrap();
             let mut b = FileEntryBuilder::new("f".into()).unwrap();
+            b.add_extra_chunk(RawChunk::from_data(
+                ChunkType::fPRM,
+                legacy_fprm_body(7, "legacy", 8, "grp", 0o600),
+            ));
             b.metadata(
                 Metadata::new()
-                    .with_permission(Some(
-                        Permission::try_from_bytes(&legacy_fprm_body(7, "legacy", 8, "grp", 0o600))
-                            .unwrap(),
-                    ))
                     // All 7 new owner facets.
                     .with_owner_uid(Some(OwnerUid::from(1)))
                     .with_owner_gid(Some(OwnerGid::from(2)))
@@ -1218,6 +1242,50 @@ mod tests {
         assert_eq!(p.gid(), 8);
         assert_eq!(p.gname(), "grp");
         assert_eq!(p.permissions(), 0o600);
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn with_permission_records_owner_facets_instead_of_fprm() {
+        use crate::entry::SealedEntryExt;
+        use crate::{Chunk, ChunkType, FileEntryBuilder};
+        let perm =
+            Permission::try_from_bytes(&legacy_fprm_body(7, "legacy", 8, "grp", 0o600)).unwrap();
+        let m = Metadata::new().with_permission(Some(perm));
+        assert_eq!(m.owner_uid().map(|v| v.get()), Some(7));
+        assert_eq!(m.owner_gid().map(|v| v.get()), Some(8));
+        assert_eq!(m.owner_user_name().map(|v| v.as_str()), Some("legacy"));
+        assert_eq!(m.owner_group_name().map(|v| v.as_str()), Some("grp"));
+        assert_eq!(m.permission_mode().map(|v| v.get()), Some(0o600));
+        assert!(m.permission().is_none());
+
+        let mut b = FileEntryBuilder::new("f".into()).unwrap();
+        b.metadata(m);
+        let chunks = b.build().unwrap().into_chunks();
+        assert!(chunks.iter().all(|c| c.ty() != ChunkType::fPRM));
+        assert!(chunks.iter().any(|c| c.ty() == ChunkType::fONm));
+    }
+
+    #[allow(deprecated)]
+    #[test]
+    fn with_permission_none_drops_an_fprm_read_from_an_archive() {
+        use crate::{Archive, ChunkType, FileEntryBuilder, RawChunk};
+        let mut buf = Vec::new();
+        {
+            let mut archive = Archive::write_header(&mut buf).unwrap();
+            let mut b = FileEntryBuilder::new("f".into()).unwrap();
+            b.add_extra_chunk(RawChunk::from_data(
+                ChunkType::fPRM,
+                legacy_fprm_body(7, "legacy", 8, "grp", 0o600),
+            ));
+            archive.add_entry(b.build().unwrap()).unwrap();
+            archive.finalize().unwrap();
+        }
+        let mut archive = Archive::read_header(&buf[..]).unwrap();
+        let entry = archive.entries().skip_solid().next().unwrap().unwrap();
+        let m = entry.metadata().clone();
+        assert!(m.permission().is_some());
+        assert!(m.with_permission(None).permission().is_none());
     }
 
     #[test]

--- a/pna/src/ext/entry_builder.rs
+++ b/pna/src/ext/entry_builder.rs
@@ -208,8 +208,6 @@ mod tests {
         assert!(out.chars().all(|c| c == two_byte_char));
     }
 
-    #[allow(deprecated)]
-    use libpna::Permission;
     use libpna::{Archive, ChunkType, OwnerGroupSid, OwnerUserSid, RawChunk, WriteOptions};
 
     /// Reads back a `Metadata` carrying the given `fPRM` values.
@@ -240,35 +238,11 @@ mod tests {
     }
 
     #[allow(deprecated)]
-    fn fprm(uid: u64, uname: &str, gid: u64, gname: &str, mode: u16) -> Permission {
-        fprm_metadata(uid, uname, gid, gname, mode)
-            .permission()
-            .cloned()
-            .expect("the raw fPRM chunk must decode")
-    }
-
-    #[allow(deprecated)]
     fn roundtrip(src: &Metadata) -> Metadata {
         let mut buf = Vec::new();
         {
             let mut a = Archive::write_header(&mut buf).unwrap();
             let mut b = OpaqueEntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
-            b.add_metadata(src);
-            a.add_entry(b.build().unwrap()).unwrap();
-            a.finalize().unwrap();
-        }
-        let mut a = Archive::read_header(&buf[..]).unwrap();
-        let e = a.entries().skip_solid().next().unwrap().unwrap();
-        e.metadata().clone()
-    }
-
-    #[allow(deprecated)]
-    fn roundtrip_with_builder_permission(src: &Metadata, permission: Permission) -> Metadata {
-        let mut buf = Vec::new();
-        {
-            let mut a = Archive::write_header(&mut buf).unwrap();
-            let mut b = OpaqueEntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
-            b.permission(permission);
             b.add_metadata(src);
             a.add_entry(b.build().unwrap()).unwrap();
             a.finalize().unwrap();
@@ -301,7 +275,7 @@ mod tests {
     #[test]
     #[allow(deprecated)]
     fn add_metadata_translates_fprm_only_source() {
-        let src = Metadata::new().with_permission(Some(fprm(7, "legacy", 8, "grp", 0o600)));
+        let src = fprm_metadata(7, "legacy", 8, "grp", 0o600);
         let m = roundtrip(&src);
         assert_eq!(m.owner_uid().map(|v| v.get()), Some(7));
         assert_eq!(m.owner_gid().map(|v| v.get()), Some(8));
@@ -314,10 +288,9 @@ mod tests {
     #[test]
     #[allow(deprecated)]
     fn add_metadata_owner_facet_wins_over_fprm() {
-        let src = Metadata::new()
+        let src = fprm_metadata(7, "legacy", 8, "grp", 0o600)
             .with_owner_uid(Some(OwnerUid::from(1)))
-            .with_owner_user_name(Some(OwnerUserName::new("new").unwrap()))
-            .with_permission(Some(fprm(7, "legacy", 8, "grp", 0o600)));
+            .with_owner_user_name(Some(OwnerUserName::new("new").unwrap()));
         let m = roundtrip(&src);
         assert_eq!(m.owner_uid().map(|v| v.get()), Some(1));
         assert_eq!(m.owner_user_name().map(|v| v.as_str()), Some("new"));
@@ -325,25 +298,5 @@ mod tests {
         assert_eq!(m.owner_group_name().map(|v| v.as_str()), Some("grp"));
         assert_eq!(m.permission_mode().map(|v| v.get()), Some(0o600));
         assert!(m.permission().is_none());
-    }
-
-    #[test]
-    #[allow(deprecated)]
-    fn add_metadata_preserves_explicit_builder_fprm_while_rescuing_metadata_fprm() {
-        let src = Metadata::new().with_permission(Some(fprm(7, "legacy", 8, "grp", 0o600)));
-        let explicit = fprm(1, "explicit", 2, "explicit_group", 0o700);
-        let m = roundtrip_with_builder_permission(&src, explicit);
-        let p = m.permission().expect("explicit builder fPRM must remain");
-        assert_eq!(p.uid(), 1);
-        assert_eq!(p.uname(), "explicit");
-        assert_eq!(p.gid(), 2);
-        assert_eq!(p.gname(), "explicit_group");
-        assert_eq!(p.permissions(), 0o700);
-
-        assert_eq!(m.owner_uid().map(|v| v.get()), Some(7));
-        assert_eq!(m.owner_gid().map(|v| v.get()), Some(8));
-        assert_eq!(m.owner_user_name().map(|v| v.as_str()), Some("legacy"));
-        assert_eq!(m.owner_group_name().map(|v| v.as_str()), Some("grp"));
-        assert_eq!(m.permission_mode().map(|v| v.get()), Some(0o600));
     }
 }


### PR DESCRIPTION
## Summary

`Metadata::with_permission` and `OpaqueEntryBuilder::permission` now record their value in the owner facet chunks (`fUId`/`fGId`/`fONm`/`fGNm`/`fMOd`) and drop any `fPRM` read from an archive, so callers still on the deprecated setters stop producing the retired chunk. `None` keeps clearing an `fPRM` the archive carried.

## Notes

Middle of a three-part stack: #3416 stops `fPRM` data from being originated, #3417 rescues the chunk on read and removes the rest of the API. Part of #3210.

`Metadata::permission` is unchanged and still reports only what an archive carried, so it no longer round-trips what the setter was given.

`fPRM` and the owner facets can no longer be made to coexist through the API — reading an archive that carries both is still faithful, and `EntryBuilderCore::metadata` still rescues an `fPRM`-only entry, so the tests for those paths now build their subject from the wire instead of through the setter.

An owner name from `fPRM` always fits the owner-facet bound, since the chunk Body length-prefixes each name with a single byte; the setter documents that as the reason its `expect` is unreachable.

`OpaqueEntryBuilder::permission` is redirected alongside `Metadata::with_permission`: leaving it writing `fPRM` would keep a second public route to the retired chunk.
