### PR TITLE
Fix remaining comment/doc mismatches from the slop audit

### DIFF
--- a/cli/src/command/bsdtar.rs
+++ b/cli/src/command/bsdtar.rs
@@ -1211,7 +1211,7 @@ fn run_list_archive(args: BsdtarCommand) -> anyhow::Result<()> {
         args.include.iter().map(|s| s.as_str()),
         exclude.iter().map(|s| s.as_str()).chain(vcs_patterns),
     );
-    // NOTE: "-" will use stdout
+    // NOTE: "-" will use stdin
     let mut file = args.file;
     file.take_if(|it| it == "-");
     if let Some(path) = &file {

--- a/cli/src/command/core/ignore.rs
+++ b/cli/src/command/core/ignore.rs
@@ -14,9 +14,9 @@ impl Ignore {
     #[inline]
     pub(crate) fn is_ignore(&self, path: impl AsRef<Path>, is_dir: bool) -> bool {
         let path = path.as_ref();
-        // Start from the directory containing the path (or the path itself if it is a dir),
-        // walk up to root, and apply the nearest .gitignore last (closest wins).
-        // Determine the first directory to check for a .gitignore
+        // Walk from the directory containing the path (or the path itself if it is a
+        // dir) up to root, checking each directory's .gitignore in turn; the first
+        // directory with a matching rule decides the result, so the closest one wins.
         let mut cur_dir_opt = if is_dir { Some(path) } else { path.parent() };
 
         while let Some(dir) = cur_dir_opt {

--- a/lib/src/chunk/types.rs
+++ b/lib/src/chunk/types.rs
@@ -115,7 +115,7 @@ impl ChunkType {
     /// Solid mode data stream end marker.
     pub const SEND: ChunkType = ChunkType(*b"SEND");
 
-    // -- Auxiliary chunks --
+    // -- Ancillary chunks --
     /// Raw file size.
     #[allow(non_upper_case_globals)]
     pub const fSIZ: ChunkType = ChunkType(*b"fSIZ");

--- a/lib/src/util/bounded.rs
+++ b/lib/src/util/bounded.rs
@@ -14,8 +14,6 @@
 //! # Examples
 //!
 //! ```ignore
-//! use libpna::util::bounded::{str::BoundedString, bytes::BoundedBytes};
-//!
 //! // A field whose on-the-wire length prefix is a `u8` accepts at most 255 bytes.
 //! let name: BoundedString<255> = "root".try_into().unwrap();
 //! assert_eq!(name.len(), 4);
@@ -42,8 +40,6 @@ use std::{error, fmt};
 /// # Examples
 ///
 /// ```ignore
-/// use libpna::util::bounded::str::BoundedString;
-///
 /// let err = BoundedString::<3>::new("hello").unwrap_err();
 /// assert_eq!(err.max(), 3);
 /// assert_eq!(err.actual(), 5);

--- a/lib/src/util/bounded/bytes.rs
+++ b/lib/src/util/bounded/bytes.rs
@@ -11,8 +11,6 @@ use std::{borrow::Borrow, ops::Deref};
 /// # Examples
 ///
 /// ```ignore
-/// use libpna::util::bounded::bytes::BoundedBytes;
-///
 /// let payload: BoundedBytes<4> = vec![0xFF, 0x00, 0x42].try_into().unwrap();
 /// assert_eq!(payload.as_slice(), &[0xFF, 0x00, 0x42]);
 ///
@@ -35,8 +33,6 @@ impl<const MAX: usize> BoundedBytes<MAX> {
     /// # Examples
     ///
     /// ```ignore
-    /// use libpna::util::bounded::bytes::BoundedBytes;
-    ///
     /// let ok = BoundedBytes::<3>::new(vec![1u8, 2, 3]).unwrap();
     /// assert_eq!(ok.as_slice(), &[1, 2, 3]);
     ///

--- a/lib/src/util/bounded/str.rs
+++ b/lib/src/util/bounded/str.rs
@@ -12,8 +12,6 @@ use std::{borrow::Borrow, fmt, ops::Deref};
 /// # Examples
 ///
 /// ```ignore
-/// use libpna::util::bounded::str::BoundedString;
-///
 /// let s: BoundedString<8> = "🦀rust".try_into().unwrap();
 /// assert_eq!(s.len(), 8); // 4-byte 🦀 + "rust"
 ///
@@ -36,8 +34,6 @@ impl<const MAX: usize> BoundedString<MAX> {
     /// # Examples
     ///
     /// ```ignore
-    /// use libpna::util::bounded::str::BoundedString;
-    ///
     /// let ok = BoundedString::<5>::new("hello").unwrap();
     /// assert_eq!(ok.as_str(), "hello");
     ///

--- a/pna/src/ext/metadata.rs
+++ b/pna/src/ext/metadata.rs
@@ -265,7 +265,7 @@ pub trait MetadataFsExt: private::Sealed {
     /// are preserved as owner facets as well.
     ///
     /// # Errors
-    /// Returns an error if converting from [`fs::Metadata`] fails.
+    /// See the implementing type's documentation for when this can fail.
     fn from_metadata(metadata: &fs::Metadata) -> io::Result<Self>
     where
         Self: Sized;


### PR DESCRIPTION
## Summary
Follow-up to #3418. The comment-slop audit found five more comments that contradict the current code, but each needed a rewrite (not a pure deletion) to keep the useful information:

- `cli/src/command/bsdtar.rs`: the `list` subcommand's `"-"` note said `stdout`, but `list` reads the archive, so it uses `stdin` — same as `extract`'s note two branches over.
- `lib/src/chunk/types.rs`: an inline section label said `Auxiliary` while the type's own doc (a few lines up) calls the same chunk class `Ancillary`.
- `lib/src/util/bounded{,/bytes,/str}.rs` (6 doctest examples): each imported through `libpna::util::bounded::...`, a path that can never resolve since `util` is `pub(crate)` — that's why every one was marked `ignore` and never actually checked. The import is dropped; the usage example itself stays.
- `pna/src/ext/metadata.rs`: the trait's `# Errors` section claimed the conversion can fail, but `fs_metadata_to_metadata` unconditionally returns `Ok` on every platform. The doc now defers to the implementing type instead of asserting a contract the only implementation doesn't uphold.
- `cli/src/command/core/ignore.rs`: the comment described applying the nearest `.gitignore` "last", but the loop walks from the nearest directory outward and returns on the first match — i.e. the nearest one is checked first, not last (the resulting "closest wins" behavior was already correct).

## Verification
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p libpna -p pna -p portable-network-archive --all-features`
- `cargo fmt --all -- --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified command-line behavior when reading archive data from standard input.
  * Improved documentation for directory traversal and `.gitignore` matching.
  * Clarified metadata conversion error conditions.
  * Corrected terminology for ancillary chunks.
  * Simplified documentation examples by removing redundant imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->