### PR TITLE
:recycle: Unify owned and slice entry iterators

### DIFF
--- a/lib/src/archive/read.rs
+++ b/lib/src/archive/read.rs
@@ -5,7 +5,7 @@ mod slice;
 use crate::{
     archive::{Archive, ArchiveHeader},
     chunk::{Chunk, ChunkType, RawChunk},
-    entry::{Entry, NormalEntry, RawEntry, ReadEntry, ReadOptions},
+    entry::{Entry, NormalEntry, RawEntry, ReadEntry, ReadOptions, SolidIntoEntries},
 };
 use std::{
     io::{self, Read, Seek},
@@ -333,20 +333,12 @@ impl<R: futures_io::AsyncRead + Unpin> futures_util::Stream for Entries<'_, R> {
 }
 
 /// An iterator over the entries in the archive.
-pub struct NormalEntries<'r, R> {
-    reader: &'r mut Archive<R>,
-    read_options: ReadOptions,
-    solid_iter: Option<crate::entry::SolidIntoEntries<Vec<u8>>>,
-}
+pub struct NormalEntries<'r, R>(ExtractSolidEntries<Entries<'r, R>, Vec<u8>>);
 
 impl<'r, R> NormalEntries<'r, R> {
     #[inline]
     pub(crate) fn new(reader: &'r mut Archive<R>, options: &ReadOptions) -> Self {
-        Self {
-            reader,
-            read_options: options.clone(),
-            solid_iter: None,
-        }
+        Self(ExtractSolidEntries::new(Entries::new(reader), options))
     }
 }
 
@@ -355,26 +347,57 @@ impl<R: Read> Iterator for NormalEntries<'_, R> {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+/// An iterator adapter that yields normal entries from an entry source,
+/// decoding each solid entry into its inner entries on the fly.
+pub(crate) struct ExtractSolidEntries<I, T: AsRef<[u8]>> {
+    entries: I,
+    read_options: ReadOptions,
+    solid_iter: Option<SolidIntoEntries<T>>,
+}
+
+impl<I, T: AsRef<[u8]>> ExtractSolidEntries<I, T> {
+    #[inline]
+    pub(crate) fn new(entries: I, options: &ReadOptions) -> Self {
+        Self {
+            entries,
+            read_options: options.clone(),
+            solid_iter: None,
+        }
+    }
+}
+
+impl<I, T> Iterator for ExtractSolidEntries<I, T>
+where
+    I: Iterator<Item = io::Result<ReadEntry<T>>>,
+    T: AsRef<[u8]>,
+    NormalEntry<T>: From<NormalEntry>,
+{
+    type Item = io::Result<NormalEntry<T>>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(iter) = &mut self.solid_iter {
                 if let Some(item) = iter.next() {
-                    return Some(item);
+                    return Some(item.map(Into::into));
                 }
                 self.solid_iter = None;
             }
 
-            match self.reader.read_entry() {
-                Ok(Some(ReadEntry::Normal(entry))) => return Some(Ok(entry)),
-                Ok(Some(ReadEntry::Solid(entry))) => {
+            match self.entries.next()? {
+                Ok(ReadEntry::Normal(entry)) => return Some(Ok(entry)),
+                Ok(ReadEntry::Solid(entry)) => {
                     match entry.into_entries_with_options(&self.read_options) {
                         Ok(iter) => {
                             self.solid_iter = Some(iter);
-                            continue;
                         }
                         Err(e) => return Some(Err(e)),
                     }
                 }
-                Ok(None) => return None,
                 Err(e) => return Some(Err(e)),
             }
         }

--- a/lib/src/archive/read/slice.rs
+++ b/lib/src/archive/read/slice.rs
@@ -2,8 +2,8 @@
 
 use crate::{
     Archive, Chunk, ChunkType, Entry, NormalEntry, RawChunk, ReadEntry, ReadOptions,
-    archive::ArchiveHeader,
-    entry::{RawEntry, SolidIntoEntries},
+    archive::{ArchiveHeader, read::ExtractSolidEntries},
+    entry::RawEntry,
 };
 use std::borrow::Cow;
 use std::io;
@@ -210,7 +210,7 @@ impl<'a, 'r> Entries<'a, 'r> {
         self,
         options: &ReadOptions,
     ) -> impl Iterator<Item = io::Result<NormalEntry<Cow<'r, [u8]>>>> + 'a {
-        SliceNormalEntries::new(self, options)
+        ExtractSolidEntries::new(self, options)
     }
 }
 
@@ -220,54 +220,6 @@ impl<'r> Iterator for Entries<'_, 'r> {
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.reader.read_entry_slice().transpose()
-    }
-}
-
-/// An iterator over normal entries read from a byte slice, including entries
-/// decoded from solid entries.
-struct SliceNormalEntries<'a, 'r> {
-    entries: Entries<'a, 'r>,
-    read_options: ReadOptions,
-    solid_iter: Option<SolidIntoEntries<Cow<'r, [u8]>>>,
-}
-
-impl<'a, 'r> SliceNormalEntries<'a, 'r> {
-    #[inline]
-    fn new(entries: Entries<'a, 'r>, options: &ReadOptions) -> Self {
-        Self {
-            entries,
-            read_options: options.clone(),
-            solid_iter: None,
-        }
-    }
-}
-
-impl<'r> Iterator for SliceNormalEntries<'_, 'r> {
-    type Item = io::Result<NormalEntry<Cow<'r, [u8]>>>;
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            if let Some(iter) = &mut self.solid_iter {
-                if let Some(item) = iter.next() {
-                    return Some(item.map(Into::into));
-                }
-                self.solid_iter = None;
-            }
-
-            match self.entries.next()? {
-                Ok(ReadEntry::Normal(entry)) => return Some(Ok(entry)),
-                Ok(ReadEntry::Solid(entry)) => {
-                    match entry.into_entries_with_options(&self.read_options) {
-                        Ok(iter) => {
-                            self.solid_iter = Some(iter);
-                        }
-                        Err(e) => return Some(Err(e)),
-                    }
-                }
-                Err(e) => return Some(Err(e)),
-            }
-        }
     }
 }
 

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -426,7 +426,8 @@ impl<'a> From<ReadEntry<&'a [u8]>> for ReadEntry<Cow<'a, [u8]>> {
     }
 }
 
-pub(crate) struct EntryIterator<'s>(EntryReader<EncodedDataReader<'s>>);
+/// An iterator over normal entries decoded from a solid entry's data stream.
+pub(crate) struct EntryIterator<R: Read>(EntryReader<R>);
 
 #[inline]
 fn read_next_normal_entry_from_stream<R: Read>(reader: &mut R) -> Option<io::Result<NormalEntry>> {
@@ -454,7 +455,7 @@ fn read_next_normal_entry_from_stream<R: Read>(reader: &mut R) -> Option<io::Res
     Some(RawEntry(chunks).try_into())
 }
 
-impl Iterator for EntryIterator<'_> {
+impl<R: Read> Iterator for EntryIterator<R> {
     type Item = io::Result<NormalEntry>;
 
     #[inline]
@@ -464,18 +465,8 @@ impl Iterator for EntryIterator<'_> {
 }
 
 /// An iterator that moves out of a solid entry.
-pub(crate) struct SolidIntoEntries<T: AsRef<[u8]> = Vec<u8>>(
-    EntryReader<ChainReader<std::vec::IntoIter<io::Cursor<T>>, io::Cursor<T>>>,
-);
-
-impl<T: AsRef<[u8]>> Iterator for SolidIntoEntries<T> {
-    type Item = io::Result<NormalEntry>;
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        read_next_normal_entry_from_stream(&mut self.0)
-    }
-}
+pub(crate) type SolidIntoEntries<T = Vec<u8>> =
+    EntryIterator<ChainReader<std::vec::IntoIter<io::Cursor<T>>, io::Cursor<T>>>;
 
 /// A solid mode entry in a PNA archive.
 ///
@@ -635,7 +626,7 @@ impl<T: AsRef<[u8]>> SolidEntry<T> {
             &self.header.to_bytes(),
         )?;
         let reader = decompress_reader(reader, self.header.compression)?;
-        Ok(SolidIntoEntries(EntryReader(reader)))
+        Ok(EntryIterator(EntryReader(reader)))
     }
 }
 


### PR DESCRIPTION
## Summary

Fold the duplicated owned/slice iterator implementations into shared generics: `SolidIntoEntries` becomes a type alias of the reader-generic `EntryIterator`, and `NormalEntries` / `SliceNormalEntries` collapse into a single `ExtractSolidEntries` adapter generic over the entry source and its data representation (`Vec<u8>` / `Cow`). No behavior change.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>