### PR TITLE
:boom: Hide the deprecated permission setters

### DIFF
--- a/cli/src/command/chmod.rs
+++ b/cli/src/command/chmod.rs
@@ -90,7 +90,6 @@ impl EntryTransform for ChmodTransform<'_> {
 }
 
 #[inline]
-#[allow(deprecated)]
 fn transform_entry<T>(entry: NormalEntry<T>, mode: &Mode) -> NormalEntry<T> {
     let metadata = entry.metadata().clone();
     let own = crate::ext::ResolvedOwnership::from_metadata(&metadata);
@@ -99,7 +98,6 @@ fn transform_entry<T>(entry: NormalEntry<T>, mode: &Mode) -> NormalEntry<T> {
         .unwrap_or_else(|| default_permission_mode(entry.header().data_kind()));
     let new_mode = mode.apply_to(cur_mode);
     let metadata = metadata
-        .with_permission(None)
         .with_owner_uid(own.uid.map(pna::OwnerUid::from))
         .with_owner_gid(own.gid.map(pna::OwnerGid::from))
         .with_owner_user_name(

--- a/cli/src/command/chown.rs
+++ b/cli/src/command/chown.rs
@@ -98,7 +98,6 @@ impl EntryTransform for ChownTransform<'_> {
 }
 
 #[inline]
-#[allow(deprecated)]
 fn transform_entry<T>(entry: NormalEntry<T>, owner: &Ownership) -> NormalEntry<T> {
     let metadata = entry.metadata().clone();
     let own = crate::ext::ResolvedOwnership::from_metadata(&metadata);
@@ -122,7 +121,6 @@ fn transform_entry<T>(entry: NormalEntry<T>, owner: &Ownership) -> NormalEntry<T
     };
     let metadata =
         metadata
-            .with_permission(None)
             .with_owner_uid(uid.map(pna::OwnerUid::from))
             .with_owner_gid(gid.map(pna::OwnerGid::from))
             .with_owner_user_name(crate::command::core::permission::owner_name_opt(&uname))

--- a/cli/src/ext.rs
+++ b/cli/src/ext.rs
@@ -201,27 +201,45 @@ impl<S: Display> Display for UserDisplay<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pna::{Archive, Metadata, OwnerGroupName, OwnerUid, OwnerUserSid};
+
+    /// Returns the metadata of the first entry in the 0.33.0
+    /// `zstd_keep_permission` fixture. Its 9 entries (all files, no
+    /// directories) carry only legacy `fPRM` (no owner facets): `uid=501
+    /// uname="kaihatsutarou" gid=20 gname="staff"`, mode `0o100644`
+    /// (unmasked, as legacy fPRM stores it). uid != gid and uname != gname,
+    /// so this source can actually catch a uid<->gid or uname<->gname
+    /// mix-up — `zstd_keep_all.pna` has both pairs equal and can't.
+    /// With the legacy permission setters removed, decoding a real fixture is
+    /// the public way to get a `Metadata` with `permission` set.
+    fn fixture_metadata() -> Metadata {
+        let src = include_bytes!("../../resources/test/0.33.0/zstd_keep_permission.pna");
+        let mut archive = Archive::read_header(src.as_slice()).unwrap();
+        archive
+            .entries()
+            .skip_solid()
+            .next()
+            .unwrap()
+            .unwrap()
+            .metadata()
+            .clone()
+    }
 
     #[test]
     fn owner_facet_overwrites_fprm_baseline() {
-        #[allow(deprecated)]
-        let m = pna::Metadata::new()
-            .with_permission(Some(pna::Permission::new(
-                7,
-                "legacy".into(),
-                8,
-                "grp".into(),
-                0o600,
-            )))
-            .with_owner_uid(Some(pna::OwnerUid::from(1)))
-            .with_owner_user_name(Some(pna::OwnerUserName::new("new").unwrap()))
-            .with_owner_user_sid(Some(pna::OwnerUserSid::new("S-1-1").unwrap()));
-        let r = ResolvedOwnership::from_metadata(&m);
+        // Diagonal overrides (uid + gname) so a uid<->gid or uname<->gname
+        // mix-up in `from_metadata` would surface as a wrong value: every
+        // one of the four differs from the other three.
+        let metadata = fixture_metadata()
+            .with_owner_uid(Some(OwnerUid::from(1)))
+            .with_owner_group_name(Some(OwnerGroupName::new("grp").unwrap()))
+            .with_owner_user_sid(Some(OwnerUserSid::new("S-1-1").unwrap()));
+        let r = ResolvedOwnership::from_metadata(&metadata);
         assert_eq!(r.uid, Some(1));
-        assert_eq!(r.uname.as_deref(), Some("new"));
-        assert_eq!(r.gid, Some(8));
+        assert_eq!(r.uname.as_deref(), Some("kaihatsutarou"));
+        assert_eq!(r.gid, Some(20));
         assert_eq!(r.gname.as_deref(), Some("grp"));
-        assert_eq!(r.mode, Some(0o600));
+        assert_eq!(r.mode, Some(0o100644));
         assert_eq!(r.user_sid.as_deref(), Some("S-1-1"));
         assert_eq!(r.group_sid, None);
     }
@@ -234,17 +252,13 @@ mod tests {
 
     #[test]
     fn fprm_only_is_rescued() {
-        #[allow(deprecated)]
-        let m = pna::Metadata::new().with_permission(Some(pna::Permission::new(
-            5,
-            "u".into(),
-            6,
-            "g".into(),
-            0o644,
-        )));
-        let r = ResolvedOwnership::from_metadata(&m);
-        assert_eq!((r.uid, r.gid, r.mode), (Some(5), Some(6), Some(0o644)));
-        assert_eq!(r.uname.as_deref(), Some("u"));
-        assert_eq!(r.gname.as_deref(), Some("g"));
+        let metadata = fixture_metadata();
+        let r = ResolvedOwnership::from_metadata(&metadata);
+        assert_eq!(
+            (r.uid, r.gid, r.mode),
+            (Some(501), Some(20), Some(0o100644))
+        );
+        assert_eq!(r.uname.as_deref(), Some("kaihatsutarou"));
+        assert_eq!(r.gname.as_deref(), Some("staff"));
     }
 }

--- a/cli/tests/cli/chmod.rs
+++ b/cli/tests/cli/chmod.rs
@@ -8,14 +8,12 @@ mod password;
 mod password_file;
 mod unsolid;
 
-use crate::utils::{archive, archive::FileEntryDef, setup};
+use crate::utils::{EmbedExt, TestResources, archive, archive::FileEntryDef, setup};
 use clap::Parser;
-#[allow(deprecated)]
-use pna::Permission;
 use pna::prelude::*;
 use pna::{
-    Archive, DirEntryBuilder, EntryName, FileEntryBuilder, HardLinkEntryBuilder, Metadata,
-    ReadOptions, SymlinkEntryBuilder,
+    Archive, DirEntryBuilder, EntryName, FileEntryBuilder, HardLinkEntryBuilder, ReadOptions,
+    SymlinkEntryBuilder,
 };
 use portable_network_archive::cli;
 use std::fs::File;
@@ -94,22 +92,12 @@ fn archive_chmod() {
 #[allow(deprecated)]
 fn archive_chmod_drops_legacy_fprm() {
     setup();
-    let path = "chmod_legacy_fprm.pna";
-    {
-        let mut archive = Archive::write_header(File::create(path).unwrap()).unwrap();
-        let mut builder =
-            FileEntryBuilder::new(EntryName::from_utf8_preserve_root(ENTRY_PATH)).unwrap();
-        builder.metadata(Metadata::new().with_permission(Some(Permission::new(
-            1000,
-            "user".to_string(),
-            1000,
-            "group".to_string(),
-            0o777,
-        ))));
-        builder.write_all(ENTRY_CONTENT).unwrap();
-        archive.add_entry(builder.build().unwrap()).unwrap();
-        archive.finalize().unwrap();
-    }
+    // The 0.33.0 `zstd_keep_permission` fixture's entries carry only legacy
+    // `fPRM` (no owner facets), mode `0o100644` unmasked for files.
+    const LEGACY_FIXTURE: &str = "0.33.0/zstd_keep_permission.pna";
+    TestResources::extract_in(LEGACY_FIXTURE, "chmod_legacy_fprm/").unwrap();
+    let path = format!("chmod_legacy_fprm/{LEGACY_FIXTURE}");
+    let target = "raw/text.txt";
 
     cli::Cli::try_parse_from([
         "pna",
@@ -117,22 +105,27 @@ fn archive_chmod_drops_legacy_fprm() {
         "experimental",
         "chmod",
         "-f",
-        path,
-        "644",
-        ENTRY_PATH,
+        path.as_str(),
+        "600",
+        target,
     ])
     .unwrap()
     .execute()
     .unwrap();
 
-    archive::for_each_entry(path, |entry| {
-        assert!(
-            entry.metadata().permission().is_none(),
-            "legacy fPRM must be removed after chmod"
-        );
-        assert_eq!(entry.metadata().permission_mode().unwrap().get(), 0o644);
+    let mut found = false;
+    archive::for_each_entry(&path, |entry| {
+        if entry.header().path().as_str() == target {
+            found = true;
+            assert!(
+                entry.metadata().permission().is_none(),
+                "legacy fPRM must be removed after chmod"
+            );
+            assert_eq!(entry.metadata().permission_mode().unwrap().get(), 0o600);
+        }
     })
     .unwrap();
+    assert!(found, "target entry not found in archive");
 }
 
 /// Precondition: An archive entry has no permission metadata.

--- a/cli/tests/cli/chown/user_only.rs
+++ b/cli/tests/cli/chown/user_only.rs
@@ -1,11 +1,13 @@
-use crate::utils::{archive, archive::FileEntryDef, setup};
+use crate::utils::{EmbedExt, TestResources, archive, archive::FileEntryDef, setup};
 use clap::Parser;
-#[allow(deprecated)]
-use pna::Permission;
-use pna::{Archive, EntryName, FileEntryBuilder, Metadata};
 use portable_network_archive::cli;
-use std::fs::File;
-use std::io::Write;
+
+/// A file entry from the 0.33.0 `zstd_keep_permission` fixture, which
+/// carries only legacy `fPRM` (no owner facets): `uid=501
+/// uname="kaihatsutarou" gid=20 gname="staff"`, mode `0o100644` unmasked
+/// (`0o644` once read back through `PermissionMode`).
+const LEGACY_FIXTURE_ENTRY: &str = "raw/text.txt";
+const LEGACY_FIXTURE: &str = "0.33.0/zstd_keep_permission.pna";
 
 /// Precondition: An archive contains entries with permission metadata.
 /// Action: Run `pna experimental chown` with `user` (no colon) to change only the user.
@@ -90,22 +92,8 @@ fn chown_user_only() {
 #[allow(deprecated)]
 fn chown_user_only_drops_legacy_fprm() {
     setup();
-    let path = "chown_legacy_fprm.pna";
-    {
-        let mut archive = Archive::write_header(File::create(path).unwrap()).unwrap();
-        let mut builder =
-            FileEntryBuilder::new(EntryName::from_utf8_preserve_root("target.txt")).unwrap();
-        builder.metadata(Metadata::new().with_permission(Some(Permission::new(
-            1000,
-            "user".to_string(),
-            1000,
-            "group".to_string(),
-            0o644,
-        ))));
-        builder.write_all(b"target").unwrap();
-        archive.add_entry(builder.build().unwrap()).unwrap();
-        archive.finalize().unwrap();
-    }
+    TestResources::extract_in(LEGACY_FIXTURE, "chown_legacy_fprm/").unwrap();
+    let path = format!("chown_legacy_fprm/{LEGACY_FIXTURE}");
 
     cli::Cli::try_parse_from([
         "pna",
@@ -113,26 +101,90 @@ fn chown_user_only_drops_legacy_fprm() {
         "experimental",
         "chown",
         "-f",
-        path,
+        path.as_str(),
         "new_user",
-        "target.txt",
+        LEGACY_FIXTURE_ENTRY,
         "--no-owner-lookup",
     ])
     .unwrap()
     .execute()
     .unwrap();
 
-    archive::for_each_entry(path, |entry| {
-        let metadata = entry.metadata();
-        assert!(
-            metadata.permission().is_none(),
-            "legacy fPRM must be removed after chown"
-        );
-        assert_eq!(metadata.owner_user_name().unwrap().as_str(), "new_user");
-        assert_eq!(metadata.owner_uid().unwrap().get(), u64::MAX);
-        assert_eq!(metadata.owner_group_name().unwrap().as_str(), "group");
-        assert_eq!(metadata.owner_gid().unwrap().get(), 1000);
-        assert_eq!(metadata.permission_mode().unwrap().get(), 0o644);
+    let mut found = false;
+    archive::for_each_entry(&path, |entry| {
+        if entry.header().path().as_str() == LEGACY_FIXTURE_ENTRY {
+            found = true;
+            let metadata = entry.metadata();
+            assert!(
+                metadata.permission().is_none(),
+                "legacy fPRM must be removed after chown"
+            );
+            assert_eq!(metadata.owner_user_name().unwrap().as_str(), "new_user");
+            assert_eq!(metadata.owner_uid().unwrap().get(), u64::MAX);
+            // The group side wasn't targeted, so it's rescued from the
+            // fixture's legacy fPRM ("staff"/20) rather than left absent.
+            assert_eq!(metadata.owner_group_name().unwrap().as_str(), "staff");
+            assert_eq!(metadata.owner_gid().unwrap().get(), 20);
+            assert_eq!(metadata.permission_mode().unwrap().get(), 0o644);
+        }
     })
     .unwrap();
+    assert!(found, "target entry not found in archive");
+}
+
+/// Precondition: An archive entry carries legacy fPRM metadata and no owner
+/// facets. Action: Run `pna experimental chown --numeric-owner` with a
+/// numeric `uid:gid` spec (no names). Expectation: uid/gid take the
+/// requested numeric values, and the owner *names* come back absent rather
+/// than resurrected from the still-present legacy fPRM — the case the
+/// all-or-nothing rescue rule exists for: a per-facet merge would instead
+/// see `owner_user_name`/`owner_group_name` as merely "unset" and refill
+/// them from `fPRM`'s `uname`/`gname`.
+#[test]
+#[allow(deprecated)]
+fn chown_numeric_owner_drops_legacy_fprm_names() {
+    setup();
+    TestResources::extract_in(LEGACY_FIXTURE, "chown_numeric_owner_legacy_fprm/").unwrap();
+    let path = format!("chown_numeric_owner_legacy_fprm/{LEGACY_FIXTURE}");
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "chown",
+        "-f",
+        path.as_str(),
+        "1000:2000",
+        LEGACY_FIXTURE_ENTRY,
+        "--numeric-owner",
+        "--no-owner-lookup",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut found = false;
+    archive::for_each_entry(&path, |entry| {
+        if entry.header().path().as_str() == LEGACY_FIXTURE_ENTRY {
+            found = true;
+            let metadata = entry.metadata();
+            assert!(
+                metadata.permission().is_none(),
+                "legacy fPRM must be removed after chown"
+            );
+            assert_eq!(metadata.owner_uid().unwrap().get(), 1000);
+            assert_eq!(metadata.owner_gid().unwrap().get(), 2000);
+            assert!(
+                metadata.owner_user_name().is_none(),
+                "numeric-only chown must not resurrect the legacy fPRM uname"
+            );
+            assert!(
+                metadata.owner_group_name().is_none(),
+                "numeric-only chown must not resurrect the legacy fPRM gname"
+            );
+            assert_eq!(metadata.permission_mode().unwrap().get(), 0o644);
+        }
+    })
+    .unwrap();
+    assert!(found, "target entry not found in archive");
 }

--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -929,21 +929,16 @@ mod tests {
                     .unwrap();
             builder.write_all(b"entry data").unwrap();
             // Attached via `with_metadata` on the built entry, which bypasses
-            // `EntryBuilderCore::metadata` entirely — the path the deleted
-            // builder-level fPRM rescue never covered either.
-            builder.build().unwrap().with_metadata(
-                Metadata::new()
-                    .with_created(Some(Duration::seconds(31)))
-                    .with_modified(Some(Duration::seconds(32)))
-                    .with_accessed(Some(Duration::seconds(33)))
-                    .with_permission(Some(Permission::new(
-                        1,
-                        "uname".into(),
-                        2,
-                        "gname".into(),
-                        0o775,
-                    ))),
-            )
+            // `EntryBuilderCore::metadata` entirely — proving the rescue in
+            // `try_for_each_metadata_facet` covers every construction path,
+            // not just the builder's own `metadata()` setter.
+            let mut metadata = Metadata::new()
+                .with_created(Some(Duration::seconds(31)))
+                .with_modified(Some(Duration::seconds(32)))
+                .with_accessed(Some(Duration::seconds(33)));
+            metadata.permission =
+                Some(Permission::new(1, "uname".into(), 2, "gname".into(), 0o775));
+            builder.build().unwrap().with_metadata(metadata)
         };
 
         let mut archive = Archive::write_header(Vec::new()).unwrap();

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -169,8 +169,10 @@ fn try_for_each_metadata_facet<E>(
         // A name too long for the owner-facet wire bound (255 bytes, a
         // 1-byte length prefix) cannot be represented as `OwnerUserName`/
         // `OwnerGroupName`; drop that facet rather than truncate or panic.
-        // `Permission::new` is still public at this stage, so this is
-        // reachable, if unlikely.
+        // A real `fPRM` chunk can't produce such a name — its own uname/gname
+        // fields are 1-byte-length-prefixed — so this only fires when
+        // `Permission` is constructed directly, which only `#[cfg(test)]`
+        // code can do.
         if let Ok(name) = OwnerUserName::new(value.uname()) {
             f(ChunkType::fONm, Cow::Owned(name.to_bytes()))?;
         }
@@ -1602,15 +1604,19 @@ mod tests {
                 .map(|(_, data)| data.clone())
         }
 
+        /// There is no public setter for `permission`, so this sets the
+        /// `pub(crate)` field directly.
+        fn set_permission(mut metadata: Metadata, permission: Permission) -> Metadata {
+            metadata.permission = Some(permission);
+            metadata
+        }
+
         #[test]
         fn permission_only_emits_five_owner_facets_and_no_fprm() {
-            let metadata = Metadata::new().with_permission(Some(Permission::new(
-                111,
-                "alice".to_string(),
-                222,
-                "staff".to_string(),
-                0o600,
-            )));
+            let metadata = set_permission(
+                Metadata::new(),
+                Permission::new(111, "alice".to_string(), 222, "staff".to_string(), 0o600),
+            );
             let facets = collect_facets(&metadata);
 
             assert!(facet(&facets, ChunkType::fPRM).is_none());
@@ -1638,15 +1644,10 @@ mod tests {
 
         #[test]
         fn existing_owner_facet_makes_permission_ignored_entirely() {
-            let metadata = Metadata::new()
-                .with_owner_uid(Some(OwnerUid::from(999u64)))
-                .with_permission(Some(Permission::new(
-                    111,
-                    "alice".to_string(),
-                    222,
-                    "staff".to_string(),
-                    0o600,
-                )));
+            let metadata = set_permission(
+                Metadata::new().with_owner_uid(Some(OwnerUid::from(999u64))),
+                Permission::new(111, "alice".to_string(), 222, "staff".to_string(), 0o600),
+            );
             let facets = collect_facets(&metadata);
 
             assert!(facet(&facets, ChunkType::fPRM).is_none());
@@ -1663,15 +1664,10 @@ mod tests {
 
         #[test]
         fn sid_only_facet_does_not_count_for_the_all_or_nothing_rule() {
-            let metadata = Metadata::new()
-                .with_owner_user_sid(Some(OwnerUserSid::new("S-1-5-21-1").unwrap()))
-                .with_permission(Some(Permission::new(
-                    111,
-                    "alice".to_string(),
-                    222,
-                    "staff".to_string(),
-                    0o600,
-                )));
+            let metadata = set_permission(
+                Metadata::new().with_owner_user_sid(Some(OwnerUserSid::new("S-1-5-21-1").unwrap())),
+                Permission::new(111, "alice".to_string(), 222, "staff".to_string(), 0o600),
+            );
             let facets = collect_facets(&metadata);
 
             assert!(facet(&facets, ChunkType::fPRM).is_none());
@@ -1704,13 +1700,10 @@ mod tests {
 
         #[test]
         fn permission_mode_from_st_mode_is_masked_to_0o7777() {
-            let metadata = Metadata::new().with_permission(Some(Permission::new(
-                0,
-                String::new(),
-                0,
-                String::new(),
-                0o100644,
-            )));
+            let metadata = set_permission(
+                Metadata::new(),
+                Permission::new(0, String::new(), 0, String::new(), 0o100644),
+            );
             let facets = collect_facets(&metadata);
 
             assert_eq!(
@@ -1723,13 +1716,10 @@ mod tests {
         #[test]
         fn overlong_name_facet_is_dropped_without_truncation_or_panic() {
             let long_name = "a".repeat(300);
-            let metadata = Metadata::new().with_permission(Some(Permission::new(
-                111,
-                long_name,
-                222,
-                "staff".to_string(),
-                0o600,
-            )));
+            let metadata = set_permission(
+                Metadata::new(),
+                Permission::new(111, long_name, 222, "staff".to_string(), 0o600),
+            );
             let facets = collect_facets(&metadata);
 
             // uid/gid/mode do not depend on the name and must still be written.

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -8,6 +8,7 @@ pub use file::FileEntryBuilder;
 pub use link::{HardLinkEntryBuilder, SymlinkEntryBuilder};
 pub use solid::SolidEntryBuilder;
 
+#[cfg(test)]
 #[allow(deprecated)]
 use crate::entry::Permission;
 use crate::{
@@ -382,18 +383,6 @@ impl OpaqueEntryBuilder {
     #[inline]
     pub fn accessed(&mut self, since_unix_epoch: impl Into<Option<Duration>>) -> &mut Self {
         self.core.metadata.accessed = since_unix_epoch.into();
-        self
-    }
-
-    /// Sets the permission of the entry to the given owner, group, and permissions.
-    #[deprecated(
-        since = "0.34.0",
-        note = "the fPRM chunk is superseded by the owner facet chunks; use `OpaqueEntryBuilder::metadata` with `Metadata::with_owner_uid`/`with_owner_gid`/`with_owner_user_name`/`with_owner_group_name`/`with_permission_mode`"
-    )]
-    #[allow(deprecated)]
-    #[inline]
-    pub fn permission(&mut self, permission: impl Into<Option<Permission>>) -> &mut Self {
-        self.core.metadata.permission = permission.into();
         self
     }
 
@@ -921,17 +910,21 @@ mod tests {
 
     #[test]
     #[allow(deprecated)]
-    fn metadata_setter_stores_permission_as_is_but_writer_derives_facets() {
+    fn permission_field_stored_as_is_but_writer_derives_facets() {
         let mut b = FileEntryBuilder::new("f".into()).unwrap();
-        b.metadata(Metadata::new().with_permission(Some(Permission::new(
+        let mut metadata = Metadata::new();
+        metadata.permission = Some(Permission::new(
             7,
             "legacy".to_string(),
             8,
             "grp".to_string(),
             0o600,
-        ))));
+        ));
+        b.metadata(metadata);
         let entry = b.build().unwrap();
 
+        // `permission()` returns what was stored, and the owner facets it
+        // never touched stay `None`.
         let m = entry.metadata();
         let p = m.permission().unwrap();
         assert_eq!(

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -171,18 +171,6 @@ impl Metadata {
         self
     }
 
-    /// Sets the permission of the entry.
-    #[deprecated(
-        since = "0.34.0",
-        note = "the fPRM chunk is superseded by the owner facet chunks; use Metadata::with_owner_uid/with_owner_gid/with_owner_user_name/with_owner_group_name/with_owner_user_sid/with_owner_group_sid/with_permission_mode"
-    )]
-    #[allow(deprecated)]
-    #[inline]
-    pub fn with_permission(mut self, permission: Option<Permission>) -> Self {
-        self.permission = permission;
-        self
-    }
-
     /// Sets the owner user id facet (`fUId`).
     #[inline]
     pub fn with_owner_uid(mut self, value: Option<OwnerUid>) -> Self {

--- a/pna/src/ext/entry_builder.rs
+++ b/pna/src/ext/entry_builder.rs
@@ -208,8 +208,6 @@ mod tests {
         assert!(out.chars().all(|c| c == two_byte_char));
     }
 
-    #[allow(deprecated)]
-    use libpna::Permission;
     use libpna::{Archive, OwnerGroupSid, OwnerUserSid, WriteOptions};
 
     #[allow(deprecated)]
@@ -225,6 +223,27 @@ mod tests {
         let mut a = Archive::read_header(&buf[..]).unwrap();
         let e = a.entries().skip_solid().next().unwrap().unwrap();
         e.metadata().clone()
+    }
+
+    /// Returns the metadata of the first entry in the 0.33.0
+    /// `zstd_keep_permission` fixture. Its 9 entries (all files, no
+    /// directories) carry only legacy `fPRM` (no owner facets): `uid=501
+    /// uname="kaihatsutarou" gid=20 gname="staff"`, mode `0o100644`
+    /// (unmasked, as legacy fPRM stores it). uid != gid and uname != gname,
+    /// so this source can actually catch a uid<->gid or uname<->gname
+    /// mix-up — `zstd_keep_all.pna` has both pairs equal and can't.
+    /// With the legacy permission setters removed, decoding a real fixture is
+    /// the public way to get a `Metadata` with `permission` set.
+    fn fixture_metadata() -> Metadata {
+        let src = include_bytes!("../../../resources/test/0.33.0/zstd_keep_permission.pna");
+        let mut a = Archive::read_header(src.as_slice()).unwrap();
+        a.entries()
+            .skip_solid()
+            .next()
+            .unwrap()
+            .unwrap()
+            .metadata()
+            .clone()
     }
 
     #[test]
@@ -250,62 +269,37 @@ mod tests {
     #[test]
     #[allow(deprecated)]
     fn add_metadata_translates_fprm_only_source() {
-        let src = Metadata::new().with_permission(Some(Permission::new(
-            7,
-            "legacy".to_string(),
-            8,
-            "grp".to_string(),
-            0o600,
-        )));
+        let src = fixture_metadata();
         let m = roundtrip(&src);
-        assert_eq!(m.owner_uid().map(|v| v.get()), Some(7));
-        assert_eq!(m.owner_gid().map(|v| v.get()), Some(8));
-        assert_eq!(m.owner_user_name().map(|v| v.as_str()), Some("legacy"));
-        assert_eq!(m.owner_group_name().map(|v| v.as_str()), Some("grp"));
-        assert_eq!(m.permission_mode().map(|v| v.get()), Some(0o600));
+        assert_eq!(m.owner_uid().map(|v| v.get()), Some(501));
+        assert_eq!(m.owner_gid().map(|v| v.get()), Some(20));
+        assert_eq!(
+            m.owner_user_name().map(|v| v.as_str()),
+            Some("kaihatsutarou")
+        );
+        assert_eq!(m.owner_group_name().map(|v| v.as_str()), Some("staff"));
+        assert_eq!(m.permission_mode().map(|v| v.get()), Some(0o644));
         assert!(m.permission().is_none());
     }
 
     #[test]
     #[allow(deprecated)]
     fn add_metadata_owner_facet_wins_over_fprm() {
-        let src = Metadata::new()
+        // Diagonal overrides (uid + gname) so a uid<->gid or uname<->gname
+        // mix-up in the rescue logic would surface as a wrong value: every
+        // one of the four differs from the other three.
+        let src = fixture_metadata()
             .with_owner_uid(Some(OwnerUid::from(1)))
-            .with_owner_user_name(Some(OwnerUserName::new("new").unwrap()))
-            .with_permission(Some(Permission::new(
-                7,
-                "legacy".to_string(),
-                8,
-                "grp".to_string(),
-                0o600,
-            )));
+            .with_owner_group_name(Some(OwnerGroupName::new("grp").unwrap()));
         let m = roundtrip(&src);
         assert_eq!(m.owner_uid().map(|v| v.get()), Some(1));
-        assert_eq!(m.owner_user_name().map(|v| v.as_str()), Some("new"));
-        assert_eq!(m.owner_gid().map(|v| v.get()), Some(8));
+        assert_eq!(
+            m.owner_user_name().map(|v| v.as_str()),
+            Some("kaihatsutarou")
+        );
+        assert_eq!(m.owner_gid().map(|v| v.get()), Some(20));
         assert_eq!(m.owner_group_name().map(|v| v.as_str()), Some("grp"));
-        assert_eq!(m.permission_mode().map(|v| v.get()), Some(0o600));
+        assert_eq!(m.permission_mode().map(|v| v.get()), Some(0o644));
         assert!(m.permission().is_none());
-    }
-
-    #[test]
-    #[allow(deprecated)]
-    fn add_metadata_truncates_overlong_fprm_name() {
-        let big_char = 'é';
-        assert_eq!(big_char.len_utf8(), 2);
-        let big = String::from(big_char).repeat(200); // 400 bytes
-        let src = Metadata::new().with_permission(Some(Permission::new(
-            7,
-            big,
-            8,
-            "grp".to_string(),
-            0o600,
-        )));
-        let m = roundtrip(&src);
-        let uname = m.owner_user_name().unwrap().as_str();
-        assert_eq!(uname.len(), 254);
-        assert_eq!(uname.chars().count(), 127);
-        assert!(uname.chars().all(|c| c == big_char));
-        assert_eq!(m.owner_uid().map(|v| v.get()), Some(7));
     }
 }


### PR DESCRIPTION
## Summary

Close every public way to set a permission: `Metadata::with_permission`, `OpaqueEntryBuilder::permission`, and `Permission::new`. Reading an archive that carries an `fPRM` chunk is now the only way a `Permission` comes into existence.

## Notes

Second of three parts retiring the `fPRM` permission API. Part of #3210, on #3434. The `Permission` type and `Metadata::permission` stay public here; the next part makes them crate-internal and adds the reader-side fill, keeping `fPRM` read support permanently.

#3434 already routes these setters' values to the owner facets at write time, so callers move to `Metadata::with_owner_*`/`with_permission_mode` with no change in what gets written.

`Permission::new` is hidden here rather than earlier on purpose. Hidden before the setters, every out-of-crate test that needed a legacy `Metadata` would have had to fabricate a raw `fPRM` chunk; hidden alongside them, those tests lose the setter at the same moment and go through a real archive instead, so the cost is nothing. It is `#[cfg(test)] pub(crate)`, which makes "libpna cannot author `fPRM` data" a compile-time fact.

`cli/src/command/chown.rs` no longer clears the permission before writing. Under the all-or-nothing rule from #3434, `chown` sets owner facets, so the permission is already ignored at write time. A new test covers the case that makes this load-bearing: `chown --numeric-owner` with a numeric spec clears the owner names on purpose, and that is the one path where a per-facet merge would resurrect them from the `fPRM` still held in the metadata.

Tests that lost a setter now build their subject from `resources/test/0.33.0/zstd_keep_permission.pna` rather than a fabricated value. That fixture's `fPRM` entries have distinct uid and gid and distinct user and group names, so a cross-wiring between either pair still fails — `zstd_keep_all.pna` has both pairs equal and would have hidden it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Archive ownership and permission updates now handle legacy metadata more consistently.
  * Numeric ownership changes retain numeric IDs without restoring legacy owner names.
  * Archive transformations now preserve relevant legacy metadata while applying explicit ownership or permission changes.

* **Tests**
  * Expanded compatibility coverage for legacy archives, ownership overrides, permission handling, and round-trip behavior.
  * Added validation using representative legacy archive fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->