### PR TITLE
Fix comment duplication where the docs sit on the wrong side

### DIFF
--- a/cli/src/command/append.rs
+++ b/cli/src/command/append.rs
@@ -398,7 +398,7 @@ fn append_to_archive(args: AppendCommand) -> anyhow::Result<()> {
     let option = entry_option(args.compression, args.cipher, args.hash, password);
     let (mode_strategy, owner_strategy) = PermissionStrategyResolver {
         keep_permission: args.keep_permission,
-        same_owner: true, // Must be `true` for creation
+        same_owner: true, // Creation always stores ownership; same_owner only matters for extraction.
         uname: args.uname,
         gname: args.gname,
         uid: args.uid,

--- a/cli/src/command/bsdtar.rs
+++ b/cli/src/command/bsdtar.rs
@@ -763,10 +763,7 @@ impl CreationPermissionStrategyResolver {
     }
 }
 
-/// Resolves permission strategies for bsdtar extraction operations.
-/// Extraction defaults: root preserves exact permissions, non-root applies umask (bsdtar behavior).
-/// -p/--same-permissions enables mode + ACL + xattr + fflags + mac-metadata (but NOT owner)
-/// Flag priority: --no-same-permissions > -p > individual flags; individual --no-* always wins
+/// CLI flags needed to resolve bsdtar-compatible extraction permission strategies.
 struct ExtractionPermissionStrategyResolver {
     same_permissions: bool,
     no_same_permissions: bool,
@@ -798,8 +795,10 @@ type ExtractionPermissionStrategies = (
 );
 
 impl ExtractionPermissionStrategyResolver {
+    /// Extraction defaults: root preserves exact permissions, non-root applies umask (bsdtar behavior).
+    /// `-p`/`--same-permissions` enables mode + ACL + xattr + fflags + mac-metadata (but NOT owner).
+    /// Flag priority: `--no-same-permissions` > `-p` > individual flags; individual `--no-*` always wins.
     fn resolve(self) -> ExtractionPermissionStrategies {
-        // bsdtar behavior: root defaults to -p (Preserve), non-root defaults to Masked
         let default_mode_strategy = if self.is_root {
             ModeStrategy::Preserve
         } else {
@@ -835,7 +834,6 @@ impl ExtractionPermissionStrategyResolver {
             OwnerStrategy::Never
         };
 
-        // -p enables these unless --no-same-permissions is set; individual --no-* always wins
         let p_enables = !self.no_same_permissions && self.same_permissions;
 
         (

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -304,9 +304,6 @@ impl PermissionStrategyResolver {
     /// The `same_owner` field controls ownership handling:
     /// - `true`: Restore/store ownership (Preserve with options)
     /// - `false`: Skip ownership restoration (Never)
-    ///
-    /// For creation contexts, pass `same_owner: true` since ownership
-    /// is always stored when `--keep-permission` is enabled.
     pub(crate) fn resolve(self) -> (ModeStrategy, OwnerStrategy) {
         if self.keep_permission {
             let mode_strategy = ModeStrategy::Preserve;

--- a/cli/src/command/create.rs
+++ b/cli/src/command/create.rs
@@ -491,7 +491,7 @@ fn create_archive(args: CreateCommand) -> anyhow::Result<()> {
     }
     let (mode_strategy, owner_strategy) = PermissionStrategyResolver {
         keep_permission: args.keep_permission,
-        same_owner: true, // Must be `true` for creation
+        same_owner: true, // Creation always stores ownership; same_owner only matters for extraction.
         uname: args.uname,
         gname: args.gname,
         uid: args.uid,

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -1573,15 +1573,12 @@ fn restore_metadata<T>(
 where
     T: AsRef<[u8]>,
 {
-    // Restore timestamps for non-file entries (symlinks, directories, hardlinks).
-    // Regular files are handled by restore_timestamps() with an open file handle.
     // On WASM, path-based timestamp restoration is not supported (filetime limitation).
     #[cfg(not(target_family = "wasm"))]
     if item.header().data_kind() != DataKind::FILE {
         restore_path_timestamps(path, item.metadata(), keep_options)?;
     }
     let ownership = crate::ext::ResolvedOwnership::from_metadata(item.metadata());
-    // Restore ownership when owner_strategy is Preserve (independent of mode).
     // A permission-mode-only entry (`fMOd`) is not owner identity and must not
     // fall back to uid/gid 0.
     if let OwnerStrategy::Preserve { options } = &keep_options.owner_strategy
@@ -1589,9 +1586,7 @@ where
     {
         restore_owner(path, &ownership, options)?;
     }
-    // Restore mode bits when configured.
-    // Skip for symlinks: symlink permissions are not settable via chmod() on most
-    // platforms, and chmod() follows symlinks, which would corrupt the target's permissions.
+    // Not settable via chmod() on most platforms.
     if item.header().data_kind() != DataKind::SYMBOLIC_LINK
         && let Some(mode) = ownership.mode
     {

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -426,7 +426,7 @@ fn update_archive(args: UpdateCommand) -> anyhow::Result<()> {
     let option = entry_option(args.compression, args.cipher, args.hash, password);
     let (mode_strategy, owner_strategy) = PermissionStrategyResolver {
         keep_permission: args.keep_permission,
-        same_owner: true, // Must be `true` for creation
+        same_owner: true, // Creation always stores ownership; same_owner only matters for extraction.
         uname: args.uname,
         gname: args.gname,
         uid: args.uid,

--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -174,15 +174,9 @@ impl<T> Archive<T> {
 
 /// Provides write access to solid mode PNA files.
 ///
-/// In solid mode, all entries are compressed together as a single unit,
-/// which typically results in better compression ratios compared to
-/// non-solid mode. However, this means that individual entries cannot
-/// be accessed randomly - they must be read sequentially.
-///
-/// Key features of solid mode:
-/// - Improved compression ratio
-/// - Sequential access only
-/// - Single compression/encryption context for all entries
+/// See [`crate::SolidEntry`] for the compression/access tradeoffs of solid
+/// mode. Writing additionally shares a single compression/encryption context
+/// across all entries.
 ///
 /// # Examples
 /// Creates a new solid mode PNA file and adds an entry to it.

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -296,9 +296,7 @@ fn encoded_data_reader<T: AsRef<[u8]>>(data: &[T]) -> EncodedDataReader<'_> {
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub enum ReadEntry<T = Vec<u8>> {
-    /// A solid mode entry that contains multiple files compressed together.
-    /// This type of entry provides better compression ratios but requires
-    /// sequential access to the contained files.
+    /// A solid mode entry. See [`SolidEntry`] for the compression/access tradeoffs.
     Solid(SolidEntry<T>),
     /// A normal entry that represents a single file in the archive.
     /// This type of entry allows random access to the file data.

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -570,7 +570,6 @@ impl OwnerUserName {
     pub(crate) fn to_bytes(&self) -> Vec<u8> {
         let b = self.0.as_str().as_bytes();
         let mut v = Vec::with_capacity(1 + b.len());
-        // Type guarantees b.len() <= 255 (BoundedString<255> invariant).
         v.push(b.len() as u8);
         v.extend_from_slice(b);
         v
@@ -637,7 +636,6 @@ impl OwnerGroupName {
     pub(crate) fn to_bytes(&self) -> Vec<u8> {
         let b = self.0.as_str().as_bytes();
         let mut v = Vec::with_capacity(1 + b.len());
-        // Type guarantees b.len() <= 255 (BoundedString<255> invariant).
         v.push(b.len() as u8);
         v.extend_from_slice(b);
         v
@@ -704,7 +702,6 @@ impl OwnerUserSid {
     pub(crate) fn to_bytes(&self) -> Vec<u8> {
         let b = self.0.as_str().as_bytes();
         let mut v = Vec::with_capacity(1 + b.len());
-        // Type guarantees b.len() <= 255 (BoundedString<255> invariant).
         v.push(b.len() as u8);
         v.extend_from_slice(b);
         v
@@ -771,7 +768,6 @@ impl OwnerGroupSid {
     pub(crate) fn to_bytes(&self) -> Vec<u8> {
         let b = self.0.as_str().as_bytes();
         let mut v = Vec::with_capacity(1 + b.len());
-        // Type guarantees b.len() <= 255 (BoundedString<255> invariant).
         v.push(b.len() as u8);
         v.extend_from_slice(b);
         v


### PR DESCRIPTION
## Summary
Third pass on the comment-slop audit's "move" candidates (following #3418, #3428). Unlike a straightforward "duplicate exists, delete the copy" case, each of these needed the actual ownership direction verified against the code before fixing — a naive "keep whichever side has more detail" call would have picked the wrong side at least once here:

- `append.rs`/`create.rs`/`update.rs` + `core.rs`: `PermissionStrategyResolver::resolve`'s doc explained a creation-only calling convention (`same_owner: true` for creation), leaking caller-specific knowledge into a resolver also used by extraction. Moved that reasoning to the three creation call sites instead.
- `bsdtar.rs`: `ExtractionPermissionStrategyResolver`'s struct doc described `resolve`'s algorithm (root/non-root defaults, flag priority) rather than the struct's own fields. Moved the algorithm description onto `resolve` itself.
- `extract.rs`: `restore_metadata`'s inline comments repeated its own doc bullets verbatim; kept only what the doc didn't already say (WASM limitation, `fMOd` not being owner identity, chmod() platform limits).
- `entry.rs`/`archive.rs`: `SolidEntry`'s compression/access tradeoffs were restated in `ReadEntry::Solid` and `SolidArchive`; both now reference `SolidEntry` instead of repeating it. Also removed `SolidArchive`'s self-duplication (same tradeoffs stated once in prose, once as a bullet list).
- `entry/meta.rs`: dropped a cast-safety comment duplicated across four owner-facet types (`OwnerUserName`/`OwnerGroupName`/`OwnerUserSid`/`OwnerGroupSid`). It hardcoded the bound as the literal `255`, but the real invariant lives on the `OWNER_STR_MAX` constant and `BoundedString`'s own contract.

## Verification
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p libpna -p pna -p portable-network-archive --all-features`
- `cargo doc --no-deps --all-features` (confirmed the new intra-doc links to `SolidEntry` resolve)
- `cargo fmt --all -- --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified permission and ownership behavior during archive creation and extraction.
  * Updated extraction flag precedence and default behavior guidance.
  * Refined solid-mode archive documentation, including compression and access trade-offs.
  * Simplified metadata serialization documentation.
* **Refactor**
  * Removed outdated and redundant comments without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->