### PR TITLE
:boom: Remove the deprecated permission setters

### DIFF
--- a/cli/src/command/chown.rs
+++ b/cli/src/command/chown.rs
@@ -104,7 +104,6 @@ fn archive_chown(args: ChownCommand) -> anyhow::Result<()> {
 }
 
 #[inline]
-#[allow(deprecated)]
 fn transform_entry<T>(entry: NormalEntry<T>, owner: &Ownership) -> NormalEntry<T> {
     let metadata = entry.metadata().clone();
     let own = crate::ext::ResolvedOwnership::from_metadata(&metadata);
@@ -128,7 +127,6 @@ fn transform_entry<T>(entry: NormalEntry<T>, owner: &Ownership) -> NormalEntry<T
     };
     let metadata =
         metadata
-            .with_permission(None)
             .with_owner_uid(uid.map(pna::OwnerUid::from))
             .with_owner_gid(gid.map(pna::OwnerGid::from))
             .with_owner_user_name(crate::command::core::permission::owner_name_opt(&uname))

--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -715,15 +715,28 @@ mod tests {
                 Metadata::new()
                     .with_created(Some(Duration::seconds(31)))
                     .with_modified(Some(Duration::seconds(32)))
-                    .with_accessed(Some(Duration::seconds(33)))
-                    .with_permission(Some(Permission::new(
-                        1,
-                        "uname".into(),
-                        2,
-                        "gname".into(),
-                        0o775,
-                    ))),
+                    .with_accessed(Some(Duration::seconds(33))),
             );
+            // A raw legacy `fPRM` chunk, as a pre-0.34.0 archive carries it.
+            let uname = "uname";
+            let gname = "gname";
+            assert!(
+                uname.len() <= u8::MAX as usize,
+                "fPRM name must fit a 1-byte length"
+            );
+            assert!(
+                gname.len() <= u8::MAX as usize,
+                "fPRM name must fit a 1-byte length"
+            );
+            let mut fprm = Vec::new();
+            fprm.extend_from_slice(&1u64.to_be_bytes());
+            fprm.push(uname.len() as u8);
+            fprm.extend_from_slice(uname.as_bytes());
+            fprm.extend_from_slice(&2u64.to_be_bytes());
+            fprm.push(gname.len() as u8);
+            fprm.extend_from_slice(gname.as_bytes());
+            fprm.extend_from_slice(&0o775u16.to_be_bytes());
+            builder.add_extra_chunk(RawChunk::from_data(ChunkType::fPRM, fprm));
             builder.write_all(b"entry data").unwrap();
             builder.build().unwrap()
         };
@@ -750,8 +763,9 @@ mod tests {
             original_entry.metadata().accessed(),
             read_entry.metadata().accessed()
         );
-        // The legacy fPRM chunk is no longer written; its values are read back
-        // as the owner facets that superseded it.
+        // The raw fPRM chunk above is copied through as an extra chunk; the
+        // owner facets asserted below come from the reader filling them from
+        // it, not from anything the metadata-facet writer produced.
         assert_eq!(read_entry.metadata().owner_uid().map(|v| v.get()), Some(1));
         assert_eq!(
             read_entry.metadata().owner_user_name().map(|v| v.as_str()),

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -145,28 +145,16 @@ fn try_for_each_metadata_facet<E>(
             f(ChunkType::aTNS, Cow::Borrowed(&nanos.to_be_bytes()))?;
         }
     }
-    // A legacy `fPRM` chunk is written back as the owner facets that
-    // superseded it, facet by facet; libpna never emits `fPRM`.
-    let legacy = metadata.legacy_owner_facets();
-    let legacy = legacy.as_ref();
-    if let Some(value) = metadata.owner_uid.or(legacy.map(|l| l.uid)) {
+    if let Some(value) = metadata.owner_uid {
         f(ChunkType::fUId, Cow::Borrowed(&value.to_bytes()))?;
     }
-    if let Some(value) = metadata.owner_gid.or(legacy.map(|l| l.gid)) {
+    if let Some(value) = metadata.owner_gid {
         f(ChunkType::fGId, Cow::Borrowed(&value.to_bytes()))?;
     }
-    if let Some(value) = metadata
-        .owner_user_name
-        .as_ref()
-        .or(legacy.map(|l| &l.user_name))
-    {
+    if let Some(value) = &metadata.owner_user_name {
         f(ChunkType::fONm, Cow::Owned(value.to_bytes()))?;
     }
-    if let Some(value) = metadata
-        .owner_group_name
-        .as_ref()
-        .or(legacy.map(|l| &l.group_name))
-    {
+    if let Some(value) = &metadata.owner_group_name {
         f(ChunkType::fGNm, Cow::Owned(value.to_bytes()))?;
     }
     if let Some(value) = &metadata.owner_user_sid {
@@ -175,7 +163,7 @@ fn try_for_each_metadata_facet<E>(
     if let Some(value) = &metadata.owner_group_sid {
         f(ChunkType::fGSi, Cow::Owned(value.to_bytes()))?;
     }
-    if let Some(value) = metadata.permission_mode.or(legacy.map(|l| l.mode)) {
+    if let Some(value) = metadata.permission_mode {
         f(ChunkType::fMOd, Cow::Borrowed(&value.to_bytes()))?;
     }
     if let Some(value) = metadata.link_target_type {
@@ -886,8 +874,8 @@ where
             permission_mode,
             xattrs,
         };
-        if let Some(legacy) = metadata.legacy_owner_facets() {
-            metadata.fill_owner_facets_from(legacy);
+        if let Some(p) = &metadata.permission {
+            metadata.fill_owner_facets_from(LegacyOwnerFacets::from(p));
         }
 
         Ok(Self {
@@ -1475,24 +1463,6 @@ mod tests {
         );
     }
 
-    /// A `Metadata` carrying only a legacy `fPRM` value, as the deprecated
-    /// setter still produces. Reading an archive now fills the owner facets,
-    /// so the write-side fallback needs a subject the reader has not touched.
-    #[allow(deprecated)]
-    fn metadata_with_legacy_fprm_only(
-        uid: u64,
-        uname: &str,
-        gid: u64,
-        gname: &str,
-        mode: u16,
-    ) -> Metadata {
-        let permission = read_back_with_legacy_fprm(uid, uname, gid, gname, mode, |m| m)
-            .permission()
-            .cloned()
-            .expect("the raw fPRM chunk must decode");
-        Metadata::new().with_permission(Some(permission))
-    }
-
     fn emitted_facets(metadata: &Metadata) -> Vec<(ChunkType, Vec<u8>)> {
         let mut out = Vec::new();
         try_for_each_metadata_facet(metadata, |ty, data| {
@@ -1539,61 +1509,6 @@ mod tests {
         assert_eq!(m.owner_user_name().map(|v| v.as_str()), Some("new"));
         assert_eq!(m.owner_gid().map(|v| v.get()), Some(8));
         assert_eq!(m.owner_group_name().map(|v| v.as_str()), Some("grp"));
-    }
-
-    #[test]
-    #[allow(deprecated)]
-    fn legacy_fprm_is_written_as_owner_facets() {
-        let m = metadata_with_legacy_fprm_only(7, "legacy", 8, "grp", 0o600);
-        let emitted = emitted_facets(&m);
-        let types: Vec<ChunkType> = emitted.iter().map(|(ty, _)| *ty).collect();
-
-        assert!(
-            !types.contains(&ChunkType::fPRM),
-            "fPRM must not be written"
-        );
-        assert_eq!(
-            find(&emitted, ChunkType::fUId),
-            Some(7u64.to_be_bytes().to_vec())
-        );
-        assert_eq!(
-            find(&emitted, ChunkType::fGId),
-            Some(8u64.to_be_bytes().to_vec())
-        );
-        assert_eq!(
-            find(&emitted, ChunkType::fONm),
-            Some(b"\x06legacy".to_vec())
-        );
-        assert_eq!(find(&emitted, ChunkType::fGNm), Some(b"\x03grp".to_vec()));
-        assert_eq!(
-            find(&emitted, ChunkType::fMOd),
-            Some(0o600u16.to_be_bytes().to_vec())
-        );
-    }
-
-    #[test]
-    fn owner_facets_win_over_legacy_fprm_facet_by_facet() {
-        let m = metadata_with_legacy_fprm_only(7, "legacy", 8, "grp", 0o600)
-            .with_owner_uid(Some(OwnerUid::from(1)))
-            .with_owner_user_name(Some(OwnerUserName::new("new").unwrap()));
-        let emitted = emitted_facets(&m);
-
-        assert_eq!(
-            find(&emitted, ChunkType::fUId),
-            Some(1u64.to_be_bytes().to_vec()),
-            "the facet the entry carries wins"
-        );
-        assert_eq!(find(&emitted, ChunkType::fONm), Some(b"\x03new".to_vec()));
-        assert_eq!(
-            find(&emitted, ChunkType::fGId),
-            Some(8u64.to_be_bytes().to_vec()),
-            "the facets it does not carry still come from fPRM"
-        );
-        assert_eq!(find(&emitted, ChunkType::fGNm), Some(b"\x03grp".to_vec()));
-        assert_eq!(
-            find(&emitted, ChunkType::fMOd),
-            Some(0o600u16.to_be_bytes().to_vec())
-        );
     }
 
     #[test]
@@ -1655,16 +1570,6 @@ mod tests {
             find(&emitted, ChunkType::fMOd),
             Some(0o755u16.to_be_bytes().to_vec()),
             "mode must come from the entry's own facet, not fPRM's 0o600"
-        );
-    }
-
-    #[test]
-    fn legacy_fprm_mode_is_masked_to_permission_bits() {
-        // 0.33.0 stored st_mode: S_IFREG | 0o644.
-        let m = metadata_with_legacy_fprm_only(0, "root", 0, "root", 0o100644);
-        assert_eq!(
-            find(&emitted_facets(&m), ChunkType::fMOd),
-            Some(0o644u16.to_be_bytes().to_vec())
         );
     }
 

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -8,8 +8,6 @@ pub use file::FileEntryBuilder;
 pub use link::{HardLinkEntryBuilder, SymlinkEntryBuilder};
 pub use solid::SolidEntryBuilder;
 
-#[allow(deprecated)]
-use crate::entry::Permission;
 use crate::{
     Duration,
     chunk::{ChunkType, RawChunk},
@@ -382,18 +380,6 @@ impl OpaqueEntryBuilder {
     #[inline]
     pub fn accessed(&mut self, since_unix_epoch: impl Into<Option<Duration>>) -> &mut Self {
         self.core.metadata.accessed = since_unix_epoch.into();
-        self
-    }
-
-    /// Sets the permission of the entry to the given owner, group, and permissions.
-    #[deprecated(
-        since = "0.34.0",
-        note = "the fPRM chunk is superseded by the owner facet chunks; use `OpaqueEntryBuilder::metadata` with `Metadata::with_owner_uid`/`with_owner_gid`/`with_owner_user_name`/`with_owner_group_name`/`with_permission_mode`"
-    )]
-    #[allow(deprecated)]
-    #[inline]
-    pub fn permission(&mut self, permission: impl Into<Option<Permission>>) -> &mut Self {
-        self.core.metadata.permission = permission.into();
         self
     }
 

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -171,18 +171,6 @@ impl Metadata {
         self
     }
 
-    /// Sets the permission of the entry.
-    #[deprecated(
-        since = "0.34.0",
-        note = "the fPRM chunk is superseded by the owner facet chunks; use Metadata::with_owner_uid/with_owner_gid/with_owner_user_name/with_owner_group_name/with_owner_user_sid/with_owner_group_sid/with_permission_mode"
-    )]
-    #[allow(deprecated)]
-    #[inline]
-    pub fn with_permission(mut self, permission: Option<Permission>) -> Self {
-        self.permission = permission;
-        self
-    }
-
     /// Sets the owner user id facet (`fUId`).
     #[inline]
     pub fn with_owner_uid(mut self, value: Option<OwnerUid>) -> Self {
@@ -329,24 +317,6 @@ impl Metadata {
     #[inline]
     pub fn xattrs(&self) -> &[ExtendedAttribute] {
         &self.xattrs
-    }
-
-    /// Owner facet values carried by this entry's legacy `fPRM` chunk, if any.
-    ///
-    /// The name conversions cannot fail: a [`Permission`] only comes off the
-    /// wire, where `fPRM` length-prefixes each name with a single byte — the
-    /// same bound `fONm`/`fGNm` carry.
-    #[allow(deprecated)]
-    pub(crate) fn legacy_owner_facets(&self) -> Option<LegacyOwnerFacets> {
-        const NAME_FITS: &str = "an fPRM name cannot exceed the owner-facet bound";
-        let p = self.permission.as_ref()?;
-        Some(LegacyOwnerFacets {
-            uid: OwnerUid::from(p.uid()),
-            gid: OwnerGid::from(p.gid()),
-            user_name: OwnerUserName::new(p.uname()).expect(NAME_FITS),
-            group_name: OwnerGroupName::new(p.gname()).expect(NAME_FITS),
-            mode: PermissionMode::from(p.permissions()),
-        })
     }
 
     /// Fills the owner facets this entry does not carry from a legacy `fPRM`
@@ -539,6 +509,23 @@ pub(crate) struct LegacyOwnerFacets {
     pub(crate) user_name: OwnerUserName,
     pub(crate) group_name: OwnerGroupName,
     pub(crate) mode: PermissionMode,
+}
+
+#[allow(deprecated)]
+impl From<&Permission> for LegacyOwnerFacets {
+    /// The name conversions cannot fail: a [`Permission`] only comes off the
+    /// wire, where `fPRM` length-prefixes each name with a single byte — the
+    /// same bound `fONm`/`fGNm` carry.
+    fn from(p: &Permission) -> Self {
+        const NAME_FITS: &str = "an fPRM name cannot exceed the owner-facet bound";
+        Self {
+            uid: OwnerUid::from(p.uid()),
+            gid: OwnerGid::from(p.gid()),
+            user_name: OwnerUserName::new(p.uname()).expect(NAME_FITS),
+            group_name: OwnerGroupName::new(p.gname()).expect(NAME_FITS),
+            mode: PermissionMode::from(p.permissions()),
+        }
+    }
 }
 
 /// Maximum owner-facet string byte length (the `fONm`/`fGNm`/`fOSi`/`fGSi`

--- a/pna/src/ext/entry_builder.rs
+++ b/pna/src/ext/entry_builder.rs
@@ -1,8 +1,6 @@
 //! Provides extension traits for [`OpaqueEntryBuilder`].
 use crate::ext::{private, time::opt_system_time_to_duration};
-use libpna::{
-    Metadata, OpaqueEntryBuilder, OwnerGid, OwnerGroupName, OwnerUid, OwnerUserName, PermissionMode,
-};
+use libpna::{Metadata, OpaqueEntryBuilder};
 use std::time::SystemTime;
 
 /// [`OpaqueEntryBuilder`] extension trait.
@@ -11,14 +9,12 @@ use std::time::SystemTime;
 /// instead of the lower-level [`Duration`](libpna::Duration) representation.
 #[deprecated(
     since = "0.36.0",
-    note = "use `Metadata` with `MetadataTimeExt::with_*_time`; a deprecated `fPRM` permission value is written back as owner-facet chunks automatically"
+    note = "use `Metadata` with `MetadataTimeExt::with_*_time`"
 )]
 pub trait EntryBuilderExt: private::Sealed {
     /// Sets metadata from a [`Metadata`] instance.
     ///
     /// Copies metadata fields from the provided metadata to this entry builder.
-    /// Deprecated `fPRM` permission data in the metadata is rescued into the
-    /// owner-facet chunks; it is not copied back as `fPRM`.
     fn add_metadata(&mut self, metadata: &Metadata) -> &mut Self;
 
     /// Sets the created time using [`SystemTime`].
@@ -40,21 +36,6 @@ pub trait EntryBuilderExt: private::Sealed {
     fn accessed_time(&mut self, time: impl Into<Option<SystemTime>>) -> &mut Self;
 }
 
-/// Largest UTF-8 char-boundary prefix of `s` whose byte length is ≤ 255 —
-/// the `fONm`/`fGNm` owner-name wire bound (1-byte length prefix). Used to
-/// rescue a legacy fPRM name that exceeds the bounded owner-facet limit.
-fn owner_name_bounded(s: &str) -> &str {
-    const MAX: usize = u8::MAX as usize;
-    if s.len() <= MAX {
-        return s;
-    }
-    let mut end = MAX;
-    while !s.is_char_boundary(end) {
-        end -= 1;
-    }
-    &s[..end]
-}
-
 #[allow(deprecated)]
 impl EntryBuilderExt for OpaqueEntryBuilder {
     /// Sets metadata from a [`Metadata`] instance.
@@ -74,44 +55,18 @@ impl EntryBuilderExt for OpaqueEntryBuilder {
     /// # Ok(())
     /// # }
     /// ```
-    #[allow(deprecated)]
     #[inline]
     fn add_metadata(&mut self, metadata: &Metadata) -> &mut Self {
-        // Legacy fPRM from the supplied Metadata is read as a per-field rescue
-        // baseline and overwritten by owner facets when present.
-        let p = metadata.permission();
         self.created(metadata.created())
             .modified(metadata.modified())
             .accessed(metadata.accessed())
-            .owner_uid(
-                metadata
-                    .owner_uid()
-                    .or_else(|| p.map(|p| OwnerUid::from(p.uid()))),
-            )
-            .owner_gid(
-                metadata
-                    .owner_gid()
-                    .or_else(|| p.map(|p| OwnerGid::from(p.gid()))),
-            )
-            .owner_user_name(metadata.owner_user_name().cloned().or_else(|| {
-                p.map(|p| {
-                    OwnerUserName::new(owner_name_bounded(p.uname()))
-                        .expect("owner_name_bounded guarantees <= 255 bytes")
-                })
-            }))
-            .owner_group_name(metadata.owner_group_name().cloned().or_else(|| {
-                p.map(|p| {
-                    OwnerGroupName::new(owner_name_bounded(p.gname()))
-                        .expect("owner_name_bounded guarantees <= 255 bytes")
-                })
-            }))
+            .owner_uid(metadata.owner_uid())
+            .owner_gid(metadata.owner_gid())
+            .owner_user_name(metadata.owner_user_name().cloned())
+            .owner_group_name(metadata.owner_group_name().cloned())
             .owner_user_sid(metadata.owner_user_sid().cloned())
             .owner_group_sid(metadata.owner_group_sid().cloned())
-            .permission_mode(
-                metadata
-                    .permission_mode()
-                    .or_else(|| p.map(|p| PermissionMode::from(p.permissions()))),
-            )
+            .permission_mode(metadata.permission_mode())
             .link_target_type(metadata.link_target_type())
     }
 
@@ -180,35 +135,10 @@ impl EntryBuilderExt for OpaqueEntryBuilder {
 mod tests {
     use super::*;
 
-    #[test]
-    fn owner_name_bounded_passes_through_short_ascii() {
-        assert_eq!(owner_name_bounded(""), "");
-        assert_eq!(owner_name_bounded("alice"), "alice");
-        let exactly_255 = "a".repeat(255);
-        assert_eq!(owner_name_bounded(&exactly_255), exactly_255);
-    }
-
-    #[test]
-    fn owner_name_bounded_truncates_long_ascii_to_255() {
-        let s = "a".repeat(300);
-        let out = owner_name_bounded(&s);
-        assert_eq!(out.len(), 255);
-        assert!(out.bytes().all(|b| b == b'a'));
-        assert_eq!(owner_name_bounded(&"a".repeat(256)).len(), 255);
-    }
-
-    #[test]
-    fn owner_name_bounded_truncates_on_utf8_boundary() {
-        let two_byte_char = 'é';
-        assert_eq!(two_byte_char.len_utf8(), 2);
-        let s = String::from(two_byte_char).repeat(200); // 400 bytes
-        let out = owner_name_bounded(&s);
-        assert_eq!(out.len(), 254);
-        assert_eq!(out.chars().count(), 127);
-        assert!(out.chars().all(|c| c == two_byte_char));
-    }
-
-    use libpna::{Archive, ChunkType, OwnerGroupSid, OwnerUserSid, RawChunk, WriteOptions};
+    use libpna::{
+        Archive, ChunkType, OwnerGid, OwnerGroupName, OwnerGroupSid, OwnerUid, OwnerUserName,
+        OwnerUserSid, PermissionMode, RawChunk, WriteOptions,
+    };
 
     #[allow(deprecated)]
     fn roundtrip(src: &Metadata) -> Metadata {
@@ -283,7 +213,7 @@ mod tests {
 
     #[test]
     #[allow(deprecated)]
-    fn add_metadata_translates_fprm_only_source() {
+    fn add_metadata_preserves_ownership_from_a_legacy_archive() {
         let src = fprm_metadata(7, "legacy", 8, "grp", 0o600);
         let m = roundtrip(&src);
         assert_eq!(m.owner_uid().map(|v| v.get()), Some(7));
@@ -296,7 +226,7 @@ mod tests {
 
     #[test]
     #[allow(deprecated)]
-    fn add_metadata_owner_facet_wins_over_fprm() {
+    fn add_metadata_preserves_mixed_legacy_and_overridden_facets() {
         let src = fprm_metadata(7, "legacy", 8, "grp", 0o600)
             .with_owner_uid(Some(OwnerUid::from(1)))
             .with_owner_user_name(Some(OwnerUserName::new("new").unwrap()));


### PR DESCRIPTION
## Summary

Remove `Metadata::with_permission` and `OpaqueEntryBuilder::permission`, and with them the two fallbacks that existed to serve those setters: the `fPRM`-to-owner-facet fill in the chunk writer, and `EntryBuilderExt::add_metadata`'s own rescue. A `Permission` can no longer be put into an entry; `Metadata::permission` still reports one read from an archive.

## Notes

Fifth of a six-part stack, on #3425. Targets `0.39.0`, so it stays a draft until `0.38.0` ships. Part of #3210.

All four removals share one cause: since #3424 fills the owner facets when an entry is read, a `Metadata` carrying `permission` always carries the facets too, so copying or emitting the facets is sufficient. They also share one hazard, which is why they go together rather than one at a time — a fallback cannot distinguish "facet never set" from "facet explicitly cleared", because `Option` has no third state, so it silently resurrects a value the caller deliberately dropped.

That hazard was not hypothetical. `pna experimental chown --numeric-owner 1000:1000` clears the owner names on purpose, and it needed `.with_permission(None)` to stop the writer's fallback refilling them from the `fPRM` still held in the metadata. That call goes away here, with the fallback; `chown` and `chmod` now touch nothing deprecated.

Exactly one place in the workspace assigns `Metadata::permission` — the entry reader — and it fills the owner facets in the same constructor, so no path can reach the removed fallbacks with ownership that would have been lost.
