### PR TITLE
:white_check_mark: Restore the keep-solid encrypted chmod assertion

### DIFF
--- a/cli/tests/cli/chmod/keep_solid.rs
+++ b/cli/tests/cli/chmod/keep_solid.rs
@@ -113,14 +113,20 @@ fn chmod_keep_solid_on_encrypted_solid_archive() {
     .execute()
     .unwrap();
 
-    assert_eq!(
-        archive::entry_mode_with_password(
-            "chmod_keep_solid_encrypted.pna",
-            ENTRY_PATH,
-            Some("password"),
-        ),
-        0o666,
-    );
+    let mut found = false;
+    archive::for_each_entry_with_password("chmod_keep_solid_encrypted.pna", "password", |entry| {
+        if entry.header().path() == ENTRY_PATH {
+            found = true;
+            let mode = entry
+                .metadata()
+                .permission_mode()
+                .expect("entry should have permission mode metadata")
+                .get();
+            assert_eq!(mode & 0o777, 0o666, "-x on 0o777 should yield 0o666");
+        }
+    })
+    .unwrap();
+    assert!(found, "target entry not found in archive");
     assert_eq!(
         solid_headers("chmod_keep_solid_encrypted.pna"),
         headers_before


### PR DESCRIPTION
## Problem

The `cli` integration test target does not compile on `main`:

```
error[E0425]: cannot find function `entry_mode_with_password` in module `archive`
   --> cli/tests/cli/chmod/keep_solid.rs:117:18
    |
117 |         archive::entry_mode_with_password(
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^ not found in `archive`
```

## Root cause

`ae07a124` (":recycle: Use logical entry APIs in test assertions") deliberately removed the generic `archive::entry_mode_with_password` helper and migrated its call sites in `chmod.rs`, `chmod/multipart.rs`, `chmod/password.rs`, and `update/option_missing_time.rs` — but missed the call site in `chmod/keep_solid.rs:117`, which had been present since `a75ec567`.

Because the whole `cli` test binary fails to compile, `chmod_keep_solid_on_encrypted_solid_archive` has not run since. This was the only stale reference left; the `extract_single_entry` in `update/option_missing_time.rs` is a file-local `fn`, which is intentional per that commit's message.

## Fix

Assert the permission mode through `archive::for_each_entry_with_password` — the helper `ae07a124` deliberately kept — mirroring the `chmod_keep_solid` sibling test in the same file. The `found` flag is retained so a missing entry fails loudly rather than passing vacuously (see `4b031b2c`, `64997753`).
