### PR TITLE
:recycle: Resolve intra-crate names from the crate root

### DIFF
--- a/cli/src/cli/value/missing_time_policy.rs
+++ b/cli/src/cli/value/missing_time_policy.rs
@@ -1,10 +1,9 @@
+use crate::cli::value::{DateTime, DateTimeError};
 use std::{
     fmt::{self, Display, Formatter},
     str::FromStr,
     time::{SystemTime, UNIX_EPOCH},
 };
-
-use super::DateTime;
 
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
 pub(crate) enum MissingTimePolicy {
@@ -16,7 +15,7 @@ pub(crate) enum MissingTimePolicy {
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum MissingTimePolicyError {
     #[error(transparent)]
-    DateTime(#[from] super::DateTimeError),
+    DateTime(#[from] DateTimeError),
 }
 
 impl Display for MissingTimePolicy {

--- a/cli/src/cli/value/options.rs
+++ b/cli/src/cli/value/options.rs
@@ -1,4 +1,4 @@
-use super::{DeflateLevel, XzLevel, ZstdLevel};
+use crate::cli::value::{DeflateLevel, XzLevel, ZstdLevel};
 use std::str::FromStr;
 
 /// Archive options parsed from `--options` argument.

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -143,7 +143,7 @@ impl Cli {
 
 #[cfg(test)]
 mod tests {
-    use super::password_bytes_need_raw_mode;
+    use super::*;
 
     #[test]
     fn detects_lf_and_cr_as_newline() {

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -2190,7 +2190,6 @@ fn re_encrypt_entry_with_name(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cli::MissingTimePolicy;
     use std::collections::HashSet;
 
     const EMPTY_PATTERNS: [&str; 0] = [];
@@ -2851,7 +2850,7 @@ mod tests {
                 ItemSource::Archive(ArchiveSource::Stdin),
                 ItemSource::Archive(ArchiveSource::File(PathBuf::from("archive.pna"))),
             ];
-            assert!(super::validate_no_duplicate_stdin(&sources).is_ok());
+            assert!(validate_no_duplicate_stdin(&sources).is_ok());
         }
 
         #[test]
@@ -2860,13 +2859,13 @@ mod tests {
                 ItemSource::Archive(ArchiveSource::Stdin),
                 ItemSource::Archive(ArchiveSource::Stdin),
             ];
-            assert!(super::validate_no_duplicate_stdin(&sources).is_err());
+            assert!(validate_no_duplicate_stdin(&sources).is_err());
         }
 
         #[test]
         fn validate_no_duplicate_stdin_empty() {
             let sources: Vec<ItemSource> = vec![];
-            assert!(super::validate_no_duplicate_stdin(&sources).is_ok());
+            assert!(validate_no_duplicate_stdin(&sources).is_ok());
         }
     }
 

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -2870,7 +2870,7 @@ mod tests {
         }
     }
 
-    mod detect_format_tests {
+    mod detect_format {
         use super::*;
         use std::io::Cursor;
 

--- a/cli/src/command/core/mtree.rs
+++ b/cli/src/command/core/mtree.rs
@@ -3,7 +3,7 @@
 //! This module provides support for reading mtree manifest files via the `@file`
 //! syntax, allowing users to specify files to archive with metadata overrides.
 
-use super::{
+use crate::command::core::{
     CreateOptions, KeepOptions, OwnerStrategy, PathFilter, PathnameEditor, TimeFilters,
     TimestampStrategy,
 };

--- a/cli/src/command/core/path.rs
+++ b/cli/src/command/core/path.rs
@@ -5,7 +5,7 @@ use std::{
 };
 use typed_path::{Utf8WindowsComponent, Utf8WindowsPath};
 
-use super::PathTransformers;
+use crate::command::core::PathTransformers;
 
 /// Centralized path transformation editor, similar to libarchive's `edit_pathname`.
 ///
@@ -441,7 +441,7 @@ mod tests {
         // Example: path "old/a/b" with transform /old/new/ and strip=1
         // bsdtar order: "old/a/b" -> transform -> "new/a/b" -> strip 1 -> "a/b"
         // (wrong order would be: "old/a/b" -> strip 1 -> "a/b" -> transform -> "a/b")
-        use super::super::{PathTransformers, re::bsd::SubstitutionRules};
+        use crate::command::core::{PathTransformers, re::bsd::SubstitutionRules};
 
         // Format: /pattern/replacement/flags - first char is the delimiter
         let rules = SubstitutionRules::new(vec!["/old/new/".parse().unwrap()]);

--- a/cli/src/command/core/path_transformer.rs
+++ b/cli/src/command/core/path_transformer.rs
@@ -1,4 +1,4 @@
-use super::re::{
+use crate::command::core::re::{
     bsd::{SubstitutionRule, SubstitutionRules},
     gnu::{TransformRule, TransformRules},
 };

--- a/cli/src/command/core/staged_archive.rs
+++ b/cli/src/command/core/staged_archive.rs
@@ -1,4 +1,4 @@
-use super::{SafeWriter, Umask};
+use crate::command::core::{SafeWriter, Umask};
 use crate::utils::GlobPatterns;
 use std::{fs, io, path::PathBuf};
 

--- a/cli/src/command/core/time_filter.rs
+++ b/cli/src/command/core/time_filter.rs
@@ -258,7 +258,6 @@ impl TimeFilters {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cli::MissingTimePolicy;
     use std::time::Duration;
 
     fn now() -> SystemTime {
@@ -587,7 +586,6 @@ mod tests {
 
     mod missing_policy {
         use super::*;
-        use crate::cli::MissingTimePolicy;
 
         #[test]
         fn include_policy_passes_none_ctime() {

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -1296,7 +1296,7 @@ where
 /// Extracts a regular file entry from the archive to the filesystem.
 ///
 /// In parallel extraction contexts, the caller must hold a
-/// [`PathOrderGuard`](super::core::path_lock::PathOrderGuard) for the entry's
+/// [`PathOrderGuard`](crate::command::core::path_lock::PathOrderGuard) for the entry's
 /// output path to guarantee archive-order writes.
 pub(crate) fn extract_file_entry<'a, T>(
     item: NormalEntry<T>,
@@ -1578,7 +1578,7 @@ where
     if item.header().data_kind() != DataKind::FILE {
         restore_path_timestamps(path, item.metadata(), keep_options)?;
     }
-    let ownership = crate::ext::ResolvedOwnership::from_metadata(item.metadata());
+    let ownership = ResolvedOwnership::from_metadata(item.metadata());
     // A permission-mode-only entry (`fMOd`) is not owner identity and must not
     // fall back to uid/gid 0.
     if let OwnerStrategy::Preserve { options } = &keep_options.owner_strategy
@@ -1751,7 +1751,7 @@ fn restore_acls(
 /// 2. Override uname/gname if specified, searching by name
 /// 3. Archive's uname/gname with fallback to archive's uid/gid
 fn resolve_owner(
-    ownership: &crate::ext::ResolvedOwnership,
+    ownership: &ResolvedOwnership,
     uname_override: Option<&str>,
     gname_override: Option<&str>,
     uid_override: Option<u32>,
@@ -1773,7 +1773,7 @@ fn resolve_owner(
 }
 
 #[inline]
-fn should_restore_owner(ownership: &crate::ext::ResolvedOwnership, options: &OwnerOptions) -> bool {
+fn should_restore_owner(ownership: &ResolvedOwnership, options: &OwnerOptions) -> bool {
     ownership.has_posix_owner_identity() || options.has_overrides()
 }
 
@@ -1782,7 +1782,7 @@ fn should_restore_owner(ownership: &crate::ext::ResolvedOwnership, options: &Own
 #[inline]
 fn restore_owner(
     path: &Path,
-    ownership: &crate::ext::ResolvedOwnership,
+    ownership: &ResolvedOwnership,
     options: &OwnerOptions,
 ) -> io::Result<()> {
     #[cfg(any(unix, windows))]
@@ -2021,7 +2021,7 @@ mod tests {
 
     #[test]
     fn mode_only_metadata_does_not_request_owner_restore() {
-        let ownership = crate::ext::ResolvedOwnership {
+        let ownership = ResolvedOwnership {
             mode: Some(0o644),
             ..Default::default()
         };
@@ -2030,7 +2030,7 @@ mod tests {
 
     #[test]
     fn explicit_owner_override_requests_owner_restore_without_archive_owner() {
-        let ownership = crate::ext::ResolvedOwnership {
+        let ownership = ResolvedOwnership {
             mode: Some(0o644),
             ..Default::default()
         };
@@ -2043,7 +2043,7 @@ mod tests {
 
     #[test]
     fn archive_owner_identity_requests_owner_restore() {
-        let ownership = crate::ext::ResolvedOwnership {
+        let ownership = ResolvedOwnership {
             uid: Some(1000),
             mode: Some(0o644),
             ..Default::default()

--- a/cli/src/ext.rs
+++ b/cli/src/ext.rs
@@ -199,7 +199,7 @@ impl<S: Display> Display for UserDisplay<S> {
 }
 
 #[cfg(test)]
-mod resolved_ownership_tests {
+mod tests {
     use super::*;
 
     #[test]

--- a/cli/src/utils/acl.rs
+++ b/cli/src/utils/acl.rs
@@ -1,4 +1,4 @@
 #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
-pub use super::os::unix::acl::*;
+pub use crate::utils::os::unix::acl::*;
 #[cfg(windows)]
-pub use super::os::windows::acl::*;
+pub use crate::utils::os::windows::acl::*;

--- a/cli/src/utils/fs.rs
+++ b/cli/src/utils/fs.rs
@@ -43,7 +43,7 @@ pub(crate) fn current_umask() -> u16 {
 
 pub(crate) fn is_pna<P: AsRef<Path>>(path: P) -> io::Result<bool> {
     let file = fs::File::open(path)?;
-    super::io::is_pna(file)
+    crate::utils::io::is_pna(file)
 }
 
 #[cfg(any(windows, unix))]

--- a/cli/src/utils/fs/owner.rs
+++ b/cli/src/utils/fs/owner.rs
@@ -6,7 +6,7 @@ use std::io;
 
 #[cfg(not(any(windows, unix)))]
 mod imp {
-    use super::*;
+    use crate::utils::fs::owner::*;
 
     pub(crate) struct User;
     impl User {

--- a/cli/src/utils/os/windows/fs.rs
+++ b/cli/src/utils/os/windows/fs.rs
@@ -1,6 +1,6 @@
 pub(crate) mod owner;
 
-use super::security::{Sid, apply_security_info};
+use crate::utils::os::windows::security::{Sid, apply_security_info};
 use crate::utils::str::encode_wide;
 use std::io;
 use std::mem::size_of;

--- a/cli/src/utils/os/windows/security.rs
+++ b/cli/src/utils/os/windows/security.rs
@@ -1,4 +1,4 @@
-use super::fs::FileHandle;
+use crate::utils::os::windows::fs::FileHandle;
 use crate::utils::str::encode_wide;
 use std::fmt::{Display, Formatter};
 use std::ptr::null_mut;

--- a/cli/src/utils/process.rs
+++ b/cli/src/utils/process.rs
@@ -6,7 +6,7 @@
 /// bsdtar excludes root-specific permission defaults from non-POSIX builds
 /// via `#ifndef _WIN32` (see libarchive/tar/bsdtar.c).
 #[cfg(unix)]
-pub(crate) use super::os::unix::process::is_running_as_root;
+pub(crate) use crate::utils::os::unix::process::is_running_as_root;
 
 #[cfg(not(unix))]
 pub(crate) fn is_running_as_root() -> bool {

--- a/lib/src/archive/read.rs
+++ b/lib/src/archive/read.rs
@@ -546,7 +546,6 @@ mod tests {
     #[cfg(feature = "unstable-async")]
     #[tokio::test]
     async fn extract_async() -> io::Result<()> {
-        use crate::ReadOptions;
         use tokio_util::compat::{FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt};
 
         let input = include_bytes!("../../../resources/test/zstd.pna");

--- a/lib/src/archive/split_parts.rs
+++ b/lib/src/archive/split_parts.rs
@@ -1,5 +1,6 @@
 //! Writing an archive across a sequence of size-bounded parts.
-use super::{ArchiveHeader, write_archive_framing};
+use super::write_archive_framing;
+use crate::archive::ArchiveHeader;
 use crate::{
     PNA_SIGNATURE,
     chunk::{Chunk, ChunkExt, ChunkType, MIN_CHUNK_BYTES_SIZE},
@@ -27,7 +28,7 @@ pub const MIN_SPLIT_PART_BYTES: usize = SPLIT_ARCHIVE_OVERHEAD_BYTES + MIN_CHUNK
 ///
 /// Every part is self-framed: opening a part writes the PNA signature and an
 /// `AHED` chunk, and switching to the next part writes `ANXT` then `AEND` to
-/// the part being closed. [`Archive::finalize`](super::Archive::finalize)
+/// the part being closed. [`Archive::finalize`](crate::archive::Archive::finalize)
 /// consumes this sink and writes the final `AEND` into its reserved tail space.
 ///
 /// If writing fails, the multipart output may be incomplete and this sink must be
@@ -251,7 +252,8 @@ impl<W: Write, F: FnMut(u32) -> io::Result<W>> WriteChunk for &mut SplitParts<W,
 
 #[cfg(test)]
 mod tests {
-    use super::super::Archive;
+    use super::*;
+    use crate::archive::Archive;
     use crate::{
         chunk::{Chunk, ChunkType},
         entry::{
@@ -384,7 +386,7 @@ mod tests {
     fn rejects_max_part_bytes_below_minimum() {
         let (_, next) = part_collector();
         // `Archive<SplitParts<..>>` isn't `Debug`, so match instead of `unwrap_err`.
-        match Archive::write_split_header(super::MIN_SPLIT_PART_BYTES - 1, next) {
+        match Archive::write_split_header(MIN_SPLIT_PART_BYTES - 1, next) {
             Err(err) => assert_eq!(err.kind(), io::ErrorKind::InvalidInput),
             Ok(_) => panic!("expected an error"),
         }
@@ -393,7 +395,7 @@ mod tests {
     #[test]
     fn rollover_rejects_part_count_overflow_before_closing_part() {
         let (parts, next) = part_collector();
-        let mut writer = super::SplitParts::new(1024, next).unwrap();
+        let mut writer = SplitParts::new(1024, next).unwrap();
         writer.parts = u32::MAX;
         assert_eq!(writer.parts(), u32::MAX);
         let bytes_before = parts.borrow()[0].0.borrow().clone();
@@ -459,7 +461,7 @@ mod tests {
         let (_, next) = part_collector();
         // Budget = MIN_SPLIT_PART_BYTES - SPLIT_ARCHIVE_OVERHEAD_BYTES = 12 bytes;
         // an FHED chunk always exceeds it.
-        let mut archive = Archive::write_split_header(super::MIN_SPLIT_PART_BYTES, next).unwrap();
+        let mut archive = Archive::write_split_header(MIN_SPLIT_PART_BYTES, next).unwrap();
         let entry = FileEntryBuilder::new("f".into()).unwrap().build().unwrap();
         let err = archive.add_entry(entry).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
@@ -469,7 +471,7 @@ mod tests {
     fn stream_chunk_that_can_never_fit_a_part_is_rejected() {
         // The 12-byte budget cannot hold even one byte of stream data.
         let (_, next) = part_collector();
-        let mut archive = Archive::write_split_header(super::MIN_SPLIT_PART_BYTES, next).unwrap();
+        let mut archive = Archive::write_split_header(MIN_SPLIT_PART_BYTES, next).unwrap();
         let err = archive
             .inner
             .write_chunk((ChunkType::FDAT, &[0u8; 1][..]))
@@ -497,7 +499,7 @@ mod tests {
     #[test]
     fn splits_stream_chunk_across_parts() {
         let (parts, next) = part_collector();
-        let max = super::MIN_SPLIT_PART_BYTES + 96; // margin small enough to force a mid-FDAT cut
+        let max = MIN_SPLIT_PART_BYTES + 96; // margin small enough to force a mid-FDAT cut
         let mut archive = Archive::write_split_header(max, next).unwrap();
         let options = WriteOptions::builder().compression(Compression::NO).build();
         let mut b = FileEntryBuilder::new_with_options("f".into(), &options).unwrap();
@@ -513,7 +515,7 @@ mod tests {
     #[test]
     fn split_writes_streaming_normal_entry_across_parts() {
         let (parts, next) = part_collector();
-        let max = super::MIN_SPLIT_PART_BYTES + 96; // margin small enough to force a mid-FDAT cut
+        let max = MIN_SPLIT_PART_BYTES + 96; // margin small enough to force a mid-FDAT cut
         let mut archive = Archive::write_split_header(max, next).unwrap();
         let options = WriteOptions::builder().compression(Compression::NO).build();
         archive
@@ -531,7 +533,7 @@ mod tests {
     #[test]
     fn part_fills_exactly_to_max_bytes() {
         let (parts, next) = part_collector();
-        let max = super::MIN_SPLIT_PART_BYTES + 96;
+        let max = MIN_SPLIT_PART_BYTES + 96;
         let mut archive = Archive::write_split_header(max, next).unwrap();
         let options = WriteOptions::builder().compression(Compression::NO).build();
         let mut b = FileEntryBuilder::new_with_options("f".into(), &options).unwrap();
@@ -547,7 +549,7 @@ mod tests {
     #[test]
     fn stream_chunk_split_across_parts_remains_decryptable() {
         let (parts, next) = part_collector();
-        let max = super::MIN_SPLIT_PART_BYTES + 64;
+        let max = MIN_SPLIT_PART_BYTES + 64;
         let mut archive = Archive::write_split_header(max, next).unwrap();
         let options = WriteOptions::builder()
             .compression(Compression::NO)
@@ -574,7 +576,7 @@ mod tests {
     #[test]
     fn splits_solid_entry_data_stream_across_parts() {
         let (parts, next) = part_collector();
-        let max = super::MIN_SPLIT_PART_BYTES + 96; // margin small enough to force a mid-SDAT cut
+        let max = MIN_SPLIT_PART_BYTES + 96; // margin small enough to force a mid-SDAT cut
         let mut archive = Archive::write_split_header(max, next).unwrap();
         let options = WriteOptions::builder().compression(Compression::NO).build();
         let mut solid = SolidEntryBuilder::new(options).unwrap();
@@ -592,7 +594,7 @@ mod tests {
     #[test]
     fn solid_split_writes_streaming_entries_across_parts() {
         let (parts, next) = part_collector();
-        let max = super::MIN_SPLIT_PART_BYTES + 96; // margin small enough to force a mid-SDAT cut
+        let max = MIN_SPLIT_PART_BYTES + 96; // margin small enough to force a mid-SDAT cut
         let options = WriteOptions::builder().compression(Compression::NO).build();
         let mut archive = Archive::write_solid_split_header(max, next, options).unwrap();
         archive
@@ -610,7 +612,7 @@ mod tests {
         let (_, next) = part_collector();
         let options = WriteOptions::builder().build();
         // `SolidArchive<SplitParts<..>>` isn't `Debug`, so match instead of `unwrap_err`.
-        match Archive::write_solid_split_header(super::MIN_SPLIT_PART_BYTES - 1, next, options) {
+        match Archive::write_solid_split_header(MIN_SPLIT_PART_BYTES - 1, next, options) {
             Err(err) => assert_eq!(err.kind(), io::ErrorKind::InvalidInput),
             Ok(_) => panic!("expected an error"),
         }
@@ -620,7 +622,7 @@ mod tests {
     fn raw_aend_is_budget_accounted() {
         // The budget is exactly one empty chunk.
         let (parts, next) = part_collector();
-        let mut archive = Archive::write_split_header(super::MIN_SPLIT_PART_BYTES, next).unwrap();
+        let mut archive = Archive::write_split_header(MIN_SPLIT_PART_BYTES, next).unwrap();
 
         archive
             .inner
@@ -638,7 +640,7 @@ mod tests {
             "raw AEND must debit the budget like any other chunk"
         );
 
-        part_bytes_within(&parts, super::MIN_SPLIT_PART_BYTES);
+        part_bytes_within(&parts, MIN_SPLIT_PART_BYTES);
     }
 
     #[test]
@@ -669,7 +671,7 @@ mod tests {
         archive.finalize().unwrap();
 
         let bytes = parts.borrow()[0].0.borrow().clone();
-        let chunk_offset = super::PART_HEADER_BYTES;
+        let chunk_offset = PART_HEADER_BYTES;
         assert_eq!(
             &bytes[chunk_offset..chunk_offset + 4],
             &0x0102_0304u32.to_be_bytes()
@@ -734,10 +736,10 @@ mod tests {
         // Part 0's writer fails partway through the ANXT/AEND tail that
         // `roll_over` writes to close it, so the rollover itself fails
         // before `next_part` is ever called for part 1.
-        let chunk_budget = ROLLOVER_PART_MAX - super::SPLIT_ARCHIVE_OVERHEAD_BYTES;
+        let chunk_budget = ROLLOVER_PART_MAX - SPLIT_ARCHIVE_OVERHEAD_BYTES;
         // Allows the signature, AHED, and entry "a"'s chunks through, but not
         // the closing ANXT chunk.
-        let limit = super::PART_HEADER_BYTES + chunk_budget;
+        let limit = PART_HEADER_BYTES + chunk_budget;
         let mut archive = Archive::write_split_header(ROLLOVER_PART_MAX, move |part_number| {
             assert_eq!(part_number, 0, "rollover must fail before opening part 1");
             Ok(FailAfter {

--- a/lib/src/archive/write.rs
+++ b/lib/src/archive/write.rs
@@ -159,7 +159,7 @@ impl<W: Write, F: FnMut(u32) -> io::Result<W>> Archive<SplitParts<W, F>> {
     /// # Errors
     ///
     /// Returns an error with kind [`io::ErrorKind::InvalidInput`] if
-    /// `max_part_bytes` is below [`MIN_SPLIT_PART_BYTES`](super::MIN_SPLIT_PART_BYTES),
+    /// `max_part_bytes` is below [`MIN_SPLIT_PART_BYTES`](crate::archive::MIN_SPLIT_PART_BYTES),
     /// or an error from `next_part` or from writing the first part's framing.
     ///
     /// # Examples
@@ -200,7 +200,7 @@ impl<W: Write, F: FnMut(u32) -> io::Result<W>> Archive<SplitParts<W, F>> {
     /// # Errors
     ///
     /// Returns an error with kind [`io::ErrorKind::InvalidInput`] if
-    /// `max_part_bytes` is below [`MIN_SPLIT_PART_BYTES`](super::MIN_SPLIT_PART_BYTES),
+    /// `max_part_bytes` is below [`MIN_SPLIT_PART_BYTES`](crate::archive::MIN_SPLIT_PART_BYTES),
     /// or an error from `next_part` or from writing the first part's framing.
     ///
     /// # Examples

--- a/lib/src/async_io.rs
+++ b/lib/src/async_io.rs
@@ -164,7 +164,6 @@ pub async fn skip_chunk<R: AsyncRead + AsyncSeek + Unpin + ?Sized>(
 #[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use super::*;
-    use crate::Chunk;
     use futures_util::io::Cursor;
     use std::pin::Pin;
     use std::task::{Context, Poll, ready};

--- a/lib/src/chunk/traits.rs
+++ b/lib/src/chunk/traits.rs
@@ -1,6 +1,6 @@
 //! Chunk trait defining the interface for PNA archive chunks.
 
-use super::ChunkType;
+use crate::chunk::ChunkType;
 
 /// A trait representing a chunk in a PNA archive.
 ///

--- a/lib/src/cipher/gcm.rs
+++ b/lib/src/cipher/gcm.rs
@@ -318,7 +318,6 @@ where
 mod tests {
     use super::*;
     use crate::cipher::aead::{KeyConfirmation, SegmentSize};
-    use crate::error::AeadError;
     use aes::Aes256;
     use aes_gcm::aead::Aead;
     use camellia::Camellia256;

--- a/lib/src/compress/deflate.rs
+++ b/lib/src/compress/deflate.rs
@@ -120,7 +120,7 @@ impl FromStr for DeflateCompressionLevel {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -621,14 +621,10 @@ impl AsyncWrite for OpaqueEntryBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ChunkType;
     use crate::ReadOptions;
     use crate::chunk::Chunk;
     use crate::entry::RawEntry;
     use crate::entry::private::SealedEntryExt;
-    use crate::entry::{
-        DirEntryBuilder, FileEntryBuilder, HardLinkEntryBuilder, SymlinkEntryBuilder,
-    };
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
@@ -705,15 +701,12 @@ mod tests {
     fn file_entry_builder_round_trips_data_and_metadata() {
         let mut b = FileEntryBuilder::new("f.txt".into()).unwrap();
         b.write_all(b"content").unwrap();
-        b.metadata(Metadata::new().with_modified(Some(crate::Duration::seconds(42))));
+        b.metadata(Metadata::new().with_modified(Some(Duration::seconds(42))));
         let entry = b.build().unwrap();
         let raw = RawEntry(entry.into_chunks());
         let restored = NormalEntry::try_from(raw).unwrap();
-        assert_eq!(restored.header().data_kind(), crate::DataKind::FILE);
-        assert_eq!(
-            restored.metadata().modified(),
-            Some(crate::Duration::seconds(42))
-        );
+        assert_eq!(restored.header().data_kind(), DataKind::FILE);
+        assert_eq!(restored.metadata().modified(), Some(Duration::seconds(42)));
         assert_eq!(restored.metadata().raw_file_size(), Some(7));
         let mut r = restored.reader(ReadOptions::builder().build()).unwrap();
         let mut buf = Vec::new();
@@ -742,14 +735,14 @@ mod tests {
     #[test]
     fn dir_entry_builder_round_trips() {
         let mut b = DirEntryBuilder::new("d/".into());
-        b.metadata(Metadata::new().with_permission_mode(Some(crate::PermissionMode::from(0o755))));
+        b.metadata(Metadata::new().with_permission_mode(Some(PermissionMode::from(0o755))));
         let entry = b.build().unwrap();
         let raw = RawEntry(entry.into_chunks());
         let restored = NormalEntry::try_from(raw).unwrap();
-        assert_eq!(restored.header().data_kind(), crate::DataKind::DIRECTORY);
+        assert_eq!(restored.header().data_kind(), DataKind::DIRECTORY);
         assert_eq!(
             restored.metadata().permission_mode(),
-            Some(crate::PermissionMode::from(0o755))
+            Some(PermissionMode::from(0o755))
         );
     }
 
@@ -871,7 +864,7 @@ mod tests {
 
     #[test]
     fn opaque_builder_round_trips_private_kind() {
-        let kind = crate::DataKind::new_private(200).unwrap();
+        let kind = DataKind::new_private(200).unwrap();
         let mut b = OpaqueEntryBuilder::new("custom".into(), kind).unwrap();
         b.write_all(b"opaque bytes").unwrap();
         let entry = b.build().unwrap();
@@ -891,7 +884,7 @@ mod tests {
 
     #[test]
     fn opaque_builder_with_file_kind_matches_file_entry_builder_wire() {
-        let mut a = OpaqueEntryBuilder::new("f".into(), crate::DataKind::FILE).unwrap();
+        let mut a = OpaqueEntryBuilder::new("f".into(), DataKind::FILE).unwrap();
         a.write_all(b"data").unwrap();
         let mut b = FileEntryBuilder::new("f".into()).unwrap();
         b.write_all(b"data").unwrap();
@@ -902,7 +895,7 @@ mod tests {
 
     #[test]
     fn opaque_builder_private_kind_omits_file_size() {
-        let kind = crate::DataKind::new_private(200).unwrap();
+        let kind = DataKind::new_private(200).unwrap();
         let mut b = OpaqueEntryBuilder::new("custom".into(), kind).unwrap();
         b.write_all(b"x").unwrap();
         let entry = b.build().unwrap();
@@ -911,14 +904,11 @@ mod tests {
 
     #[test]
     fn opaque_builder_metadata_replaces_previous() {
-        let mut b = OpaqueEntryBuilder::new("f".into(), crate::DataKind::FILE).unwrap();
-        b.metadata(Metadata::new().with_modified(Some(crate::Duration::seconds(1))));
-        b.metadata(Metadata::new().with_modified(Some(crate::Duration::seconds(2))));
+        let mut b = OpaqueEntryBuilder::new("f".into(), DataKind::FILE).unwrap();
+        b.metadata(Metadata::new().with_modified(Some(Duration::seconds(1))));
+        b.metadata(Metadata::new().with_modified(Some(Duration::seconds(2))));
         let entry = b.build().unwrap();
-        assert_eq!(
-            entry.metadata().modified(),
-            Some(crate::Duration::seconds(2))
-        );
+        assert_eq!(entry.metadata().modified(), Some(Duration::seconds(2)));
     }
 
     #[test]
@@ -1019,12 +1009,12 @@ mod tests {
     #[test]
     fn deprecated_builder_paths_match_new_builders() {
         let mut old = EntryBuilder::new_file("f".into(), WriteOptions::store()).unwrap();
-        old.created(Some(crate::Duration::seconds(1)));
+        old.created(Some(Duration::seconds(1)));
         old.write_all(b"data").unwrap();
         let old = old.build().unwrap();
 
         let mut new = FileEntryBuilder::new("f".into()).unwrap();
-        new.metadata(Metadata::new().with_created(Some(crate::Duration::seconds(1))));
+        new.metadata(Metadata::new().with_created(Some(Duration::seconds(1))));
         new.write_all(b"data").unwrap();
         let new = new.build().unwrap();
 
@@ -1063,13 +1053,11 @@ mod tests {
     #[test]
     fn deprecated_new_dir_matches_dir_entry_builder_wire() {
         let mut old = EntryBuilder::new_dir("dir".into());
-        old.permission_mode(Some(crate::PermissionMode::from(0o755)));
+        old.permission_mode(Some(PermissionMode::from(0o755)));
         let old = old.build().unwrap();
 
         let mut new = DirEntryBuilder::new("dir".into());
-        new.metadata(
-            Metadata::new().with_permission_mode(Some(crate::PermissionMode::from(0o755))),
-        );
+        new.metadata(Metadata::new().with_permission_mode(Some(PermissionMode::from(0o755))));
         let new = new.build().unwrap();
 
         assert_eq!(old.into_chunks(), new.into_chunks());

--- a/lib/src/entry/builder/dir.rs
+++ b/lib/src/entry/builder/dir.rs
@@ -1,5 +1,5 @@
 //! Builder for directory entries.
-use super::EntryBuilderCore;
+use crate::entry::builder::EntryBuilderCore;
 use crate::{
     Metadata, NormalEntry,
     chunk::RawChunk,

--- a/lib/src/entry/builder/file.rs
+++ b/lib/src/entry/builder/file.rs
@@ -1,5 +1,5 @@
 //! Builder for regular file entries.
-use super::{EntryBuilderCore, data_writer};
+use crate::entry::builder::{EntryBuilderCore, data_writer};
 use crate::{
     Metadata, NormalEntry, WriteOptions,
     chunk::RawChunk,

--- a/lib/src/entry/builder/link.rs
+++ b/lib/src/entry/builder/link.rs
@@ -1,5 +1,5 @@
 //! Builders for symbolic link and hard link entries.
-use super::{EntryBuilderCore, data_writer};
+use crate::entry::builder::{EntryBuilderCore, data_writer};
 use crate::{
     CipherMode, Encryption, Metadata, NormalEntry, WriteOptions,
     chunk::RawChunk,

--- a/lib/src/entry/content.rs
+++ b/lib/src/entry/content.rs
@@ -1,6 +1,6 @@
 //! Decoded view of entry data.
 
-use super::*;
+use crate::entry::*;
 use std::fmt;
 
 /// Decoded content of a [`NormalEntry`], interpreted according to its

--- a/lib/src/entry/header.rs
+++ b/lib/src/entry/header.rs
@@ -1,6 +1,6 @@
 //! Entry header types for normal and solid mode entries.
 
-use super::{CipherMode, Compression, DataKind, Encryption, EntryName};
+use crate::entry::{CipherMode, Compression, DataKind, Encryption, EntryName};
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
 use std::io;

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -971,7 +971,6 @@ mod tests {
 
     #[test]
     fn owner_string_newtype_bound_and_codec() {
-        use crate::entry::OwnerUserName;
         assert!(OwnerUserName::new("").is_ok());
         assert!(OwnerUserName::new("alice").is_ok());
         assert!(OwnerUserName::new("a".repeat(255)).is_ok());
@@ -993,7 +992,6 @@ mod tests {
 
     #[test]
     fn owner_uid_and_permission_mode_codec() {
-        use crate::entry::{OwnerUid, PermissionMode};
         let u = OwnerUid::from(1000u64);
         assert_eq!(u.get(), 1000);
         assert_eq!(u.to_bytes(), 1000u64.to_be_bytes());
@@ -1027,7 +1025,6 @@ mod tests {
 
     #[test]
     fn owner_id_facets_round_trip_via_entry() {
-        use crate::entry::{OwnerGid, OwnerUid};
         use crate::{Archive, FileEntryBuilder};
         let mut buf = Vec::new();
         {
@@ -1051,7 +1048,6 @@ mod tests {
 
     #[test]
     fn owner_name_facets_round_trip_via_entry() {
-        use crate::entry::{OwnerGroupName, OwnerUserName};
         use crate::{Archive, FileEntryBuilder};
         let mut buf = Vec::new();
         {
@@ -1075,7 +1071,6 @@ mod tests {
 
     #[test]
     fn owner_sid_facets_round_trip_via_entry() {
-        use crate::entry::{OwnerGroupSid, OwnerUserSid};
         use crate::{Archive, FileEntryBuilder};
         let mut buf = Vec::new();
         {
@@ -1105,7 +1100,6 @@ mod tests {
 
     #[test]
     fn fosi_length_prefixed_round_trip_and_empty() {
-        use crate::entry::{OwnerGroupSid, OwnerUserSid};
         use crate::{Archive, FileEntryBuilder};
         let mut buf = Vec::new();
         {
@@ -1130,7 +1124,6 @@ mod tests {
 
     #[test]
     fn permission_mode_facet_round_trip_via_entry() {
-        use crate::entry::PermissionMode;
         use crate::{Archive, FileEntryBuilder};
         let mut buf = Vec::new();
         {
@@ -1239,10 +1232,6 @@ mod tests {
     #[allow(deprecated)]
     #[test]
     fn fprm_alongside_owner_facets_reads_both_independently() {
-        use crate::entry::{
-            OwnerGid, OwnerGroupName, OwnerGroupSid, OwnerUid, OwnerUserName, OwnerUserSid,
-            PermissionMode,
-        };
         use crate::{Archive, ChunkType, FileEntryBuilder, RawChunk};
         let mut buf = Vec::new();
         {

--- a/lib/src/entry/reference.rs
+++ b/lib/src/entry/reference.rs
@@ -123,7 +123,7 @@ impl EntryReference {
 
     /// Returns a sanitized reference with root separators removed.
     ///
-    /// Unlike [`EntryName::sanitize`](super::EntryName), this preserves prefixes, `.` and `..`
+    /// Unlike [`EntryName::sanitize`](crate::entry::EntryName), this preserves prefixes, `.` and `..`
     /// components because hardlink targets may legitimately contain relative
     /// traversals.
     #[inline]

--- a/pna/src/ext/metadata.rs
+++ b/pna/src/ext/metadata.rs
@@ -387,7 +387,7 @@ fn fs_metadata_to_metadata(meta: &fs::Metadata) -> io::Result<Metadata> {
 }
 
 #[cfg(test)]
-mod time_ext_tests {
+mod tests {
     use super::*;
     use libpna::Duration;
 

--- a/pna/src/fs.rs
+++ b/pna/src/fs.rs
@@ -181,7 +181,7 @@ pub fn remove_path<P: AsRef<Path>>(path: P) -> io::Result<()> {
 
 #[cfg(all(test, windows))]
 mod tests {
-    use super::normalize_windows_separators;
+    use super::*;
     use std::borrow::Cow;
     use std::ffi::OsString;
     use std::os::windows::ffi::{OsStrExt, OsStringExt};

--- a/pna/src/fs.rs
+++ b/pna/src/fs.rs
@@ -180,7 +180,7 @@ pub fn remove_path<P: AsRef<Path>>(path: P) -> io::Result<()> {
 }
 
 #[cfg(all(test, windows))]
-mod windows_tests {
+mod tests {
     use super::normalize_windows_separators;
     use std::borrow::Cow;
     use std::ffi::OsString;


### PR DESCRIPTION
Two conventions, one commit each.

## Test module naming

Every `#[cfg(test)]` module is now named `tests`. Four used other spellings — `test`, `resolved_ownership_tests`, `time_ext_tests`, `windows_tests` — and in each case the `cfg` attribute above already recorded what the module was gated on, so the qualifier in the name carried nothing. None of them were referenced from anywhere else.

The nested `detect_format_tests` group inside `command::core::tests` also loses its `_tests` suffix, matching the eight sibling groups that use plain descriptive names.

## Intra-crate name resolution

Intra-crate paths are spelled from `crate::`. Relative paths break when a file moves, and they leave the reader without a way to tell where the name comes from.

`super::` remains in two shapes:

- `use super::*;`, where a module is tied to its parent — test modules and the `private` sealing modules.
- A named `super::X`, where `X` is private to the parent or `pub(super)`. Those items can only be named from inside the parent's subtree, so an absolute `crate::` path would read as crate-wide reach it does not have. This covers `write_archive_framing` (private in `archive`), `prepend_data_prefix` (`pub(super)` in `entry::builder`), and the `private` modules in `pna::ext`.

Test modules pull the parent in with `use super::*;` rather than naming it. That covers both what the parent defines and what the parent imports, so the qualified paths and the `use crate::...` lines that merely repeated the parent's own imports are gone — `archive/split_parts.rs` alone drops sixteen of them.

Where a module already imported from a path, the remaining references fold into that import instead of repeating the prefix inline. In `cli/src/cli/value/missing_time_policy.rs` that collapses two references to `crate::cli::value` into one `use`.

## Scope

- `cli/tests` is untouched. The whole crate is a test, so `mod tests` would not mean anything there.
- `cli/src/command/core/archive_source.rs` is excluded: a large refactor of that file is in flight on another branch.
- Pre-existing full paths that have no matching import are left alone. They are the correct spelling under this convention, not duplication.

## Verification

`cargo fmt --all --check`, `cargo clippy -p libpna -p pna --all-features --all-targets`, and `cargo clippy -p portable-network-archive` under both `memmap` settings are clean. `cargo test` passes: libpna 513 unit and 125 doc, portable-network-archive 537, pna 25 + 28.

`cargo check --all-targets` still fails to compile the `cli` integration test target because `main` references `archive::entry_mode_with_password`, which no longer exists. That break is inherited from `main` and is fixed by #3478.

Four lines are gated behind `windows` or `not(any(windows, unix))` and are therefore not type-checked here: the `use` statements in `cli/src/utils/os/windows/{fs,security}.rs`, the windows branch of `cli/src/utils/acl.rs`, and `mod imp` in `cli/src/utils/fs/owner.rs`. The `pna/src/fs.rs` test module rename is in the same position.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized internal module references across the CLI, library, and platform-specific components.
  - Removed redundant imports and simplified test module organization.
- **Documentation**
  - Updated internal documentation links for archive and entry APIs.
- **Tests**
  - Preserved existing test coverage and behavior while improving test organization and references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->