### PR TITLE
:recycle: Keep reader and byte archive cores distinct

### DIFF
--- a/cli/src/command/bsdtar.rs
+++ b/cli/src/command/bsdtar.rs
@@ -16,7 +16,7 @@ use crate::{
             collect_split_archives,
             path_lock::OrderedPathLocks,
             re::{bsd::SubstitutionRule, gnu::TransformRule},
-            read_paths, run_across_archive, validate_no_duplicate_stdin,
+            read_paths, run_across_archive_readers, validate_no_duplicate_stdin,
         },
         create::{CreationContext, create_archive_file},
         extract::{OutputOption, OverwriteStrategy, run_extract_archive_reader},
@@ -1366,7 +1366,7 @@ fn run_append(args: BsdtarCommand) -> anyhow::Result<()> {
     } else {
         let target_items = collect_items_from_sources(sources, &collect_options, &mut resolver)?;
         let mut output_archive = Archive::write_header(io::stdout().lock())?;
-        run_across_archive(
+        run_across_archive_readers(
             std::iter::once(io::stdin().lock()),
             #[hooq::skip_all]
             |input_archive| {

--- a/cli/src/command/concat.rs
+++ b/cli/src/command/concat.rs
@@ -1,7 +1,7 @@
-#[cfg(not(feature = "memmap"))]
-use crate::command::core::run_across_archive;
 #[cfg(feature = "memmap")]
-use crate::command::core::run_across_archive_mem as run_across_archive;
+use crate::command::core::run_across_archive_bytes;
+#[cfg(not(feature = "memmap"))]
+use crate::command::core::run_across_archive_readers;
 use crate::{
     command::{Command, core::collect_split_archives},
     utils::{self, PathWithCwd},
@@ -56,7 +56,7 @@ fn concat_entry(args: ConcatCommand) -> anyhow::Result<()> {
                 .map(utils::mmap::Mmap::try_from)
                 .collect::<io::Result<Vec<_>>>()?;
             let archives = mmaps.iter().map(|m| m.as_ref());
-            run_across_archive(
+            run_across_archive_bytes(
                 archives,
                 #[hooq::skip_all]
                 |reader| {
@@ -70,7 +70,7 @@ fn concat_entry(args: ConcatCommand) -> anyhow::Result<()> {
         }
         #[cfg(not(feature = "memmap"))]
         {
-            run_across_archive(
+            run_across_archive_readers(
                 archives,
                 #[hooq::skip_all]
                 |reader| {

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -1344,7 +1344,7 @@ impl TransformStrategy for TransformStrategyKeepSolid {
     }
 }
 
-pub(crate) fn run_across_archive<R, F>(
+pub(crate) fn run_across_archive_readers<R, F>(
     provider: impl IntoIterator<Item = R>,
     mut processor: F,
     allow_concatenated_archives: bool,
@@ -1380,7 +1380,7 @@ where
     Ok(())
 }
 
-fn run_across_archive_stoppable<R, F>(
+fn run_across_archive_readers_stoppable<R, F>(
     provider: impl IntoIterator<Item = R>,
     mut processor: F,
     allow_concatenated_archives: bool,
@@ -1418,7 +1418,7 @@ where
     Ok(())
 }
 
-pub(crate) fn run_process_archive<F>(
+pub(crate) fn run_process_archive_readers<F>(
     archive_provider: impl IntoIterator<Item = impl Read>,
     read_options: &ReadOptions,
     mut processor: F,
@@ -1427,7 +1427,7 @@ pub(crate) fn run_process_archive<F>(
 where
     F: FnMut(io::Result<NormalEntry>) -> io::Result<()>,
 {
-    run_read_entries(
+    run_read_entries_readers(
         archive_provider,
         |entry| match entry? {
             ReadEntry::Solid(solid) => solid.entries(read_options)?.try_for_each(&mut processor),
@@ -1437,7 +1437,7 @@ where
     )
 }
 
-pub(crate) fn run_process_archive_stoppable<F>(
+pub(crate) fn run_process_archive_readers_stoppable<F>(
     archive_provider: impl IntoIterator<Item = impl Read>,
     read_options: &ReadOptions,
     mut processor: F,
@@ -1446,7 +1446,7 @@ pub(crate) fn run_process_archive_stoppable<F>(
 where
     F: FnMut(io::Result<NormalEntry>) -> io::Result<ProcessAction>,
 {
-    run_read_entries_stoppable(
+    run_read_entries_readers_stoppable(
         archive_provider,
         |entry| match entry? {
             ReadEntry::Solid(solid) => {
@@ -1465,7 +1465,7 @@ where
 }
 
 #[cfg(feature = "memmap")]
-pub(crate) fn run_across_archive_mem<'d, F>(
+pub(crate) fn run_across_archive_bytes<'d, F>(
     archives: impl IntoIterator<Item = &'d [u8]>,
     mut processor: F,
     allow_concatenated_archives: bool,
@@ -1502,7 +1502,7 @@ where
 }
 
 #[cfg(feature = "memmap")]
-pub(crate) fn run_read_entries_mem<'d, F>(
+pub(crate) fn run_read_entries_bytes<'d, F>(
     archives: impl IntoIterator<Item = &'d [u8]>,
     mut processor: F,
     allow_concatenated_archives: bool,
@@ -1510,7 +1510,7 @@ pub(crate) fn run_read_entries_mem<'d, F>(
 where
     F: FnMut(io::Result<ReadEntry<Cow<'d, [u8]>>>) -> io::Result<()>,
 {
-    run_across_archive_mem(
+    run_across_archive_bytes(
         archives,
         |archive| archive.entries_slice().try_for_each(&mut processor),
         allow_concatenated_archives,
@@ -1518,7 +1518,7 @@ where
 }
 
 #[cfg(feature = "memmap")]
-pub(crate) fn run_entries<'d, F>(
+pub(crate) fn run_process_archive_bytes<'d, F>(
     archives: impl IntoIterator<Item = &'d [u8]>,
     read_options: &ReadOptions,
     mut processor: F,
@@ -1526,7 +1526,7 @@ pub(crate) fn run_entries<'d, F>(
 where
     F: FnMut(io::Result<NormalEntry<Cow<'d, [u8]>>>) -> io::Result<()>,
 {
-    run_read_entries_mem(
+    run_read_entries_bytes(
         archives,
         |entry| match entry? {
             ReadEntry::Solid(s) => s
@@ -1539,7 +1539,7 @@ where
 }
 
 #[cfg(feature = "memmap")]
-fn run_across_archive_mem_stoppable<'d, F>(
+fn run_across_archive_bytes_stoppable<'d, F>(
     archives: impl IntoIterator<Item = &'d [u8]>,
     mut processor: F,
     allow_concatenated_archives: bool,
@@ -1577,7 +1577,7 @@ where
 }
 
 #[cfg(feature = "memmap")]
-fn run_read_entries_mem_stoppable<'d, F>(
+fn run_read_entries_bytes_stoppable<'d, F>(
     archives: impl IntoIterator<Item = &'d [u8]>,
     mut processor: F,
     allow_concatenated_archives: bool,
@@ -1585,7 +1585,7 @@ fn run_read_entries_mem_stoppable<'d, F>(
 where
     F: FnMut(io::Result<ReadEntry<Cow<'d, [u8]>>>) -> io::Result<ProcessAction>,
 {
-    run_across_archive_mem_stoppable(
+    run_across_archive_bytes_stoppable(
         archives,
         |archive| {
             for entry in archive.entries_slice() {
@@ -1601,7 +1601,7 @@ where
 }
 
 #[cfg(feature = "memmap")]
-pub(crate) fn run_entries_stoppable<'d, F>(
+pub(crate) fn run_process_archive_bytes_stoppable<'d, F>(
     archives: impl IntoIterator<Item = &'d [u8]>,
     read_options: &ReadOptions,
     mut processor: F,
@@ -1609,7 +1609,7 @@ pub(crate) fn run_entries_stoppable<'d, F>(
 where
     F: FnMut(io::Result<NormalEntry<Cow<'d, [u8]>>>) -> io::Result<ProcessAction>,
 {
-    run_read_entries_mem_stoppable(
+    run_read_entries_bytes_stoppable(
         archives,
         |entry| match entry? {
             ReadEntry::Solid(s) => {
@@ -1628,7 +1628,7 @@ where
 }
 
 #[cfg(feature = "memmap")]
-fn run_transform_entry<'d, 'p, W, Provider, F, Transform>(
+fn run_transform_entries_bytes<'d, 'p, W, Provider, F, Transform>(
     writer: W,
     archives: impl IntoIterator<Item = &'d [u8]>,
     mut password_provider: Provider,
@@ -1646,7 +1646,7 @@ where
     let password = password_provider();
     let context = TransformContext::new(password);
     let mut out_archive = Archive::write_header(writer)?;
-    run_read_entries_mem(
+    run_read_entries_bytes(
         archives,
         |entry| Transform::transform(&mut out_archive, &context, entry, &mut processor),
         false,
@@ -1655,7 +1655,7 @@ where
     Ok(())
 }
 
-pub(crate) fn run_read_entries<F>(
+pub(crate) fn run_read_entries_readers<F>(
     archive_provider: impl IntoIterator<Item = impl Read>,
     mut processor: F,
     allow_concatenated_archives: bool,
@@ -1663,14 +1663,14 @@ pub(crate) fn run_read_entries<F>(
 where
     F: FnMut(io::Result<ReadEntry>) -> io::Result<()>,
 {
-    run_across_archive(
+    run_across_archive_readers(
         archive_provider,
         |archive| archive.entries().try_for_each(&mut processor),
         allow_concatenated_archives,
     )
 }
 
-pub(crate) fn run_read_entries_stoppable<F>(
+pub(crate) fn run_read_entries_readers_stoppable<F>(
     archive_provider: impl IntoIterator<Item = impl Read>,
     mut processor: F,
     allow_concatenated_archives: bool,
@@ -1678,7 +1678,7 @@ pub(crate) fn run_read_entries_stoppable<F>(
 where
     F: FnMut(io::Result<ReadEntry>) -> io::Result<ProcessAction>,
 {
-    run_across_archive_stoppable(
+    run_across_archive_readers_stoppable(
         archive_provider,
         |archive| {
             for entry in archive.entries() {
@@ -1693,8 +1693,9 @@ where
     )
 }
 
-#[cfg(not(feature = "memmap"))]
-fn run_transform_entry<'p, W, Provider, F, Transform>(
+// Kept available in memmap builds for non-file sources introduced by the stdio stack.
+#[cfg_attr(feature = "memmap", allow(dead_code))]
+fn run_transform_entries_readers<'p, W, Provider, F, Transform>(
     writer: W,
     archives: impl IntoIterator<Item = impl Read>,
     mut password_provider: Provider,
@@ -1710,7 +1711,7 @@ where
     let password = password_provider();
     let context = TransformContext::new(password);
     let mut out_archive = Archive::write_header(writer)?;
-    run_read_entries(
+    run_read_entries_readers(
         archives,
         |entry| Transform::transform(&mut out_archive, &context, entry, &mut processor),
         false,
@@ -1852,7 +1853,7 @@ pub(crate) fn transform_archive_entries<R: io::Read>(
     let mut results = Vec::new();
     let mut reencrypt_options = HashMap::new();
     let read_options = ReadOptions::with_password(password);
-    run_process_archive(
+    run_process_archive_readers(
         std::iter::once(reader),
         &read_options,
         |entry| {

--- a/cli/src/command/core/archive_source.rs
+++ b/cli/src/command/core/archive_source.rs
@@ -42,7 +42,7 @@ impl SplitArchiveReader {
         F: FnMut(io::Result<NormalEntry>) -> io::Result<Option<NormalEntry>>,
         S: TransformStrategy,
     {
-        super::run_transform_entry(
+        super::run_transform_entries_readers(
             writer,
             self.files.drain(..),
             || password,
@@ -66,7 +66,7 @@ impl SplitArchiveReader {
         ) -> io::Result<Option<NormalEntry<Cow<'s, [u8]>>>>,
         S: TransformStrategy,
     {
-        super::run_transform_entry(
+        super::run_transform_entries_bytes(
             writer,
             self.mmaps.iter().map(|m| m.as_ref()),
             || password,
@@ -81,24 +81,19 @@ impl SplitArchiveReader {
         read_options: &ReadOptions,
         processor: impl FnMut(io::Result<NormalEntry>) -> io::Result<()>,
     ) -> io::Result<()> {
-        super::run_process_archive(self.files.drain(..), read_options, processor, false)
+        super::run_process_archive_readers(self.files.drain(..), read_options, processor, false)
     }
 
     #[cfg(feature = "memmap")]
     pub(crate) fn for_each_entry<'s>(
         &'s mut self,
         read_options: &ReadOptions,
-        mut processor: impl FnMut(io::Result<NormalEntry<Cow<'s, [u8]>>>) -> io::Result<()>,
+        processor: impl FnMut(io::Result<NormalEntry<Cow<'s, [u8]>>>) -> io::Result<()>,
     ) -> io::Result<()> {
-        super::run_read_entries_mem(
+        super::run_process_archive_bytes(
             self.mmaps.iter().map(|m| m.as_ref()),
-            |entry| match entry? {
-                ReadEntry::Solid(s) => s
-                    .entries(read_options)?
-                    .try_for_each(|r| processor(r.map(Into::into))),
-                ReadEntry::Normal(n) => processor(Ok(n)),
-            },
-            false,
+            read_options,
+            processor,
         )
     }
 
@@ -108,7 +103,11 @@ impl SplitArchiveReader {
         processor: impl FnMut(io::Result<ReadEntry>) -> io::Result<()>,
         allow_concatenated_archives: bool,
     ) -> io::Result<()> {
-        super::run_read_entries(self.files.drain(..), processor, allow_concatenated_archives)
+        super::run_read_entries_readers(
+            self.files.drain(..),
+            processor,
+            allow_concatenated_archives,
+        )
     }
 
     #[cfg(feature = "memmap")]
@@ -117,7 +116,7 @@ impl SplitArchiveReader {
         processor: impl FnMut(io::Result<ReadEntry<Cow<'s, [u8]>>>) -> io::Result<()>,
         allow_concatenated_archives: bool,
     ) -> io::Result<()> {
-        super::run_read_entries_mem(
+        super::run_read_entries_bytes(
             self.mmaps.iter().map(|m| m.as_ref()),
             processor,
             allow_concatenated_archives,

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "memmap")]
-use crate::command::core::{run_entries, run_entries_stoppable};
+use crate::command::core::{run_process_archive_bytes, run_process_archive_bytes_stoppable};
 use crate::ext::*;
 #[cfg(any(unix, windows))]
 use crate::utils::fs::lchown;
@@ -15,7 +15,7 @@ use crate::{
             collect_split_archives,
             path_lock::OrderedPathLocks,
             re::{bsd::SubstitutionRule, gnu::TransformRule},
-            read_paths, run_process_archive, run_process_archive_stoppable,
+            read_paths, run_process_archive_readers, run_process_archive_readers_stoppable,
         },
     },
     utils::{
@@ -622,7 +622,7 @@ where
         let (tx, rx) = std::sync::mpsc::channel();
         rayon::scope_fifo(|s| -> anyhow::Result<()> {
             if fast_read && !globs.is_empty() {
-                run_process_archive_stoppable(
+                run_process_archive_readers_stoppable(
                     reader,
                     read_options,
                     |entry| {
@@ -688,7 +688,7 @@ where
                 )
                 .with_context(|| "streaming archive entries")?;
             } else {
-                run_process_archive(
+                run_process_archive_readers(
                     reader,
                     read_options,
                     |entry| {
@@ -749,7 +749,7 @@ where
     #[cfg(target_family = "wasm")]
     {
         if fast_read && !globs.is_empty() {
-            run_process_archive_stoppable(
+            run_process_archive_readers_stoppable(
                 reader,
                 read_options,
                 |entry| {
@@ -804,7 +804,7 @@ where
             )
             .with_context(|| "streaming archive entries")?;
         } else {
-            run_process_archive(
+            run_process_archive_readers(
                 reader,
                 read_options,
                 |entry| {
@@ -894,7 +894,7 @@ where
     rayon::scope_fifo(|s| -> anyhow::Result<()> {
         if fast_read && !globs.is_empty() {
             #[hooq::skip_all]
-            run_entries_stoppable(archives, read_options, |entry| {
+            run_process_archive_bytes_stoppable(archives, read_options, |entry| {
                 let item = entry
                     .map_err(|e| io::Error::new(e.kind(), format!("reading archive entry: {e}")))?;
                 let item_path = item.name().to_string();
@@ -954,7 +954,7 @@ where
             .with_context(|| "streaming archive entries")?;
         } else {
             #[hooq::skip_all]
-            run_entries(archives, read_options, |entry| {
+            run_process_archive_bytes(archives, read_options, |entry| {
                 let item = entry
                     .map_err(|e| io::Error::new(e.kind(), format!("reading archive entry: {e}")))?;
                 let Some(name) = filter_entry(&item, &mut globs, &args) else {

--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -5,7 +5,8 @@ use crate::{
         Command, ask_password,
         core::{
             PathFilter, ProcessAction, SplitArchiveReader, TimeFilterResolver, TimeFilters,
-            collect_split_archives, read_paths, run_read_entries, run_read_entries_stoppable,
+            collect_split_archives, read_paths, run_read_entries_readers,
+            run_read_entries_readers_stoppable,
         },
     },
     ext::*,
@@ -661,7 +662,7 @@ pub(crate) fn run_list_archive<'a>(
 
     if !fast_read || files_globs.is_empty() {
         let mut entries = Vec::new();
-        run_read_entries(
+        run_read_entries_readers(
             archive_provider,
             |entry| {
                 match entry? {
@@ -697,7 +698,7 @@ pub(crate) fn run_list_archive<'a>(
     let mut entries = Vec::new();
     let mut globs = files_globs;
     let filter_ref = &filter;
-    run_read_entries_stoppable(
+    run_read_entries_readers_stoppable(
         archive_provider,
         |entry| {
             match entry? {

--- a/cli/src/command/verify.rs
+++ b/cli/src/command/verify.rs
@@ -2,7 +2,7 @@ use crate::{
     cli::{ArchiveFileArgs, GlobalContext, PasswordArgs},
     command::{
         Command, ask_password,
-        core::{collect_split_archives, run_read_entries},
+        core::{collect_split_archives, run_read_entries_readers},
     },
 };
 use clap::Parser;
@@ -57,7 +57,7 @@ fn verify_archive(args: VerifyCommand) -> anyhow::Result<()> {
     let mut report = VerifyReport::default();
     let mut solid_blocks = 0usize;
     let mut resyncing = false;
-    let result = run_read_entries(
+    let result = run_read_entries_readers(
         archives,
         |entry| {
             // A chunk that fails its CRC32 arrives as `Err(InvalidData)`, so an `Ok`


### PR DESCRIPTION
## Stack

Stack 3/22 — Stage 3 of the native stdio stack.

Depends on #3444.

## Summary

- give generic `Read` traversal, read-entry, processing, and transform helpers explicit `*_readers` names
- keep memmap byte-slice helpers as distinct `*_bytes` paths
- compile the reader transform core even when memmap is enabled, preparing non-file sources without changing native CLI behavior
- preserve `SplitArchiveReader` as the optimized filesystem adapter

## Test strategy

No new test was added. The existing `bsdtar --ignore-zeros` integration tests already exercise sequential concatenated archives through one locked stdin stream, which is the critical reader property for this stage. Duplicating that setup at a lower layer would add maintenance without a new failure signal. The complete suites also exercise traversal, extraction, listing, verification, concatenation, and transforms through both implementations.

- `cargo test --locked -p portable-network-archive`
- `cargo test --locked -p portable-network-archive --features memmap`
- `cargo clippy --locked -p portable-network-archive --all-targets -- -D warnings`
- `cargo clippy --locked -p portable-network-archive --all-targets --features memmap -- -D warnings`