### PR TITLE
:recycle: Write the legacy fPRM values as owner facets

### DIFF
--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -750,9 +750,21 @@ mod tests {
             original_entry.metadata().accessed(),
             read_entry.metadata().accessed()
         );
+        // The legacy fPRM chunk is no longer written; its values are read back
+        // as the owner facets that superseded it.
+        assert_eq!(read_entry.metadata().owner_uid().map(|v| v.get()), Some(1));
         assert_eq!(
-            original_entry.metadata().permission(),
-            read_entry.metadata().permission()
+            read_entry.metadata().owner_user_name().map(|v| v.as_str()),
+            Some("uname")
+        );
+        assert_eq!(read_entry.metadata().owner_gid().map(|v| v.get()), Some(2));
+        assert_eq!(
+            read_entry.metadata().owner_group_name().map(|v| v.as_str()),
+            Some("gname")
+        );
+        assert_eq!(
+            read_entry.metadata().permission_mode().map(|v| v.get()),
+            Some(0o775)
         );
         assert_eq!(
             original_entry.metadata().compressed_size(),

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -120,7 +120,6 @@ impl<W: WriteChunk> EntryChunkSink for EntryChunkWriter<'_, W> {
     }
 }
 
-#[allow(deprecated)]
 fn try_for_each_metadata_facet<E>(
     metadata: &Metadata,
     mut f: impl FnMut(ChunkType, Cow<[u8]>) -> Result<(), E>,
@@ -146,19 +145,28 @@ fn try_for_each_metadata_facet<E>(
             f(ChunkType::aTNS, Cow::Borrowed(&nanos.to_be_bytes()))?;
         }
     }
-    if let Some(value) = &metadata.permission {
-        f(ChunkType::fPRM, Cow::Owned(value.to_bytes()))?;
-    }
-    if let Some(value) = metadata.owner_uid {
+    // A legacy `fPRM` chunk is written back as the owner facets that
+    // superseded it, facet by facet; libpna never emits `fPRM`.
+    let legacy = metadata.legacy_owner_facets();
+    let legacy = legacy.as_ref();
+    if let Some(value) = metadata.owner_uid.or(legacy.map(|l| l.uid)) {
         f(ChunkType::fUId, Cow::Borrowed(&value.to_bytes()))?;
     }
-    if let Some(value) = metadata.owner_gid {
+    if let Some(value) = metadata.owner_gid.or(legacy.map(|l| l.gid)) {
         f(ChunkType::fGId, Cow::Borrowed(&value.to_bytes()))?;
     }
-    if let Some(value) = &metadata.owner_user_name {
+    if let Some(value) = metadata
+        .owner_user_name
+        .as_ref()
+        .or(legacy.map(|l| &l.user_name))
+    {
         f(ChunkType::fONm, Cow::Owned(value.to_bytes()))?;
     }
-    if let Some(value) = &metadata.owner_group_name {
+    if let Some(value) = metadata
+        .owner_group_name
+        .as_ref()
+        .or(legacy.map(|l| &l.group_name))
+    {
         f(ChunkType::fGNm, Cow::Owned(value.to_bytes()))?;
     }
     if let Some(value) = &metadata.owner_user_sid {
@@ -167,7 +175,7 @@ fn try_for_each_metadata_facet<E>(
     if let Some(value) = &metadata.owner_group_sid {
         f(ChunkType::fGSi, Cow::Owned(value.to_bytes()))?;
     }
-    if let Some(value) = metadata.permission_mode {
+    if let Some(value) = metadata.permission_mode.or(legacy.map(|l| l.mode)) {
         f(ChunkType::fMOd, Cow::Borrowed(&value.to_bytes()))?;
     }
     if let Some(value) = metadata.link_target_type {
@@ -892,7 +900,6 @@ where
     RawChunk<T>: Chunk + Into<RawChunk>,
     (ChunkType, T): Chunk + Into<RawChunk>,
 {
-    #[allow(deprecated)]
     #[inline]
     fn write_chunks_to<S: EntryChunkSink>(self, sink: &mut S) -> Result<(), S::Error> {
         sink.write_chunk((ChunkType::FHED, self.header.to_bytes()))?;
@@ -1363,6 +1370,238 @@ mod tests {
             u128_from_be_bytes_last(&u32::MAX.to_be_bytes())
         );
         assert_eq!(u128::MAX, u128_from_be_bytes_last(&u128::MAX.to_be_bytes()));
+    }
+
+    /// A `Metadata` read back from an entry whose `fPRM` chunk was written raw,
+    /// optionally carrying the owner facets `facets` sets.
+    #[allow(deprecated)]
+    fn read_back_with_legacy_fprm(
+        uid: u64,
+        uname: &str,
+        gid: u64,
+        gname: &str,
+        mode: u16,
+        facets: impl FnOnce(Metadata) -> Metadata,
+    ) -> Metadata {
+        assert!(
+            uname.len() <= u8::MAX as usize,
+            "fPRM name must fit a 1-byte length"
+        );
+        assert!(
+            gname.len() <= u8::MAX as usize,
+            "fPRM name must fit a 1-byte length"
+        );
+
+        let mut body = Vec::new();
+        body.extend_from_slice(&uid.to_be_bytes());
+        body.push(uname.len() as u8);
+        body.extend_from_slice(uname.as_bytes());
+        body.extend_from_slice(&gid.to_be_bytes());
+        body.push(gname.len() as u8);
+        body.extend_from_slice(gname.as_bytes());
+        body.extend_from_slice(&mode.to_be_bytes());
+
+        let mut buf = Vec::new();
+        {
+            let mut archive = crate::Archive::write_header(&mut buf).unwrap();
+            let mut b = FileEntryBuilder::new("f".into()).unwrap();
+            b.add_extra_chunk(RawChunk::from_data(ChunkType::fPRM, body));
+            b.metadata(facets(Metadata::new()));
+            archive.add_entry(b.build().unwrap()).unwrap();
+            archive.finalize().unwrap();
+        }
+        let mut archive = crate::Archive::read_header(&buf[..]).unwrap();
+        archive
+            .entries()
+            .skip_solid()
+            .next()
+            .unwrap()
+            .unwrap()
+            .metadata()
+            .clone()
+    }
+
+    fn emitted_facets(metadata: &Metadata) -> Vec<(ChunkType, Vec<u8>)> {
+        let mut out = Vec::new();
+        try_for_each_metadata_facet(metadata, |ty, data| {
+            out.push((ty, data.into_owned()));
+            Ok::<(), std::convert::Infallible>(())
+        })
+        .unwrap();
+        out
+    }
+
+    fn find(emitted: &[(ChunkType, Vec<u8>)], ty: ChunkType) -> Option<Vec<u8>> {
+        emitted
+            .iter()
+            .find(|(t, _)| *t == ty)
+            .map(|(_, d)| d.clone())
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn legacy_fprm_is_written_as_owner_facets() {
+        let m = read_back_with_legacy_fprm(7, "legacy", 8, "grp", 0o600, |m| m);
+        let emitted = emitted_facets(&m);
+        let types: Vec<ChunkType> = emitted.iter().map(|(ty, _)| *ty).collect();
+
+        assert!(
+            !types.contains(&ChunkType::fPRM),
+            "fPRM must not be written"
+        );
+        assert_eq!(
+            find(&emitted, ChunkType::fUId),
+            Some(7u64.to_be_bytes().to_vec())
+        );
+        assert_eq!(
+            find(&emitted, ChunkType::fGId),
+            Some(8u64.to_be_bytes().to_vec())
+        );
+        assert_eq!(
+            find(&emitted, ChunkType::fONm),
+            Some(b"\x06legacy".to_vec())
+        );
+        assert_eq!(find(&emitted, ChunkType::fGNm), Some(b"\x03grp".to_vec()));
+        assert_eq!(
+            find(&emitted, ChunkType::fMOd),
+            Some(0o600u16.to_be_bytes().to_vec())
+        );
+    }
+
+    #[test]
+    fn owner_facets_win_over_legacy_fprm_facet_by_facet() {
+        let m = read_back_with_legacy_fprm(7, "legacy", 8, "grp", 0o600, |m| {
+            m.with_owner_uid(Some(OwnerUid::from(1)))
+                .with_owner_user_name(Some(OwnerUserName::new("new").unwrap()))
+        });
+        let emitted = emitted_facets(&m);
+
+        assert_eq!(
+            find(&emitted, ChunkType::fUId),
+            Some(1u64.to_be_bytes().to_vec()),
+            "the facet the entry carries wins"
+        );
+        assert_eq!(find(&emitted, ChunkType::fONm), Some(b"\x03new".to_vec()));
+        assert_eq!(
+            find(&emitted, ChunkType::fGId),
+            Some(8u64.to_be_bytes().to_vec()),
+            "the facets it does not carry still come from fPRM"
+        );
+        assert_eq!(find(&emitted, ChunkType::fGNm), Some(b"\x03grp".to_vec()));
+        assert_eq!(
+            find(&emitted, ChunkType::fMOd),
+            Some(0o600u16.to_be_bytes().to_vec())
+        );
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn all_owner_facets_win_over_legacy_fprm_including_sids() {
+        let user_sid = "S-1-5-21-1-2-3-1001";
+        let group_sid = "S-1-5-32-544";
+        let m = read_back_with_legacy_fprm(7, "legacy", 8, "grp", 0o600, |m| {
+            m.with_owner_uid(Some(OwnerUid::from(100)))
+                .with_owner_gid(Some(OwnerGid::from(200)))
+                .with_owner_user_name(Some(OwnerUserName::new("owner").unwrap()))
+                .with_owner_group_name(Some(OwnerGroupName::new("group").unwrap()))
+                .with_owner_user_sid(Some(OwnerUserSid::new(user_sid).unwrap()))
+                .with_owner_group_sid(Some(OwnerGroupSid::new(group_sid).unwrap()))
+                .with_permission_mode(Some(PermissionMode::from(0o755)))
+        });
+        let emitted = emitted_facets(&m);
+        let types: Vec<ChunkType> = emitted.iter().map(|(ty, _)| *ty).collect();
+
+        assert!(
+            !types.contains(&ChunkType::fPRM),
+            "fPRM must not be written"
+        );
+        assert_eq!(
+            find(&emitted, ChunkType::fUId),
+            Some(100u64.to_be_bytes().to_vec()),
+            "uid must come from the entry's own facet, not fPRM's 7"
+        );
+        assert_eq!(
+            find(&emitted, ChunkType::fGId),
+            Some(200u64.to_be_bytes().to_vec()),
+            "gid must come from the entry's own facet, not fPRM's 8"
+        );
+        assert_eq!(
+            find(&emitted, ChunkType::fONm),
+            Some(b"\x05owner".to_vec()),
+            "user name must come from the entry's own facet, not fPRM's \"legacy\""
+        );
+        assert_eq!(
+            find(&emitted, ChunkType::fGNm),
+            Some(b"\x05group".to_vec()),
+            "group name must come from the entry's own facet, not fPRM's \"grp\""
+        );
+        let mut expected_user_sid = vec![user_sid.len() as u8];
+        expected_user_sid.extend_from_slice(user_sid.as_bytes());
+        assert_eq!(
+            find(&emitted, ChunkType::fOSi),
+            Some(expected_user_sid),
+            "fOSi has no legacy source and must still be emitted as set"
+        );
+        let mut expected_group_sid = vec![group_sid.len() as u8];
+        expected_group_sid.extend_from_slice(group_sid.as_bytes());
+        assert_eq!(
+            find(&emitted, ChunkType::fGSi),
+            Some(expected_group_sid),
+            "fGSi has no legacy source and must still be emitted as set"
+        );
+        assert_eq!(
+            find(&emitted, ChunkType::fMOd),
+            Some(0o755u16.to_be_bytes().to_vec()),
+            "mode must come from the entry's own facet, not fPRM's 0o600"
+        );
+    }
+
+    #[test]
+    fn legacy_fprm_mode_is_masked_to_permission_bits() {
+        // 0.33.0 stored st_mode: S_IFREG | 0o644.
+        let m = read_back_with_legacy_fprm(0, "root", 0, "root", 0o100644, |m| m);
+        assert_eq!(
+            find(&emitted_facets(&m), ChunkType::fMOd),
+            Some(0o644u16.to_be_bytes().to_vec())
+        );
+    }
+
+    #[test]
+    fn legacy_archive_round_trips_as_owner_facets() {
+        let src = include_bytes!("../../resources/test/0.33.0/zstd_keep_all.pna");
+        let mut archive = crate::Archive::read_header(&src[..]).unwrap();
+        let entries: Vec<_> = archive.entries().skip_solid().map(|e| e.unwrap()).collect();
+        assert_eq!(entries.len(), 16);
+
+        let mut out = Vec::new();
+        {
+            let mut w = crate::Archive::write_header(&mut out).unwrap();
+            for entry in entries {
+                w.add_entry(entry).unwrap();
+            }
+            w.finalize().unwrap();
+        }
+
+        let mut archive = crate::Archive::read_header(&out[..]).unwrap();
+        let mut count = 0;
+        for entry in archive.entries().skip_solid() {
+            let entry = entry.unwrap();
+            let m = entry.metadata();
+            assert_eq!(m.owner_user_name().map(|v| v.as_str()), Some("root"));
+            assert_eq!(m.owner_uid().map(|v| v.get()), Some(0));
+            let expected_mode = match entry.header().data_kind() {
+                DataKind::DIRECTORY => 0o755,
+                DataKind::FILE => 0o644,
+                other => panic!("unexpected data kind in fixture: {other:?}"),
+            };
+            assert_eq!(m.permission_mode().map(|v| v.get()), Some(expected_mode));
+            count += 1;
+        }
+        assert_eq!(count, 16);
+        assert!(
+            !out.windows(4).any(|w| w == b"fPRM"),
+            "the rewritten archive must carry no fPRM chunk"
+        );
     }
 
     static TEST_ENTRY: LazyLock<RawEntry> = LazyLock::new(|| {

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -68,21 +68,6 @@ pub(super) fn prepend_data_prefix(
     data.splice(0..0, prefix.chunks(max_chunk_size).map(<[u8]>::to_vec));
 }
 
-/// Largest UTF-8 char-boundary prefix of `s` whose byte length is ≤ 255 —
-/// the `fONm`/`fGNm` owner-name wire bound (1-byte length prefix). Used to
-/// rescue a legacy fPRM name that exceeds the bounded owner-facet limit.
-fn owner_name_bounded(s: &str) -> &str {
-    const MAX: usize = u8::MAX as usize;
-    if s.len() <= MAX {
-        return s;
-    }
-    let mut end = MAX;
-    while !s.is_char_boundary(end) {
-        end -= 1;
-    }
-    &s[..end]
-}
-
 /// Fields and logic shared by the kind-specific entry builders.
 pub(crate) struct EntryBuilderCore {
     header: EntryHeader,
@@ -118,50 +103,9 @@ impl EntryBuilderCore {
         &self.header
     }
 
-    /// Sets the metadata, rescuing deprecated `fPRM` permission data into
-    /// the owner-facet fields when no owner facet is set.
-    ///
-    /// If none of the owner-facet fields are populated, they are filled
-    /// from the `fPRM` data when present, and the `fPRM` data itself is
-    /// dropped from the stored metadata. Owner names longer than the
-    /// 255-byte wire bound of `fONm`/`fGNm` are truncated at a UTF-8
-    /// character boundary. If any owner-facet field is already populated,
-    /// the metadata is stored as-is (including `fPRM`, if set), preserving
-    /// the contract that `fPRM` and the owner facets are independent
-    /// chunks that may coexist.
-    ///
-    /// TODO: rescue unconditionally (dropping `fPRM` whenever it is
-    /// present, regardless of owner-facet fields) once the fPRM/owner-facet
-    /// coexistence contract is retired.
-    #[allow(deprecated)]
+    /// Sets the metadata.
     pub(crate) fn metadata(&mut self, metadata: Metadata) {
-        let has_owner_facet = metadata.owner_uid().is_some()
-            || metadata.owner_gid().is_some()
-            || metadata.owner_user_name().is_some()
-            || metadata.owner_group_name().is_some()
-            || metadata.owner_user_sid().is_some()
-            || metadata.owner_group_sid().is_some()
-            || metadata.permission_mode().is_some();
-        let Some(p) = (!has_owner_facet)
-            .then(|| metadata.permission().cloned())
-            .flatten()
-        else {
-            self.metadata = metadata;
-            return;
-        };
-        self.metadata = metadata
-            .with_owner_uid(Some(OwnerUid::from(p.uid())))
-            .with_owner_gid(Some(OwnerGid::from(p.gid())))
-            .with_owner_user_name(Some(
-                OwnerUserName::new(owner_name_bounded(p.uname()))
-                    .expect("owner_name_bounded guarantees <= 255 bytes"),
-            ))
-            .with_owner_group_name(Some(
-                OwnerGroupName::new(owner_name_bounded(p.gname()))
-                    .expect("owner_name_bounded guarantees <= 255 bytes"),
-            ))
-            .with_permission_mode(Some(PermissionMode::from(p.permissions())))
-            .with_permission(None);
+        self.metadata = metadata;
     }
 
     pub(crate) fn add_extra_chunk(&mut self, chunk: impl Into<RawChunk>) {
@@ -978,34 +922,6 @@ mod tests {
     }
 
     #[test]
-    fn owner_name_bounded_passes_through_short_ascii() {
-        assert_eq!(owner_name_bounded(""), "");
-        assert_eq!(owner_name_bounded("alice"), "alice");
-        let exactly_255 = "a".repeat(255);
-        assert_eq!(owner_name_bounded(&exactly_255), exactly_255);
-    }
-
-    #[test]
-    fn owner_name_bounded_truncates_long_ascii_to_255() {
-        let s = "a".repeat(300);
-        let out = owner_name_bounded(&s);
-        assert_eq!(out.len(), 255);
-        assert!(out.bytes().all(|b| b == b'a'));
-        assert_eq!(owner_name_bounded(&"a".repeat(256)).len(), 255);
-    }
-
-    #[test]
-    fn owner_name_bounded_truncates_on_utf8_boundary() {
-        let two_byte_char = 'é';
-        assert_eq!(two_byte_char.len_utf8(), 2);
-        let s = String::from(two_byte_char).repeat(200); // 400 bytes
-        let out = owner_name_bounded(&s);
-        assert_eq!(out.len(), 254);
-        assert_eq!(out.chars().count(), 127);
-        assert!(out.chars().all(|c| c == two_byte_char));
-    }
-
-    #[test]
     #[allow(deprecated)]
     fn metadata_preserves_all_owner_facets() {
         let mut b = FileEntryBuilder::new("f".into()).unwrap();
@@ -1028,79 +944,6 @@ mod tests {
         assert_eq!(m.owner_user_sid().map(|v| v.as_str()), Some("S-1-1"));
         assert_eq!(m.owner_group_sid().map(|v| v.as_str()), Some("S-1-2"));
         assert_eq!(m.permission_mode().map(|v| v.get()), Some(0o644));
-    }
-
-    #[test]
-    #[allow(deprecated)]
-    fn metadata_rescues_fprm_only_source() {
-        let mut b = FileEntryBuilder::new("f".into()).unwrap();
-        b.metadata(Metadata::new().with_permission(Some(Permission::new(
-            7,
-            "legacy".to_string(),
-            8,
-            "grp".to_string(),
-            0o600,
-        ))));
-        let entry = b.build().unwrap();
-        let m = entry.metadata();
-        assert_eq!(m.owner_uid().map(|v| v.get()), Some(7));
-        assert_eq!(m.owner_gid().map(|v| v.get()), Some(8));
-        assert_eq!(m.owner_user_name().map(|v| v.as_str()), Some("legacy"));
-        assert_eq!(m.owner_group_name().map(|v| v.as_str()), Some("grp"));
-        assert_eq!(m.permission_mode().map(|v| v.get()), Some(0o600));
-        assert!(m.permission().is_none());
-    }
-
-    #[test]
-    #[allow(deprecated)]
-    fn metadata_partial_owner_facet_skips_rescue() {
-        let mut b = FileEntryBuilder::new("f".into()).unwrap();
-        b.metadata(
-            Metadata::new()
-                .with_owner_uid(Some(OwnerUid::from(1)))
-                .with_owner_user_name(Some(OwnerUserName::new("new").unwrap()))
-                .with_permission(Some(Permission::new(
-                    7,
-                    "legacy".to_string(),
-                    8,
-                    "grp".to_string(),
-                    0o600,
-                ))),
-        );
-        let entry = b.build().unwrap();
-        let m = entry.metadata();
-        assert_eq!(m.owner_uid().map(|v| v.get()), Some(1));
-        assert_eq!(m.owner_user_name().map(|v| v.as_str()), Some("new"));
-        assert_eq!(m.owner_gid(), None);
-        assert_eq!(m.owner_group_name(), None);
-        assert_eq!(m.permission_mode(), None);
-        assert!(
-            m.permission().is_some(),
-            "fPRM must coexist with a partially set owner facet"
-        );
-    }
-
-    #[test]
-    #[allow(deprecated)]
-    fn metadata_truncates_overlong_fprm_name() {
-        let big_char = 'é';
-        assert_eq!(big_char.len_utf8(), 2);
-        let big = String::from(big_char).repeat(200); // 400 bytes
-        let mut b = FileEntryBuilder::new("f".into()).unwrap();
-        b.metadata(Metadata::new().with_permission(Some(Permission::new(
-            7,
-            big,
-            8,
-            "grp".to_string(),
-            0o600,
-        ))));
-        let entry = b.build().unwrap();
-        let m = entry.metadata();
-        let uname = m.owner_user_name().unwrap().as_str();
-        assert_eq!(uname.len(), 254);
-        assert_eq!(uname.chars().count(), 127);
-        assert!(uname.chars().all(|c| c == big_char));
-        assert_eq!(m.owner_uid().map(|v| v.get()), Some(7));
     }
 
     #[allow(deprecated)]

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -330,6 +330,24 @@ impl Metadata {
     pub fn xattrs(&self) -> &[ExtendedAttribute] {
         &self.xattrs
     }
+
+    /// Owner facet values carried by this entry's legacy `fPRM` chunk, if any.
+    ///
+    /// The name conversions cannot fail: a [`Permission`] only comes off the
+    /// wire, where `fPRM` length-prefixes each name with a single byte — the
+    /// same bound `fONm`/`fGNm` carry.
+    #[allow(deprecated)]
+    pub(crate) fn legacy_owner_facets(&self) -> Option<LegacyOwnerFacets> {
+        const NAME_FITS: &str = "an fPRM name cannot exceed the owner-facet bound";
+        let p = self.permission.as_ref()?;
+        Some(LegacyOwnerFacets {
+            uid: OwnerUid::from(p.uid()),
+            gid: OwnerGid::from(p.gid()),
+            user_name: OwnerUserName::new(p.uname()).expect(NAME_FITS),
+            group_name: OwnerGroupName::new(p.gname()).expect(NAME_FITS),
+            mode: PermissionMode::from(p.permissions()),
+        })
+    }
 }
 
 impl Default for Metadata {
@@ -433,6 +451,11 @@ impl Permission {
         self.permission
     }
 
+    /// Encodes this permission back to `fPRM` chunk bytes.
+    ///
+    /// Test-only: libpna no longer writes `fPRM`, so this exists solely to
+    /// round-trip [`Permission::try_from_bytes`] in tests.
+    #[cfg(test)]
     pub(crate) fn to_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::with_capacity(20 + self.uname.len() + self.gname.len());
         bytes.extend_from_slice(&self.uid.to_be_bytes());
@@ -491,6 +514,18 @@ impl Permission {
             permission,
         })
     }
+}
+
+/// Owner facet values that a legacy `fPRM` chunk supplies.
+///
+/// `fPRM` predates the owner facet chunks and carries no SID, so `fOSi`/`fGSi`
+/// have no legacy source.
+pub(crate) struct LegacyOwnerFacets {
+    pub(crate) uid: OwnerUid,
+    pub(crate) gid: OwnerGid,
+    pub(crate) user_name: OwnerUserName,
+    pub(crate) group_name: OwnerGroupName,
+    pub(crate) mode: PermissionMode,
 }
 
 /// Maximum owner-facet string byte length (the `fONm`/`fGNm`/`fOSi`/`fGSi`
@@ -1170,63 +1205,6 @@ mod tests {
             LinkTargetType::try_from_bytes(&[0x01, 0xFF, 0xFF]).unwrap(),
             Some(LinkTargetType::File),
         );
-    }
-
-    #[allow(deprecated)]
-    #[test]
-    fn all_owner_facets_and_fprm_coexist_round_trip() {
-        use crate::entry::{
-            OwnerGid, OwnerGroupName, OwnerGroupSid, OwnerUid, OwnerUserName, OwnerUserSid,
-            PermissionMode,
-        };
-        use crate::{Archive, FileEntryBuilder};
-        let mut buf = Vec::new();
-        {
-            let mut archive = Archive::write_header(&mut buf).unwrap();
-            let mut b = FileEntryBuilder::new("f".into()).unwrap();
-            b.metadata(
-                Metadata::new()
-                    // Legacy fPRM (Permission uses plain String uname/gname on this branch).
-                    .with_permission(Some(Permission::new(
-                        7,
-                        "legacy".to_string(),
-                        8,
-                        "grp".to_string(),
-                        0o600,
-                    )))
-                    // All 7 new owner facets.
-                    .with_owner_uid(Some(OwnerUid::from(1)))
-                    .with_owner_gid(Some(OwnerGid::from(2)))
-                    .with_owner_user_name(Some(OwnerUserName::new("u").unwrap()))
-                    .with_owner_group_name(Some(OwnerGroupName::new("g").unwrap()))
-                    .with_owner_user_sid(Some(OwnerUserSid::new("S-1-1").unwrap()))
-                    .with_owner_group_sid(Some(OwnerGroupSid::new("S-1-2").unwrap()))
-                    .with_permission_mode(Some(PermissionMode::from(0o644))),
-            );
-            let entry = b.build().unwrap();
-            archive.add_entry(entry).unwrap();
-            archive.finalize().unwrap();
-        }
-        let mut archive = Archive::read_header(&buf[..]).unwrap();
-        let entry = archive.entries().skip_solid().next().unwrap().unwrap();
-        let m = entry.metadata();
-        // All 7 new facets survived.
-        assert_eq!(m.owner_uid().map(|v| v.get()), Some(1));
-        assert_eq!(m.owner_gid().map(|v| v.get()), Some(2));
-        assert_eq!(m.owner_user_name().map(|v| v.as_str()), Some("u"));
-        assert_eq!(m.owner_group_name().map(|v| v.as_str()), Some("g"));
-        assert_eq!(m.owner_user_sid().map(|v| v.as_str()), Some("S-1-1"));
-        assert_eq!(m.owner_group_sid().map(|v| v.as_str()), Some("S-1-2"));
-        assert_eq!(m.permission_mode().map(|v| v.get()), Some(0o644));
-        // Legacy fPRM still round-trips intact, independently of the new owner facets.
-        let p = m
-            .permission()
-            .expect("fPRM permission must still be present");
-        assert_eq!(p.uid(), 7);
-        assert_eq!(p.uname(), "legacy");
-        assert_eq!(p.gid(), 8);
-        assert_eq!(p.gname(), "grp");
-        assert_eq!(p.permissions(), 0o600);
     }
 
     #[test]

--- a/pna/src/ext/entry_builder.rs
+++ b/pna/src/ext/entry_builder.rs
@@ -11,7 +11,7 @@ use std::time::SystemTime;
 /// instead of the lower-level [`Duration`](libpna::Duration) representation.
 #[deprecated(
     since = "0.36.0",
-    note = "use `Metadata` with `MetadataTimeExt::with_*_time`; the kind-specific builders' `metadata()` setter rescues deprecated `fPRM` permission data automatically"
+    note = "use `Metadata` with `MetadataTimeExt::with_*_time`; a deprecated `fPRM` permission value is written back as owner-facet chunks automatically"
 )]
 pub trait EntryBuilderExt: private::Sealed {
     /// Sets metadata from a [`Metadata`] instance.
@@ -208,8 +208,6 @@ mod tests {
         assert!(out.chars().all(|c| c == two_byte_char));
     }
 
-    #[allow(deprecated)]
-    use libpna::Permission;
     use libpna::{Archive, ChunkType, OwnerGroupSid, OwnerUserSid, RawChunk, WriteOptions};
 
     #[allow(deprecated)]
@@ -218,22 +216,6 @@ mod tests {
         {
             let mut a = Archive::write_header(&mut buf).unwrap();
             let mut b = OpaqueEntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
-            b.add_metadata(src);
-            a.add_entry(b.build().unwrap()).unwrap();
-            a.finalize().unwrap();
-        }
-        let mut a = Archive::read_header(&buf[..]).unwrap();
-        let e = a.entries().skip_solid().next().unwrap().unwrap();
-        e.metadata().clone()
-    }
-
-    #[allow(deprecated)]
-    fn roundtrip_with_builder_permission(src: &Metadata, permission: Permission) -> Metadata {
-        let mut buf = Vec::new();
-        {
-            let mut a = Archive::write_header(&mut buf).unwrap();
-            let mut b = OpaqueEntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
-            b.permission(permission);
             b.add_metadata(src);
             a.add_entry(b.build().unwrap()).unwrap();
             a.finalize().unwrap();
@@ -325,28 +307,5 @@ mod tests {
         assert_eq!(m.owner_group_name().map(|v| v.as_str()), Some("grp"));
         assert_eq!(m.permission_mode().map(|v| v.get()), Some(0o600));
         assert!(m.permission().is_none());
-    }
-
-    #[test]
-    #[allow(deprecated)]
-    fn add_metadata_preserves_explicit_builder_fprm_while_rescuing_metadata_fprm() {
-        let src = fprm_metadata(7, "legacy", 8, "grp", 0o600);
-        let explicit = fprm_metadata(1, "explicit", 2, "explicit_group", 0o700)
-            .permission()
-            .cloned()
-            .expect("the raw fPRM chunk must decode");
-        let m = roundtrip_with_builder_permission(&src, explicit);
-        let p = m.permission().expect("explicit builder fPRM must remain");
-        assert_eq!(p.uid(), 1);
-        assert_eq!(p.uname(), "explicit");
-        assert_eq!(p.gid(), 2);
-        assert_eq!(p.gname(), "explicit_group");
-        assert_eq!(p.permissions(), 0o700);
-
-        assert_eq!(m.owner_uid().map(|v| v.get()), Some(7));
-        assert_eq!(m.owner_gid().map(|v| v.get()), Some(8));
-        assert_eq!(m.owner_user_name().map(|v| v.as_str()), Some("legacy"));
-        assert_eq!(m.owner_group_name().map(|v| v.as_str()), Some("grp"));
-        assert_eq!(m.permission_mode().map(|v| v.get()), Some(0o600));
     }
 }


### PR DESCRIPTION
## Summary

`libpna` no longer writes the `fPRM` chunk. When an entry carries one, its values fill the owner facets the entry does not have — facet by facet, so a facet the entry does carry always wins.

## Notes

Second of a six-part stack, on #3421. Part of #3210.

The redirect sits in the single place the chunk was emitted (`try_for_each_metadata_facet`), so it covers every write path — including `NormalEntry::with_metadata` and `EntryBuilder::permission`, both of which bypass `EntryBuilderCore::metadata`. That retires the `TODO` on that setter and its truncating `owner_name_bounded` helper: a `Permission` is wire-only since #3421, and `fPRM` length-prefixes each name with a single byte, so a name always fits the owner-facet bound.

`EntryBuilderExt::add_metadata` keeps its own rescue for now. It does not copy `permission` to the target builder, so that rescue is the only thing carrying `fPRM` values across a builder-to-builder copy; it goes away once the type does.

Reading an archive and writing it back now migrates `fPRM` to the owner facets. Archives passed through as raw chunks (`sort`, `concat`) are untouched.

`Metadata` seen in memory changes with the builder rescue gone: right after `build()`, an entry built from a legacy `Metadata` reports `permission` as `Some` with the owner facets still `None`, where the setter used to fill the facets and clear `permission`. The chunks written are the owner facets either way, so a read-back is unaffected.

A rescued mode goes through `PermissionMode`, which masks to `0o7777`. Every `fPRM` chunk in `resources/test/0.33.0/*.pna` stores `st_mode` with its file-type bits (`0o40755`, `0o100644`), so those bits stop reaching `fMOd`. The entry's kind comes from `FHED`, and every CLI consumer of the mode already ignores bits above `0o7777`.
