### PR TITLE
:sparkles: Add Archive::write_solid_with

### DIFF
--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -106,14 +106,15 @@ impl<T> Archive<T> {
     /// - **Reading**: Chunks larger than this size will be rejected with an error,
     ///   protecting against maliciously crafted archives with extremely large chunks.
     /// - **Writing**: Data written via [`write_file()`](Archive::write_file) or
-    ///   [`write_opaque()`](Archive::write_opaque) will be split into chunks no
-    ///   larger than this size.
+    ///   [`write_opaque()`](Archive::write_opaque), and the `SDAT` stream of a
+    ///   solid block opened by
+    ///   [`write_solid_with()`](Archive::write_solid_with), will be split into
+    ///   chunks no larger than this size.
     ///
-    /// **Note**: This setting only affects the streaming write path
-    /// ([`write_file()`](Archive::write_file) and
-    /// [`write_opaque()`](Archive::write_opaque)). Pre-built entries added via
-    /// [`add_entry()`](Archive::add_entry) use their own chunk size configured
-    /// through [`FileEntryBuilder::max_chunk_size()`](crate::FileEntryBuilder::max_chunk_size).
+    /// **Note**: This setting only affects the streaming write path. Pre-built
+    /// entries added via [`add_entry()`](Archive::add_entry) use their own chunk
+    /// size configured through
+    /// [`FileEntryBuilder::max_chunk_size()`](crate::FileEntryBuilder::max_chunk_size).
     ///
     #[inline]
     pub fn set_max_chunk_size(&mut self, size: NonZeroU32) {
@@ -611,6 +612,97 @@ mod tests {
                 .password(Some("PASSWORD"))
                 .build(),
         );
+    }
+
+    fn text_entry(name: &str, body: &str) -> NormalEntry {
+        let mut builder = FileEntryBuilder::new(name.into()).unwrap();
+        builder.write_all(body.as_bytes()).unwrap();
+        builder.build().unwrap()
+    }
+
+    fn read_texts(bytes: &[u8], password: Option<&str>) -> Vec<(String, String)> {
+        let read_options = ReadOptions::with_password(password);
+        let mut archive = Archive::read_header(bytes).unwrap();
+        archive
+            .entries_with_options(&read_options)
+            .map(|entry| {
+                let entry = entry.unwrap();
+                let name = entry.header().path().to_string();
+                let mut body = String::new();
+                entry
+                    .reader(ReadOptions::builder().build())
+                    .unwrap()
+                    .read_to_string(&mut body)
+                    .unwrap();
+                (name, body)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn write_solid_with_mixes_solid_and_normal_entries() {
+        let mut archive = Archive::write_header(Vec::new()).unwrap();
+        archive
+            .add_entry(text_entry("outer/before.txt", "before"))
+            .unwrap();
+        archive
+            .write_solid_with(WriteOptions::store(), |solid| {
+                solid.add_entry(text_entry("inner/a.txt", "solid a"))?;
+                solid.add_entry(text_entry("inner/b.txt", "solid b"))
+            })
+            .unwrap();
+        archive
+            .add_entry(text_entry("outer/after.txt", "after"))
+            .unwrap();
+        let buf = archive.finalize().unwrap();
+
+        assert_eq!(
+            read_texts(&buf, None),
+            [
+                ("outer/before.txt".into(), "before".into()),
+                ("inner/a.txt".into(), "solid a".into()),
+                ("inner/b.txt".into(), "solid b".into()),
+                ("outer/after.txt".into(), "after".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn write_solid_with_returns_closure_value() {
+        let mut archive = Archive::write_header(Vec::new()).unwrap();
+        let value = archive
+            .write_solid_with(WriteOptions::store(), |_| Ok(42))
+            .unwrap();
+        archive.finalize().unwrap();
+
+        assert_eq!(value, 42);
+    }
+
+    #[test]
+    fn write_solid_with_empty_block_roundtrips() {
+        let mut archive = Archive::write_header(Vec::new()).unwrap();
+        archive
+            .write_solid_with(WriteOptions::store(), |_| Ok(()))
+            .unwrap();
+        archive.add_entry(text_entry("after.txt", "after")).unwrap();
+        let buf = archive.finalize().unwrap();
+
+        assert_eq!(
+            read_texts(&buf, None),
+            [("after.txt".into(), "after".into())]
+        );
+    }
+
+    #[test]
+    fn write_solid_with_propagates_closure_error() {
+        let mut archive = Archive::write_header(Vec::new()).unwrap();
+        let err = archive
+            .write_solid_with(WriteOptions::store(), |_| {
+                Err::<(), _>(io::Error::other("boom"))
+            })
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), "boom");
     }
 
     #[test]

--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -630,7 +630,7 @@ mod tests {
                 let name = entry.header().path().to_string();
                 let mut body = String::new();
                 entry
-                    .reader(ReadOptions::builder().build())
+                    .reader(read_options.clone())
                     .unwrap()
                     .read_to_string(&mut body)
                     .unwrap();
@@ -691,6 +691,136 @@ mod tests {
             read_texts(&buf, None),
             [("after.txt".into(), "after".into())]
         );
+    }
+
+    #[test]
+    fn write_solid_with_zstd_aes_ctr_roundtrips() {
+        let options = WriteOptions::builder()
+            .compression(Compression::ZSTANDARD)
+            .encryption(Encryption::AES)
+            .cipher_mode(CipherMode::CTR)
+            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .password(Some("password"))
+            .build();
+        let mut archive = Archive::write_header(Vec::new()).unwrap();
+        archive
+            .write_solid_with(options, |solid| {
+                solid.add_entry(text_entry("inner/secret.txt", "secret body"))
+            })
+            .unwrap();
+        let buf = archive.finalize().unwrap();
+
+        assert_eq!(
+            read_texts(&buf, Some("password")),
+            [("inner/secret.txt".into(), "secret body".into())]
+        );
+    }
+
+    #[test]
+    fn write_solid_with_consecutive_blocks_roundtrip() {
+        let mut archive = Archive::write_header(Vec::new()).unwrap();
+        archive
+            .write_solid_with(WriteOptions::store(), |solid| {
+                solid.add_entry(text_entry("first/a.txt", "first"))
+            })
+            .unwrap();
+        archive
+            .write_solid_with(WriteOptions::store(), |solid| {
+                solid.add_entry(text_entry("second/b.txt", "second"))
+            })
+            .unwrap();
+        let buf = archive.finalize().unwrap();
+
+        assert_eq!(
+            read_texts(&buf, None),
+            [
+                ("first/a.txt".into(), "first".into()),
+                ("second/b.txt".into(), "second".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn write_solid_with_write_file_roundtrips() {
+        let mut archive = Archive::write_header(Vec::new()).unwrap();
+        archive
+            .write_solid_with(WriteOptions::store(), |solid| {
+                solid.write_file("inner/streamed.txt".into(), Metadata::new(), |writer| {
+                    writer.write_all(b"streamed body")
+                })
+            })
+            .unwrap();
+        let buf = archive.finalize().unwrap();
+
+        assert_eq!(
+            read_texts(&buf, None),
+            [("inner/streamed.txt".into(), "streamed body".into())]
+        );
+    }
+
+    #[test]
+    fn write_solid_with_frames_block_between_normal_entries() {
+        use crate::chunk::{Chunk, ChunkType};
+
+        let mut archive = Archive::write_header(Vec::new()).unwrap();
+        archive
+            .add_entry(text_entry("before.txt", "before"))
+            .unwrap();
+        archive
+            .write_solid_with(WriteOptions::store(), |solid| {
+                solid.add_entry(text_entry("inner.txt", "inner"))
+            })
+            .unwrap();
+        archive.add_entry(text_entry("after.txt", "after")).unwrap();
+        let buf = archive.finalize().unwrap();
+
+        let mut types: Vec<ChunkType> = crate::read_as_chunks(&buf[..])
+            .unwrap()
+            .map(|chunk| chunk.unwrap().ty())
+            .collect();
+        types.dedup();
+        assert_eq!(
+            types,
+            [
+                ChunkType::AHED,
+                ChunkType::FHED,
+                ChunkType::fSIZ,
+                ChunkType::FDAT,
+                ChunkType::FEND,
+                ChunkType::SHED,
+                ChunkType::SDAT,
+                ChunkType::SEND,
+                ChunkType::FHED,
+                ChunkType::fSIZ,
+                ChunkType::FDAT,
+                ChunkType::FEND,
+                ChunkType::AEND,
+            ]
+        );
+    }
+
+    #[test]
+    fn write_solid_with_splits_sdat_at_max_chunk_size() {
+        use crate::chunk::{Chunk, ChunkType};
+
+        let mut archive = Archive::write_header(Vec::new()).unwrap();
+        archive.set_max_chunk_size(NonZeroU32::new(64).unwrap());
+        archive
+            .write_solid_with(WriteOptions::store(), |solid| {
+                solid.add_entry(text_entry("inner.txt", &"x".repeat(500)))
+            })
+            .unwrap();
+        let buf = archive.finalize().unwrap();
+
+        let sdat_lengths = crate::read_as_chunks(&buf[..])
+            .unwrap()
+            .map(|chunk| chunk.unwrap())
+            .filter(|chunk| chunk.ty() == ChunkType::SDAT)
+            .map(|chunk| chunk.length())
+            .collect::<Vec<_>>();
+
+        assert!(sdat_lengths.contains(&64));
+        assert!(sdat_lengths.iter().all(|length| *length <= 64));
     }
 
     #[test]

--- a/lib/src/archive/split_parts.rs
+++ b/lib/src/archive/split_parts.rs
@@ -770,4 +770,26 @@ mod tests {
         let err = add_zero_entry(&mut archive, "b").unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::Other);
     }
+
+    #[test]
+    fn solid_block_written_with_closure_survives_part_rollover() {
+        let (parts, next_part) = part_collector();
+        let mut archive = Archive::write_split_header(200, next_part).unwrap();
+        archive
+            .write_solid_with(
+                WriteOptions::builder().compression(Compression::NO).build(),
+                |solid| {
+                    solid.write_file("inner.txt".into(), Metadata::new(), |writer| {
+                        writer.write_all(&[b'x'; 300])
+                    })
+                },
+            )
+            .unwrap();
+        let parts_written = archive.finalize().unwrap().parts();
+
+        let part_bytes = part_bytes_within(&parts, 200);
+        assert_eq!(parts_written as usize, part_bytes.len());
+        assert!(parts_written >= 2);
+        assert_eq!(read_all_solid_parts(&part_bytes), [b'x'; 300]);
+    }
 }

--- a/lib/src/archive/write.rs
+++ b/lib/src/archive/write.rs
@@ -440,34 +440,47 @@ impl<W: WriteChunk> Archive<W> {
     }
 
     #[inline]
-    fn into_solid_archive(mut self, option: impl WriteOption) -> io::Result<SolidArchive<W>> {
-        let header = SolidHeader::new(
-            option.compression(),
-            option.encryption(),
-            option.cipher_mode(),
-        );
-        let context = get_writer_context(option, ChunkType::SHED, &header.to_bytes())?;
-
-        self.inner
-            .write_chunk((ChunkType::SHED, header.to_bytes()))?;
-        if let Some(WriteCipher { context: c, .. }) = &context.cipher {
-            self.inner
-                .write_chunk((ChunkType::PHSF, c.phsf.as_bytes()))?;
-        }
-        self.inner.flush_chunks()?;
-        let max_chunk_size = self.max_chunk_size;
-        let mut writer = ChunkStreamWriter::new(ChunkType::SDAT, self.inner, max_chunk_size);
-        if let Some(WriteCipher { context: c, .. }) = &context.cipher {
-            writer.write_all(&c.prefix_bytes())?;
-        }
-        let writer = get_writer(writer, &context)?;
-
+    fn into_solid_archive(self, option: impl WriteOption) -> io::Result<SolidArchive<W>> {
         Ok(SolidArchive {
             archive_header: self.header,
-            inner: writer,
+            inner: begin_solid_stream(self.inner, self.max_chunk_size, option)?,
             max_chunk_size: None,
         })
     }
+}
+
+/// Opens a solid stream over `inner`. The returned writer must be closed by
+/// `end_solid_stream`; dropping it instead leaves an unterminated block in the
+/// output.
+fn begin_solid_stream<W: WriteChunk>(
+    mut inner: W,
+    max_chunk_size: Option<NonZeroU32>,
+    option: impl WriteOption,
+) -> io::Result<InternalArchiveDataWriter<W>> {
+    let header = SolidHeader::new(
+        option.compression(),
+        option.encryption(),
+        option.cipher_mode(),
+    );
+    let context = get_writer_context(option, ChunkType::SHED, &header.to_bytes())?;
+
+    inner.write_chunk((ChunkType::SHED, header.to_bytes()))?;
+    if let Some(WriteCipher { context: c, .. }) = &context.cipher {
+        inner.write_chunk((ChunkType::PHSF, c.phsf.as_bytes()))?;
+    }
+    inner.flush_chunks()?;
+    let mut writer = ChunkStreamWriter::new(ChunkType::SDAT, inner, max_chunk_size);
+    if let Some(WriteCipher { context: c, .. }) = &context.cipher {
+        writer.write_all(&c.prefix_bytes())?;
+    }
+    get_writer(writer, &context)
+}
+
+fn end_solid_stream<W: WriteChunk>(mut writer: InternalArchiveDataWriter<W>) -> io::Result<W> {
+    writer.flush()?;
+    let mut inner = writer.try_into_inner()?.try_into_inner()?.into_inner();
+    inner.write_chunk((ChunkType::SEND, []))?;
+    Ok(inner)
 }
 
 #[cfg(feature = "unstable-async")]
@@ -719,11 +732,11 @@ impl<W: WriteChunk> SolidArchive<W> {
     }
 
     #[inline]
-    fn finalize_solid_entry(mut self) -> io::Result<Archive<W>> {
-        self.inner.flush()?;
-        let mut inner = self.inner.try_into_inner()?.try_into_inner()?.into_inner();
-        inner.write_chunk((ChunkType::SEND, []))?;
-        Ok(Archive::new(inner, self.archive_header))
+    fn finalize_solid_entry(self) -> io::Result<Archive<W>> {
+        Ok(Archive::new(
+            end_solid_stream(self.inner)?,
+            self.archive_header,
+        ))
     }
 }
 

--- a/lib/src/archive/write.rs
+++ b/lib/src/archive/write.rs
@@ -337,6 +337,57 @@ where
             },
         )
     }
+
+    /// Writes one solid block into this archive and returns the closure's
+    /// value.
+    ///
+    /// The closure receives a [`SolidArchive`] writing into this archive's
+    /// output; entries added to it are compressed and encrypted together
+    /// according to `option`. When the closure returns `Ok`, the block is
+    /// closed with an `SEND` chunk and this archive accepts further entries —
+    /// normal entries and other solid blocks alike. To write an archive whose
+    /// entire contents form a single solid block, use
+    /// [`write_solid_header`](Archive::write_solid_header) instead.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an I/O error occurs while writing to the archive,
+    /// or if the closure returns an error. If this method returns an error,
+    /// the archive may contain a partial solid block and must be discarded
+    /// without further use.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use libpna::{Archive, FileEntryBuilder, WriteOptions};
+    /// # use std::io;
+    ///
+    /// # fn main() -> io::Result<()> {
+    /// let mut archive = Archive::write_header(Vec::new())?;
+    /// archive.write_solid_with(WriteOptions::builder().build(), |solid| {
+    ///     solid.add_entry(FileEntryBuilder::new("a.txt".into())?.build()?)?;
+    ///     solid.add_entry(FileEntryBuilder::new("b.txt".into())?.build()?)
+    /// })?;
+    /// archive.add_entry(FileEntryBuilder::new("c.txt".into())?.build()?)?;
+    /// archive.finalize()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn write_solid_with<T>(
+        &mut self,
+        option: impl WriteOption,
+        f: impl FnOnce(&mut SolidArchive<&mut W>) -> io::Result<T>,
+    ) -> io::Result<T> {
+        let mut solid = SolidArchive {
+            archive_header: self.header.clone(),
+            inner: begin_solid_stream(&mut self.inner, self.max_chunk_size, option)?,
+            max_chunk_size: None,
+        };
+        let value = f(&mut solid)?;
+        end_solid_stream(solid.inner)?;
+        Ok(value)
+    }
 }
 
 impl<W: WriteChunk> Archive<W> {
@@ -691,7 +742,7 @@ impl<W: WriteChunk> SolidArchive<W> {
     /// the solid stream. The outer SDAT chunk size is fixed when `SolidArchive` is
     /// constructed and cannot be changed afterward. To control the outer SDAT chunk
     /// size, call [`Archive::set_max_chunk_size`] before
-    /// [`write_solid_header()`](Archive::write_solid_header).
+    /// [`write_solid_with()`](Archive::write_solid_with).
     ///
     /// Pre-built entries added via [`add_entry()`](SolidArchive::add_entry) use their own
     /// chunk size configured through [`FileEntryBuilder::max_chunk_size()`](crate::FileEntryBuilder::max_chunk_size).


### PR DESCRIPTION
## Summary
Add `Archive::write_solid_with`, which writes one solid block into an archive being written and returns to normal entry writing after its `SEND` chunk. The public API previously had no way to mix solid blocks and normal entries in a single streamed archive: `write_solid_header` turns the whole archive into one solid block and closes it on finalize.

Internally, the solid stream open/close sequences are extracted from `into_solid_archive` / `finalize_solid_entry` into helpers shared with the new method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added callback-based writing for grouped solid archive content, with support for returning values and propagating errors.
  - Archives can continue accepting regular entries or additional solid blocks afterward.
  - Solid content remains readable when split across multiple archive parts.

- **Bug Fixes**
  - Improved handling of chunk boundaries and maximum archive part sizes.
  - Verified compatibility with encryption, compression, streamed files, empty blocks, and consecutive solid blocks.

- **Documentation**
  - Clarified configuration guidance for solid archive streams and chunk sizing.

- **Tests**
  - Expanded coverage for solid archive writing and chunk framing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->