### PR TITLE
:recycle: Use current archive APIs in tests

### DIFF
--- a/cli/tests/cli/chmod.rs
+++ b/cli/tests/cli/chmod.rs
@@ -11,16 +11,42 @@ use crate::utils::{archive, archive::FileEntryDef, setup};
 use clap::Parser;
 #[allow(deprecated)]
 use pna::Permission;
+use pna::prelude::*;
 use pna::{
     Archive, DirEntryBuilder, EntryName, FileEntryBuilder, HardLinkEntryBuilder, Metadata,
-    SymlinkEntryBuilder,
+    ReadOptions, SymlinkEntryBuilder,
 };
 use portable_network_archive::cli;
 use std::fs::File;
-use std::io::Write;
+use std::io::{Read, Write};
 
 const ENTRY_PATH: &str = "test.txt";
 const ENTRY_CONTENT: &[u8] = b"test content";
+
+fn entry_snapshot(path: &str, name: &str, password: Option<&str>) -> (u16, Vec<u8>) {
+    let options = ReadOptions::with_password(password.map(str::as_bytes));
+    let mut archive = Archive::open(path).unwrap();
+    let entry = archive
+        .entries_with_options(&options)
+        .find_map(|entry| {
+            let entry = entry.unwrap();
+            (entry.name() == name).then_some(entry)
+        })
+        .expect("target entry should exist");
+    let mode = entry
+        .metadata()
+        .permission_mode()
+        .expect("entry should have permission mode metadata")
+        .get()
+        & 0o777;
+    let mut contents = Vec::new();
+    entry
+        .reader(options)
+        .unwrap()
+        .read_to_end(&mut contents)
+        .unwrap();
+    (mode, contents)
+}
 
 /// Precondition: An archive contains a file with permission 0o777 (rwxrwxrwx).
 /// Action: Run `pna experimental chmod` with `-x` to remove execute permission for all.

--- a/cli/tests/cli/chmod/multipart.rs
+++ b/cli/tests/cli/chmod/multipart.rs
@@ -58,17 +58,11 @@ fn chmod_multipart_archive_updates_consolidated_output() {
     .execute()
     .unwrap();
 
+    let (mode, contents) =
+        super::entry_snapshot("chmod_multipart/split/archive.pna", ENTRY_PATH, None);
+    assert_eq!(mode, 0o600);
     assert_eq!(
-        archive::entry_mode("chmod_multipart/split/archive.pna", ENTRY_PATH),
-        0o600
-    );
-    assert_eq!(
-        archive::entry_contents_with_password(
-            "chmod_multipart/split/archive.pna",
-            ENTRY_PATH,
-            None,
-        ),
-        content,
+        contents, content,
         "chmod must preserve content spanning multipart archive boundaries"
     );
 }

--- a/cli/tests/cli/chmod/password.rs
+++ b/cli/tests/cli/chmod/password.rs
@@ -106,7 +106,7 @@ fn chmod_wrong_password_on_solid_archive_fails_without_modifying_archive() {
         "failed chmod must leave the original archive untouched"
     );
     assert_eq!(
-        archive::entry_mode_with_password(archive_path, ENTRY_PATH, Some(PASSWORD)),
+        super::entry_snapshot(archive_path, ENTRY_PATH, Some(PASSWORD)).0,
         0o777
     );
 }
@@ -149,12 +149,7 @@ fn chmod_wrong_password_on_normal_encrypted_archive_updates_metadata_only() {
     .execute()
     .unwrap();
 
-    assert_eq!(
-        archive::entry_mode_with_password(archive_path, ENTRY_PATH, Some(PASSWORD)),
-        0o600
-    );
-    assert_eq!(
-        archive::entry_contents_with_password(archive_path, ENTRY_PATH, Some(PASSWORD)),
-        ENTRY_CONTENT
-    );
+    let (mode, contents) = super::entry_snapshot(archive_path, ENTRY_PATH, Some(PASSWORD));
+    assert_eq!(mode, 0o600);
+    assert_eq!(contents, ENTRY_CONTENT);
 }

--- a/cli/tests/cli/update/option_missing_time.rs
+++ b/cli/tests/cli/update/option_missing_time.rs
@@ -1,8 +1,20 @@
 use crate::utils::{archive, setup};
 use clap::Parser;
-use pna::ReadOptions;
+use pna::{Archive, NormalEntry, ReadOptions, prelude::*};
 use portable_network_archive::cli;
-use std::{fs, io::prelude::*};
+use std::{fs, io, io::prelude::*};
+
+fn extract_single_entry(path: &str, name: &str) -> io::Result<Option<NormalEntry>> {
+    let mut archive = Archive::open(path)?;
+    let options = ReadOptions::builder().build();
+    for entry in archive.entries_with_options(&options) {
+        let entry = entry?;
+        if entry.name() == name {
+            return Ok(Some(entry));
+        }
+    }
+    Ok(None)
+}
 
 /// Precondition: Archive contains an entry without mtime (mTIM chunk omitted).
 /// Action: Run `pna experimental update` without `--missing-time`.
@@ -143,7 +155,7 @@ fn update_missing_time_exclude_keeps_entry() {
     .unwrap();
 
     // Exclude policy keeps the mtime-less entry untouched: content is OLD.
-    let entry = archive::extract_single_entry(archive_path, source)
+    let entry = extract_single_entry(archive_path, source)
         .unwrap()
         .expect("entry should exist");
     let mut buf = Vec::new();
@@ -266,7 +278,7 @@ fn update_missing_time_future_datetime_keeps_entry() {
     .execute()
     .unwrap();
 
-    let entry = archive::extract_single_entry(archive_path, source)
+    let entry = extract_single_entry(archive_path, source)
         .unwrap()
         .expect("entry should exist");
     let mut buf = Vec::new();

--- a/cli/tests/cli/utils/archive.rs
+++ b/cli/tests/cli/utils/archive.rs
@@ -14,6 +14,15 @@ pub struct FileEntryDef<'a> {
     pub permission: u16,
 }
 
+fn metadata_with_mode(mode: u16) -> pna::Metadata {
+    pna::Metadata::new()
+        .with_owner_uid(Some(pna::OwnerUid::from(1000)))
+        .with_owner_gid(Some(pna::OwnerGid::from(1000)))
+        .with_owner_user_name(Some(pna::OwnerUserName::new("user").unwrap()))
+        .with_owner_group_name(Some(pna::OwnerGroupName::new("group").unwrap()))
+        .with_permission_mode(Some(pna::PermissionMode::from(mode)))
+}
+
 /// Constructs an [`pna::ExtendedAttribute`] from raw name/value, panicking on
 /// length-bound violations. Test-only helper; production code must propagate
 /// the [`pna::LengthExceeded`] error instead.
@@ -34,18 +43,12 @@ pub fn create_archive_with_permissions(
     let mut archive = pna::Archive::write_header(file)?;
 
     for entry_def in entries {
-        let mut builder = pna::FileEntryBuilder::new(entry_def.path.into())?;
-        builder.metadata(
-            pna::Metadata::new()
-                .with_owner_uid(Some(pna::OwnerUid::from(1000)))
-                .with_owner_gid(Some(pna::OwnerGid::from(1000)))
-                .with_owner_user_name(Some(pna::OwnerUserName::new("user").unwrap()))
-                .with_owner_group_name(Some(pna::OwnerGroupName::new("group").unwrap()))
-                .with_permission_mode(Some(pna::PermissionMode::from(entry_def.permission))),
-        );
-        builder.write_all(entry_def.content)?;
-        let entry = builder.build()?;
-        archive.add_entry(entry)?;
+        archive.write_file(
+            entry_def.path.into(),
+            metadata_with_mode(entry_def.permission),
+            pna::WriteOptions::store(),
+            |writer| writer.write_all(entry_def.content),
+        )?;
     }
 
     archive.finalize()?;
@@ -58,25 +61,14 @@ pub fn create_solid_archive_with_permissions(
     entries: &[FileEntryDef],
 ) -> io::Result<()> {
     let file = File::create(archive_path)?;
-    let mut archive = pna::Archive::write_header(file)?;
-
-    let mut solid_builder = pna::SolidEntryBuilder::new(pna::WriteOptions::store())?;
+    let mut archive = pna::Archive::write_solid_header(file, pna::WriteOptions::store())?;
     for entry_def in entries {
-        let mut builder = pna::FileEntryBuilder::new(entry_def.path.into())?;
-        builder.metadata(
-            pna::Metadata::new()
-                .with_owner_uid(Some(pna::OwnerUid::from(1000)))
-                .with_owner_gid(Some(pna::OwnerGid::from(1000)))
-                .with_owner_user_name(Some(pna::OwnerUserName::new("user").unwrap()))
-                .with_owner_group_name(Some(pna::OwnerGroupName::new("group").unwrap()))
-                .with_permission_mode(Some(pna::PermissionMode::from(entry_def.permission))),
-        );
-        builder.write_all(entry_def.content)?;
-        let entry = builder.build()?;
-        solid_builder.add_entry(entry)?;
+        archive.write_file(
+            entry_def.path.into(),
+            metadata_with_mode(entry_def.permission),
+            |writer| writer.write_all(entry_def.content),
+        )?;
     }
-    let solid_entry = solid_builder.build()?;
-    archive.add_entry(solid_entry)?;
 
     archive.finalize()?;
     Ok(())
@@ -89,34 +81,20 @@ pub fn create_encrypted_solid_archive_with_permissions(
     password: &str,
 ) -> io::Result<()> {
     let file = File::create(archive_path)?;
-    let mut archive = pna::Archive::write_header(file)?;
-
     let write_options = pna::WriteOptions::builder()
         .password(Some(password))
         .encryption(pna::Encryption::AES)
         .cipher_mode(pna::CipherMode::GCM)
         .build();
 
-    let mut solid_builder = pna::SolidEntryBuilder::new(write_options)?;
+    let mut archive = pna::Archive::write_solid_header(file, write_options)?;
     for entry_def in entries {
-        let mut builder = pna::FileEntryBuilder::new_with_options(
+        archive.write_file(
             entry_def.path.into(),
-            pna::WriteOptions::store(),
+            metadata_with_mode(entry_def.permission),
+            |writer| writer.write_all(entry_def.content),
         )?;
-        builder.metadata(
-            pna::Metadata::new()
-                .with_owner_uid(Some(pna::OwnerUid::from(1000)))
-                .with_owner_gid(Some(pna::OwnerGid::from(1000)))
-                .with_owner_user_name(Some(pna::OwnerUserName::new("user").unwrap()))
-                .with_owner_group_name(Some(pna::OwnerGroupName::new("group").unwrap()))
-                .with_permission_mode(Some(pna::PermissionMode::from(entry_def.permission))),
-        );
-        builder.write_all(entry_def.content)?;
-        let entry = builder.build()?;
-        solid_builder.add_entry(entry)?;
     }
-    let solid_entry = solid_builder.build()?;
-    archive.add_entry(solid_entry)?;
 
     archive.finalize()?;
     Ok(())
@@ -138,19 +116,12 @@ pub fn create_encrypted_archive_with_permissions(
         .build();
 
     for entry_def in entries {
-        let mut builder =
-            pna::FileEntryBuilder::new_with_options(entry_def.path.into(), write_options.clone())?;
-        builder.metadata(
-            pna::Metadata::new()
-                .with_owner_uid(Some(pna::OwnerUid::from(1000)))
-                .with_owner_gid(Some(pna::OwnerGid::from(1000)))
-                .with_owner_user_name(Some(pna::OwnerUserName::new("user").unwrap()))
-                .with_owner_group_name(Some(pna::OwnerGroupName::new("group").unwrap()))
-                .with_permission_mode(Some(pna::PermissionMode::from(entry_def.permission))),
-        );
-        builder.write_all(entry_def.content)?;
-        let entry = builder.build()?;
-        archive.add_entry(entry)?;
+        archive.write_file(
+            entry_def.path.into(),
+            metadata_with_mode(entry_def.permission),
+            write_options.clone(),
+            |writer| writer.write_all(entry_def.content),
+        )?;
     }
 
     archive.finalize()?;
@@ -262,11 +233,12 @@ pub fn create_test_archive(path: impl AsRef<Path>, entries: &[(&str, &str)]) {
     let mut writer = pna::Archive::write_header(file).unwrap();
     for (name, contents) in entries {
         writer
-            .add_entry({
-                let mut builder = pna::FileEntryBuilder::new((*name).into()).unwrap();
-                builder.write_all(contents.as_bytes()).unwrap();
-                builder.build().unwrap()
-            })
+            .write_file(
+                (*name).into(),
+                pna::Metadata::new(),
+                pna::WriteOptions::store(),
+                |entry| entry.write_all(contents.as_bytes()),
+            )
             .unwrap();
     }
     writer.finalize().unwrap();
@@ -294,18 +266,12 @@ pub fn create_archive_with_symlinks(
     let mut archive = pna::Archive::write_header(file)?;
 
     for entry_def in file_entries {
-        let mut builder = pna::FileEntryBuilder::new(entry_def.path.into())?;
-        builder.metadata(
-            pna::Metadata::new()
-                .with_owner_uid(Some(pna::OwnerUid::from(1000)))
-                .with_owner_gid(Some(pna::OwnerGid::from(1000)))
-                .with_owner_user_name(Some(pna::OwnerUserName::new("user").unwrap()))
-                .with_owner_group_name(Some(pna::OwnerGroupName::new("group").unwrap()))
-                .with_permission_mode(Some(pna::PermissionMode::from(entry_def.permission))),
-        );
-        builder.write_all(entry_def.content)?;
-        let entry = builder.build()?;
-        archive.add_entry(entry)?;
+        archive.write_file(
+            entry_def.path.into(),
+            metadata_with_mode(entry_def.permission),
+            pna::WriteOptions::store(),
+            |writer| writer.write_all(entry_def.content),
+        )?;
     }
 
     for symlink_def in symlink_entries {

--- a/cli/tests/cli/utils/archive.rs
+++ b/cli/tests/cli/utils/archive.rs
@@ -2,7 +2,7 @@ use pna::ReadOptions;
 use pna::prelude::*;
 use std::{
     fs::File,
-    io::{self, Read, Write},
+    io::{self, Write},
     mem,
     path::Path,
 };
@@ -128,23 +128,6 @@ pub fn create_encrypted_archive_with_permissions(
     Ok(())
 }
 
-pub fn extract_single_entry(
-    path: impl AsRef<Path>,
-    name: &str,
-) -> io::Result<Option<pna::NormalEntry>> {
-    let mut archive = pna::Archive::open(path)?;
-    let entries = archive
-        .entries()
-        .extract_solid_entries(&ReadOptions::builder().build());
-    for entry in entries {
-        let entry = entry?;
-        if entry.header().path() == name {
-            return Ok(Some(entry));
-        }
-    }
-    Ok(None)
-}
-
 pub fn for_each_entry<F>(path: impl AsRef<Path>, f: F) -> io::Result<()>
 where
     F: FnMut(pna::NormalEntry),
@@ -163,64 +146,21 @@ where
     let password = password.into().map(|p| p.as_bytes());
     let mut archive = pna::Archive::open(path)?;
     let read_options = ReadOptions::with_password(password);
-    let entries = archive.entries().extract_solid_entries(&read_options);
+    let entries = archive.entries_with_options(&read_options);
     for entry in entries {
         f(entry?);
     }
     Ok(())
 }
 
-pub fn entry_mode(path: impl AsRef<Path>, name: &str) -> u16 {
-    entry_mode_with_password(path, name, None)
-}
-
-pub fn entry_mode_with_password(path: impl AsRef<Path>, name: &str, password: Option<&str>) -> u16 {
-    let mut mode = None;
-    for_each_entry_with_password(path, password, |entry| {
-        if entry.name() == name {
-            mode = Some(
-                entry
-                    .metadata()
-                    .permission_mode()
-                    .expect("entry should have permission mode metadata")
-                    .get()
-                    & 0o777,
-            );
-        }
-    })
-    .unwrap();
-    mode.expect("target entry should exist")
-}
-
-pub fn entry_contents_with_password(
-    path: impl AsRef<Path>,
-    name: &str,
-    password: Option<&str>,
-) -> Vec<u8> {
-    let password_bytes = password.map(str::as_bytes);
-    let mut contents = None;
-    for_each_entry_with_password(path, password, |entry| {
-        if entry.name() == name {
-            let mut reader = entry
-                .reader(pna::ReadOptions::with_password(password_bytes))
-                .unwrap();
-            let mut data = Vec::new();
-            reader.read_to_end(&mut data).unwrap();
-            contents = Some(data);
-        }
-    })
-    .unwrap();
-    contents.expect("target entry should exist")
-}
-
 pub fn read_symlink_target(entry: &pna::NormalEntry) -> String {
-    let mut target = Vec::new();
-    entry
-        .reader(pna::ReadOptions::with_password::<&[u8]>(None))
+    let pna::EntryContent::SymbolicLink(target) = entry
+        .content(pna::ReadOptions::with_password::<&[u8]>(None))
         .unwrap()
-        .read_to_end(&mut target)
-        .unwrap();
-    String::from_utf8(target).unwrap()
+    else {
+        panic!("entry should contain a symbolic link target");
+    };
+    target.to_string()
 }
 
 /// Creates a simple archive with named text entries.

--- a/lib/src/archive/read/slice.rs
+++ b/lib/src/archive/read/slice.rs
@@ -236,7 +236,7 @@ impl<'r> Iterator for Entries<'_, 'r> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{FileEntryBuilder, WriteOptions};
+    use crate::{Metadata, WriteOptions};
     use std::{io::Write, num::NonZeroU32};
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
@@ -282,11 +282,15 @@ mod tests {
     }
 
     fn archive_with_eight_byte_data() -> Vec<u8> {
-        let mut builder =
-            FileEntryBuilder::new_with_options("a".into(), WriteOptions::store()).unwrap();
-        builder.write_all(b"12345678").unwrap();
         let mut archive = Archive::write_header(Vec::new()).unwrap();
-        archive.add_entry(builder.build().unwrap()).unwrap();
+        archive
+            .write_file(
+                "a".into(),
+                Metadata::new(),
+                WriteOptions::store(),
+                |writer| writer.write_all(b"12345678"),
+            )
+            .unwrap();
         archive.finalize().unwrap()
     }
 
@@ -308,10 +312,14 @@ mod tests {
         let first = Archive::write_header(&mut first_bytes).unwrap();
         let mut second = first.split_to_next_archive(Vec::new()).unwrap();
 
-        let mut builder =
-            FileEntryBuilder::new_with_options("a".into(), WriteOptions::store()).unwrap();
-        builder.write_all(b"12345678").unwrap();
-        second.add_entry(builder.build().unwrap()).unwrap();
+        second
+            .write_file(
+                "a".into(),
+                Metadata::new(),
+                WriteOptions::store(),
+                |writer| writer.write_all(b"12345678"),
+            )
+            .unwrap();
         let second_bytes = second.finalize().unwrap();
 
         let mut first = Archive::read_header_from_slice(&first_bytes).unwrap();

--- a/lib/src/entry/content.rs
+++ b/lib/src/entry/content.rs
@@ -110,7 +110,6 @@ impl<T: AsRef<[u8]>> NormalEntry<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::util::io::TryIntoInner;
     use std::io::Write;
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
@@ -267,43 +266,20 @@ mod tests {
         assert_eq!("raw", io::read_to_string(reader).unwrap());
     }
 
-    /// Wire format allows encrypted link entries, but the public builder
-    /// always writes links with store options; assemble one manually the
-    /// same way `SymlinkEntryBuilder::build` does. The header is finalized
-    /// before encryption because the stream key is derived from it.
     fn encrypted_symlink_entry(target: &str, password: &str) -> NormalEntry {
         let options = WriteOptions::builder()
             .encryption(Encryption::AES)
             .password(Some(password))
             .try_build()
             .unwrap();
-        let mut entry =
-            SymlinkEntryBuilder::new("l".into(), EntryReference::from_utf8_preserve_root(target))
-                .unwrap()
-                .build()
-                .unwrap();
-        entry.header.encryption = options.encryption();
-        entry.header.cipher_mode = options.cipher_mode();
-        let context =
-            get_writer_context(&options, ChunkType::FHED, &entry.header.to_bytes()).unwrap();
-        let mut writer = get_writer(crate::util::io::FlattenWriter::new(), &context).unwrap();
-        writer.write_all(target.as_bytes()).unwrap();
-        let mut data = writer
-            .try_into_inner()
-            .unwrap()
-            .try_into_inner()
-            .unwrap()
-            .inner;
-        let (prefix, phsf) = match context.cipher {
-            None => (None, None),
-            Some(WriteCipher { context: c, .. }) => (Some(c.prefix_bytes()), Some(c.phsf)),
-        };
-        if let Some(prefix) = prefix {
-            data.insert(0, prefix);
-        }
-        entry.phsf = phsf;
-        entry.data = data;
-        entry
+        SymlinkEntryBuilder::new_with_options(
+            "l".into(),
+            EntryReference::from_utf8_preserve_root(target),
+            options,
+        )
+        .unwrap()
+        .build()
+        .unwrap()
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- migrate normal, solid, and encrypted test fixtures to the current streaming write APIs
- read logical entries through `entries_with_options` and decode symbolic links through `EntryContent`
- replace manual encrypted-symlink assembly with `SymlinkEntryBuilder::new_with_options`
- remove broad archive-inspection helpers and keep the remaining lookups close to their assertions

## Stack

- Depends on #3438
- This is PR 2 of the two-PR test cleanup stack

## Testing

- `cargo test -p libpna`
- `cargo test -p portable-network-archive --test cli` (686 passed, 2 ignored)
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

