### PR TITLE
:boom: Hide Permission::new from the public API

### DIFF
--- a/cli/src/ext.rs
+++ b/cli/src/ext.rs
@@ -202,17 +202,46 @@ impl<S: Display> Display for UserDisplay<S> {
 mod resolved_ownership_tests {
     use super::*;
 
+    /// A `Metadata` carrying only the given `fPRM` values, as reading a
+    /// pre-`0.34.0` archive produces. `Permission` cannot be constructed
+    /// outside `libpna`, so the chunk is written raw and read back.
+    #[allow(deprecated)]
+    fn fprm_metadata(uid: u64, uname: &str, gid: u64, gname: &str, mode: u16) -> pna::Metadata {
+        assert!(
+            uname.len() <= u8::MAX as usize,
+            "fPRM name must fit a 1-byte length"
+        );
+        assert!(
+            gname.len() <= u8::MAX as usize,
+            "fPRM name must fit a 1-byte length"
+        );
+
+        let mut body = Vec::new();
+        body.extend_from_slice(&uid.to_be_bytes());
+        body.push(uname.len() as u8);
+        body.extend_from_slice(uname.as_bytes());
+        body.extend_from_slice(&gid.to_be_bytes());
+        body.push(gname.len() as u8);
+        body.extend_from_slice(gname.as_bytes());
+        body.extend_from_slice(&mode.to_be_bytes());
+
+        let mut buf = Vec::new();
+        {
+            let mut archive = pna::Archive::write_header(&mut buf).unwrap();
+            let mut b =
+                pna::OpaqueEntryBuilder::new_file("f".into(), pna::WriteOptions::store()).unwrap();
+            b.add_extra_chunk(pna::RawChunk::from_data(pna::ChunkType::fPRM, body));
+            archive.add_entry(b.build().unwrap()).unwrap();
+            archive.finalize().unwrap();
+        }
+        let mut archive = pna::Archive::read_header(&buf[..]).unwrap();
+        let entry = archive.entries().skip_solid().next().unwrap().unwrap();
+        entry.metadata().clone()
+    }
+
     #[test]
     fn owner_facet_overwrites_fprm_baseline() {
-        #[allow(deprecated)]
-        let m = pna::Metadata::new()
-            .with_permission(Some(pna::Permission::new(
-                7,
-                "legacy".into(),
-                8,
-                "grp".into(),
-                0o600,
-            )))
+        let m = fprm_metadata(7, "legacy", 8, "grp", 0o600)
             .with_owner_uid(Some(pna::OwnerUid::from(1)))
             .with_owner_user_name(Some(pna::OwnerUserName::new("new").unwrap()))
             .with_owner_user_sid(Some(pna::OwnerUserSid::new("S-1-1").unwrap()));
@@ -234,14 +263,7 @@ mod resolved_ownership_tests {
 
     #[test]
     fn fprm_only_is_rescued() {
-        #[allow(deprecated)]
-        let m = pna::Metadata::new().with_permission(Some(pna::Permission::new(
-            5,
-            "u".into(),
-            6,
-            "g".into(),
-            0o644,
-        )));
+        let m = fprm_metadata(5, "u", 6, "g", 0o644);
         let r = ResolvedOwnership::from_metadata(&m);
         assert_eq!((r.uid, r.gid, r.mode), (Some(5), Some(6), Some(0o644)));
         assert_eq!(r.uname.as_deref(), Some("u"));

--- a/cli/tests/cli/chmod.rs
+++ b/cli/tests/cli/chmod.rs
@@ -14,12 +14,10 @@ mod symbolic_other;
 mod symbolic_user;
 mod unsolid;
 
-use crate::utils::{archive, archive::FileEntryDef, setup};
+use crate::utils::{EmbedExt, TestResources, archive, archive::FileEntryDef, setup};
 use clap::Parser;
-#[allow(deprecated)]
-use pna::Permission;
 use pna::{
-    Archive, DirEntryBuilder, EntryName, FileEntryBuilder, HardLinkEntryBuilder, Metadata,
+    Archive, DirEntryBuilder, EntryName, FileEntryBuilder, HardLinkEntryBuilder,
     SymlinkEntryBuilder,
 };
 use portable_network_archive::cli;
@@ -74,29 +72,16 @@ fn archive_chmod() {
     .unwrap();
 }
 
-/// Precondition: An archive entry carries legacy fPRM metadata.
+/// Precondition: An archive entry carries legacy fPRM metadata (no owner facets).
 /// Action: Run `pna experimental chmod` to change its mode.
-/// Expectation: The updated mode is emitted as fMOd, and stale fPRM is removed.
+/// Expectation: The requested mode bit is cleared, the ownership rescued from fPRM
+/// survives, and the stale fPRM chunk is removed.
 #[test]
 #[allow(deprecated)]
-fn archive_chmod_drops_legacy_fprm() {
+fn chmod_preserves_ownership_of_a_legacy_fprm_archive() {
     setup();
-    let path = "chmod_legacy_fprm.pna";
-    {
-        let mut archive = Archive::write_header(File::create(path).unwrap()).unwrap();
-        let mut builder =
-            FileEntryBuilder::new(EntryName::from_utf8_preserve_root(ENTRY_PATH)).unwrap();
-        builder.metadata(Metadata::new().with_permission(Some(Permission::new(
-            1000,
-            "user".to_string(),
-            1000,
-            "group".to_string(),
-            0o777,
-        ))));
-        builder.write_all(ENTRY_CONTENT).unwrap();
-        archive.add_entry(builder.build().unwrap()).unwrap();
-        archive.finalize().unwrap();
-    }
+    TestResources::extract_in("0.33.0/zstd_keep_all.pna", "chmod_legacy_fprm/").unwrap();
+    let archive = "chmod_legacy_fprm/0.33.0/zstd_keep_all.pna";
 
     cli::Cli::try_parse_from([
         "pna",
@@ -104,22 +89,35 @@ fn archive_chmod_drops_legacy_fprm() {
         "experimental",
         "chmod",
         "-f",
-        path,
-        "644",
-        ENTRY_PATH,
+        archive,
+        "u-w",
+        "**",
     ])
     .unwrap()
     .execute()
     .unwrap();
 
-    archive::for_each_entry(path, |entry| {
+    let mut seen = 0usize;
+    archive::for_each_entry(archive, |entry| {
+        seen += 1;
+        let m = entry.metadata();
         assert!(
-            entry.metadata().permission().is_none(),
+            m.permission().is_none(),
             "legacy fPRM must be removed after chmod"
         );
-        assert_eq!(entry.metadata().permission_mode().unwrap().get(), 0o644);
+        assert_eq!(m.owner_uid().map(|v| v.get()), Some(0));
+        assert_eq!(m.owner_user_name().map(|v| v.as_str()), Some("root"));
+        assert_eq!(m.owner_group_name().map(|v| v.as_str()), Some("root"));
+        let mode = m.permission_mode().expect("mode must survive").get();
+        assert_eq!(
+            mode & 0o200,
+            0,
+            "u-w must be cleared on {}",
+            entry.header().path()
+        );
     })
     .unwrap();
+    assert_eq!(seen, 16, "fixture has 16 entries");
 }
 
 /// Precondition: An archive entry has no permission metadata.

--- a/cli/tests/cli/chown/user_only.rs
+++ b/cli/tests/cli/chown/user_only.rs
@@ -1,11 +1,6 @@
-use crate::utils::{archive, archive::FileEntryDef, setup};
+use crate::utils::{EmbedExt, TestResources, archive, archive::FileEntryDef, setup};
 use clap::Parser;
-#[allow(deprecated)]
-use pna::Permission;
-use pna::{Archive, EntryName, FileEntryBuilder, Metadata};
 use portable_network_archive::cli;
-use std::fs::File;
-use std::io::Write;
 
 /// Precondition: An archive contains entries with permission metadata.
 /// Action: Run `pna experimental chown` with `user` (no colon) to change only the user.
@@ -83,29 +78,16 @@ fn chown_user_only() {
     assert_eq!(count, 2, "archive should contain exactly 2 entries");
 }
 
-/// Precondition: An archive entry carries legacy fPRM metadata.
-/// Action: Run `pna experimental chown` to change the user.
-/// Expectation: Ownership is emitted as owner facets, and stale fPRM is removed.
+/// Precondition: An archive entry carries legacy fPRM metadata (no owner facets).
+/// Action: Run `pna experimental chown` to change uid and gid.
+/// Expectation: The requested uid/gid are set as owner facets, the permission mode
+/// survives, and the stale fPRM chunk is removed.
 #[test]
 #[allow(deprecated)]
-fn chown_user_only_drops_legacy_fprm() {
+fn chown_updates_ownership_of_a_legacy_fprm_archive() {
     setup();
-    let path = "chown_legacy_fprm.pna";
-    {
-        let mut archive = Archive::write_header(File::create(path).unwrap()).unwrap();
-        let mut builder =
-            FileEntryBuilder::new(EntryName::from_utf8_preserve_root("target.txt")).unwrap();
-        builder.metadata(Metadata::new().with_permission(Some(Permission::new(
-            1000,
-            "user".to_string(),
-            1000,
-            "group".to_string(),
-            0o644,
-        ))));
-        builder.write_all(b"target").unwrap();
-        archive.add_entry(builder.build().unwrap()).unwrap();
-        archive.finalize().unwrap();
-    }
+    TestResources::extract_in("0.33.0/zstd_keep_all.pna", "chown_legacy_fprm/").unwrap();
+    let archive = "chown_legacy_fprm/0.33.0/zstd_keep_all.pna";
 
     cli::Cli::try_parse_from([
         "pna",
@@ -113,26 +95,40 @@ fn chown_user_only_drops_legacy_fprm() {
         "experimental",
         "chown",
         "-f",
-        path,
-        "new_user",
-        "target.txt",
+        archive,
+        "1000:1000",
+        "**",
+        "--numeric-owner",
         "--no-owner-lookup",
     ])
     .unwrap()
     .execute()
     .unwrap();
 
-    archive::for_each_entry(path, |entry| {
-        let metadata = entry.metadata();
+    let mut seen = 0usize;
+    archive::for_each_entry(archive, |entry| {
+        seen += 1;
+        let m = entry.metadata();
         assert!(
-            metadata.permission().is_none(),
+            m.permission().is_none(),
             "legacy fPRM must be removed after chown"
         );
-        assert_eq!(metadata.owner_user_name().unwrap().as_str(), "new_user");
-        assert_eq!(metadata.owner_uid().unwrap().get(), u64::MAX);
-        assert_eq!(metadata.owner_group_name().unwrap().as_str(), "group");
-        assert_eq!(metadata.owner_gid().unwrap().get(), 1000);
-        assert_eq!(metadata.permission_mode().unwrap().get(), 0o644);
+        assert_eq!(m.owner_uid().map(|v| v.get()), Some(1000));
+        assert_eq!(m.owner_gid().map(|v| v.get()), Some(1000));
+        assert_eq!(m.owner_user_name().map(|v| v.as_str()), None);
+        assert_eq!(m.owner_group_name().map(|v| v.as_str()), None);
+        let expected_mode = if entry.header().data_kind() == pna::DataKind::DIRECTORY {
+            0o755
+        } else {
+            0o644
+        };
+        assert_eq!(
+            m.permission_mode().map(|v| v.get()),
+            Some(expected_mode),
+            "mode must survive on {}",
+            entry.header().path()
+        );
     })
     .unwrap();
+    assert_eq!(seen, 16, "fixture has 16 entries");
 }

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -340,6 +340,9 @@ impl Default for Metadata {
 }
 
 /// Owner, group, and permission bits for an archive entry.
+///
+/// Values only come from reading an entry that carries an `fPRM` chunk, via
+/// [`Metadata::permission`]. The chunk cannot be authored through this API.
 #[deprecated(
     since = "0.34.0",
     note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching Metadata::with_* setters)"
@@ -355,25 +358,23 @@ pub struct Permission {
 
 #[allow(deprecated)]
 impl Permission {
-    /// Creates a new [`Permission`] with the given user, group, and permission bits.
+    /// Creates a new [`Permission`] from `fPRM` chunk values.
     ///
-    /// The `uid`/`gid` are numeric POSIX IDs, `uname`/`gname` are the
-    /// corresponding names, and `permission` holds the file mode bits (e.g. `0o755`).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #![allow(deprecated)]
-    /// use libpna::Permission;
-    ///
-    /// let perm = Permission::new(1000, "user".into(), 100, "group".into(), 0o755);
-    /// ```
+    /// Test-only: production code obtains a [`Permission`] solely by reading an
+    /// entry that carries an `fPRM` chunk, so no code path can author one.
+    #[cfg(test)]
     #[deprecated(
         since = "0.34.0",
         note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching Metadata::with_* setters)"
     )]
     #[inline]
-    pub const fn new(uid: u64, uname: String, gid: u64, gname: String, permission: u16) -> Self {
+    pub(crate) const fn new(
+        uid: u64,
+        uname: String,
+        gid: u64,
+        gname: String,
+        permission: u16,
+    ) -> Self {
         Self {
             uid,
             uname,
@@ -383,16 +384,6 @@ impl Permission {
         }
     }
     /// Returns the user ID associated with this permission.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #![allow(deprecated)]
-    /// use libpna::Permission;
-    ///
-    /// let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
-    /// assert_eq!(perm.uid(), 1000);
-    /// ```
     #[deprecated(
         since = "0.34.0",
         note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching Metadata::with_* setters)"
@@ -403,16 +394,6 @@ impl Permission {
     }
 
     /// Returns the user name associated with this permission.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #![allow(deprecated)]
-    /// use libpna::Permission;
-    ///
-    /// let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
-    /// assert_eq!(perm.uname(), "user1");
-    /// ```
     #[deprecated(
         since = "0.34.0",
         note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching Metadata::with_* setters)"
@@ -423,16 +404,6 @@ impl Permission {
     }
 
     /// Returns the group ID associated with this permission.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #![allow(deprecated)]
-    /// use libpna::Permission;
-    ///
-    /// let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
-    /// assert_eq!(perm.gid(), 100);
-    /// ```
     #[deprecated(
         since = "0.34.0",
         note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching Metadata::with_* setters)"
@@ -443,16 +414,6 @@ impl Permission {
     }
 
     /// Returns the group name associated with this permission.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #![allow(deprecated)]
-    /// use libpna::Permission;
-    ///
-    /// let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
-    /// assert_eq!(perm.gname(), "group1");
-    /// ```
     #[deprecated(
         since = "0.34.0",
         note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching Metadata::with_* setters)"
@@ -463,16 +424,6 @@ impl Permission {
     }
 
     /// Returns the permission bits associated with this permission.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # #![allow(deprecated)]
-    /// use libpna::Permission;
-    ///
-    /// let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
-    /// assert_eq!(perm.permissions(), 0o644);
-    /// ```
     #[deprecated(
         since = "0.34.0",
         note = "the fPRM chunk is superseded by the owner facet chunks; use the owner facet API (Metadata::owner_uid/owner_gid/owner_user_name/owner_group_name/owner_user_sid/owner_group_sid/permission_mode and the matching Metadata::with_* setters)"

--- a/pna/src/ext/entry_builder.rs
+++ b/pna/src/ext/entry_builder.rs
@@ -210,7 +210,7 @@ mod tests {
 
     #[allow(deprecated)]
     use libpna::Permission;
-    use libpna::{Archive, OwnerGroupSid, OwnerUserSid, WriteOptions};
+    use libpna::{Archive, ChunkType, OwnerGroupSid, OwnerUserSid, RawChunk, WriteOptions};
 
     #[allow(deprecated)]
     fn roundtrip(src: &Metadata) -> Metadata {
@@ -243,6 +243,42 @@ mod tests {
         e.metadata().clone()
     }
 
+    /// A `Metadata` carrying only the given `fPRM` values, as reading a
+    /// pre-`0.34.0` archive produces. `Permission` cannot be constructed
+    /// outside `libpna`, so the chunk is written raw and read back.
+    #[allow(deprecated)]
+    fn fprm_metadata(uid: u64, uname: &str, gid: u64, gname: &str, mode: u16) -> Metadata {
+        assert!(
+            uname.len() <= u8::MAX as usize,
+            "fPRM name must fit a 1-byte length"
+        );
+        assert!(
+            gname.len() <= u8::MAX as usize,
+            "fPRM name must fit a 1-byte length"
+        );
+
+        let mut body = Vec::new();
+        body.extend_from_slice(&uid.to_be_bytes());
+        body.push(uname.len() as u8);
+        body.extend_from_slice(uname.as_bytes());
+        body.extend_from_slice(&gid.to_be_bytes());
+        body.push(gname.len() as u8);
+        body.extend_from_slice(gname.as_bytes());
+        body.extend_from_slice(&mode.to_be_bytes());
+
+        let mut buf = Vec::new();
+        {
+            let mut archive = Archive::write_header(&mut buf).unwrap();
+            let mut b = OpaqueEntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
+            b.add_extra_chunk(RawChunk::from_data(ChunkType::fPRM, body));
+            archive.add_entry(b.build().unwrap()).unwrap();
+            archive.finalize().unwrap();
+        }
+        let mut archive = Archive::read_header(&buf[..]).unwrap();
+        let entry = archive.entries().skip_solid().next().unwrap().unwrap();
+        entry.metadata().clone()
+    }
+
     #[test]
     fn add_metadata_preserves_all_owner_facets() {
         let src = Metadata::new()
@@ -266,13 +302,7 @@ mod tests {
     #[test]
     #[allow(deprecated)]
     fn add_metadata_translates_fprm_only_source() {
-        let src = Metadata::new().with_permission(Some(Permission::new(
-            7,
-            "legacy".to_string(),
-            8,
-            "grp".to_string(),
-            0o600,
-        )));
+        let src = fprm_metadata(7, "legacy", 8, "grp", 0o600);
         let m = roundtrip(&src);
         assert_eq!(m.owner_uid().map(|v| v.get()), Some(7));
         assert_eq!(m.owner_gid().map(|v| v.get()), Some(8));
@@ -285,16 +315,9 @@ mod tests {
     #[test]
     #[allow(deprecated)]
     fn add_metadata_owner_facet_wins_over_fprm() {
-        let src = Metadata::new()
+        let src = fprm_metadata(7, "legacy", 8, "grp", 0o600)
             .with_owner_uid(Some(OwnerUid::from(1)))
-            .with_owner_user_name(Some(OwnerUserName::new("new").unwrap()))
-            .with_permission(Some(Permission::new(
-                7,
-                "legacy".to_string(),
-                8,
-                "grp".to_string(),
-                0o600,
-            )));
+            .with_owner_user_name(Some(OwnerUserName::new("new").unwrap()));
         let m = roundtrip(&src);
         assert_eq!(m.owner_uid().map(|v| v.get()), Some(1));
         assert_eq!(m.owner_user_name().map(|v| v.as_str()), Some("new"));
@@ -306,42 +329,12 @@ mod tests {
 
     #[test]
     #[allow(deprecated)]
-    fn add_metadata_truncates_overlong_fprm_name() {
-        let big_char = 'é';
-        assert_eq!(big_char.len_utf8(), 2);
-        let big = String::from(big_char).repeat(200); // 400 bytes
-        let src = Metadata::new().with_permission(Some(Permission::new(
-            7,
-            big,
-            8,
-            "grp".to_string(),
-            0o600,
-        )));
-        let m = roundtrip(&src);
-        let uname = m.owner_user_name().unwrap().as_str();
-        assert_eq!(uname.len(), 254);
-        assert_eq!(uname.chars().count(), 127);
-        assert!(uname.chars().all(|c| c == big_char));
-        assert_eq!(m.owner_uid().map(|v| v.get()), Some(7));
-    }
-
-    #[test]
-    #[allow(deprecated)]
     fn add_metadata_preserves_explicit_builder_fprm_while_rescuing_metadata_fprm() {
-        let src = Metadata::new().with_permission(Some(Permission::new(
-            7,
-            "legacy".to_string(),
-            8,
-            "grp".to_string(),
-            0o600,
-        )));
-        let explicit = Permission::new(
-            1,
-            "explicit".to_string(),
-            2,
-            "explicit_group".to_string(),
-            0o700,
-        );
+        let src = fprm_metadata(7, "legacy", 8, "grp", 0o600);
+        let explicit = fprm_metadata(1, "explicit", 2, "explicit_group", 0o700)
+            .permission()
+            .cloned()
+            .expect("the raw fPRM chunk must decode");
         let m = roundtrip_with_builder_permission(&src, explicit);
         let p = m.permission().expect("explicit builder fPRM must remain");
         assert_eq!(p.uid(), 1);


### PR DESCRIPTION
## Summary

Make `Permission::new` test-only. A `Permission` now comes solely from reading an entry that carries an `fPRM` chunk, so the chunk's values can no longer be authored through the API.

## Notes

First of a six-part stack retiring the `fPRM` permission API. Part of #3210.

`Permission` values being wire-only is what lets the later parts map them onto the owner facets infallibly: `fPRM` length-prefixes each name with a single byte, the same bound `fONm`/`fGNm` carry. That also makes the truncating rescue paths unreachable, so the test that fed one an over-long name is gone rather than converted — no reachable input can enter that branch.

Tests outside `libpna` cannot construct a `Permission` any more, so they build their subject from a raw `fPRM` chunk or from `resources/test/0.33.0/zstd_keep_all.pna`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of legacy permission metadata during archive operations.
  * `chmod` now removes legacy permission metadata while preserving ownership and correctly updating write permissions.
  * `chown` now updates numeric ownership across all archive entries while preserving permission modes.
* **Documentation**
  * Clarified that legacy permission metadata is read-only and cannot be created through the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->