### PR TITLE
:sparkles: Add owned multipart entry iterators

### DIFF
--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use core::num::NonZeroU32;
 pub use header::*;
-pub use part::*;
+pub use part::{IntoEntries, NoParts, PartProvider};
 pub use split_parts::{MIN_SPLIT_PART_BYTES, SplitParts};
 use std::io::{self, Write};
 pub use stream::*;

--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use core::num::NonZeroU32;
 pub use header::*;
-pub use part::{IntoEntries, NoParts, PartProvider};
+pub use part::{IntoEntries, IntoSliceEntries, NoParts, PartProvider};
 pub use split_parts::{MIN_SPLIT_PART_BYTES, SplitParts};
 use std::io::{self, Write};
 pub use stream::*;

--- a/lib/src/archive/part.rs
+++ b/lib/src/archive/part.rs
@@ -1,12 +1,28 @@
-//! Continuation across the parts of a multipart archive.
+//! Multipart archive continuation shared by every read path.
 //!
-//! A PNA archive may be split across several parts, each self-framed and, when
-//! it is not the last, closed by `ANXT` followed by `AEND`. Reading past that
-//! boundary means obtaining the next part from somewhere the archive itself
-//! cannot know about - a file next to the current one, a network range request,
-//! a buffer already in memory. [`PartProvider`] is that seam.
-use crate::{Chunk, ChunkType, archive::ArchiveHeader};
-use std::io::{self, Read};
+//! A PNA archive may be split across several parts. Each part is self-framed,
+//! and a non-final part is closed by `ANXT` followed by `AEND`. Continuing past
+//! that boundary means obtaining the next part, validating its framing, and
+//! resuming the entry that the boundary interrupted.
+//!
+//! This module holds that logic once. [`ChunkSource`] abstracts over the two
+//! ways a part is consumed - through [`io::Read`] and directly from a byte
+//! slice - so the byte-level readers stay in `crate::io` and `crate::bytes`
+//! while the archive grammar above them is written a single time.
+use crate::{
+    Chunk, ChunkType, NormalEntry, RawChunk, ReadEntry, ReadOptions,
+    archive::{ArchiveHeader, read::ExtractSolidEntries},
+    entry::RawEntry,
+};
+use std::{
+    io::{self, Read},
+    iter::FusedIterator,
+    mem,
+};
+
+mod sealed {
+    pub trait Sealed {}
+}
 
 /// Supplies the next physical part of a multipart archive.
 pub trait PartProvider<R: Read> {
@@ -49,6 +65,77 @@ impl<R: Read> PartProvider<R> for NoParts {
     #[inline]
     fn next_part(&mut self, _expected: u32) -> io::Result<Option<R>> {
         Ok(None)
+    }
+}
+
+/// A replaceable source of PNA chunks.
+///
+/// Implementors carry the cursor for one part and can swap in the next part
+/// handed out by a [`PartProvider`]. This trait is sealed and cannot be
+/// implemented outside this crate.
+pub(crate) trait ChunkSource: sealed::Sealed {
+    /// Payload type of the chunks this source produces.
+    type Data: AsRef<[u8]>;
+
+    /// Handle a [`PartProvider`] hands out for the next part.
+    type Part: Read;
+
+    /// Replaces the current part, discarding any unread bytes of the old one.
+    fn set_part(&mut self, part: Self::Part);
+
+    /// Consumes the PNA signature at the current position.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the signature is incomplete or does not match.
+    fn read_signature(&mut self) -> io::Result<()>;
+
+    /// Reads one chunk from the current position.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the chunk is incomplete, exceeds `max_data_len`,
+    /// carries an invalid type, or fails its CRC.
+    fn read_chunk(&mut self, max_data_len: u32) -> io::Result<RawChunk<Self::Data>>;
+}
+
+/// The chunk source backed by an [`io::Read`] implementor.
+///
+/// Chunk payloads are copied out of the reader, so entries it produces own
+/// their data.
+pub(crate) struct ReaderSource<R>(R);
+
+impl<R> ReaderSource<R> {
+    #[inline]
+    pub(crate) const fn new(inner: R) -> Self {
+        Self(inner)
+    }
+
+    #[inline]
+    pub(crate) fn into_inner(self) -> R {
+        self.0
+    }
+}
+
+impl<R> sealed::Sealed for ReaderSource<R> {}
+
+impl<R: Read> ChunkSource for ReaderSource<R> {
+    type Data = Vec<u8>;
+    type Part = R;
+
+    #[inline]
+    fn set_part(&mut self, part: R) {
+        self.0 = part;
+    }
+
+    #[inline]
+    fn read_signature(&mut self) -> io::Result<()> {
+        crate::io::read_signature(&mut self.0)
+    }
+
+    #[inline]
+    fn read_chunk(&mut self, max_data_len: u32) -> io::Result<RawChunk<Vec<u8>>> {
+        crate::io::read_chunk(&mut self.0, max_data_len)
     }
 }
 
@@ -98,4 +185,513 @@ pub(crate) fn part_header(
         ));
     }
     Ok(header)
+}
+
+/// Advances `source` to the part following `header` and updates `header` to
+/// the one that part declares.
+///
+/// # Errors
+///
+/// Returns an error if the archive number would overflow, if `provider` cannot
+/// supply the part, or if the part's framing is invalid.
+pub(crate) fn open_next_part<S, P>(
+    source: &mut S,
+    header: &mut ArchiveHeader,
+    provider: &mut P,
+    max_chunk_data_len: u32,
+) -> io::Result<()>
+where
+    S: ChunkSource,
+    P: PartProvider<S::Part>,
+{
+    let expected = next_part_number(header.archive_number)?;
+    let next = provider
+        .next_part(expected)?
+        .ok_or_else(|| missing_part_error(expected))?;
+    source.set_part(next);
+    source.read_signature()?;
+    let chunk = source.read_chunk(max_chunk_data_len)?;
+    *header = part_header(&chunk, expected)?;
+    Ok(())
+}
+
+/// The error reported when an archive ends while an entry is still open.
+fn truncated_entry_error() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("`{}` reached while an entry is still open", ChunkType::AEND),
+    )
+}
+
+/// An owned iterator over the entries of an archive, continuing across the
+/// parts a [`PartProvider`] supplies.
+///
+/// Unlike the borrowing iterators, this owns its source, so an entry that a
+/// part boundary interrupts is resumed in place: the accumulated chunks stay in
+/// this iterator instead of being handed to a freshly built archive.
+///
+/// Reaching `ANXT` without a part to continue into is an error rather than a
+/// silent stop, so a truncated multipart archive cannot be mistaken for a
+/// complete one.
+pub(crate) struct MultipartEntries<S: ChunkSource, P = NoParts> {
+    source: S,
+    provider: P,
+    header: ArchiveHeader,
+    max_chunk_data_len: u32,
+    next_archive: bool,
+    pending: Vec<RawChunk<S::Data>>,
+    done: bool,
+}
+
+impl<S: ChunkSource, P> MultipartEntries<S, P> {
+    #[inline]
+    pub(crate) const fn new(
+        source: S,
+        provider: P,
+        header: ArchiveHeader,
+        max_chunk_data_len: u32,
+        pending: Vec<RawChunk<S::Data>>,
+    ) -> Self {
+        Self {
+            source,
+            provider,
+            header,
+            max_chunk_data_len,
+            next_archive: false,
+            pending,
+            done: false,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn into_source(self) -> S {
+        self.source
+    }
+}
+
+impl<S, P> MultipartEntries<S, P>
+where
+    S: ChunkSource,
+    P: PartProvider<S::Part>,
+{
+    /// Accumulates chunks up to the entry terminator, crossing part boundaries
+    /// as they are met.
+    fn next_raw_entry(&mut self) -> io::Result<Option<RawEntry<S::Data>>> {
+        let mut chunks = mem::take(&mut self.pending);
+        loop {
+            let chunk = self.source.read_chunk(self.max_chunk_data_len)?;
+            match chunk.ty() {
+                ChunkType::FEND | ChunkType::SEND => {
+                    chunks.push(chunk);
+                    return Ok(Some(RawEntry(chunks)));
+                }
+                ChunkType::ANXT => self.next_archive = true,
+                ChunkType::AEND => {
+                    if !self.next_archive {
+                        return if chunks.is_empty() {
+                            Ok(None)
+                        } else {
+                            Err(truncated_entry_error())
+                        };
+                    }
+                    open_next_part(
+                        &mut self.source,
+                        &mut self.header,
+                        &mut self.provider,
+                        self.max_chunk_data_len,
+                    )?;
+                    self.next_archive = false;
+                }
+                _ => chunks.push(chunk),
+            }
+        }
+    }
+
+    #[inline]
+    fn extract_solid_entries(
+        self,
+        options: ReadOptions,
+    ) -> impl Iterator<Item = io::Result<NormalEntry<S::Data>>>
+    where
+        NormalEntry<S::Data>: From<NormalEntry>,
+    {
+        ExtractSolidEntries::new(self, options)
+    }
+
+    #[inline]
+    fn skip_solid(self) -> impl Iterator<Item = io::Result<NormalEntry<S::Data>>> {
+        self.filter_map(|it| match it {
+            Ok(ReadEntry::Solid(_)) => None,
+            Ok(ReadEntry::Normal(entry)) => Some(Ok(entry)),
+            Err(e) => Some(Err(e)),
+        })
+    }
+}
+
+impl<S, P> Iterator for MultipartEntries<S, P>
+where
+    S: ChunkSource,
+    P: PartProvider<S::Part>,
+{
+    type Item = io::Result<ReadEntry<S::Data>>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+        match self.next_raw_entry() {
+            Ok(Some(raw)) => Some(raw.try_into()),
+            Ok(None) => {
+                self.done = true;
+                None
+            }
+            Err(e) => {
+                self.done = true;
+                Some(Err(e))
+            }
+        }
+    }
+}
+
+impl<S, P> FusedIterator for MultipartEntries<S, P>
+where
+    S: ChunkSource,
+    P: PartProvider<S::Part>,
+{
+}
+
+/// An owned iterator over the entries of an archive read through [`io::Read`].
+///
+/// Built by [`Archive::into_entries`] and
+/// [`Archive::into_entries_with_parts`](crate::Archive::into_entries_with_parts).
+/// Entry payloads are copied out of the reader, so they own their data.
+///
+/// [`Archive::into_entries`]: crate::Archive::into_entries
+#[must_use = "iterate the entries; dropping this discards the archive"]
+pub struct IntoEntries<R: Read, P = NoParts>(MultipartEntries<ReaderSource<R>, P>);
+
+impl<R: Read, P> IntoEntries<R, P> {
+    #[inline]
+    pub(crate) const fn new(
+        reader: R,
+        provider: P,
+        header: ArchiveHeader,
+        max_chunk_data_len: u32,
+        pending: Vec<RawChunk<Vec<u8>>>,
+    ) -> Self {
+        Self(MultipartEntries::new(
+            ReaderSource::new(reader),
+            provider,
+            header,
+            max_chunk_data_len,
+            pending,
+        ))
+    }
+
+    /// Returns the underlying reader.
+    ///
+    /// Once this iterator has yielded `None` the reader is positioned past the
+    /// end of the archive, so an archive concatenated after it can be read from
+    /// there. Stopping earlier, or stopping on an error, leaves the position
+    /// unspecified.
+    #[inline]
+    pub fn into_inner(self) -> R {
+        self.0.into_source().into_inner()
+    }
+}
+
+impl<R: Read, P: PartProvider<R>> IntoEntries<R, P> {
+    /// Returns an iterator that decodes each solid entry into the entries it
+    /// contains.
+    #[inline]
+    pub fn extract_solid_entries(
+        self,
+        options: ReadOptions,
+    ) -> impl Iterator<Item = io::Result<NormalEntry>> {
+        self.0.extract_solid_entries(options)
+    }
+
+    /// Returns an iterator over the entries that are not in solid mode.
+    #[inline]
+    pub fn skip_solid(self) -> impl Iterator<Item = io::Result<NormalEntry>> {
+        self.0.skip_solid()
+    }
+}
+
+impl<R: Read, P: PartProvider<R>> Iterator for IntoEntries<R, P> {
+    type Item = io::Result<ReadEntry>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl<R: Read, P: PartProvider<R>> FusedIterator for IntoEntries<R, P> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        Archive, MIN_SPLIT_PART_BYTES,
+        entry::{Compression, FileEntryBuilder, Metadata, SolidEntryBuilder, WriteOptions},
+    };
+    use std::{cell::RefCell, io::Write, rc::Rc};
+    #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+    use wasm_bindgen_test::wasm_bindgen_test as test;
+
+    #[derive(Clone, Default)]
+    struct SharedBuf(Rc<RefCell<Vec<u8>>>);
+
+    impl Write for SharedBuf {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.borrow_mut().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Collects the bytes of every part a split write opens.
+    fn part_collector() -> (
+        Rc<RefCell<Vec<SharedBuf>>>,
+        impl FnMut(u32) -> io::Result<SharedBuf>,
+    ) {
+        let parts = Rc::new(RefCell::new(Vec::new()));
+        let handle = parts.clone();
+        (parts, move |_| {
+            let buf = SharedBuf::default();
+            handle.borrow_mut().push(buf.clone());
+            Ok(buf)
+        })
+    }
+
+    fn collected(parts: &RefCell<Vec<SharedBuf>>) -> Vec<Vec<u8>> {
+        parts
+            .borrow()
+            .iter()
+            .map(|p| p.0.borrow().clone())
+            .collect()
+    }
+
+    /// Writes `entries` into a split archive at most `max_part_bytes` per part.
+    fn split_archive(max_part_bytes: usize, entries: &[(&str, &[u8])]) -> Vec<Vec<u8>> {
+        let (parts, next) = part_collector();
+        let mut archive = Archive::write_split_header(max_part_bytes, next).unwrap();
+        for (name, data) in entries {
+            let mut builder =
+                FileEntryBuilder::new_with_options((*name).into(), WriteOptions::store()).unwrap();
+            builder.write_all(data).unwrap();
+            archive.add_entry(builder.build().unwrap()).unwrap();
+        }
+        archive.finalize().unwrap();
+        collected(&parts)
+    }
+
+    /// Hands out `parts[expected]`, so the provider mirrors the archive numbering.
+    fn provider_over<'p>(parts: &'p [Vec<u8>]) -> impl FnMut(u32) -> io::Result<Option<&'p [u8]>> {
+        move |expected| Ok(parts.get(expected as usize).map(|part| &part[..]))
+    }
+
+    fn names_and_contents<T: AsRef<[u8]>>(
+        entries: impl Iterator<Item = io::Result<ReadEntry<T>>>,
+    ) -> Vec<(String, Vec<u8>)> {
+        entries
+            .map(|entry| match entry.unwrap() {
+                ReadEntry::Normal(entry) => {
+                    let name = entry.header().path().to_string();
+                    let mut data = Vec::new();
+                    entry
+                        .reader(ReadOptions::builder().build())
+                        .unwrap()
+                        .read_to_end(&mut data)
+                        .unwrap();
+                    (name, data)
+                }
+                ReadEntry::Solid(_) => panic!("unexpected solid entry"),
+            })
+            .collect()
+    }
+
+    fn raw_archive(header: ArchiveHeader, chunks: &[(ChunkType, &[u8])]) -> Vec<u8> {
+        let mut bytes = crate::PNA_SIGNATURE.to_vec();
+        crate::io::write_chunk(&mut bytes, (ChunkType::AHED, header.to_bytes())).unwrap();
+        for (ty, data) in chunks {
+            crate::io::write_chunk(&mut bytes, (*ty, *data)).unwrap();
+        }
+        bytes
+    }
+
+    #[test]
+    fn into_entries_matches_borrowing_iterator() {
+        let bytes = include_bytes!("../../../resources/test/zstd.pna");
+        let mut borrowed = Archive::read_header(&bytes[..]).unwrap();
+        let expected = names_and_contents(borrowed.entries());
+
+        let owned = Archive::read_header(&bytes[..]).unwrap();
+        assert_eq!(names_and_contents(owned.into_entries()), expected);
+        assert!(!expected.is_empty());
+    }
+
+    #[test]
+    fn into_entries_with_parts_spans_parts() {
+        let parts = split_archive(
+            MIN_SPLIT_PART_BYTES + 64,
+            &[("a.txt", b"first"), ("b.txt", b"second")],
+        );
+        assert!(parts.len() >= 2);
+
+        let archive = Archive::read_header(&parts[0][..]).unwrap();
+        let read = names_and_contents(archive.into_entries_with_parts(provider_over(&parts)));
+        assert_eq!(
+            read,
+            vec![
+                ("a.txt".to_string(), b"first".to_vec()),
+                ("b.txt".to_string(), b"second".to_vec()),
+            ]
+        );
+    }
+
+    #[test]
+    fn into_entries_with_parts_resumes_entry_split_across_parts() {
+        let payload = vec![7u8; 8192];
+        // A budget this small cuts the payload's `FDAT` stream mid-entry.
+        let parts = split_archive(MIN_SPLIT_PART_BYTES + 64, &[("big.bin", &payload)]);
+        assert!(parts.len() >= 3);
+
+        let archive = Archive::read_header(&parts[0][..]).unwrap();
+        let read = names_and_contents(archive.into_entries_with_parts(provider_over(&parts)));
+        assert_eq!(read, vec![("big.bin".to_string(), payload)]);
+    }
+
+    #[test]
+    fn extract_solid_entries_spans_parts() {
+        let (parts, next) = part_collector();
+        let max = MIN_SPLIT_PART_BYTES + 96;
+        let mut archive = Archive::write_split_header(max, next).unwrap();
+        let mut solid =
+            SolidEntryBuilder::new(WriteOptions::builder().compression(Compression::NO).build())
+                .unwrap();
+        solid
+            .write_file("inner.bin".into(), Metadata::new(), |w| {
+                w.write_all(&[3u8; 4096])
+            })
+            .unwrap();
+        archive.add_entry(solid.build().unwrap()).unwrap();
+        assert!(archive.finalize().unwrap().parts() >= 2);
+
+        let parts = collected(&parts);
+        let archive = Archive::read_header(&parts[0][..]).unwrap();
+        let entries = archive
+            .into_entries_with_parts(provider_over(&parts))
+            .extract_solid_entries(ReadOptions::builder().build())
+            .collect::<io::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(entries.len(), 1);
+        let mut data = Vec::new();
+        entries[0]
+            .reader(ReadOptions::builder().build())
+            .unwrap()
+            .read_to_end(&mut data)
+            .unwrap();
+        assert_eq!(data, vec![3u8; 4096]);
+    }
+
+    #[test]
+    fn into_entries_rejects_archive_that_continues() {
+        let parts = split_archive(
+            MIN_SPLIT_PART_BYTES + 64,
+            &[("a.txt", b"first"), ("b.txt", b"second")],
+        );
+        assert!(parts.len() >= 2);
+
+        let archive = Archive::read_header(&parts[0][..]).unwrap();
+        let err = archive
+            .into_entries()
+            .find_map(Result::err)
+            .expect("a truncated multipart archive must not read as complete");
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn into_entries_with_parts_rejects_missing_part() {
+        let parts = split_archive(
+            MIN_SPLIT_PART_BYTES + 64,
+            &[("a.txt", b"first"), ("b.txt", b"second")],
+        );
+        let archive = Archive::read_header(&parts[0][..]).unwrap();
+        let err = archive
+            .into_entries_with_parts(|_: u32| Ok(None::<&[u8]>))
+            .find_map(Result::err)
+            .unwrap();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn into_entries_with_parts_rejects_non_consecutive_part() {
+        let parts = split_archive(
+            MIN_SPLIT_PART_BYTES + 64,
+            &[("a.txt", b"first"), ("b.txt", b"second")],
+        );
+        let wrong = raw_archive(ArchiveHeader::new(0, 0, 5), &[(ChunkType::AEND, &[])]);
+        let archive = Archive::read_header(&parts[0][..]).unwrap();
+        let err = archive
+            .into_entries_with_parts(|_: u32| Ok(Some(&wrong[..])))
+            .find_map(Result::err)
+            .unwrap();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn into_entries_with_parts_rejects_part_without_an_archive_header() {
+        let parts = split_archive(
+            MIN_SPLIT_PART_BYTES + 64,
+            &[("a.txt", b"first"), ("b.txt", b"second")],
+        );
+        let mut headerless = crate::PNA_SIGNATURE.to_vec();
+        crate::io::write_chunk(&mut headerless, (ChunkType::FEND, [])).unwrap();
+
+        let archive = Archive::read_header(&parts[0][..]).unwrap();
+        let err = archive
+            .into_entries_with_parts(|_: u32| Ok(Some(&headerless[..])))
+            .find_map(Result::err)
+            .unwrap();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn into_entries_with_parts_rejects_archive_number_overflow() {
+        let bytes = raw_archive(
+            ArchiveHeader::new(0, 0, u32::MAX),
+            &[(ChunkType::ANXT, &[]), (ChunkType::AEND, &[])],
+        );
+        let archive = Archive::read_header(&bytes[..]).unwrap();
+        let err = archive
+            .into_entries_with_parts(|_: u32| Ok(Some(&bytes[..])))
+            .find_map(Result::err)
+            .unwrap();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn into_entries_rejects_entry_left_open_at_archive_end() {
+        let bytes = raw_archive(
+            ArchiveHeader::new(0, 0, 0),
+            &[(ChunkType::FHED, &[0, 0, 0, 0]), (ChunkType::AEND, &[])],
+        );
+        let archive = Archive::read_header(&bytes[..]).unwrap();
+        let err = archive.into_entries().find_map(Result::err).unwrap();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn into_entries_stops_after_the_first_none() {
+        let bytes = include_bytes!("../../../resources/test/empty.pna");
+        let mut entries = Archive::read_header(&bytes[..]).unwrap().into_entries();
+        assert!(entries.next().is_none());
+        assert!(entries.next().is_none());
+    }
 }

--- a/lib/src/archive/part.rs
+++ b/lib/src/archive/part.rs
@@ -15,6 +15,7 @@ use crate::{
     entry::RawEntry,
 };
 use std::{
+    borrow::Cow,
     io::{self, Read},
     iter::FusedIterator,
     mem,
@@ -136,6 +137,48 @@ impl<R: Read> ChunkSource for ReaderSource<R> {
     #[inline]
     fn read_chunk(&mut self, max_data_len: u32) -> io::Result<RawChunk<Vec<u8>>> {
         crate::io::read_chunk(&mut self.0, max_data_len)
+    }
+}
+
+/// The chunk source backed by a byte slice.
+///
+/// Chunk payloads borrow from the slice, so entries it produces stay zero-copy.
+pub(crate) struct SliceSource<'d>(&'d [u8]);
+
+impl<'d> SliceSource<'d> {
+    #[inline]
+    pub(crate) const fn new(bytes: &'d [u8]) -> Self {
+        Self(bytes)
+    }
+
+    #[inline]
+    pub(crate) const fn into_inner(self) -> &'d [u8] {
+        self.0
+    }
+}
+
+impl sealed::Sealed for SliceSource<'_> {}
+
+impl<'d> ChunkSource for SliceSource<'d> {
+    type Data = Cow<'d, [u8]>;
+    type Part = &'d [u8];
+
+    #[inline]
+    fn set_part(&mut self, part: &'d [u8]) {
+        self.0 = part;
+    }
+
+    #[inline]
+    fn read_signature(&mut self) -> io::Result<()> {
+        self.0 = crate::bytes::read_signature(self.0)?;
+        Ok(())
+    }
+
+    #[inline]
+    fn read_chunk(&mut self, max_data_len: u32) -> io::Result<RawChunk<Cow<'d, [u8]>>> {
+        let (chunk, rest) = crate::bytes::read_chunk(self.0, max_data_len)?;
+        self.0 = rest;
+        Ok(chunk.into())
     }
 }
 
@@ -430,6 +473,76 @@ impl<R: Read, P: PartProvider<R>> Iterator for IntoEntries<R, P> {
 
 impl<R: Read, P: PartProvider<R>> FusedIterator for IntoEntries<R, P> {}
 
+/// An owned iterator over the entries of an archive read from a byte slice.
+///
+/// Built by [`Archive::into_entries_slice`] and
+/// [`Archive::into_entries_slice_with_parts`](crate::Archive::into_entries_slice_with_parts).
+/// Entry payloads keep borrowing the bytes of the part they came from, across
+/// part boundaries included.
+///
+/// [`Archive::into_entries_slice`]: crate::Archive::into_entries_slice
+#[must_use = "iterate the entries; dropping this discards the archive"]
+pub struct IntoSliceEntries<'d, P = NoParts>(MultipartEntries<SliceSource<'d>, P>);
+
+impl<'d, P> IntoSliceEntries<'d, P> {
+    #[inline]
+    pub(crate) const fn new(
+        bytes: &'d [u8],
+        provider: P,
+        header: ArchiveHeader,
+        max_chunk_data_len: u32,
+        pending: Vec<RawChunk<Cow<'d, [u8]>>>,
+    ) -> Self {
+        Self(MultipartEntries::new(
+            SliceSource::new(bytes),
+            provider,
+            header,
+            max_chunk_data_len,
+            pending,
+        ))
+    }
+
+    /// Returns the bytes this iterator has not consumed.
+    ///
+    /// Once this iterator has yielded `None` those bytes begin past the end of
+    /// the archive, so an archive concatenated after it can be read from them.
+    /// Stopping earlier, or stopping on an error, leaves the position
+    /// unspecified.
+    #[inline]
+    pub fn into_inner(self) -> &'d [u8] {
+        self.0.into_source().into_inner()
+    }
+}
+
+impl<'d, P: PartProvider<&'d [u8]>> IntoSliceEntries<'d, P> {
+    /// Returns an iterator that decodes each solid entry into the entries it
+    /// contains.
+    #[inline]
+    pub fn extract_solid_entries(
+        self,
+        options: ReadOptions,
+    ) -> impl Iterator<Item = io::Result<NormalEntry<Cow<'d, [u8]>>>> {
+        self.0.extract_solid_entries(options)
+    }
+
+    /// Returns an iterator over the entries that are not in solid mode.
+    #[inline]
+    pub fn skip_solid(self) -> impl Iterator<Item = io::Result<NormalEntry<Cow<'d, [u8]>>>> {
+        self.0.skip_solid()
+    }
+}
+
+impl<'d, P: PartProvider<&'d [u8]>> Iterator for IntoSliceEntries<'d, P> {
+    type Item = io::Result<ReadEntry<Cow<'d, [u8]>>>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
+impl<'d, P: PartProvider<&'d [u8]>> FusedIterator for IntoSliceEntries<'d, P> {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -516,6 +629,20 @@ mod tests {
             .collect()
     }
 
+    /// Writes `entries` into a single-part archive.
+    fn archive_bytes(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        let mut archive = Archive::write_header(&mut bytes).unwrap();
+        for (name, data) in entries {
+            let mut builder =
+                FileEntryBuilder::new_with_options((*name).into(), WriteOptions::store()).unwrap();
+            builder.write_all(data).unwrap();
+            archive.add_entry(builder.build().unwrap()).unwrap();
+        }
+        archive.finalize().unwrap();
+        bytes
+    }
+
     fn raw_archive(header: ArchiveHeader, chunks: &[(ChunkType, &[u8])]) -> Vec<u8> {
         let mut bytes = crate::PNA_SIGNATURE.to_vec();
         crate::io::write_chunk(&mut bytes, (ChunkType::AHED, header.to_bytes())).unwrap();
@@ -534,6 +661,16 @@ mod tests {
         let owned = Archive::read_header(&bytes[..]).unwrap();
         assert_eq!(names_and_contents(owned.into_entries()), expected);
         assert!(!expected.is_empty());
+    }
+
+    #[test]
+    fn into_entries_slice_matches_borrowing_iterator() {
+        let bytes = include_bytes!("../../../resources/test/zstd.pna");
+        let mut borrowed = Archive::read_header_from_slice(bytes).unwrap();
+        let expected = names_and_contents(borrowed.entries_slice());
+
+        let owned = Archive::read_header_from_slice(bytes).unwrap();
+        assert_eq!(names_and_contents(owned.into_entries_slice()), expected);
     }
 
     #[test]
@@ -564,6 +701,17 @@ mod tests {
 
         let archive = Archive::read_header(&parts[0][..]).unwrap();
         let read = names_and_contents(archive.into_entries_with_parts(provider_over(&parts)));
+        assert_eq!(read, vec![("big.bin".to_string(), payload)]);
+    }
+
+    #[test]
+    fn into_entries_slice_with_parts_resumes_entry_split_across_parts() {
+        let payload = vec![7u8; 8192];
+        let parts = split_archive(MIN_SPLIT_PART_BYTES + 64, &[("big.bin", &payload)]);
+        assert!(parts.len() >= 3);
+
+        let archive = Archive::read_header_from_slice(&parts[0]).unwrap();
+        let read = names_and_contents(archive.into_entries_slice_with_parts(provider_over(&parts)));
         assert_eq!(read, vec![("big.bin".to_string(), payload)]);
     }
 
@@ -693,5 +841,75 @@ mod tests {
         let mut entries = Archive::read_header(&bytes[..]).unwrap().into_entries();
         assert!(entries.next().is_none());
         assert!(entries.next().is_none());
+    }
+
+    #[test]
+    fn into_inner_resumes_a_concatenated_archive() {
+        let mut bytes = archive_bytes(&[("a.txt", b"first")]);
+        bytes.extend_from_slice(&archive_bytes(&[("b.txt", b"second")]));
+
+        // A borrowed provider outlives the iterator, so one part source spans
+        // every archive in the stream.
+        let mut provider = |_: u32| Ok(None::<&[u8]>);
+        let mut entries = Archive::read_header(&bytes[..])
+            .unwrap()
+            .into_entries_with_parts(&mut provider);
+        assert_eq!(
+            names_and_contents(&mut entries),
+            vec![("a.txt".to_string(), b"first".to_vec())]
+        );
+        let mut next = Archive::read_header(entries.into_inner()).unwrap();
+        assert_eq!(
+            names_and_contents(next.entries()),
+            vec![("b.txt".to_string(), b"second".to_vec())]
+        );
+
+        let mut entries = Archive::read_header_from_slice(&bytes)
+            .unwrap()
+            .into_entries_slice();
+        assert_eq!(
+            names_and_contents(&mut entries),
+            vec![("a.txt".to_string(), b"first".to_vec())]
+        );
+        let mut next = Archive::read_header_from_slice(entries.into_inner()).unwrap();
+        assert_eq!(
+            names_and_contents(next.entries_slice()),
+            vec![("b.txt".to_string(), b"second".to_vec())]
+        );
+    }
+
+    #[test]
+    fn into_entries_slice_borrows_payloads_from_every_part() {
+        let payload = vec![7u8; 8192];
+        let parts = split_archive(MIN_SPLIT_PART_BYTES + 64, &[("big.bin", &payload)]);
+        assert!(parts.len() >= 3);
+
+        let archive = Archive::read_header_from_slice(&parts[0]).unwrap();
+        let entries = archive
+            .into_entries_slice_with_parts(provider_over(&parts))
+            .collect::<io::Result<Vec<_>>>()
+            .unwrap();
+        let ReadEntry::Normal(entry) = &entries[0] else {
+            panic!("expected a normal entry");
+        };
+
+        // The payload crossed part boundaries, so it arrived as several `FDAT`
+        // fragments. Every one of them must still point into the part it came
+        // from rather than into a copy made while crossing.
+        assert!(entry.data.len() >= 2);
+        for fragment in &entry.data {
+            assert!(
+                matches!(fragment, Cow::Borrowed(_)),
+                "payload fragment was copied"
+            );
+            let start = fragment.as_ptr() as usize;
+            assert!(
+                parts.iter().any(|part| {
+                    let base = part.as_ptr() as usize;
+                    start >= base && start + fragment.len() <= base + part.len()
+                }),
+                "payload fragment does not borrow from any part"
+            );
+        }
     }
 }

--- a/lib/src/archive/part.rs
+++ b/lib/src/archive/part.rs
@@ -5,6 +5,7 @@
 //! boundary means obtaining the next part from somewhere the archive itself
 //! cannot know about - a file next to the current one, a network range request,
 //! a buffer already in memory. [`PartProvider`] is that seam.
+use crate::{Chunk, ChunkType, archive::ArchiveHeader};
 use std::io::{self, Read};
 
 /// Supplies the next physical part of a multipart archive.
@@ -49,4 +50,52 @@ impl<R: Read> PartProvider<R> for NoParts {
     fn next_part(&mut self, _expected: u32) -> io::Result<Option<R>> {
         Ok(None)
     }
+}
+
+/// Returns the archive number the part after `current` must carry.
+///
+/// # Errors
+///
+/// Returns an error if `current` is [`u32::MAX`].
+pub(crate) fn next_part_number(current: u32) -> io::Result<u32> {
+    current
+        .checked_add(1)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "archive number overflow"))
+}
+
+/// The error reported when a provider cannot supply a part the archive needs.
+pub(crate) fn missing_part_error(expected: u32) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::NotFound,
+        format!("archive part {expected} is required"),
+    )
+}
+
+/// Validates a part's opening chunk and returns the header it carries.
+///
+/// # Errors
+///
+/// Returns an error if `chunk` is not an `AHED`, if its body is malformed, or
+/// if it numbers the archive anything other than `expected`.
+pub(crate) fn part_header(
+    chunk: &(impl Chunk + ?Sized),
+    expected: u32,
+) -> io::Result<ArchiveHeader> {
+    if chunk.ty() != ChunkType::AHED {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("expected `{}`, got `{}`", ChunkType::AHED, chunk.ty()),
+        ));
+    }
+    let header = ArchiveHeader::try_from_bytes(chunk.data())?;
+    if header.archive_number != expected {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "next archive number must be {expected}, got {}",
+                header.archive_number
+            ),
+        ));
+    }
+    Ok(header)
 }

--- a/lib/src/archive/read.rs
+++ b/lib/src/archive/read.rs
@@ -3,7 +3,7 @@
 mod slice;
 
 use crate::{
-    archive::{Archive, ArchiveHeader},
+    archive::{Archive, ArchiveHeader, IntoEntries, NoParts, PartProvider},
     chunk::{Chunk, ChunkType, RawChunk},
     entry::{Entry, NormalEntry, RawEntry, ReadEntry, ReadOptions, SolidIntoEntries},
 };
@@ -107,6 +107,74 @@ impl<R: Read> Archive<R> {
         options: &ReadOptions,
     ) -> impl Iterator<Item = io::Result<NormalEntry>> + 'a {
         self.entries().extract_solid_entries(options)
+    }
+
+    /// Converts this archive into an owned iterator over its entries.
+    ///
+    /// Unlike [`entries`](Archive::entries) the iterator owns the archive, so it
+    /// can outlive the binding it was built from. Reaching an `ANXT` chunk is an
+    /// error: use [`into_entries_with_parts`](Archive::into_entries_with_parts)
+    /// to read a split archive.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use std::io;
+    /// use libpna::Archive;
+    /// use std::fs::File;
+    ///
+    /// # fn main() -> io::Result<()> {
+    /// let archive = Archive::read_header(File::open("foo.pna")?)?;
+    /// for entry in archive.into_entries() {
+    ///     let entry = entry?;
+    ///     // process the entry
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn into_entries(self) -> IntoEntries<R> {
+        self.into_entries_with_parts(NoParts::NEW)
+    }
+
+    /// Converts this archive into an owned iterator that continues across the
+    /// parts `provider` supplies.
+    ///
+    /// An entry interrupted by a part boundary is resumed in place, so callers
+    /// see one flat sequence of entries regardless of how the archive was split.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use std::io;
+    /// use libpna::Archive;
+    /// use std::fs::File;
+    ///
+    /// # fn main() -> io::Result<()> {
+    /// let archive = Archive::read_header(File::open("foo.part1.pna")?)?;
+    /// // `expected` numbers archives from 0, one less than the file name suffix.
+    /// let entries = archive.into_entries_with_parts(|expected: u32| {
+    ///     match File::open(format!("foo.part{}.pna", expected + 1)) {
+    ///         Ok(file) => Ok(Some(file)),
+    ///         Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+    ///         Err(e) => Err(e),
+    ///     }
+    /// });
+    /// for entry in entries {
+    ///     let entry = entry?;
+    ///     // process the entry
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn into_entries_with_parts<P: PartProvider<R>>(self, provider: P) -> IntoEntries<R, P> {
+        let max_chunk_data_len = self.max_chunk_size.map_or(u32::MAX, |max| max.get());
+        IntoEntries::new(
+            self.inner,
+            provider,
+            self.header,
+            max_chunk_data_len,
+            self.buf,
+        )
     }
 
     /// Reads the next archive from the provided reader and returns a new [`Archive`].
@@ -338,7 +406,10 @@ pub struct NormalEntries<'r, R>(ExtractSolidEntries<Entries<'r, R>, Vec<u8>>);
 impl<'r, R> NormalEntries<'r, R> {
     #[inline]
     pub(crate) fn new(reader: &'r mut Archive<R>, options: &ReadOptions) -> Self {
-        Self(ExtractSolidEntries::new(Entries::new(reader), options))
+        Self(ExtractSolidEntries::new(
+            Entries::new(reader),
+            options.clone(),
+        ))
     }
 }
 
@@ -361,10 +432,10 @@ pub(crate) struct ExtractSolidEntries<I, T: AsRef<[u8]>> {
 
 impl<I, T: AsRef<[u8]>> ExtractSolidEntries<I, T> {
     #[inline]
-    pub(crate) fn new(entries: I, options: &ReadOptions) -> Self {
+    pub(crate) fn new(entries: I, read_options: ReadOptions) -> Self {
         Self {
             entries,
-            read_options: options.clone(),
+            read_options,
             solid_iter: None,
         }
     }

--- a/lib/src/archive/read/slice.rs
+++ b/lib/src/archive/read/slice.rs
@@ -210,7 +210,7 @@ impl<'a, 'r> Entries<'a, 'r> {
         self,
         options: &ReadOptions,
     ) -> impl Iterator<Item = io::Result<NormalEntry<Cow<'r, [u8]>>>> + 'a {
-        ExtractSolidEntries::new(self, options)
+        ExtractSolidEntries::new(self, options.clone())
     }
 }
 

--- a/lib/src/archive/read/slice.rs
+++ b/lib/src/archive/read/slice.rs
@@ -1,7 +1,8 @@
 //! Slice-based archive reading for memory-mapped access.
 
 use crate::{
-    Archive, Chunk, ChunkType, Entry, NormalEntry, RawChunk, ReadEntry, ReadOptions,
+    Archive, Chunk, ChunkType, Entry, IntoSliceEntries, NoParts, NormalEntry, PartProvider,
+    RawChunk, ReadEntry, ReadOptions,
     archive::{ArchiveHeader, read::ExtractSolidEntries},
     entry::RawEntry,
 };
@@ -131,6 +132,78 @@ impl<'d> Archive<&'d [u8]> {
         &'s mut self,
     ) -> impl Iterator<Item = io::Result<impl Entry + Sized + 'd>> + 's {
         RawEntries::<'s, 'd>(self)
+    }
+
+    /// Converts this archive into an owned iterator over its entries.
+    ///
+    /// Entry payloads keep borrowing the original bytes. Unlike
+    /// [`entries_slice`](Archive::entries_slice) the iterator owns the archive,
+    /// so it can outlive the binding it was built from. Reaching an `ANXT` chunk
+    /// is an error: use
+    /// [`into_entries_slice_with_parts`](Archive::into_entries_slice_with_parts)
+    /// to read a split archive.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use std::io;
+    /// use libpna::Archive;
+    /// use std::fs;
+    ///
+    /// # fn main() -> io::Result<()> {
+    /// let bytes = fs::read("foo.pna")?;
+    /// let archive = Archive::read_header_from_slice(&bytes[..])?;
+    /// for entry in archive.into_entries_slice() {
+    ///     let entry = entry?;
+    ///     // process the entry
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn into_entries_slice(self) -> IntoSliceEntries<'d> {
+        self.into_entries_slice_with_parts(NoParts::NEW)
+    }
+
+    /// Converts this archive into an owned iterator that continues across the
+    /// parts `provider` supplies.
+    ///
+    /// An entry interrupted by a part boundary is resumed in place, and its
+    /// payload keeps borrowing from the parts it came from.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # use std::io;
+    /// use libpna::Archive;
+    /// use std::fs;
+    ///
+    /// # fn main() -> io::Result<()> {
+    /// let parts = [fs::read("foo.part1.pna")?, fs::read("foo.part2.pna")?];
+    /// let archive = Archive::read_header_from_slice(&parts[0])?;
+    /// // `expected` numbers archives from 0, one less than the file name suffix.
+    /// let entries = archive
+    ///     .into_entries_slice_with_parts(|expected: u32| {
+    ///         Ok(parts.get(expected as usize).map(|part| &part[..]))
+    ///     });
+    /// for entry in entries {
+    ///     let entry = entry?;
+    ///     // process the entry
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn into_entries_slice_with_parts<P: PartProvider<&'d [u8]>>(
+        self,
+        provider: P,
+    ) -> IntoSliceEntries<'d, P> {
+        let max_chunk_data_len = self.max_chunk_size.map_or(u32::MAX, |max| max.get());
+        IntoSliceEntries::new(
+            self.inner,
+            provider,
+            self.header,
+            max_chunk_data_len,
+            self.buf.into_iter().map(Into::into).collect(),
+        )
     }
 
     /// Reads the next archive from the provided bytes and returns a new [`Archive`].

--- a/lib/src/archive/stream.rs
+++ b/lib/src/archive/stream.rs
@@ -3,7 +3,7 @@
 use super::{Archive, ArchiveHeader};
 use crate::{
     Chunk, ChunkType, EntryHeader, Metadata, NormalEntry, RawChunk, ReadOptions, SolidHeader,
-    archive::part::{NoParts, PartProvider},
+    archive::part::{NoParts, PartProvider, missing_part_error, next_part_number, part_header},
     cipher::DecryptReader,
     compress::DecompressReader,
     entry::{RawEntry, decompress_reader, decrypt_reader},
@@ -240,36 +240,14 @@ impl<R: Read, P: PartProvider<R>> StreamingSource<R, P> {
     }
 
     fn open_next_part(&mut self) -> io::Result<()> {
-        let expected =
-            self.header.archive_number.checked_add(1).ok_or_else(|| {
-                io::Error::new(io::ErrorKind::InvalidData, "archive number overflow")
-            })?;
-        let next = self.provider.next_part(expected)?.ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::NotFound,
-                format!("archive part {expected} is required"),
-            )
-        })?;
-        self.reader = next;
+        let expected = next_part_number(self.header.archive_number)?;
+        self.reader = self
+            .provider
+            .next_part(expected)?
+            .ok_or_else(|| missing_part_error(expected))?;
         crate::io::read_signature(&mut self.reader)?;
         let chunk = crate::io::read_chunk(&mut self.reader, self.max_chunk_data_len)?;
-        if chunk.ty() != ChunkType::AHED {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("expected `{}`, got `{}`", ChunkType::AHED, chunk.ty()),
-            ));
-        }
-        let header = ArchiveHeader::try_from_bytes(chunk.data())?;
-        if header.archive_number != expected {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "next archive number must be {expected}, got {}",
-                    header.archive_number
-                ),
-            ));
-        }
-        self.header = header;
+        self.header = part_header(&chunk, expected)?;
         Ok(())
     }
 }


### PR DESCRIPTION
Closes the gap where a split archive could be read through the streaming API but not through the owned one.

## Why

`Archive::read_next_archive` consumes the archive and returns one built over a *new* reader type:

```rust
pub fn read_next_archive<OR: Read>(self, reader: OR) -> io::Result<Archive<OR>>
```

`Entries<'r, R>` borrows `&mut Archive<R>`, so no entry iterator could survive that call. Crossing a part boundary was not merely inconvenient, it was unrepresentable: callers had to drive the part chain themselves, drop out of the iterator at every `AEND`, and resume against a freshly built archive.

`StreamingEntries<R, P>` does not have that problem because it owns its reader and replaces it in place at the same `R`. `into_streaming_entries_with_parts` has taken a `PartProvider` since #3368; the owned path had no counterpart.

The `OR ≠ R` generality of `read_next_archive` is not exercised anywhere in this repository — every call site passes the same reader type, and the slice path already has its own `read_next_archive_from_slice`. So this PR adds the missing owned iterators rather than reworking the existing method, which stays as it is.

## What this adds

| | entry type | continues across parts |
|---|---|---|
| `Archive::<R>::into_entries()` | `ReadEntry` | no |
| `Archive::<R>::into_entries_with_parts(provider)` | `ReadEntry` | yes |
| `Archive::<&[u8]>::into_entries_slice()` | `ReadEntry<Cow<'d, [u8]>>` | no |
| `Archive::<&[u8]>::into_entries_slice_with_parts(provider)` | `ReadEntry<Cow<'d, [u8]>>` | yes |

All four are `Iterator + FusedIterator` and carry `extract_solid_entries(&options)` and `skip_solid()`, matching the borrowing iterators they mirror.

```rust
let archive = Archive::read_header(File::open("foo.part1.pna")?)?;
// `expected` numbers archives from 0, one less than the file name suffix.
let entries = archive.into_entries_with_parts(|expected: u32| {
    match File::open(format!("foo.part{}.pna", expected + 1)) {
        Ok(file) => Ok(Some(file)),
        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
        Err(e) => Err(e),
    }
});
for entry in entries {
    // one flat sequence, regardless of how the archive was split
}
```

An entry that a part boundary interrupts is resumed in place, so a solid block or a large `FDAT` stream spanning three parts still arrives as one entry.

## Deliberate divergence from `entries()`

`into_entries()` treats reaching `ANXT` with no part to continue into as an error (`NotFound`). `entries()` stops silently and leaves the caller to check `has_next_archive()`.

This is intentional and matches `into_streaming_entries()`, which already fails the same way through `NoParts`. Reading only the first part of a split archive and concluding it was complete is a silent data-loss bug, and the owned iterator is the natural place to stop allowing it. `entries()` behaviour is unchanged.

For the same reason, an `AEND` that arrives while an entry is still open — no `ANXT`, chunks already accumulated — is now an error rather than a truncated `None`.

## Commits

| | |
|---|---|
| `:recycle: Share multipart part continuation rules` | `StreamingSource::open_next_part` inlined the archive-numbering rule, the missing-part error, and the `AHED` framing check. Those belong to the multipart format, so they move next to `PartProvider`. No behaviour or message changes; `stream.rs` nets −22 lines. |
| `:sparkles: Add owned entry iteration across archive parts` | `ChunkSource`, `MultipartEntries`, `IntoEntries`, and `Archive::into_entries*`. |
| `:sparkles: Read split archives from byte slices without copying` | `SliceSource`, `IntoSliceEntries`, and `Archive::into_entries_slice*`. |

## Internals

`ChunkSource` names what the iterator needs from one part, so the reader and slice paths share the archive grammar above the byte level:

| | `ReaderSource<R>` | `SliceSource<'d>` |
|---|---|---|
| chunk payload | `Vec<u8>` | `Cow<'d, [u8]>` |
| byte layer | `crate::io` | `crate::bytes` |

The accumulation loop, `open_next_part`, the `AHED` validation, and the archive-numbering rule are each written once, and `stream.rs` uses the same rules rather than its own copy.

### Memory

`Archive::buf` existed only because `read_next_archive` rebuilds the archive and needs somewhere to hand off a half-read entry. In-place advancement removes that hand-off: the new iterators never write to `buf`, and the per-entry `Vec::new()` + `swap` goes away.

The slice path gains more than the reader path. It previously round-tripped chunks through `Vec<u8>` at every boundary, so a zero-copy read silently copied its payload whenever the archive was split:

```rust
// slice.rs, before
self.buf = chunks.into_iter().map(Into::into).collect::<Vec<_>>();  // Cow -> Vec, a real copy
```

That is gone. A test reads an 8 KiB payload spread across three parts and asserts every `FDAT` fragment is still `Cow::Borrowed` and points inside the part buffer it came from.

Peak memory is otherwise unchanged: `ReadEntry` owns its chunks, so one entry is resident at a time whether or not the archive is split. Callers who cannot afford that already have `into_streaming_entries`.

### Public surface

Only `IntoEntries` and `IntoSliceEntries` are added. `ChunkSource`, `ReaderSource`, `SliceSource`, and the shared `MultipartEntries` are `pub(crate)`.

The slice iterators yield `Cow<'d, [u8]>` to match `entries_slice`. A borrowed-only item type is possible for plain iteration, but `Cow` is what lets one iterator carry both borrowed normal payloads and the owned entries produced by decoding a solid block.

## Tests

14 cases in `archive::part::tests`:

- owned iterators agree with `entries()` / `entries_slice()` on a single-part archive
- entries read across parts; an entry split across a boundary is reassembled (reader and slice)
- a solid block spanning parts decodes through `extract_solid_entries`
- slice payloads stay borrowed from every part they cross
- `ANXT` with no continuation, a missing part, a non-consecutive archive number, a part whose first chunk is not `AHED`, and archive-number overflow all report the expected error kind
- `AEND` while an entry is open is rejected
- the iterator stays fused after the first `None`
