### PR TITLE
Stream solid blocks through write_solid_with in keep-solid transforms

### DIFF
--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -31,7 +31,7 @@ pub(crate) use path_transformer::PathTransformers;
 use pna::{
     Archive, DataKind, DirEntryBuilder, EntryContent, FileEntryBuilder, HardLinkEntryBuilder,
     LinkTargetType, Metadata, NormalEntry, OpaqueEntryBuilder, PNA_SIGNATURE, ReadEntry,
-    ReadOptions, SolidEntryBuilder, SymlinkEntryBuilder, WriteOptions, prelude::*,
+    ReadOptions, SymlinkEntryBuilder, WriteOptions, prelude::*,
 };
 use std::{
     borrow::Cow,
@@ -1318,21 +1318,20 @@ impl TransformStrategy for TransformStrategyKeepSolid {
         match read_entry? {
             ReadEntry::Solid(s) => {
                 let header = s.header();
-                let mut builder = SolidEntryBuilder::new(
-                    WriteOptions::builder()
-                        .compression(header.compression())
-                        .encryption(header.encryption())
-                        .cipher_mode(header.cipher_mode())
-                        .password(context.password)
-                        .build(),
-                )?;
-                for n in s.entries(&context.read_options)? {
-                    if let Some(entry) = transformer(n.map(Into::into))? {
-                        builder.add_entry(entry)?;
+                let option = WriteOptions::builder()
+                    .compression(header.compression())
+                    .encryption(header.encryption())
+                    .cipher_mode(header.cipher_mode())
+                    .password(context.password)
+                    .build();
+                archive.write_solid_with(option, |solid| {
+                    for n in s.entries(&context.read_options)? {
+                        if let Some(entry) = transformer(n.map(Into::into))? {
+                            solid.add_entry(entry)?;
+                        }
                     }
-                }
-                archive.add_entry(builder.build()?)?;
-                Ok(())
+                    Ok(())
+                })
             }
             ReadEntry::Normal(n) => {
                 if let Some(entry) = transformer(Ok(n))? {

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -2214,6 +2214,50 @@ mod tests {
     }
 
     #[test]
+    fn keep_solid_transform_propagates_transformer_error_mid_block() {
+        let bytes = {
+            let mut archive = Archive::write_header(Vec::new()).unwrap();
+            let mut builder = pna::SolidEntryBuilder::new(WriteOptions::store()).unwrap();
+            builder
+                .add_entry(
+                    FileEntryBuilder::new("a.txt".into())
+                        .unwrap()
+                        .build()
+                        .unwrap(),
+                )
+                .unwrap();
+            builder
+                .add_entry(
+                    FileEntryBuilder::new("b.txt".into())
+                        .unwrap()
+                        .build()
+                        .unwrap(),
+                )
+                .unwrap();
+            archive.add_entry(builder.build().unwrap()).unwrap();
+            archive.finalize().unwrap()
+        };
+
+        let mut src = Archive::read_header(&bytes[..]).unwrap();
+        let read_entry = src.entries().next().unwrap();
+        let mut out = Archive::write_header(Vec::new()).unwrap();
+        let context = TransformContext::new(None);
+        let mut seen = 0;
+        let err = TransformStrategyKeepSolid::transform(&mut out, &context, read_entry, |entry| {
+            let entry = entry?;
+            seen += 1;
+            if seen == 2 {
+                return Err(io::Error::other("boom"));
+            }
+            Ok(Some(entry))
+        })
+        .unwrap_err();
+
+        assert_eq!(seen, 2);
+        assert_eq!(err.to_string(), "boom");
+    }
+
+    #[test]
     fn gcm_reencrypt_options_are_reused_for_matching_entries() {
         let source_options = WriteOptions::builder()
             .encryption(pna::Encryption::AES)

--- a/cli/tests/cli/chmod/keep_solid.rs
+++ b/cli/tests/cli/chmod/keep_solid.rs
@@ -1,5 +1,6 @@
 use crate::utils::{archive, archive::FileEntryDef, setup};
 use clap::Parser;
+use pna::prelude::*;
 use portable_network_archive::cli;
 
 const ENTRY_PATH: &str = "test.txt";
@@ -52,4 +53,163 @@ fn chmod_keep_solid() {
     })
     .unwrap();
     assert!(found, "target entry not found in archive");
+}
+
+fn solid_headers(path: &str) -> Vec<(pna::Compression, pna::Encryption, pna::CipherMode)> {
+    let mut archive = pna::Archive::open(path).unwrap();
+    archive
+        .entries()
+        .map(|entry| match entry.unwrap() {
+            pna::ReadEntry::Solid(s) => {
+                let header = s.header();
+                (
+                    header.compression(),
+                    header.encryption(),
+                    header.cipher_mode(),
+                )
+            }
+            pna::ReadEntry::Normal(_) => panic!("expected a solid entry"),
+        })
+        .collect()
+}
+
+/// Precondition: An encrypted solid archive contains a file entry.
+/// Action: Run `pna experimental chmod` with `--keep-solid` and the correct password.
+/// Expectation: The permission change is applied, the archive remains solid with its
+///              compression, encryption, and cipher mode unchanged, and it still decrypts
+///              with the same password.
+#[test]
+fn chmod_keep_solid_on_encrypted_solid_archive() {
+    setup();
+
+    archive::create_encrypted_solid_archive_with_permissions(
+        "chmod_keep_solid_encrypted.pna",
+        &[FileEntryDef {
+            path: ENTRY_PATH,
+            content: ENTRY_CONTENT,
+            permission: 0o777,
+        }],
+        "password",
+    )
+    .unwrap();
+    let headers_before = solid_headers("chmod_keep_solid_encrypted.pna");
+    assert_eq!(headers_before.len(), 1);
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "chmod",
+        "--keep-solid",
+        "-f",
+        "chmod_keep_solid_encrypted.pna",
+        "--password",
+        "password",
+        "--",
+        "-x",
+        ENTRY_PATH,
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    assert_eq!(
+        archive::entry_mode_with_password(
+            "chmod_keep_solid_encrypted.pna",
+            ENTRY_PATH,
+            Some("password"),
+        ),
+        0o666,
+    );
+    assert_eq!(
+        solid_headers("chmod_keep_solid_encrypted.pna"),
+        headers_before
+    );
+}
+
+fn stored_file_entry(path: &str, permission: u16) -> pna::NormalEntry {
+    use std::io::Write;
+
+    let mut builder =
+        pna::FileEntryBuilder::new_with_options(path.into(), pna::WriteOptions::store()).unwrap();
+    builder.metadata(
+        pna::Metadata::new().with_permission_mode(Some(pna::PermissionMode::from(permission))),
+    );
+    builder.write_all(ENTRY_CONTENT).unwrap();
+    builder.build().unwrap()
+}
+
+/// Precondition: An archive interleaves normal entries around one solid block.
+/// Action: Run `pna experimental chmod` with `--keep-solid` over every entry.
+/// Expectation: The entry order and the normal/solid layout survive, and the permission
+///              change is applied to every entry.
+#[test]
+fn chmod_keep_solid_preserves_mixed_normal_and_solid_layout() {
+    setup();
+
+    let path = "chmod_keep_solid_mixed.pna";
+    let file = std::fs::File::create(path).unwrap();
+    let mut out = pna::Archive::write_header(file).unwrap();
+    out.add_entry(stored_file_entry("outer/before.txt", 0o777))
+        .unwrap();
+    let mut solid = pna::SolidEntryBuilder::new(pna::WriteOptions::store()).unwrap();
+    solid
+        .add_entry(stored_file_entry("inner/a.txt", 0o777))
+        .unwrap();
+    solid
+        .add_entry(stored_file_entry("inner/b.txt", 0o777))
+        .unwrap();
+    out.add_entry(solid.build().unwrap()).unwrap();
+    out.add_entry(stored_file_entry("outer/after.txt", 0o777))
+        .unwrap();
+    out.finalize().unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "chmod",
+        "--keep-solid",
+        "-f",
+        path,
+        "--",
+        "-x",
+        "outer/before.txt",
+        "inner/a.txt",
+        "inner/b.txt",
+        "outer/after.txt",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut archive = pna::Archive::open(path).unwrap();
+    let layout = archive
+        .entries()
+        .map(|entry| matches!(entry.unwrap(), pna::ReadEntry::Solid(_)))
+        .collect::<Vec<_>>();
+    assert_eq!(layout, [false, true, false]);
+
+    let mut entries = Vec::new();
+    archive::for_each_entry(path, |entry| {
+        entries.push((
+            entry.header().path().to_string(),
+            entry
+                .metadata()
+                .permission_mode()
+                .expect("entry should have permission mode metadata")
+                .get()
+                & 0o777,
+        ));
+    })
+    .unwrap();
+    assert_eq!(
+        entries,
+        [
+            ("outer/before.txt".to_string(), 0o666),
+            ("inner/a.txt".to_string(), 0o666),
+            ("inner/b.txt".to_string(), 0o666),
+            ("outer/after.txt".to_string(), 0o666),
+        ]
+    );
 }


### PR DESCRIPTION
## Summary
`TransformStrategyKeepSolid` now streams solid blocks into the output through `Archive::write_solid_with` instead of building the whole re-encoded block in memory via `SolidEntryBuilder`.

## Notes
- On mid-block failure the output holds an unterminated solid block. Every keep-solid user writes through `StagedArchive`, so the temp file is discarded without commit and the original archive is untouched.
- Keep-solid output now carries the same per-write SDAT chunking as `create --solid`. Archives of many tiny entries grow compared to the old coalesced output (1000×57B entries: 128 KB → 308 KB); payload is identical and the 300 MB single-entry case grows by 154 bytes.

## Verification
max RSS of `chmod --keep-solid` on a 300 MB single-entry solid archive (release build, /usr/bin/time -l):

| features | before | after |
|---|---|---|
| default | 954 MB | 637 MB |
| memmap | 954 MB | 639 MB |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `chmod --keep-solid` processing for solid archives.
  * Permission changes now preserve compression, encryption, and cipher settings.
  * Mixed archives retain their original entry order and structure.
  * Errors encountered during processing are now correctly reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->