### PR TITLE
:recycle: Separate archive paths from file operands

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     utils::{fs::current_umask, process::is_running_as_root},
 };
-use clap::{ArgGroup, Parser, Subcommand, ValueEnum, ValueHint};
+use clap::{ArgGroup, Args, Parser, Subcommand, ValueEnum, ValueHint};
 use log::{Level, LevelFilter};
 use pna::HashAlgorithm;
 use std::{io, path::PathBuf};
@@ -213,10 +213,20 @@ pub(crate) enum Commands {
     Experimental(ExperimentalCommand),
 }
 
-#[derive(Parser, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub(crate) struct FileArgs {
-    #[arg(short = 'f', long = "file", help = "Archive file path", value_hint = ValueHint::FilePath)]
-    pub(crate) archive: PathBuf,
+#[derive(Args, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub(crate) struct ArchiveFileArgs {
+    #[arg(
+        short = 'f',
+        long = "file",
+        value_name = "ARCHIVE",
+        help = "Archive file path",
+        value_hint = ValueHint::FilePath
+    )]
+    pub(crate) file: PathBuf,
+}
+
+#[derive(Args, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub(crate) struct FileOperands {
     #[arg(help = "Files or directories to process", value_hint = ValueHint::FilePath)]
     pub(crate) files: Vec<String>,
 }

--- a/cli/src/command/acl.rs
+++ b/cli/src/command/acl.rs
@@ -1,7 +1,8 @@
 use crate::{
     chunk::{Ace, AcePlatform, Flag, Identifier, OwnerType, Permission},
     cli::{
-        FileArgs, PasswordArgs, SolidEntriesTransformStrategy, SolidEntriesTransformStrategyArgs,
+        ArchiveFileArgs, FileOperands, PasswordArgs, SolidEntriesTransformStrategy,
+        SolidEntriesTransformStrategyArgs,
     },
     command::{
         Command, ask_password,
@@ -63,7 +64,9 @@ pub(crate) struct GetAclCommand {
     #[arg(short, long, help = "List numeric user and group IDs")]
     numeric: bool,
     #[command(flatten)]
-    file: FileArgs,
+    archive: ArchiveFileArgs,
+    #[command(flatten)]
+    files: FileOperands,
     #[command(flatten)]
     password: PasswordArgs,
 }
@@ -82,7 +85,9 @@ impl Command for GetAclCommand {
 )]
 pub(crate) struct SetAclCommand {
     #[command(flatten)]
-    file: FileArgs,
+    archive: ArchiveFileArgs,
+    #[command(flatten)]
+    files: FileOperands,
     #[arg(long, help = "Set the ACL on the specified file.")]
     set: Option<AclEntries>,
     #[arg(
@@ -287,15 +292,15 @@ impl FromStr for AclEntries {
 #[hooq::hooq(anyhow)]
 fn archive_get_acl(args: GetAclCommand) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
-    if args.file.files.is_empty() {
+    if args.files.files.is_empty() {
         return Ok(());
     }
-    let files = args.file.files;
+    let files = args.files.files;
     let mut globs = GlobPatterns::new(files.iter().map(|it| it.as_str()))?;
     let platforms = args.platform.into_iter().collect::<HashSet<_>>();
     let numeric_owner = args.numeric;
 
-    let mut source = SplitArchiveReader::new(collect_split_archives(args.file.archive)?)?;
+    let mut source = SplitArchiveReader::new(collect_split_archives(args.archive.file)?)?;
     let read_options = ReadOptions::with_password(password.as_deref());
 
     source.for_each_entry(
@@ -336,7 +341,7 @@ fn archive_get_acl(args: GetAclCommand) -> anyhow::Result<()> {
 #[hooq::hooq(anyhow)]
 fn archive_set_acl(args: SetAclCommand, umask: Umask) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
-    let files = args.file.files;
+    let files = args.files.files;
     let mut set_strategy = if args.restore_from_stdin {
         SetAclsStrategy::Restore(parse_acl_dump(io::stdin().lock())?)
     } else if let Some(path) = args.restore.as_deref() {
@@ -354,9 +359,9 @@ fn archive_set_acl(args: SetAclCommand, umask: Umask) -> anyhow::Result<()> {
         }
     };
 
-    let mut source = SplitArchiveReader::new(collect_split_archives(&args.file.archive)?)?;
+    let mut source = SplitArchiveReader::new(collect_split_archives(&args.archive.file)?)?;
 
-    let output_path = args.file.archive.remove_part();
+    let output_path = args.archive.file.remove_part();
     let mut staged = StagedArchive::new(output_path, umask)?;
 
     match args.transform_strategy.strategy() {

--- a/cli/src/command/append.rs
+++ b/cli/src/command/append.rs
@@ -1,7 +1,7 @@
 use crate::{
     cli::{
-        CipherAlgorithmArgs, CompressionAlgorithmArgs, DateTime, FileArgs, HashAlgorithmArgs,
-        MissingTimePolicy, PasswordArgs,
+        ArchiveFileArgs, CipherAlgorithmArgs, CompressionAlgorithmArgs, DateTime, FileOperands,
+        HashAlgorithmArgs, MissingTimePolicy, PasswordArgs,
     },
     command::{
         Command, ask_password,
@@ -377,7 +377,9 @@ pub(crate) struct AppendCommand {
     #[command(flatten)]
     pub(crate) hash: HashAlgorithmArgs,
     #[command(flatten)]
-    pub(crate) file: FileArgs,
+    pub(crate) archive: ArchiveFileArgs,
+    #[command(flatten)]
+    pub(crate) files: FileOperands,
 }
 
 impl Command for AppendCommand {
@@ -390,7 +392,7 @@ impl Command for AppendCommand {
 #[hooq::hooq(anyhow)]
 fn append_to_archive(args: AppendCommand) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
-    let archive_path = args.file.archive;
+    let archive_path = args.archive.file;
     if !archive_path.exists() {
         anyhow::bail!("{} is not exists", archive_path.display());
     }
@@ -452,7 +454,7 @@ fn append_to_archive(args: AppendCommand) -> anyhow::Result<()> {
 
     let archive = open_archive_then_seek_to_end(&archive_path, false)?;
 
-    let mut files = args.file.files;
+    let mut files = args.files.files;
     if args.files_from_stdin {
         files.extend(read_paths_stdin(args.null)?);
     } else if let Some(path) = args.files_from {

--- a/cli/src/command/chmod.rs
+++ b/cli/src/command/chmod.rs
@@ -1,5 +1,8 @@
 use crate::{
-    cli::{PasswordArgs, SolidEntriesTransformStrategy, SolidEntriesTransformStrategyArgs},
+    cli::{
+        ArchiveFileArgs, PasswordArgs, SolidEntriesTransformStrategy,
+        SolidEntriesTransformStrategyArgs,
+    },
     command::{
         Command, ask_password,
         core::{
@@ -19,12 +22,12 @@ use nom::{
     multi::{many0, many1, separated_list1},
 };
 use pna::{DataKind, NormalEntry};
-use std::{ops::BitOr, path::PathBuf, str::FromStr};
+use std::{ops::BitOr, str::FromStr};
 
 #[derive(Parser, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub(crate) struct ChmodCommand {
-    #[arg(short = 'f', long = "file", value_hint = ValueHint::FilePath)]
-    archive: PathBuf,
+    #[command(flatten)]
+    archive: ArchiveFileArgs,
     #[arg(help = "mode")]
     mode: Mode,
     #[arg(value_hint = ValueHint::AnyPath)]
@@ -50,9 +53,9 @@ fn archive_chmod(args: ChmodCommand, umask: Umask) -> anyhow::Result<()> {
     }
     let mut globs = GlobPatterns::new(args.files.iter().map(|p| p.as_str()))?;
 
-    let mut source = SplitArchiveReader::new(collect_split_archives(&args.archive)?)?;
+    let mut source = SplitArchiveReader::new(collect_split_archives(&args.archive.file)?)?;
 
-    let output_path = args.archive.remove_part();
+    let output_path = args.archive.file.remove_part();
     let mut staged = StagedArchive::new(output_path, umask)?;
 
     match args.transform_strategy.strategy() {

--- a/cli/src/command/chown.rs
+++ b/cli/src/command/chown.rs
@@ -1,5 +1,8 @@
 use crate::{
-    cli::{PasswordArgs, SolidEntriesTransformStrategy, SolidEntriesTransformStrategyArgs},
+    cli::{
+        ArchiveFileArgs, PasswordArgs, SolidEntriesTransformStrategy,
+        SolidEntriesTransformStrategyArgs,
+    },
     command::{
         Command, ask_password,
         core::{
@@ -14,12 +17,12 @@ use crate::{
 };
 use clap::{ArgAction, Parser, ValueHint, builder::ArgPredicate};
 use pna::NormalEntry;
-use std::{io, ops::Not, path::PathBuf, str::FromStr};
+use std::{io, ops::Not, str::FromStr};
 
 #[derive(Parser, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub(crate) struct ChownCommand {
-    #[arg(short = 'f', long = "file", value_hint = ValueHint::FilePath)]
-    archive: PathBuf,
+    #[command(flatten)]
+    archive: ArchiveFileArgs,
     #[arg(help = "owner[:group]|:group")]
     owner: RawOwnership,
     #[arg(long, help = "force numeric owner and group IDs (no name resolution)")]
@@ -61,9 +64,9 @@ fn archive_chown(args: ChownCommand, umask: Umask) -> anyhow::Result<()> {
         .owner
         .lookup_platform_owner(args.numeric_owner, args.owner_lookup)?;
 
-    let mut source = SplitArchiveReader::new(collect_split_archives(&args.archive)?)?;
+    let mut source = SplitArchiveReader::new(collect_split_archives(&args.archive.file)?)?;
 
-    let output_path = args.archive.remove_part();
+    let output_path = args.archive.file.remove_part();
     let mut staged = StagedArchive::new(output_path, umask)?;
 
     match args.transform_strategy.strategy() {

--- a/cli/src/command/chunk.rs
+++ b/cli/src/command/chunk.rs
@@ -1,7 +1,10 @@
-use crate::{cli::value::ChunkType, command::Command};
-use clap::{Parser, ValueHint};
+use crate::{
+    cli::{ArchiveFileArgs, value::ChunkType},
+    command::Command,
+};
+use clap::Parser;
 use pna::prelude::*;
-use std::{collections::HashSet, fs, path::PathBuf};
+use std::{collections::HashSet, fs};
 use tabled::{builder::Builder as TableBuilder, settings::Style as TableStyle};
 
 #[derive(Parser, Clone, Eq, PartialEq, Hash, Debug)]
@@ -45,8 +48,8 @@ pub(crate) struct ListCommand {
         help = "Do not list chunks of the specified type"
     )]
     exclude_ty: Vec<ChunkType>,
-    #[arg(short = 'f', long = "file", value_hint = ValueHint::FilePath)]
-    archive: PathBuf,
+    #[command(flatten)]
+    archive: ArchiveFileArgs,
     #[arg(long, action = clap::ArgAction::Help, help = "Print help")]
     help: (),
 }
@@ -60,7 +63,7 @@ impl Command for ListCommand {
 
 #[hooq::hooq(anyhow)]
 fn list_archive_chunks(args: ListCommand) -> anyhow::Result<()> {
-    let archive = fs::File::open(args.archive)?;
+    let archive = fs::File::open(args.archive.file)?;
     let mut builder = TableBuilder::new();
     if args.header {
         builder.push_record(

--- a/cli/src/command/create.rs
+++ b/cli/src/command/create.rs
@@ -1,7 +1,7 @@
 use crate::{
     cli::{
-        CipherAlgorithmArgs, CompressionAlgorithmArgs, DateTime, FileArgs, HashAlgorithmArgs,
-        MissingTimePolicy, PasswordArgs,
+        ArchiveFileArgs, CipherAlgorithmArgs, CompressionAlgorithmArgs, DateTime, FileOperands,
+        HashAlgorithmArgs, MissingTimePolicy, PasswordArgs,
     },
     command::{
         Command, ask_password,
@@ -403,7 +403,9 @@ pub(crate) struct CreateCommand {
     #[command(flatten)]
     pub(crate) password: PasswordArgs,
     #[command(flatten)]
-    pub(crate) file: FileArgs,
+    pub(crate) archive: ArchiveFileArgs,
+    #[command(flatten)]
+    pub(crate) files: FileOperands,
 }
 
 impl Command for CreateCommand {
@@ -417,7 +419,7 @@ impl Command for CreateCommand {
 fn create_archive(args: CreateCommand) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
     let start = Instant::now();
-    let archive = &args.file.archive;
+    let archive = &args.archive.file;
     let max_file_size = args
         .split
         .map(|opt| {
@@ -436,7 +438,7 @@ fn create_archive(args: CreateCommand) -> anyhow::Result<()> {
         anyhow::bail!("{} already exists", archive.display());
     }
     log::info!("Create an archive: {}", archive.display());
-    let mut files = args.file.files;
+    let mut files = args.files.files;
     if args.files_from_stdin {
         files.extend(read_paths_stdin(args.null)?);
     } else if let Some(path) = args.files_from {

--- a/cli/src/command/delete.rs
+++ b/cli/src/command/delete.rs
@@ -1,6 +1,7 @@
 use crate::{
     cli::{
-        FileArgs, PasswordArgs, SolidEntriesTransformStrategy, SolidEntriesTransformStrategyArgs,
+        ArchiveFileArgs, FileOperands, PasswordArgs, SolidEntriesTransformStrategy,
+        SolidEntriesTransformStrategyArgs,
     },
     command::{
         Command, ask_password,
@@ -87,7 +88,9 @@ pub(crate) struct DeleteCommand {
     #[command(flatten)]
     pub(crate) transform_strategy: SolidEntriesTransformStrategyArgs,
     #[command(flatten)]
-    file: FileArgs,
+    archive: ArchiveFileArgs,
+    #[command(flatten)]
+    files: FileOperands,
 }
 
 impl Command for DeleteCommand {
@@ -100,7 +103,7 @@ impl Command for DeleteCommand {
 #[hooq::hooq(anyhow)]
 fn delete_file_from_archive(args: DeleteCommand, umask: Umask) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
-    let mut files = args.file.files;
+    let mut files = args.files.files;
     if args.files_from_stdin {
         files.extend(read_paths_stdin(args.null)?);
     } else if let Some(path) = args.files_from {
@@ -122,11 +125,11 @@ fn delete_file_from_archive(args: DeleteCommand, umask: Umask) -> anyhow::Result
         exclude.iter().map(|s| s.as_str()).chain(vcs_patterns),
     );
 
-    let mut source = SplitArchiveReader::new(collect_split_archives(&args.file.archive)?)?;
+    let mut source = SplitArchiveReader::new(collect_split_archives(&args.archive.file)?)?;
 
     let output_path = args
         .output
-        .unwrap_or_else(|| args.file.archive.remove_part());
+        .unwrap_or_else(|| args.archive.file.remove_part());
     let mut staged = StagedArchive::new(output_path, umask)?;
 
     match args.transform_strategy.strategy() {

--- a/cli/src/command/diff.rs
+++ b/cli/src/command/diff.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::{FileArgs, PasswordArgs},
+    cli::{ArchiveFileArgs, FileOperands, PasswordArgs},
     command::{
         Command, ExitCodeError, ask_password,
         core::{SplitArchiveReader, collect_split_archives},
@@ -27,7 +27,9 @@ use std::{fmt, fs, io, path::Path};
 #[derive(Parser, Clone, Debug)]
 pub(crate) struct DiffCommand {
     #[command(flatten)]
-    file: FileArgs,
+    archive: ArchiveFileArgs,
+    #[command(flatten)]
+    files: FileOperands,
     #[command(flatten)]
     password: PasswordArgs,
     #[arg(
@@ -86,13 +88,13 @@ fn diff_archive(ctx: &crate::cli::GlobalContext, args: DiffCommand) -> anyhow::R
         );
     }
     let password = ask_password(args.password)?;
-    let archives = collect_split_archives(&args.file.archive)?;
+    let archives = collect_split_archives(&args.archive.file)?;
     let options = CompareOptions {
         full_compare: args.full_compare,
         format: args.format,
     };
 
-    let mut globs = BsdGlobMatcher::new(args.file.files.iter().map(|s| s.as_str()));
+    let mut globs = BsdGlobMatcher::new(args.files.files.iter().map(|s| s.as_str()));
     let filter_enabled = !globs.is_empty();
 
     let read_options = ReadOptions::with_password(password.as_deref());

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -4,7 +4,7 @@ use crate::ext::*;
 #[cfg(any(unix, windows))]
 use crate::utils::fs::lchown;
 use crate::{
-    cli::{DateTime, FileArgs, MissingTimePolicy, PasswordArgs},
+    cli::{ArchiveFileArgs, DateTime, FileOperands, MissingTimePolicy, PasswordArgs},
     command::{
         Command, ask_password,
         core::{
@@ -387,7 +387,9 @@ pub(crate) struct ExtractCommand {
     )]
     no_safe_writes: (),
     #[command(flatten)]
-    pub(crate) file: FileArgs,
+    pub(crate) archive: ArchiveFileArgs,
+    #[command(flatten)]
+    pub(crate) files: FileOperands,
 }
 
 impl Command for ExtractCommand {
@@ -400,7 +402,7 @@ impl Command for ExtractCommand {
 fn extract_archive(args: ExtractCommand) -> anyhow::Result<()> {
     let password = ask_password(args.password).with_context(|| "reading password")?;
     let start = Instant::now();
-    let archive = args.file.archive;
+    let archive = args.archive.file;
     log::info!("Extract archive {}", PathWithCwd::new(&archive));
 
     let archives = collect_split_archives(&archive)
@@ -424,7 +426,7 @@ fn extract_archive(args: ExtractCommand) -> anyhow::Result<()> {
         exclude.iter().map(|s| s.as_str()).chain(vcs_patterns),
     );
 
-    let mut files = args.file.files;
+    let mut files = args.files.files;
     if let Some(path) = &args.files_from {
         files.extend(
             read_paths(path, args.null)

--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -1,6 +1,6 @@
 use crate::{
     chunk,
-    cli::{ColorChoice, DateTime, FileArgs, MissingTimePolicy, PasswordArgs},
+    cli::{ArchiveFileArgs, ColorChoice, DateTime, FileOperands, MissingTimePolicy, PasswordArgs},
     command::{
         Command, ask_password,
         core::{
@@ -236,7 +236,9 @@ pub(crate) struct ListCommand {
     #[command(flatten)]
     pub(crate) password: PasswordArgs,
     #[command(flatten)]
-    pub(crate) file: FileArgs,
+    pub(crate) archive: ArchiveFileArgs,
+    #[command(flatten)]
+    pub(crate) files: FileOperands,
     #[arg(long, action = clap::ArgAction::Help, help = "Print help")]
     help: (),
 }
@@ -527,8 +529,8 @@ fn list_archive(ctx: &crate::cli::GlobalContext, args: ListCommand) -> anyhow::R
         time_filters,
         line_ending: LineEnding::default(),
     };
-    let archive = args.file.archive;
-    let files = args.file.files;
+    let archive = args.archive.file;
+    let files = args.files.files;
     let files_globs =
         BsdGlobMatcher::new(files.iter().map(|it| it.as_str())).with_no_recursive(!args.recursive);
 

--- a/cli/src/command/migrate.rs
+++ b/cli/src/command/migrate.rs
@@ -1,5 +1,8 @@
 use crate::{
-    cli::{PasswordArgs, SolidEntriesTransformStrategy, SolidEntriesTransformStrategyArgs},
+    cli::{
+        ArchiveFileArgs, PasswordArgs, SolidEntriesTransformStrategy,
+        SolidEntriesTransformStrategyArgs,
+    },
     command::{
         Command, ask_password,
         core::{
@@ -19,8 +22,8 @@ pub(crate) struct MigrateCommand {
     transform_strategy: SolidEntriesTransformStrategyArgs,
     #[command(flatten)]
     password: PasswordArgs,
-    #[arg(short = 'f', long = "file", value_hint = ValueHint::FilePath)]
-    archive: PathBuf,
+    #[command(flatten)]
+    archive: ArchiveFileArgs,
     #[arg(long, help = "Output file path", value_hint = ValueHint::AnyPath)]
     output: PathBuf,
 }
@@ -36,7 +39,7 @@ impl Command for MigrateCommand {
 fn migrate_metadata(args: MigrateCommand, umask: Umask) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
 
-    let mut source = SplitArchiveReader::new(collect_split_archives(&args.archive)?)?;
+    let mut source = SplitArchiveReader::new(collect_split_archives(&args.archive.file)?)?;
 
     let output_path = args.output;
     let mut staged = StagedArchive::new(output_path, umask)?;

--- a/cli/src/command/sort.rs
+++ b/cli/src/command/sort.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::PasswordArgs,
+    cli::{ArchiveFileArgs, PasswordArgs},
     command::{
         Command, ask_password,
         core::{SplitArchiveReader, StagedArchive, Umask, collect_split_archives},
@@ -120,8 +120,8 @@ impl FromStr for SortKey {
 
 #[derive(Parser, Clone, Eq, PartialEq, Hash, Debug)]
 pub(crate) struct SortCommand {
-    #[arg(short = 'f', long = "file", help = "Archive file path", value_hint = ValueHint::FilePath)]
-    archive: PathBuf,
+    #[command(flatten)]
+    archive: ArchiveFileArgs,
     #[arg(long, help = "Output archive file path", value_hint = ValueHint::FilePath)]
     output: Option<PathBuf>,
     #[arg(
@@ -146,7 +146,7 @@ impl Command for SortCommand {
 #[hooq::hooq(anyhow)]
 fn sort_archive(args: SortCommand, umask: Umask) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
-    let archives = collect_split_archives(&args.archive)?;
+    let archives = collect_split_archives(&args.archive.file)?;
     let mut source = SplitArchiveReader::new(archives)?;
     let read_options = ReadOptions::with_password(password.as_deref());
     let mut entries = Vec::<NormalEntry<_>>::new();
@@ -177,7 +177,9 @@ fn sort_archive(args: SortCommand, umask: Umask) -> anyhow::Result<()> {
         std::cmp::Ordering::Equal
     });
 
-    let output = args.output.unwrap_or_else(|| args.archive.remove_part());
+    let output = args
+        .output
+        .unwrap_or_else(|| args.archive.file.remove_part());
     let mut staged = StagedArchive::new(output, umask)?;
     let mut archive = Archive::write_header(staged.as_file_mut())?;
     for entry in entries {

--- a/cli/src/command/split.rs
+++ b/cli/src/command/split.rs
@@ -1,4 +1,5 @@
 use crate::{
+    cli::ArchiveFileArgs,
     command::{Command, core::write_split_archive},
     utils::PathWithCwd,
 };
@@ -10,8 +11,8 @@ use std::{borrow::Cow, fs, path::PathBuf};
 
 #[derive(Parser, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub(crate) struct SplitCommand {
-    #[arg(short = 'f', long = "file", help = "Archive file path", value_hint = ValueHint::FilePath)]
-    file: PathBuf,
+    #[command(flatten)]
+    archive: ArchiveFileArgs,
     #[arg(long, value_name = "DIRECTORY", help = "Output directory for split archives", value_hint = ValueHint::DirPath)]
     out_dir: Option<PathBuf>,
     #[arg(long, conflicts_with = "no_overwrite", help = "Overwrite file")]
@@ -39,7 +40,7 @@ impl Command for SplitCommand {
 
 #[hooq::hooq(anyhow)]
 fn split_archive(args: SplitCommand) -> anyhow::Result<()> {
-    let archive_path = args.file;
+    let archive_path = args.archive.file;
     let max_file_size = usize::try_from(args.max_size.unwrap_or_else(|| ByteSize::gb(1)).as_u64())
         .context("--max-size is too large for this platform")?;
     ensure!(

--- a/cli/src/command/strip.rs
+++ b/cli/src/command/strip.rs
@@ -1,7 +1,7 @@
 use crate::{
     cli::{
-        FileArgs, PasswordArgs, PrivateChunkType, SolidEntriesTransformStrategy,
-        SolidEntriesTransformStrategyArgs,
+        ArchiveFileArgs, FileOperands, PasswordArgs, PrivateChunkType,
+        SolidEntriesTransformStrategy, SolidEntriesTransformStrategyArgs,
     },
     command::{
         Command, ask_password,
@@ -57,7 +57,9 @@ pub(crate) struct StripCommand {
     #[command(flatten)]
     pub(crate) password: PasswordArgs,
     #[command(flatten)]
-    pub(crate) file: FileArgs,
+    pub(crate) archive: ArchiveFileArgs,
+    #[command(flatten)]
+    pub(crate) files: FileOperands,
 }
 
 impl Command for StripCommand {
@@ -70,7 +72,7 @@ impl Command for StripCommand {
 #[hooq::hooq(anyhow)]
 fn strip_metadata(args: StripCommand, umask: Umask) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
-    let archive = args.file.archive;
+    let archive = args.archive.file;
     let mut source = SplitArchiveReader::new(collect_split_archives(&archive)?)?;
 
     let output_path = args.output.unwrap_or_else(|| archive.remove_part());

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -1,7 +1,7 @@
 use crate::{
     cli::{
-        CipherAlgorithmArgs, CompressionAlgorithmArgs, DateTime, FileArgs, HashAlgorithmArgs,
-        MissingTimePolicy, PasswordArgs, SolidEntriesTransformStrategy,
+        ArchiveFileArgs, CipherAlgorithmArgs, CompressionAlgorithmArgs, DateTime, FileOperands,
+        HashAlgorithmArgs, MissingTimePolicy, PasswordArgs, SolidEntriesTransformStrategy,
         SolidEntriesTransformStrategyArgs,
     },
     command::{
@@ -373,7 +373,9 @@ pub(crate) struct UpdateCommand {
     #[command(flatten)]
     pub(crate) transform_strategy: SolidEntriesTransformStrategyArgs,
     #[command(flatten)]
-    pub(crate) file: FileArgs,
+    pub(crate) archive: ArchiveFileArgs,
+    #[command(flatten)]
+    pub(crate) files: FileOperands,
     #[arg(
         long,
         help = "Filenames or patterns are separated by null characters, not by newlines"
@@ -418,7 +420,7 @@ fn update_archive(args: UpdateCommand, umask: Umask) -> anyhow::Result<()> {
     let transform_strategy = args.transform_strategy.strategy();
     let sync = args.sync;
     let password = ask_password(args.password)?;
-    let archive_path = &args.file.archive;
+    let archive_path = &args.archive.file;
     if !archive_path.exists() {
         anyhow::bail!("{} is not exists", archive_path.display());
     }
@@ -479,9 +481,9 @@ fn update_archive(args: UpdateCommand, umask: Umask) -> anyhow::Result<()> {
         ),
     };
 
-    let archives = collect_split_archives(&args.file.archive)?;
+    let archives = collect_split_archives(&args.archive.file)?;
 
-    let mut files = args.file.files;
+    let mut files = args.files.files;
     if args.files_from_stdin {
         files.extend(read_paths_stdin(args.null)?);
     } else if let Some(path) = args.files_from {

--- a/cli/src/command/verify.rs
+++ b/cli/src/command/verify.rs
@@ -1,21 +1,21 @@
 use crate::{
-    cli::{GlobalContext, PasswordArgs},
+    cli::{ArchiveFileArgs, GlobalContext, PasswordArgs},
     command::{
         Command, ask_password,
         core::{collect_split_archives, run_read_entries},
     },
 };
-use clap::{Parser, ValueHint};
+use clap::Parser;
 use pna::{CipherMode, Encryption, NormalEntry, ReadEntry, ReadOptions, SolidEntry};
-use std::{io, path::PathBuf};
+use std::io;
 
 #[derive(Parser, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 #[command(
     after_long_help = "Note: for entries encrypted in CBC or CTR mode, a wrong password is indistinguishable from corruption. GCM mode instead reports a key mismatch, meaning the password does not match the key derivation parameters recorded for the entry: either the password is wrong, or those recorded parameters were themselves altered."
 )]
 pub(crate) struct VerifyCommand {
-    #[arg(short = 'f', long = "file", help = "Archive file path", value_hint = ValueHint::FilePath)]
-    archive: PathBuf,
+    #[command(flatten)]
+    archive: ArchiveFileArgs,
     #[arg(
         long,
         help = "Verify chunk structure and CRC32 only, without decoding entry data",
@@ -53,7 +53,7 @@ fn verify_archive(args: VerifyCommand) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
     let password = password.as_deref();
     let read_options = ReadOptions::with_password(password);
-    let archives = collect_split_archives(&args.archive)?;
+    let archives = collect_split_archives(&args.archive.file)?;
     let mut report = VerifyReport::default();
     let mut solid_blocks = 0usize;
     let mut resyncing = false;

--- a/cli/src/command/xattr.rs
+++ b/cli/src/command/xattr.rs
@@ -1,6 +1,7 @@
 use crate::{
     cli::{
-        FileArgs, PasswordArgs, SolidEntriesTransformStrategy, SolidEntriesTransformStrategyArgs,
+        ArchiveFileArgs, FileOperands, PasswordArgs, SolidEntriesTransformStrategy,
+        SolidEntriesTransformStrategyArgs,
     },
     command::{
         Command, ask_password,
@@ -56,7 +57,9 @@ pub(crate) enum XattrCommands {
 )]
 pub(crate) struct GetXattrCommand {
     #[command(flatten)]
-    file: FileArgs,
+    archive: ArchiveFileArgs,
+    #[command(flatten)]
+    files: FileOperands,
     #[arg(short, long, help = "Dump the value of the named extended attribute")]
     name: Option<String>,
     #[arg(
@@ -91,7 +94,9 @@ impl Command for GetXattrCommand {
 ))]
 pub(crate) struct SetXattrCommand {
     #[command(flatten)]
-    file: FileArgs,
+    archive: ArchiveFileArgs,
+    #[command(flatten)]
+    files: FileOperands,
     #[arg(short, long, help = "Name of extended attribute")]
     name: Option<pna::XattrName>,
     #[arg(short, long, help = "Value of extended attribute")]
@@ -195,16 +200,16 @@ impl<'a> DumpOption<'a> {
 #[hooq::hooq(anyhow)]
 fn archive_get_xattr(args: GetXattrCommand) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
-    if args.file.files.is_empty() {
+    if args.files.files.is_empty() {
         return Ok(());
     }
-    let files = args.file.files;
+    let files = args.files.files;
     let mut globs = GlobPatterns::new(files.iter().map(|p| p.as_str()))?;
     let encoding = args.encoding;
     let dump_option = DumpOption::new(args.dump, args.name.as_deref(), args.regex_match.as_deref())
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
 
-    let mut source = SplitArchiveReader::new(collect_split_archives(&args.file.archive)?)?;
+    let mut source = SplitArchiveReader::new(collect_split_archives(&args.archive.file)?)?;
     let read_options = ReadOptions::with_password(password.as_deref());
 
     source.for_each_entry(
@@ -243,7 +248,7 @@ fn archive_get_xattr(args: GetXattrCommand) -> anyhow::Result<()> {
 #[hooq::hooq(anyhow)]
 fn archive_set_xattr(args: SetXattrCommand, umask: Umask) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
-    let files = args.file.files;
+    let files = args.files.files;
     let mut set_strategy = if args.restore_from_stdin {
         SetAttrStrategy::Restore(parse_dump(io::stdin().lock())?)
     } else if let Some(path) = args.restore.as_deref() {
@@ -268,9 +273,9 @@ fn archive_set_xattr(args: SetXattrCommand, umask: Umask) -> anyhow::Result<()> 
         }
     };
 
-    let mut source = SplitArchiveReader::new(collect_split_archives(&args.file.archive)?)?;
+    let mut source = SplitArchiveReader::new(collect_split_archives(&args.archive.file)?)?;
 
-    let output_path = args.file.archive.remove_part();
+    let output_path = args.archive.file.remove_part();
     let mut staged = StagedArchive::new(output_path, umask)?;
 
     match args.transform_strategy.strategy() {


### PR DESCRIPTION
## Stack

Stack 2/22 — Stage 2 of the native stdio stack.

Depends on #3441.

## Summary

- split the shared archive-path and entry-operand container into independent clap argument groups
- reuse the archive-path group across native commands that previously declared their own required `--file`
- preserve command syntax and runtime behavior while preparing source selection to evolve independently
- leave the generated `docs/cli-reference.md` untouched

## Test strategy

No new test was added because this is a pure clap-structure refactor; a new behavior-specific test would duplicate coverage without adding a distinct failure signal. The existing broad CLI and integration suites are the appropriate layer for proving parsing and dispatch remain unchanged in both core configurations.

- `cargo test --locked -p portable-network-archive`
- `cargo test --locked -p portable-network-archive --features memmap`
- `cargo clippy --locked -p portable-network-archive --all-targets --features memmap -- -D warnings`