### PR TITLE
:recycle: Write the legacy fPRM values as owner facets

### DIFF
--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -711,7 +711,11 @@ mod tests {
             let mut builder =
                 FileEntryBuilder::new_with_options("name".into(), WriteOptions::builder().build())
                     .unwrap();
-            builder.metadata(
+            builder.write_all(b"entry data").unwrap();
+            // Attached via `with_metadata` on the built entry, which bypasses
+            // `EntryBuilderCore::metadata` entirely — the path the deleted
+            // builder-level fPRM rescue never covered either.
+            builder.build().unwrap().with_metadata(
                 Metadata::new()
                     .with_created(Some(Duration::seconds(31)))
                     .with_modified(Some(Duration::seconds(32)))
@@ -723,9 +727,7 @@ mod tests {
                         "gname".into(),
                         0o775,
                     ))),
-            );
-            builder.write_all(b"entry data").unwrap();
-            builder.build().unwrap()
+            )
         };
 
         let mut archive = Archive::write_header(Vec::new()).unwrap();
@@ -750,9 +752,20 @@ mod tests {
             original_entry.metadata().accessed(),
             read_entry.metadata().accessed()
         );
+        assert_eq!(read_entry.metadata().permission(), None);
+        assert_eq!(read_entry.metadata().owner_uid().map(|v| v.get()), Some(1));
+        assert_eq!(read_entry.metadata().owner_gid().map(|v| v.get()), Some(2));
         assert_eq!(
-            original_entry.metadata().permission(),
-            read_entry.metadata().permission()
+            read_entry.metadata().owner_user_name().map(|v| v.as_str()),
+            Some("uname")
+        );
+        assert_eq!(
+            read_entry.metadata().owner_group_name().map(|v| v.as_str()),
+            Some("gname")
+        );
+        assert_eq!(
+            read_entry.metadata().permission_mode().map(|v| v.get()),
+            Some(0o775)
         );
         assert_eq!(
             original_entry.metadata().compressed_size(),

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -146,8 +146,41 @@ fn try_for_each_metadata_facet<E>(
             f(ChunkType::aTNS, Cow::Borrowed(&nanos.to_be_bytes()))?;
         }
     }
-    if let Some(value) = &metadata.permission {
-        f(ChunkType::fPRM, Cow::Owned(value.to_bytes()))?;
+    // A legacy `Permission` (fPRM) is written as the five owner facets it
+    // supplies, but only when none of them is already set: setting any one
+    // facet means the caller manages ownership through facets, and `Option`
+    // cannot tell "never set" from "explicitly cleared" (e.g. `chown
+    // --numeric-owner` clears the owner names), so a per-facet merge would
+    // resurrect a value the caller deliberately dropped.
+    let has_owner_facet = metadata.owner_uid.is_some()
+        || metadata.owner_gid.is_some()
+        || metadata.owner_user_name.is_some()
+        || metadata.owner_group_name.is_some()
+        || metadata.permission_mode.is_some();
+    if let Some(value) = metadata.permission.as_ref().filter(|_| !has_owner_facet) {
+        f(
+            ChunkType::fUId,
+            Cow::Borrowed(&OwnerUid::from(value.uid()).to_bytes()),
+        )?;
+        f(
+            ChunkType::fGId,
+            Cow::Borrowed(&OwnerGid::from(value.gid()).to_bytes()),
+        )?;
+        // A name too long for the owner-facet wire bound (255 bytes, a
+        // 1-byte length prefix) cannot be represented as `OwnerUserName`/
+        // `OwnerGroupName`; drop that facet rather than truncate or panic.
+        // `Permission::new` is still public at this stage, so this is
+        // reachable, if unlikely.
+        if let Ok(name) = OwnerUserName::new(value.uname()) {
+            f(ChunkType::fONm, Cow::Owned(name.to_bytes()))?;
+        }
+        if let Ok(name) = OwnerGroupName::new(value.gname()) {
+            f(ChunkType::fGNm, Cow::Owned(name.to_bytes()))?;
+        }
+        f(
+            ChunkType::fMOd,
+            Cow::Borrowed(&PermissionMode::from(value.permissions()).to_bytes()),
+        )?;
     }
     if let Some(value) = metadata.owner_uid {
         f(ChunkType::fUId, Cow::Borrowed(&value.to_bytes()))?;
@@ -1363,6 +1396,181 @@ mod tests {
         assert_eq!(u128::MAX, u128_from_be_bytes_last(&u128::MAX.to_be_bytes()));
     }
 
+    #[allow(deprecated)]
+    mod permission_facet_priority {
+        use super::*;
+        #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+        use wasm_bindgen_test::wasm_bindgen_test as test;
+
+        fn collect_facets(metadata: &Metadata) -> Vec<(ChunkType, Vec<u8>)> {
+            let mut out = Vec::new();
+            try_for_each_metadata_facet(metadata, |ty, data| {
+                out.push((ty, data.into_owned()));
+                Ok::<(), Infallible>(())
+            })
+            .unwrap();
+            out
+        }
+
+        fn facet(facets: &[(ChunkType, Vec<u8>)], ty: ChunkType) -> Option<Vec<u8>> {
+            facets
+                .iter()
+                .find(|(t, _)| *t == ty)
+                .map(|(_, data)| data.clone())
+        }
+
+        #[test]
+        fn permission_only_emits_five_owner_facets_and_no_fprm() {
+            let metadata = Metadata::new().with_permission(Some(Permission::new(
+                111,
+                "alice".to_string(),
+                222,
+                "staff".to_string(),
+                0o600,
+            )));
+            let facets = collect_facets(&metadata);
+
+            assert!(facet(&facets, ChunkType::fPRM).is_none());
+            assert_eq!(
+                facet(&facets, ChunkType::fUId),
+                Some(OwnerUid::from(111u64).to_bytes().to_vec())
+            );
+            assert_eq!(
+                facet(&facets, ChunkType::fGId),
+                Some(OwnerGid::from(222u64).to_bytes().to_vec())
+            );
+            assert_eq!(
+                facet(&facets, ChunkType::fONm),
+                Some(OwnerUserName::new("alice").unwrap().to_bytes())
+            );
+            assert_eq!(
+                facet(&facets, ChunkType::fGNm),
+                Some(OwnerGroupName::new("staff").unwrap().to_bytes())
+            );
+            assert_eq!(
+                facet(&facets, ChunkType::fMOd),
+                Some(PermissionMode::from(0o600u16).to_bytes().to_vec())
+            );
+        }
+
+        #[test]
+        fn existing_owner_facet_makes_permission_ignored_entirely() {
+            let metadata = Metadata::new()
+                .with_owner_uid(Some(OwnerUid::from(999u64)))
+                .with_permission(Some(Permission::new(
+                    111,
+                    "alice".to_string(),
+                    222,
+                    "staff".to_string(),
+                    0o600,
+                )));
+            let facets = collect_facets(&metadata);
+
+            assert!(facet(&facets, ChunkType::fPRM).is_none());
+            assert_eq!(
+                facet(&facets, ChunkType::fUId),
+                Some(OwnerUid::from(999u64).to_bytes().to_vec()),
+                "the set facet's own value must win, not the permission's"
+            );
+            assert!(facet(&facets, ChunkType::fGId).is_none());
+            assert!(facet(&facets, ChunkType::fONm).is_none());
+            assert!(facet(&facets, ChunkType::fGNm).is_none());
+            assert!(facet(&facets, ChunkType::fMOd).is_none());
+        }
+
+        #[test]
+        fn sid_only_facet_does_not_count_for_the_all_or_nothing_rule() {
+            let metadata = Metadata::new()
+                .with_owner_user_sid(Some(OwnerUserSid::new("S-1-5-21-1").unwrap()))
+                .with_permission(Some(Permission::new(
+                    111,
+                    "alice".to_string(),
+                    222,
+                    "staff".to_string(),
+                    0o600,
+                )));
+            let facets = collect_facets(&metadata);
+
+            assert!(facet(&facets, ChunkType::fPRM).is_none());
+            assert_eq!(
+                facet(&facets, ChunkType::fOSi),
+                Some(OwnerUserSid::new("S-1-5-21-1").unwrap().to_bytes()),
+                "guard: the SID must still be present for the five facets below to be meaningful"
+            );
+            assert_eq!(
+                facet(&facets, ChunkType::fUId),
+                Some(OwnerUid::from(111u64).to_bytes().to_vec())
+            );
+            assert_eq!(
+                facet(&facets, ChunkType::fGId),
+                Some(OwnerGid::from(222u64).to_bytes().to_vec())
+            );
+            assert_eq!(
+                facet(&facets, ChunkType::fONm),
+                Some(OwnerUserName::new("alice").unwrap().to_bytes())
+            );
+            assert_eq!(
+                facet(&facets, ChunkType::fGNm),
+                Some(OwnerGroupName::new("staff").unwrap().to_bytes())
+            );
+            assert_eq!(
+                facet(&facets, ChunkType::fMOd),
+                Some(PermissionMode::from(0o600u16).to_bytes().to_vec())
+            );
+        }
+
+        #[test]
+        fn permission_mode_from_st_mode_is_masked_to_0o7777() {
+            let metadata = Metadata::new().with_permission(Some(Permission::new(
+                0,
+                String::new(),
+                0,
+                String::new(),
+                0o100644,
+            )));
+            let facets = collect_facets(&metadata);
+
+            assert_eq!(
+                facet(&facets, ChunkType::fMOd),
+                Some(PermissionMode::from(0o644u16).to_bytes().to_vec()),
+                "fMOd must mask off the file-type bits fPRM used to carry"
+            );
+        }
+
+        #[test]
+        fn overlong_name_facet_is_dropped_without_truncation_or_panic() {
+            let long_name = "a".repeat(300);
+            let metadata = Metadata::new().with_permission(Some(Permission::new(
+                111,
+                long_name,
+                222,
+                "staff".to_string(),
+                0o600,
+            )));
+            let facets = collect_facets(&metadata);
+
+            // uid/gid/mode do not depend on the name and must still be written.
+            assert_eq!(
+                facet(&facets, ChunkType::fUId),
+                Some(OwnerUid::from(111u64).to_bytes().to_vec())
+            );
+            assert_eq!(
+                facet(&facets, ChunkType::fGId),
+                Some(OwnerGid::from(222u64).to_bytes().to_vec())
+            );
+            assert_eq!(
+                facet(&facets, ChunkType::fMOd),
+                Some(PermissionMode::from(0o600u16).to_bytes().to_vec())
+            );
+            // a name too long for the 1-byte length prefix is dropped, not truncated.
+            assert!(facet(&facets, ChunkType::fONm).is_none());
+            assert_eq!(
+                facet(&facets, ChunkType::fGNm),
+                Some(OwnerGroupName::new("staff").unwrap().to_bytes())
+            );
+        }
+    }
+
     static TEST_ENTRY: LazyLock<RawEntry> = LazyLock::new(|| {
         RawEntry(vec![
             RawChunk::from_data(
@@ -1817,5 +2025,64 @@ mod tests {
             let pos = chunks.iter().position(|c| c.ty == ty).unwrap();
             assert!(pos < fdat_pos, "{ty:?} must appear before FDAT");
         }
+    }
+
+    /// Reads a 0.33.0 fixture whose entries carry only legacy `fPRM`, writes
+    /// every entry back out through the production writer, and checks that
+    /// the output carries no `fPRM` while every entry has the owner facets
+    /// derived from it. Counts both loops so a regression that drops entries
+    /// cannot leave a loop body unexecuted and still pass.
+    #[test]
+    fn zstd_keep_all_fixture_rewrites_owner_facets_without_fprm() {
+        use crate::{Archive, DataKind};
+
+        let src = include_bytes!("../../resources/test/0.33.0/zstd_keep_all.pna");
+        let read_options = ReadOptions::builder().build();
+
+        let mut out = Vec::new();
+        let mut read_count = 0;
+        {
+            let mut reader = Archive::read_header(src.as_slice()).unwrap();
+            let mut writer = Archive::write_header(&mut out).unwrap();
+            for entry in reader.entries_with_options(&read_options) {
+                let entry = entry.unwrap();
+                read_count += 1;
+                writer.add_entry(entry).unwrap();
+            }
+            writer.finalize().unwrap();
+        }
+        assert_eq!(read_count, 16, "fixture must have 16 entries");
+        assert!(
+            !out.windows(4).any(|w| w == b"fPRM"),
+            "the rewritten archive must carry no fPRM chunk"
+        );
+
+        let mut reread = Archive::read_header(out.as_slice()).unwrap();
+        let mut written_count = 0;
+        for entry in reread.entries_with_options(&read_options) {
+            let entry = entry.unwrap();
+            written_count += 1;
+            let metadata = entry.metadata();
+            assert_eq!(metadata.owner_uid().map(|v| v.get()), Some(0));
+            assert_eq!(metadata.owner_gid().map(|v| v.get()), Some(0));
+            assert_eq!(metadata.owner_user_name().map(|v| v.as_str()), Some("root"));
+            assert_eq!(
+                metadata.owner_group_name().map(|v| v.as_str()),
+                Some("root")
+            );
+            let expected_mode = if entry.header().data_kind() == DataKind::DIRECTORY {
+                0o755
+            } else {
+                0o644
+            };
+            assert_eq!(
+                metadata.permission_mode().map(|v| v.get()),
+                Some(expected_mode)
+            );
+        }
+        assert_eq!(
+            written_count, 16,
+            "no entry must be dropped by the round trip"
+        );
     }
 }

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -68,21 +68,6 @@ pub(super) fn prepend_data_prefix(
     data.splice(0..0, prefix.chunks(max_chunk_size).map(<[u8]>::to_vec));
 }
 
-/// Largest UTF-8 char-boundary prefix of `s` whose byte length is ≤ 255 —
-/// the `fONm`/`fGNm` owner-name wire bound (1-byte length prefix). Used to
-/// rescue a legacy fPRM name that exceeds the bounded owner-facet limit.
-fn owner_name_bounded(s: &str) -> &str {
-    const MAX: usize = u8::MAX as usize;
-    if s.len() <= MAX {
-        return s;
-    }
-    let mut end = MAX;
-    while !s.is_char_boundary(end) {
-        end -= 1;
-    }
-    &s[..end]
-}
-
 /// Fields and logic shared by the kind-specific entry builders.
 pub(crate) struct EntryBuilderCore {
     header: EntryHeader,
@@ -118,50 +103,9 @@ impl EntryBuilderCore {
         &self.header
     }
 
-    /// Sets the metadata, rescuing deprecated `fPRM` permission data into
-    /// the owner-facet fields when no owner facet is set.
-    ///
-    /// If none of the owner-facet fields are populated, they are filled
-    /// from the `fPRM` data when present, and the `fPRM` data itself is
-    /// dropped from the stored metadata. Owner names longer than the
-    /// 255-byte wire bound of `fONm`/`fGNm` are truncated at a UTF-8
-    /// character boundary. If any owner-facet field is already populated,
-    /// the metadata is stored as-is (including `fPRM`, if set), preserving
-    /// the contract that `fPRM` and the owner facets are independent
-    /// chunks that may coexist.
-    ///
-    /// TODO: rescue unconditionally (dropping `fPRM` whenever it is
-    /// present, regardless of owner-facet fields) once the fPRM/owner-facet
-    /// coexistence contract is retired.
-    #[allow(deprecated)]
+    /// Sets the metadata, replacing any previously set metadata.
     pub(crate) fn metadata(&mut self, metadata: Metadata) {
-        let has_owner_facet = metadata.owner_uid().is_some()
-            || metadata.owner_gid().is_some()
-            || metadata.owner_user_name().is_some()
-            || metadata.owner_group_name().is_some()
-            || metadata.owner_user_sid().is_some()
-            || metadata.owner_group_sid().is_some()
-            || metadata.permission_mode().is_some();
-        let Some(p) = (!has_owner_facet)
-            .then(|| metadata.permission().cloned())
-            .flatten()
-        else {
-            self.metadata = metadata;
-            return;
-        };
-        self.metadata = metadata
-            .with_owner_uid(Some(OwnerUid::from(p.uid())))
-            .with_owner_gid(Some(OwnerGid::from(p.gid())))
-            .with_owner_user_name(Some(
-                OwnerUserName::new(owner_name_bounded(p.uname()))
-                    .expect("owner_name_bounded guarantees <= 255 bytes"),
-            ))
-            .with_owner_group_name(Some(
-                OwnerGroupName::new(owner_name_bounded(p.gname()))
-                    .expect("owner_name_bounded guarantees <= 255 bytes"),
-            ))
-            .with_permission_mode(Some(PermissionMode::from(p.permissions())))
-            .with_permission(None);
+        self.metadata = metadata;
     }
 
     pub(crate) fn add_extra_chunk(&mut self, chunk: impl Into<RawChunk>) {
@@ -978,34 +922,6 @@ mod tests {
     }
 
     #[test]
-    fn owner_name_bounded_passes_through_short_ascii() {
-        assert_eq!(owner_name_bounded(""), "");
-        assert_eq!(owner_name_bounded("alice"), "alice");
-        let exactly_255 = "a".repeat(255);
-        assert_eq!(owner_name_bounded(&exactly_255), exactly_255);
-    }
-
-    #[test]
-    fn owner_name_bounded_truncates_long_ascii_to_255() {
-        let s = "a".repeat(300);
-        let out = owner_name_bounded(&s);
-        assert_eq!(out.len(), 255);
-        assert!(out.bytes().all(|b| b == b'a'));
-        assert_eq!(owner_name_bounded(&"a".repeat(256)).len(), 255);
-    }
-
-    #[test]
-    fn owner_name_bounded_truncates_on_utf8_boundary() {
-        let two_byte_char = 'é';
-        assert_eq!(two_byte_char.len_utf8(), 2);
-        let s = String::from(two_byte_char).repeat(200); // 400 bytes
-        let out = owner_name_bounded(&s);
-        assert_eq!(out.len(), 254);
-        assert_eq!(out.chars().count(), 127);
-        assert!(out.chars().all(|c| c == two_byte_char));
-    }
-
-    #[test]
     #[allow(deprecated)]
     fn metadata_preserves_all_owner_facets() {
         let mut b = FileEntryBuilder::new("f".into()).unwrap();
@@ -1032,7 +948,7 @@ mod tests {
 
     #[test]
     #[allow(deprecated)]
-    fn metadata_rescues_fprm_only_source() {
+    fn metadata_setter_stores_permission_as_is_but_writer_derives_facets() {
         let mut b = FileEntryBuilder::new("f".into()).unwrap();
         b.metadata(Metadata::new().with_permission(Some(Permission::new(
             7,
@@ -1042,65 +958,61 @@ mod tests {
             0o600,
         ))));
         let entry = b.build().unwrap();
-        let m = entry.metadata();
-        assert_eq!(m.owner_uid().map(|v| v.get()), Some(7));
-        assert_eq!(m.owner_gid().map(|v| v.get()), Some(8));
-        assert_eq!(m.owner_user_name().map(|v| v.as_str()), Some("legacy"));
-        assert_eq!(m.owner_group_name().map(|v| v.as_str()), Some("grp"));
-        assert_eq!(m.permission_mode().map(|v| v.get()), Some(0o600));
-        assert!(m.permission().is_none());
-    }
 
-    #[test]
-    #[allow(deprecated)]
-    fn metadata_partial_owner_facet_skips_rescue() {
-        let mut b = FileEntryBuilder::new("f".into()).unwrap();
-        b.metadata(
-            Metadata::new()
-                .with_owner_uid(Some(OwnerUid::from(1)))
-                .with_owner_user_name(Some(OwnerUserName::new("new").unwrap()))
-                .with_permission(Some(Permission::new(
-                    7,
-                    "legacy".to_string(),
-                    8,
-                    "grp".to_string(),
-                    0o600,
-                ))),
-        );
-        let entry = b.build().unwrap();
+        // The setter stores the metadata as-is: `permission()` returns what
+        // was set, and the owner facets it never touched stay `None`.
         let m = entry.metadata();
-        assert_eq!(m.owner_uid().map(|v| v.get()), Some(1));
-        assert_eq!(m.owner_user_name().map(|v| v.as_str()), Some("new"));
+        assert!(m.permission().is_some());
+        assert_eq!(m.owner_uid(), None);
         assert_eq!(m.owner_gid(), None);
+        assert_eq!(m.owner_user_name(), None);
         assert_eq!(m.owner_group_name(), None);
         assert_eq!(m.permission_mode(), None);
-        assert!(
-            m.permission().is_some(),
-            "fPRM must coexist with a partially set owner facet"
-        );
-    }
 
-    #[test]
-    #[allow(deprecated)]
-    fn metadata_truncates_overlong_fprm_name() {
-        let big_char = 'é';
-        assert_eq!(big_char.len_utf8(), 2);
-        let big = String::from(big_char).repeat(200); // 400 bytes
-        let mut b = FileEntryBuilder::new("f".into()).unwrap();
-        b.metadata(Metadata::new().with_permission(Some(Permission::new(
-            7,
-            big,
-            8,
-            "grp".to_string(),
-            0o600,
-        ))));
-        let entry = b.build().unwrap();
-        let m = entry.metadata();
-        let uname = m.owner_user_name().unwrap().as_str();
-        assert_eq!(uname.len(), 254);
-        assert_eq!(uname.chars().count(), 127);
-        assert!(uname.chars().all(|c| c == big_char));
-        assert_eq!(m.owner_uid().map(|v| v.get()), Some(7));
+        // The chunks this entry writes carry the facets derived from that
+        // permission, and no fPRM.
+        let chunks = entry.into_chunks();
+        assert!(!chunks.iter().any(|c| c.ty == ChunkType::fPRM));
+        assert_eq!(
+            chunks
+                .iter()
+                .find(|c| c.ty == ChunkType::fUId)
+                .unwrap()
+                .data(),
+            OwnerUid::from(7u64).to_bytes()
+        );
+        assert_eq!(
+            chunks
+                .iter()
+                .find(|c| c.ty == ChunkType::fGId)
+                .unwrap()
+                .data(),
+            OwnerGid::from(8u64).to_bytes()
+        );
+        assert_eq!(
+            chunks
+                .iter()
+                .find(|c| c.ty == ChunkType::fONm)
+                .unwrap()
+                .data(),
+            OwnerUserName::new("legacy").unwrap().to_bytes()
+        );
+        assert_eq!(
+            chunks
+                .iter()
+                .find(|c| c.ty == ChunkType::fGNm)
+                .unwrap()
+                .data(),
+            OwnerGroupName::new("grp").unwrap().to_bytes()
+        );
+        assert_eq!(
+            chunks
+                .iter()
+                .find(|c| c.ty == ChunkType::fMOd)
+                .unwrap()
+                .data(),
+            PermissionMode::from(0o600u16).to_bytes()
+        );
     }
 
     #[allow(deprecated)]

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -482,18 +482,6 @@ impl Permission {
         self.permission
     }
 
-    pub(crate) fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(20 + self.uname.len() + self.gname.len());
-        bytes.extend_from_slice(&self.uid.to_be_bytes());
-        bytes.extend_from_slice(&(self.uname.len() as u8).to_be_bytes());
-        bytes.extend_from_slice(self.uname.as_bytes());
-        bytes.extend_from_slice(&self.gid.to_be_bytes());
-        bytes.extend_from_slice(&(self.gname.len() as u8).to_be_bytes());
-        bytes.extend_from_slice(self.gname.as_bytes());
-        bytes.extend_from_slice(&self.permission.to_be_bytes());
-        bytes
-    }
-
     pub(crate) fn try_from_bytes(mut bytes: &[u8]) -> io::Result<Self> {
         let uid = u64::from_be_bytes({
             let mut buf = [0; 8];
@@ -975,9 +963,14 @@ mod tests {
 
     #[allow(deprecated)]
     #[test]
-    fn permission() {
-        let perm = Permission::new(1000, "user1".into(), 100, "group1".into(), 0o644);
-        assert_eq!(perm, Permission::try_from_bytes(&perm.to_bytes()).unwrap());
+    fn permission_decodes_an_fprm_body() {
+        let perm =
+            Permission::try_from_bytes(&fprm_body(1000, "user1", 100, "group1", 0o644)).unwrap();
+        assert_eq!(perm.uid(), 1000);
+        assert_eq!(perm.uname(), "user1");
+        assert_eq!(perm.gid(), 100);
+        assert_eq!(perm.gname(), "group1");
+        assert_eq!(perm.permissions(), 0o644);
     }
 
     #[test]
@@ -1221,28 +1214,46 @@ mod tests {
         );
     }
 
+    /// Raw `fPRM` chunk body: `uid(8) | uname_len(1) | uname | gid(8) |
+    /// gname_len(1) | gname | mode(2)`, all big-endian (mirrors
+    /// `Permission::try_from_bytes`). Asserts both names fit the 1-byte
+    /// length prefix before the `as u8` cast, so a name too long for the
+    /// format fails loudly here instead of silently truncating the length
+    /// byte and producing a malformed chunk.
+    fn fprm_body(uid: u64, uname: &str, gid: u64, gname: &str, mode: u16) -> Vec<u8> {
+        assert!(uname.len() <= u8::MAX as usize);
+        assert!(gname.len() <= u8::MAX as usize);
+        let mut body = Vec::new();
+        body.extend_from_slice(&uid.to_be_bytes());
+        body.push(uname.len() as u8);
+        body.extend_from_slice(uname.as_bytes());
+        body.extend_from_slice(&gid.to_be_bytes());
+        body.push(gname.len() as u8);
+        body.extend_from_slice(gname.as_bytes());
+        body.extend_from_slice(&mode.to_be_bytes());
+        body
+    }
+
+    /// A pre-existing archive can carry both a legacy `fPRM` chunk and owner
+    /// facets — third-party writers and archives from 0.34 through 0.37 can
+    /// do this even though libpna itself no longer writes `fPRM`. Reading
+    /// must keep decoding `fPRM` into `permission()` regardless of the owner
+    /// facets alongside it; the two are independent chunks on read, and only
+    /// the writer's priority rule treats them as either/or.
     #[allow(deprecated)]
     #[test]
-    fn all_owner_facets_and_fprm_coexist_round_trip() {
+    fn fprm_alongside_owner_facets_reads_both_independently() {
         use crate::entry::{
             OwnerGid, OwnerGroupName, OwnerGroupSid, OwnerUid, OwnerUserName, OwnerUserSid,
             PermissionMode,
         };
-        use crate::{Archive, FileEntryBuilder};
+        use crate::{Archive, ChunkType, FileEntryBuilder, RawChunk};
         let mut buf = Vec::new();
         {
             let mut archive = Archive::write_header(&mut buf).unwrap();
             let mut b = FileEntryBuilder::new("f".into()).unwrap();
             b.metadata(
                 Metadata::new()
-                    // Legacy fPRM (Permission uses plain String uname/gname on this branch).
-                    .with_permission(Some(Permission::new(
-                        7,
-                        "legacy".to_string(),
-                        8,
-                        "grp".to_string(),
-                        0o600,
-                    )))
                     // All 7 new owner facets.
                     .with_owner_uid(Some(OwnerUid::from(1)))
                     .with_owner_gid(Some(OwnerGid::from(2)))
@@ -1252,6 +1263,13 @@ mod tests {
                     .with_owner_group_sid(Some(OwnerGroupSid::new("S-1-2").unwrap()))
                     .with_permission_mode(Some(PermissionMode::from(0o644))),
             );
+            // A raw fPRM extra chunk stands in for a pre-existing/third-party
+            // archive: libpna itself never writes fPRM anymore, so this is
+            // the only way left to construct one.
+            b.add_extra_chunk(RawChunk::from_data(
+                ChunkType::fPRM,
+                fprm_body(7, "legacy", 8, "grp", 0o600),
+            ));
             let entry = b.build().unwrap();
             archive.add_entry(entry).unwrap();
             archive.finalize().unwrap();
@@ -1267,10 +1285,9 @@ mod tests {
         assert_eq!(m.owner_user_sid().map(|v| v.as_str()), Some("S-1-1"));
         assert_eq!(m.owner_group_sid().map(|v| v.as_str()), Some("S-1-2"));
         assert_eq!(m.permission_mode().map(|v| v.get()), Some(0o644));
-        // Legacy fPRM still round-trips intact, independently of the new owner facets.
-        let p = m
-            .permission()
-            .expect("fPRM permission must still be present");
+        // The fPRM chunk decodes into `permission()` independently of the
+        // owner facets alongside it.
+        let p = m.permission().expect("fPRM chunk must still be readable");
         assert_eq!(p.uid(), 7);
         assert_eq!(p.uname(), "legacy");
         assert_eq!(p.gid(), 8);

--- a/pna/src/ext/entry_builder.rs
+++ b/pna/src/ext/entry_builder.rs
@@ -11,7 +11,7 @@ use std::time::SystemTime;
 /// instead of the lower-level [`Duration`](libpna::Duration) representation.
 #[deprecated(
     since = "0.36.0",
-    note = "use `Metadata` with `MetadataTimeExt::with_*_time`; the kind-specific builders' `metadata()` setter rescues deprecated `fPRM` permission data automatically"
+    note = "use `Metadata` with `MetadataTimeExt::with_*_time`; a deprecated `fPRM` permission with no owner facet set is written as the owner-facet chunks automatically"
 )]
 pub trait EntryBuilderExt: private::Sealed {
     /// Sets metadata from a [`Metadata`] instance.
@@ -227,22 +227,6 @@ mod tests {
         e.metadata().clone()
     }
 
-    #[allow(deprecated)]
-    fn roundtrip_with_builder_permission(src: &Metadata, permission: Permission) -> Metadata {
-        let mut buf = Vec::new();
-        {
-            let mut a = Archive::write_header(&mut buf).unwrap();
-            let mut b = OpaqueEntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
-            b.permission(permission);
-            b.add_metadata(src);
-            a.add_entry(b.build().unwrap()).unwrap();
-            a.finalize().unwrap();
-        }
-        let mut a = Archive::read_header(&buf[..]).unwrap();
-        let e = a.entries().skip_solid().next().unwrap().unwrap();
-        e.metadata().clone()
-    }
-
     #[test]
     fn add_metadata_preserves_all_owner_facets() {
         let src = Metadata::new()
@@ -323,37 +307,5 @@ mod tests {
         assert_eq!(uname.chars().count(), 127);
         assert!(uname.chars().all(|c| c == big_char));
         assert_eq!(m.owner_uid().map(|v| v.get()), Some(7));
-    }
-
-    #[test]
-    #[allow(deprecated)]
-    fn add_metadata_preserves_explicit_builder_fprm_while_rescuing_metadata_fprm() {
-        let src = Metadata::new().with_permission(Some(Permission::new(
-            7,
-            "legacy".to_string(),
-            8,
-            "grp".to_string(),
-            0o600,
-        )));
-        let explicit = Permission::new(
-            1,
-            "explicit".to_string(),
-            2,
-            "explicit_group".to_string(),
-            0o700,
-        );
-        let m = roundtrip_with_builder_permission(&src, explicit);
-        let p = m.permission().expect("explicit builder fPRM must remain");
-        assert_eq!(p.uid(), 1);
-        assert_eq!(p.uname(), "explicit");
-        assert_eq!(p.gid(), 2);
-        assert_eq!(p.gname(), "explicit_group");
-        assert_eq!(p.permissions(), 0o700);
-
-        assert_eq!(m.owner_uid().map(|v| v.get()), Some(7));
-        assert_eq!(m.owner_gid().map(|v| v.get()), Some(8));
-        assert_eq!(m.owner_user_name().map(|v| v.as_str()), Some("legacy"));
-        assert_eq!(m.owner_group_name().map(|v| v.as_str()), Some("grp"));
-        assert_eq!(m.permission_mode().map(|v| v.get()), Some(0o600));
     }
 }


### PR DESCRIPTION
## Summary

`libpna` no longer writes the `fPRM` chunk. An entry that carries none of the five owner facets `fPRM` supplies has its `permission` values written as those facets instead, so a caller still on the deprecated setters gets archives in the new format without changing any code.

## Notes

First of three parts retiring the `fPRM` permission API. Part of #3210. The public API is unchanged here, deliberately — the parts that hide and then internalise `Permission` come next.

The rule is all-or-nothing: setting any one of `fUId`/`fGId`/`fONm`/`fGNm`/`fMOd` means the caller manages ownership through facets, and `permission` is ignored entirely. A per-facet merge would resurrect values a caller deliberately dropped, because `Option` cannot tell "never set" from "explicitly cleared" — `pna experimental chown --numeric-owner` clears the owner names on purpose. `fOSi`/`fGSi` are not counted, since `fPRM` carries no SID and a Windows SID says nothing about POSIX ownership.

The rule lives at the one place chunks are emitted rather than in the builder, because `NormalEntry::with_metadata` bypasses `EntryBuilderCore` and `EntryBuilder::permission` assigns the field directly. That retires the `TODO` on `EntryBuilderCore::metadata`, whose conditional rescue and truncating `owner_name_bounded` helper are gone.

`Metadata::permission` is unchanged: a caller who sets a permission still reads it back. A built entry therefore reports `permission` while the archive it produces carries the five facets and no `fPRM`.

Two behaviour changes worth naming. An owner name too long for the facet wire bound is now dropped rather than truncated — the previous helper produced a 255-byte prefix, which presents a name that never existed as if it were real, and for ownership an absent value is the safer failure. And a mode from `fPRM` now goes through `PermissionMode`, which masks to `0o7777`: every `fPRM` chunk in `resources/test/0.33.0/*.pna` stores `st_mode` with its file-type bits (`0o40755`, `0o100644`), so those bits stop reaching `fMOd`. The entry's kind comes from `FHED`, and every CLI consumer of the mode reads only the permission bits.

Reading an archive that carries both an `fPRM` and owner facets stays supported, with the facets winning — third-party writers and archives from `0.34` through `0.37` can contain both.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive metadata serialization for file ownership and permissions.
  * Preserved compatibility with legacy permission metadata when reading existing archives.
  * Ensured explicit owner information takes precedence over permission-derived metadata.
  * Safely handles overly long owner and group names without corrupting archive entries.
  * Improved round-trip compatibility and metadata preservation across archive operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->