### PR TITLE
Buffer transform output writes

### DIFF
--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -1648,13 +1648,16 @@ where
 {
     let password = password_provider();
     let context = TransformContext::new(password);
-    let mut out_archive = Archive::write_header(writer)?;
+    let mut out_archive = Archive::write_header(io::BufWriter::with_capacity(64 * 1024, writer))?;
     run_read_entries_mem(
         archives,
         |entry| Transform::transform(&mut out_archive, &context, entry, &mut processor),
         false,
     )?;
-    out_archive.finalize()?;
+    out_archive
+        .finalize()?
+        .into_inner()
+        .map_err(|error| error.into_error())?;
     Ok(())
 }
 
@@ -1712,13 +1715,16 @@ where
 {
     let password = password_provider();
     let context = TransformContext::new(password);
-    let mut out_archive = Archive::write_header(writer)?;
+    let mut out_archive = Archive::write_header(io::BufWriter::with_capacity(64 * 1024, writer))?;
     run_read_entries(
         archives,
         |entry| Transform::transform(&mut out_archive, &context, entry, &mut processor),
         false,
     )?;
-    out_archive.finalize()?;
+    out_archive
+        .finalize()?
+        .into_inner()
+        .map_err(|error| error.into_error())?;
     Ok(())
 }
 

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -518,7 +518,10 @@ fn update_archive(args: UpdateCommand, umask: Umask) -> anyhow::Result<()> {
 
     let output_path = args.output.unwrap_or_else(|| archive_path.remove_part());
     let mut staged = StagedArchive::new(output_path, umask)?;
-    let mut out_archive = Archive::write_header(staged.as_file_mut())?;
+    let mut out_archive = Archive::write_header(io::BufWriter::with_capacity(
+        64 * 1024,
+        staged.as_file_mut(),
+    ))?;
 
     let mut source = SplitArchiveReader::new(archives)?;
     match transform_strategy {
@@ -547,7 +550,10 @@ fn update_archive(args: UpdateCommand, umask: Umask) -> anyhow::Result<()> {
             false,
         ),
     }?;
-    out_archive.finalize()?;
+    out_archive
+        .finalize()?
+        .into_inner()
+        .map_err(|error| error.into_error())?;
     drop(source);
 
     staged.commit(None)?;


### PR DESCRIPTION
## Summary
Transform commands hand `StagedArchive`'s bare `fs::File` to the output `Archive`, so every chunk field write is its own syscall. Wrap the output in a 64 KiB `BufWriter`, matching `create`, and surface flush errors through `into_inner`.