### PR TITLE
:recycle: Generalize consuming solid entry iteration

### DIFF
--- a/lib/src/archive/read.rs
+++ b/lib/src/archive/read.rs
@@ -336,7 +336,7 @@ impl<R: futures_io::AsyncRead + Unpin> futures_util::Stream for Entries<'_, R> {
 pub struct NormalEntries<'r, R> {
     reader: &'r mut Archive<R>,
     read_options: ReadOptions,
-    solid_iter: Option<crate::entry::SolidIntoEntries>,
+    solid_iter: Option<crate::entry::SolidIntoEntries<Vec<u8>>>,
 }
 
 impl<'r, R> NormalEntries<'r, R> {

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -432,14 +432,12 @@ impl Iterator for EntryIterator<'_> {
     }
 }
 
-type BytesCursor = io::Cursor<Vec<u8>>;
-
 /// An iterator that moves out of a solid entry.
-pub(crate) struct SolidIntoEntries(
-    EntryReader<ChainReader<std::vec::IntoIter<BytesCursor>, BytesCursor>>,
+pub(crate) struct SolidIntoEntries<T: AsRef<[u8]> = Vec<u8>>(
+    EntryReader<ChainReader<std::vec::IntoIter<io::Cursor<T>>, io::Cursor<T>>>,
 );
 
-impl Iterator for SolidIntoEntries {
+impl<T: AsRef<[u8]>> Iterator for SolidIntoEntries<T> {
     type Item = io::Result<NormalEntry>;
 
     #[inline]
@@ -581,23 +579,19 @@ impl<T: AsRef<[u8]>> SolidEntry<T> {
 
         Ok(EntryIterator(EntryReader(reader)))
     }
-}
 
-impl<T> SolidEntry<T>
-where
-    T: Into<Vec<u8>>,
-{
     /// Consumes this solid entry and returns a streaming iterator of normal
-    /// entries, reusing derived keys cached in the supplied options.
+    /// entries without copying its encoded data, reusing derived keys cached in
+    /// the supplied options.
     #[inline]
     pub(crate) fn into_entries_with_options(
         self,
         options: &ReadOptions,
-    ) -> io::Result<SolidIntoEntries> {
+    ) -> io::Result<SolidIntoEntries<T>> {
         let bufs = self
             .data
             .into_iter()
-            .map(|v| io::Cursor::new(v.into()))
+            .map(io::Cursor::new)
             .collect::<Vec<_>>();
         let chain = ChainReader::new(bufs);
         let reader = decrypt_reader(


### PR DESCRIPTION
## Summary

Generalize SolidIntoEntries to AsRef<[u8]> so that both borrowed and owned SDAT chunks can be decoded without copying, while preserving the behavior of the existing direct-to-Vec path.

## Testing

- `cargo test --workspace --exclude portable-network-archive-fuzz`
- `cargo clippy -p libpna --all-targets --all-features -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved archive entry processing to stream data directly from existing buffers.
  * Reduced unnecessary buffer conversions while preserving existing iteration behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->