### PR TITLE
Add selectable fields to diff

### DIFF
--- a/cli/src/command/diff.rs
+++ b/cli/src/command/diff.rs
@@ -2,27 +2,22 @@ use crate::{
     cli::{ArchiveFileArgs, FileOperands, PasswordArgs},
     command::{
         Command, ExitCodeError, ask_password,
-        core::{SplitArchiveReader, collect_split_archives},
+        core::{SplitArchiveReader, cmp_at_stored_precision, collect_split_archives},
     },
     utils::{BsdGlobMatcher, io::streams_equal},
 };
-
-#[cfg(unix)]
-use crate::command::core::cmp_at_stored_precision;
+use bitflags::bitflags;
 use clap::{Parser, ValueEnum};
-#[cfg(unix)]
 use pna::prelude::SystemTimeDurationExt;
 use pna::{DataKind, EntryContent, NormalEntry, ReadOptions};
 use same_file::is_same_file;
-#[cfg(unix)]
 use std::cmp::Ordering;
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
-#[cfg(unix)]
 use std::time::SystemTime;
-use std::{fmt, fs, io, path::Path};
+use std::{collections::BTreeMap, fmt, fs, io, path::Path};
 
 #[derive(Parser, Clone, Debug)]
 pub(crate) struct DiffCommand {
@@ -34,16 +29,185 @@ pub(crate) struct DiffCommand {
     password: PasswordArgs,
     #[arg(
         long,
+        conflicts_with = "compare",
         help = "Compare directory mtime and ownership (by default, only mode is compared for directories)"
     )]
     full_compare: bool,
     #[arg(
         long,
+        value_enum,
+        value_delimiter = ',',
+        requires = "unstable",
+        help_heading = "Unstable Options",
+        help = "Compare only selected fields; repeat or separate values with commas",
+        long_help = "Compare only selected fields; repeat or separate values with commas. `default` stands for the fields compared when this option is omitted, and combines with any other value rather than replacing it. Missing paths and file type mismatches are reported regardless of the selection. Naming a field that cannot be compared - unsupported on this platform, or no value recorded in the archive - reports the differences it did find and then exits 2, so a run with both differences and uncomparable fields is indistinguishable from an uncomparable-only run by exit code alone. Conflicts with --full-compare."
+    )]
+    compare: Vec<CompareFieldArg>,
+    #[arg(
+        long,
         default_value = "plain",
         help = "Output format [unstable: jsonl]",
-        long_help = "Output format. plain: tar-style text. jsonl: one JSON Lines record per difference with fields `path`, `kind` (one of: missing, size, content, mode, mtime, uid, gid, type, symlink, hardlink) and, for kind=hardlink only, `target` (the stored link target). mode/mtime/uid/gid comparisons only occur on Unix."
+        long_help = "Output format. plain: GNU tar --diff style text. jsonl: one JSON Lines record per difference with fields `path`, `kind` (one of: missing, size, content, mode, mtime, uid, gid, type, symlink, hardlink) and, for kind=hardlink only, `target` (the stored link target). mode/uid/gid comparisons only occur on Unix."
     )]
     format: Format,
+}
+
+/// A value accepted by `--compare`.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+#[value(rename_all = "lower")]
+enum CompareFieldArg {
+    /// Not a field; adds the default fields.
+    Default,
+    Size,
+    Content,
+    Mtime,
+    Mode,
+    Uid,
+    Gid,
+    Symlink,
+    Hardlink,
+}
+
+impl CompareFieldArg {
+    const fn field(self) -> Option<CompareField> {
+        match self {
+            Self::Default => None,
+            Self::Size => Some(CompareField::Size),
+            Self::Content => Some(CompareField::Content),
+            Self::Mtime => Some(CompareField::Mtime),
+            Self::Mode => Some(CompareField::Mode),
+            Self::Uid => Some(CompareField::Uid),
+            Self::Gid => Some(CompareField::Gid),
+            Self::Symlink => Some(CompareField::Symlink),
+            Self::Hardlink => Some(CompareField::Hardlink),
+        }
+    }
+}
+
+/// An aspect of an entry that can be compared against the filesystem.
+///
+/// Each discriminant is the single bit this field occupies in [`CompareFields`].
+/// `ValueEnum` is derived only for its spelling: diagnostics name a field the
+/// way `--compare` accepts it.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, ValueEnum)]
+#[value(rename_all = "lower")]
+#[repr(u8)]
+enum CompareField {
+    Size = 1 << 0,
+    Content = 1 << 1,
+    Mtime = 1 << 2,
+    Mode = 1 << 3,
+    Uid = 1 << 4,
+    Gid = 1 << 5,
+    Symlink = 1 << 6,
+    Hardlink = 1 << 7,
+}
+
+bitflags! {
+    #[derive(Copy, Clone, Eq, PartialEq, Debug)]
+    struct CompareFields: u8 {
+        const SIZE = CompareField::Size as u8;
+        const CONTENT = CompareField::Content as u8;
+        const MTIME = CompareField::Mtime as u8;
+        const MODE = CompareField::Mode as u8;
+        const UID = CompareField::Uid as u8;
+        const GID = CompareField::Gid as u8;
+        const SYMLINK = CompareField::Symlink as u8;
+        const HARDLINK = CompareField::Hardlink as u8;
+    }
+}
+
+impl CompareField {
+    #[inline]
+    const fn flag(self) -> CompareFields {
+        CompareFields::from_bits_retain(self as u8)
+    }
+
+    #[inline]
+    const fn is_supported(self) -> bool {
+        cfg!(unix) || !matches!(self, Self::Mode | Self::Uid | Self::Gid)
+    }
+}
+
+impl fmt::Display for CompareField {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.to_possible_value().unwrap().get_name())
+    }
+}
+
+/// Why an explicitly requested field could not be compared.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+enum Uncomparable {
+    UnsupportedPlatform,
+    NotRecorded,
+    NotReported,
+}
+
+impl fmt::Display for Uncomparable {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::UnsupportedPlatform => "unsupported on this platform",
+            Self::NotRecorded => "not recorded in the archive",
+            Self::NotReported => "not reported by the filesystem",
+        })
+    }
+}
+
+/// Explicitly requested fields that turned out not to be comparable.
+///
+/// A field the user named by hand is a demand, so failing to compare it must not
+/// pass as "no difference". Fields reached through the default profile stay
+/// best-effort: [`Self::record_entry`] ignores them.
+#[derive(Debug)]
+struct UncomparedFields {
+    requested: CompareFields,
+    /// Value is the first entry path that hit this and how many entries did.
+    /// `None` for a platform-level failure, which is tied to no entry.
+    seen: BTreeMap<(CompareField, Uncomparable), Option<(String, usize)>>,
+}
+
+impl UncomparedFields {
+    fn new(requested: CompareFields) -> Self {
+        Self {
+            requested,
+            seen: BTreeMap::new(),
+        }
+    }
+
+    fn record_platform(&mut self, field: CompareField) {
+        self.seen
+            .insert((field, Uncomparable::UnsupportedPlatform), None);
+    }
+
+    fn record_entry(&mut self, field: CompareField, reason: Uncomparable, path: &str) {
+        if !self.requested.contains(field.flag()) {
+            return;
+        }
+        self.seen
+            .entry((field, reason))
+            .or_insert(None)
+            .get_or_insert_with(|| (path.to_owned(), 0))
+            .1 += 1;
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.seen.is_empty()
+    }
+}
+
+impl fmt::Display for UncomparedFields {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("cannot compare the requested field(s):")?;
+        for ((field, reason), occurrences) in &self.seen {
+            write!(f, "\n  {field}: {reason}")?;
+            if let Some((path, count)) = occurrences {
+                write!(f, " ({count} entries, e.g. {path})")?;
+            }
+        }
+        Ok(())
+    }
 }
 
 #[derive(Copy, Clone, Debug, ValueEnum)]
@@ -87,12 +251,14 @@ fn diff_archive(ctx: &crate::cli::GlobalContext, args: DiffCommand) -> anyhow::R
             args.format
         );
     }
+    let (options, mut uncompared) =
+        CompareOptions::new(args.compare, args.full_compare, args.format);
+    if options.compares_nothing() {
+        // Nothing survives to compare, so fail before prompting for a password.
+        anyhow::bail!("{uncompared}");
+    }
     let password = ask_password(args.password)?;
     let archives = collect_split_archives(&args.archive.file)?;
-    let options = CompareOptions {
-        full_compare: args.full_compare,
-        format: args.format,
-    };
 
     let mut globs = BsdGlobMatcher::new(args.files.files.iter().map(|s| s.as_str()));
     let filter_enabled = !globs.is_empty();
@@ -111,18 +277,23 @@ fn diff_archive(ctx: &crate::cli::GlobalContext, args: DiffCommand) -> anyhow::R
                 return Ok(());
             }
 
-            diff_count += compare_entry(entry, &read_options, &options)?;
+            diff_count += compare_entry(entry, &read_options, &options, &mut uncompared)?;
             Ok(())
         },
     )?;
 
     globs.ensure_all_matched()?;
 
+    // Differences found are already on stdout, so failing here loses no output.
+    if !uncompared.is_empty() {
+        anyhow::bail!("{uncompared}");
+    }
+
     Ok(diff_count)
 }
 
 /// Difference types detected during archive-filesystem comparison.
-/// Message format follows tar --diff for compatibility.
+/// Message format follows GNU tar --diff for compatibility.
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
 #[serde(tag = "kind")]
 enum DiffKind {
@@ -140,7 +311,6 @@ enum DiffKind {
     #[serde(rename = "mode")]
     ModeDiffers,
     /// Modification time differs
-    #[cfg(unix)]
     #[serde(rename = "mtime")]
     MtimeDiffers,
     /// User ID differs
@@ -206,7 +376,6 @@ impl fmt::Display for DiffMessage<'_> {
             DiffKind::ContentsDiffer => write!(f, "{}: Contents differ", self.path),
             #[cfg(unix)]
             DiffKind::ModeDiffers => write!(f, "{}: Mode differs", self.path),
-            #[cfg(unix)]
             DiffKind::MtimeDiffers => write!(f, "{}: Mod time differs", self.path),
             #[cfg(unix)]
             DiffKind::UidDiffers => write!(f, "{}: Uid differs", self.path),
@@ -219,126 +388,154 @@ impl fmt::Display for DiffMessage<'_> {
     }
 }
 
-/// Options controlling what aspects to compare.
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 struct CompareOptions {
-    /// Compare directory mtime and ownership (not just mode)
-    #[cfg_attr(not(unix), allow(dead_code))]
+    default_profile: bool,
+    /// Fields named explicitly on the command line, with the fields unsupported
+    /// on this platform already dropped.
+    fields: CompareFields,
     full_compare: bool,
     format: Format,
 }
 
-#[cfg(unix)]
+impl CompareOptions {
+    fn new(
+        compare: Vec<CompareFieldArg>,
+        full_compare: bool,
+        format: Format,
+    ) -> (Self, UncomparedFields) {
+        let default_profile = compare.is_empty() || compare.contains(&CompareFieldArg::Default);
+        let named = compare.iter().filter_map(|arg| arg.field());
+        let fields = named
+            .clone()
+            .filter(|field| field.is_supported())
+            .fold(CompareFields::empty(), |acc, field| acc | field.flag());
+        let mut uncompared = UncomparedFields::new(fields);
+        for field in named.filter(|field| !field.is_supported()) {
+            uncompared.record_platform(field);
+        }
+        (
+            Self {
+                default_profile,
+                fields,
+                full_compare,
+                format,
+            },
+            uncompared,
+        )
+    }
+
+    #[inline]
+    fn enabled(&self, field: CompareField, data_kind: DataKind) -> bool {
+        self.fields.contains(field.flag()) || self.default_enabled(field, data_kind)
+    }
+
+    fn default_enabled(&self, field: CompareField, data_kind: DataKind) -> bool {
+        if !self.default_profile || !field.is_supported() {
+            return false;
+        }
+        match field {
+            CompareField::Size | CompareField::Content => data_kind == DataKind::FILE,
+            CompareField::Symlink => data_kind == DataKind::SYMBOLIC_LINK,
+            CompareField::Hardlink => data_kind == DataKind::HARD_LINK,
+            CompareField::Mode => matches!(data_kind, DataKind::FILE | DataKind::DIRECTORY),
+            CompareField::Mtime | CompareField::Uid | CompareField::Gid => {
+                data_kind == DataKind::FILE
+                    || (data_kind == DataKind::DIRECTORY && self.full_compare)
+            }
+        }
+    }
+
+    /// True when every explicitly named field was dropped as unsupported on this
+    /// platform, leaving nothing to compare.
+    #[inline]
+    fn compares_nothing(&self) -> bool {
+        !self.default_profile && self.fields.is_empty()
+    }
+}
+
 fn matches_at_stored_precision(archived: pna::Duration, fs: SystemTime) -> bool {
     fs.try_duration_since_unix_epoch_signed()
         .is_ok_and(|fs| cmp_at_stored_precision(archived, fs) == Ordering::Equal)
 }
 
-/// Compare file metadata and return list of differences.
-#[cfg(unix)]
-fn compare_file_metadata<T: AsRef<[u8]>>(
+fn compare_metadata<T: AsRef<[u8]>>(
     entry: &NormalEntry<T>,
     fs_meta: &fs::Metadata,
-    _options: &CompareOptions,
-) -> Vec<DiffKind> {
-    let mut diffs = Vec::new();
-    let ownership = crate::ext::ResolvedOwnership::from_metadata(entry.metadata());
-
-    if let Some(mode) = ownership.mode {
-        let archive_mode = mode & 0o7777;
-        let fs_mode = (fs_meta.permissions().mode() & 0o7777) as u16;
-        if archive_mode != fs_mode {
-            diffs.push(DiffKind::ModeDiffers);
-        }
-    }
-
-    if let Some(archive_mtime) = entry.metadata().modified()
-        && let Ok(fs_mtime) = fs_meta.modified()
-        && !matches_at_stored_precision(archive_mtime, fs_mtime)
-    {
-        diffs.push(DiffKind::MtimeDiffers);
-    }
-
-    if let Some(uid) = ownership.uid
-        && uid != fs_meta.uid() as u64
-    {
-        diffs.push(DiffKind::UidDiffers);
-    }
-    if let Some(gid) = ownership.gid
-        && gid != fs_meta.gid() as u64
-    {
-        diffs.push(DiffKind::GidDiffers);
-    }
-
-    diffs
-}
-
-#[cfg(not(unix))]
-fn compare_file_metadata<T: AsRef<[u8]>>(
-    _entry: &NormalEntry<T>,
-    _fs_meta: &fs::Metadata,
-    _options: &CompareOptions,
-) -> Vec<DiffKind> {
-    Vec::new()
-}
-
-/// Compare directory metadata and return list of differences.
-/// By default only compares mode. With full_compare, also checks mtime and ownership.
-#[cfg(unix)]
-fn compare_directory_metadata<T: AsRef<[u8]>>(
-    entry: &NormalEntry<T>,
-    fs_meta: &fs::Metadata,
+    data_kind: DataKind,
     options: &CompareOptions,
+    uncompared: &mut UncomparedFields,
 ) -> Vec<DiffKind> {
+    let path = entry.header().path().as_str();
+    let mut missing =
+        |field: CompareField, reason: Uncomparable| uncompared.record_entry(field, reason, path);
     let mut diffs = Vec::new();
-    let ownership = crate::ext::ResolvedOwnership::from_metadata(entry.metadata());
+    // Resolving ownership allocates owner name and SID strings that are never
+    // compared here, so only pay for it when an ownership field is enabled.
+    #[cfg(unix)]
+    let ownership = if options.enabled(CompareField::Mode, data_kind)
+        || options.enabled(CompareField::Uid, data_kind)
+        || options.enabled(CompareField::Gid, data_kind)
+    {
+        crate::ext::ResolvedOwnership::from_metadata(entry.metadata())
+    } else {
+        crate::ext::ResolvedOwnership::default()
+    };
 
-    // Always compare mode for directories
-    if let Some(mode) = ownership.mode {
-        let archive_mode = mode & 0o7777;
-        let fs_mode = (fs_meta.permissions().mode() & 0o7777) as u16;
-        if archive_mode != fs_mode {
-            diffs.push(DiffKind::ModeDiffers);
+    #[cfg(unix)]
+    if options.enabled(CompareField::Mode, data_kind) {
+        match ownership.mode {
+            Some(mode) => {
+                let archive_mode = mode & 0o7777;
+                let fs_mode = (fs_meta.permissions().mode() & 0o7777) as u16;
+                if archive_mode != fs_mode {
+                    diffs.push(DiffKind::ModeDiffers);
+                }
+            }
+            None => missing(CompareField::Mode, Uncomparable::NotRecorded),
         }
     }
 
-    // Only compare mtime and ownership with --full-compare
-    if options.full_compare {
-        if let Some(archive_mtime) = entry.metadata().modified()
-            && let Ok(fs_mtime) = fs_meta.modified()
-            && !matches_at_stored_precision(archive_mtime, fs_mtime)
-        {
-            diffs.push(DiffKind::MtimeDiffers);
+    if options.enabled(CompareField::Mtime, data_kind) {
+        match entry.metadata().modified() {
+            Some(archive_mtime) => match fs_meta.modified() {
+                Ok(fs_mtime) => {
+                    if !matches_at_stored_precision(archive_mtime, fs_mtime) {
+                        diffs.push(DiffKind::MtimeDiffers);
+                    }
+                }
+                Err(_) => missing(CompareField::Mtime, Uncomparable::NotReported),
+            },
+            None => missing(CompareField::Mtime, Uncomparable::NotRecorded),
         }
+    }
 
-        if let Some(uid) = ownership.uid
-            && uid != fs_meta.uid() as u64
-        {
-            diffs.push(DiffKind::UidDiffers);
+    #[cfg(unix)]
+    if options.enabled(CompareField::Uid, data_kind) {
+        match ownership.uid {
+            Some(uid) if uid != fs_meta.uid() as u64 => diffs.push(DiffKind::UidDiffers),
+            Some(_) => {}
+            None => missing(CompareField::Uid, Uncomparable::NotRecorded),
         }
-        if let Some(gid) = ownership.gid
-            && gid != fs_meta.gid() as u64
-        {
-            diffs.push(DiffKind::GidDiffers);
+    }
+
+    #[cfg(unix)]
+    if options.enabled(CompareField::Gid, data_kind) {
+        match ownership.gid {
+            Some(gid) if gid != fs_meta.gid() as u64 => diffs.push(DiffKind::GidDiffers),
+            Some(_) => {}
+            None => missing(CompareField::Gid, Uncomparable::NotRecorded),
         }
     }
 
     diffs
-}
-
-#[cfg(not(unix))]
-fn compare_directory_metadata<T: AsRef<[u8]>>(
-    _entry: &NormalEntry<T>,
-    _fs_meta: &fs::Metadata,
-    _options: &CompareOptions,
-) -> Vec<DiffKind> {
-    Vec::new()
 }
 
 fn compare_entry<T: AsRef<[u8]>>(
     entry: NormalEntry<T>,
     read_options: &ReadOptions,
     options: &CompareOptions,
+    uncompared: &mut UncomparedFields,
 ) -> io::Result<usize> {
     let data_kind = entry.header().data_kind();
     let path = entry.header().path();
@@ -351,73 +548,241 @@ fn compare_entry<T: AsRef<[u8]>>(
         }
         Err(e) => return Err(e),
     };
-    let mut diff_count = 0usize;
-    match data_kind {
-        DataKind::FILE if meta.is_file() => {
-            let meta_diffs = compare_file_metadata(&entry, &meta, options);
-            diff_count += meta_diffs.len();
-            for diff in &meta_diffs {
-                report(diff, path_str, options.format);
-            }
 
-            let fs_size = meta.len();
-            let archive_size = entry.metadata().raw_file_size();
-            if archive_size.is_some_and(|s| s != fs_size as u128) {
-                report(&DiffKind::SizeDiffers, path_str, options.format);
-                diff_count += 1;
-            } else {
-                let fs_file = fs::File::open(path)?;
-                let archive_reader = entry.reader(read_options)?;
-                if !streams_equal(fs_file, archive_reader)? {
-                    report(&DiffKind::ContentsDiffer, path_str, options.format);
-                    diff_count += 1;
+    let type_matches = match data_kind {
+        DataKind::FILE => meta.is_file(),
+        DataKind::DIRECTORY => meta.is_dir(),
+        DataKind::SYMBOLIC_LINK => meta.is_symlink(),
+        DataKind::HARD_LINK => meta.is_file(),
+        _ => false,
+    };
+    if !type_matches {
+        report(&DiffKind::TypeMismatch, path_str, options.format);
+        return Ok(1);
+    }
+
+    // Report metadata differences before touching the entry data, so that an I/O
+    // failure while reading it cannot swallow what has already been found.
+    let meta_diffs = compare_metadata(&entry, &meta, data_kind, options, uncompared);
+    for diff in &meta_diffs {
+        report(diff, path_str, options.format);
+    }
+    let mut diff_count = meta_diffs.len();
+
+    if let Some(diff) = compare_data(
+        &entry,
+        &meta,
+        path,
+        data_kind,
+        read_options,
+        options,
+        uncompared,
+    )? {
+        report(&diff, path_str, options.format);
+        diff_count += 1;
+    }
+    Ok(diff_count)
+}
+
+fn compare_data<T: AsRef<[u8]>>(
+    entry: &NormalEntry<T>,
+    fs_meta: &fs::Metadata,
+    path: &pna::EntryName,
+    data_kind: DataKind,
+    read_options: &ReadOptions,
+    options: &CompareOptions,
+    uncompared: &mut UncomparedFields,
+) -> io::Result<Option<DiffKind>> {
+    match data_kind {
+        DataKind::FILE => {
+            if options.enabled(CompareField::Size, data_kind) {
+                // fSIZ is a recorded size, not a measured one, so it settles the
+                // question only when the caller asked about size.
+                match entry.metadata().raw_file_size() {
+                    Some(archive_size) if archive_size != fs_meta.len() as u128 => {
+                        return Ok(Some(DiffKind::SizeDiffers));
+                    }
+                    Some(_) => {}
+                    None => uncompared.record_entry(
+                        CompareField::Size,
+                        Uncomparable::NotRecorded,
+                        path.as_str(),
+                    ),
                 }
             }
-        }
-        DataKind::DIRECTORY if meta.is_dir() => {
-            let diffs = compare_directory_metadata(&entry, &meta, options);
-            diff_count += diffs.len();
-            for diff in &diffs {
-                report(diff, path_str, options.format);
+            if options.enabled(CompareField::Content, data_kind)
+                && !streams_equal(fs::File::open(path)?, entry.reader(read_options)?)?
+            {
+                return Ok(Some(DiffKind::ContentsDiffer));
             }
+            Ok(None)
         }
-        DataKind::SYMBOLIC_LINK if meta.is_symlink() => {
+        DataKind::SYMBOLIC_LINK if options.enabled(CompareField::Symlink, data_kind) => {
             let link = fs::read_link(path)?;
             let EntryContent::SymbolicLink(stored) = entry.content(read_options)? else {
                 unreachable!("data_kind() returned SymbolicLink");
             };
-            if link.as_path() != Path::new(stored.as_str()) {
-                report(&DiffKind::SymlinkDiffers, path_str, options.format);
-                diff_count += 1;
-            }
+            Ok((link.as_path() != Path::new(stored.as_str())).then_some(DiffKind::SymlinkDiffers))
         }
-        DataKind::HARD_LINK if meta.is_file() => {
+        DataKind::HARD_LINK if options.enabled(CompareField::Hardlink, data_kind) => {
             let EntryContent::HardLink(stored) = entry.content(read_options)? else {
                 unreachable!("data_kind() returned HardLink");
             };
             match is_same_file(path, stored.as_str()) {
-                Ok(true) => (),
-                Ok(false) => {
-                    report(
-                        &DiffKind::NotLinked {
-                            target: stored.to_string(),
-                        },
-                        path_str,
-                        options.format,
-                    );
-                    diff_count += 1;
-                }
-                Err(e) if e.kind() == io::ErrorKind::NotFound => {
-                    report(&DiffKind::Missing, path_str, options.format);
-                    diff_count += 1;
-                }
-                Err(e) => return Err(e),
+                Ok(true) => Ok(None),
+                Ok(false) => Ok(Some(DiffKind::NotLinked {
+                    target: stored.to_string(),
+                })),
+                Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(Some(DiffKind::Missing)),
+                Err(e) => Err(e),
             }
         }
-        _ => {
-            report(&DiffKind::TypeMismatch, path_str, options.format);
-            diff_count += 1;
+        _ => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn options(compare: &[CompareFieldArg], full_compare: bool) -> CompareOptions {
+        CompareOptions::new(compare.to_vec(), full_compare, Format::Plain).0
+    }
+
+    #[test]
+    fn default_profile_compares_size_and_content_for_files_only() {
+        let o = options(&[], false);
+        for field in [CompareField::Size, CompareField::Content] {
+            assert!(o.enabled(field, DataKind::FILE));
+            assert!(!o.enabled(field, DataKind::DIRECTORY));
+            assert!(!o.enabled(field, DataKind::SYMBOLIC_LINK));
+            assert!(!o.enabled(field, DataKind::HARD_LINK));
         }
     }
-    Ok(diff_count)
+
+    #[test]
+    fn default_profile_compares_link_targets_for_matching_kind_only() {
+        let o = options(&[], false);
+        assert!(o.enabled(CompareField::Symlink, DataKind::SYMBOLIC_LINK));
+        assert!(!o.enabled(CompareField::Symlink, DataKind::HARD_LINK));
+        assert!(o.enabled(CompareField::Hardlink, DataKind::HARD_LINK));
+        assert!(!o.enabled(CompareField::Hardlink, DataKind::SYMBOLIC_LINK));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn default_profile_compares_directory_mode_without_full_compare() {
+        let o = options(&[], false);
+        assert!(o.enabled(CompareField::Mode, DataKind::FILE));
+        assert!(o.enabled(CompareField::Mode, DataKind::DIRECTORY));
+    }
+
+    #[test]
+    fn default_profile_compares_directory_mtime_only_with_full_compare() {
+        assert!(!options(&[], false).enabled(CompareField::Mtime, DataKind::DIRECTORY));
+        assert!(options(&[], true).enabled(CompareField::Mtime, DataKind::DIRECTORY));
+        assert!(options(&[], false).enabled(CompareField::Mtime, DataKind::FILE));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn default_profile_compares_directory_ownership_only_with_full_compare() {
+        for field in [CompareField::Uid, CompareField::Gid] {
+            assert!(!options(&[], false).enabled(field, DataKind::DIRECTORY));
+            assert!(options(&[], true).enabled(field, DataKind::DIRECTORY));
+            assert!(options(&[], false).enabled(field, DataKind::FILE));
+        }
+    }
+
+    #[test]
+    fn mtime_is_compared_on_every_platform() {
+        assert!(CompareField::Mtime.is_supported());
+        assert!(options(&[], false).enabled(CompareField::Mtime, DataKind::FILE));
+    }
+
+    #[test]
+    fn explicit_field_suppresses_the_default_profile() {
+        let o = options(&[CompareFieldArg::Size], false);
+        assert!(o.enabled(CompareField::Size, DataKind::FILE));
+        assert!(!o.enabled(CompareField::Content, DataKind::FILE));
+        assert!(!o.enabled(CompareField::Symlink, DataKind::SYMBOLIC_LINK));
+    }
+
+    #[test]
+    fn default_value_adds_the_default_profile_to_explicit_fields() {
+        let o = options(&[CompareFieldArg::Default, CompareFieldArg::Mtime], false);
+        assert!(o.enabled(CompareField::Content, DataKind::FILE));
+        assert!(o.enabled(CompareField::Mtime, DataKind::DIRECTORY));
+    }
+
+    #[test]
+    fn default_value_alone_is_the_same_as_omitting_the_option() {
+        let explicit = options(&[CompareFieldArg::Default], false);
+        let implicit = options(&[], false);
+        for field in [
+            CompareField::Size,
+            CompareField::Content,
+            CompareField::Mtime,
+            CompareField::Mode,
+            CompareField::Uid,
+            CompareField::Gid,
+            CompareField::Symlink,
+            CompareField::Hardlink,
+        ] {
+            for kind in [
+                DataKind::FILE,
+                DataKind::DIRECTORY,
+                DataKind::SYMBOLIC_LINK,
+                DataKind::HARD_LINK,
+            ] {
+                assert_eq!(
+                    explicit.enabled(field, kind),
+                    implicit.enabled(field, kind),
+                    "{field:?} on {kind:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn repeated_fields_are_stored_once() {
+        let o = options(&[CompareFieldArg::Size, CompareFieldArg::Size], false);
+        assert_eq!(o.fields, CompareFields::SIZE);
+    }
+
+    #[test]
+    fn omitting_the_option_compares_something() {
+        assert!(!options(&[], false).compares_nothing());
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn unsupported_fields_are_dropped_and_leave_nothing_to_compare() {
+        let o = options(&[CompareFieldArg::Uid], false);
+        assert!(o.fields.is_empty());
+        assert!(o.compares_nothing());
+    }
+
+    #[test]
+    fn uncompared_fields_is_empty_until_something_is_recorded() {
+        let mut uncompared = UncomparedFields::new(CompareFields::empty());
+        assert!(uncompared.is_empty());
+        uncompared.record_platform(CompareField::Uid);
+        assert!(!uncompared.is_empty());
+    }
+
+    #[test]
+    fn uncompared_fields_counts_entries_and_keeps_the_first_path() {
+        let mut uncompared = UncomparedFields::new(CompareFields::SIZE);
+        uncompared.record_entry(CompareField::Size, Uncomparable::NotRecorded, "a.txt");
+        uncompared.record_entry(CompareField::Size, Uncomparable::NotRecorded, "b.txt");
+        uncompared.record_platform(CompareField::Uid);
+
+        assert_eq!(
+            uncompared.to_string(),
+            "cannot compare the requested field(s):\n  \
+             size: not recorded in the archive (2 entries, e.g. a.txt)\n  \
+             uid: unsupported on this platform"
+        );
+    }
 }

--- a/cli/tests/cli/diff.rs
+++ b/cli/tests/cli/diff.rs
@@ -6,6 +6,7 @@ mod metadata;
 mod missing;
 mod multipart;
 mod no_diff;
+mod option_compare;
 mod option_format;
 mod path_filter;
 mod solid_archive;

--- a/cli/tests/cli/diff/option_compare.rs
+++ b/cli/tests/cli/diff/option_compare.rs
@@ -1,0 +1,466 @@
+use crate::utils::{EmbedExt, TestResources, setup};
+use assert_cmd::cargo::cargo_bin_cmd;
+use clap::Parser;
+use portable_network_archive::cli;
+use predicates::prelude::*;
+use std::fs;
+
+/// Lays out `store.pna`, which predates the fSIZ chunk, next to the tree it was
+/// built from, so that diff resolves every entry instead of reporting it missing.
+fn place_archive_without_recorded_sizes(dir: &str) -> &str {
+    let _ = fs::remove_dir_all(dir);
+    TestResources::extract_in("raw/", dir).unwrap();
+    TestResources::extract_in("store.pna", dir).unwrap();
+    dir
+}
+
+/// Archives a file, then rewrites it either at its original length or longer.
+fn create_archive_with_resized_file(dir: &str, resized: bool) -> (String, String) {
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let file_path = format!("{dir}/file.txt");
+    fs::write(&file_path, "old-a").unwrap();
+
+    let archive_path = format!("{dir}/test.pna");
+    cargo_bin_cmd!("pna")
+        .args(["create", "-f", &archive_path, "--overwrite", &file_path])
+        .assert()
+        .success();
+
+    let updated = if resized {
+        "a much longer content"
+    } else {
+        "new-a"
+    };
+    fs::write(&file_path, updated).unwrap();
+
+    (archive_path, file_path)
+}
+
+/// Archives a directory and the file inside it, then changes both the file
+/// content and the directory mtime.
+fn create_archive_with_retimed_directory(dir: &str) -> (String, String) {
+    use std::time::{Duration, SystemTime};
+
+    let _ = fs::remove_dir_all(dir);
+    let subdir = format!("{dir}/subdir");
+    fs::create_dir_all(&subdir).unwrap();
+
+    let file_path = format!("{subdir}/file.txt");
+    fs::write(&file_path, "old-a").unwrap();
+
+    let archive_path = format!("{dir}/test.pna");
+    cargo_bin_cmd!("pna")
+        .args([
+            "create",
+            "-f",
+            &archive_path,
+            "--overwrite",
+            "--keep-timestamp",
+            "--keep-dir",
+            &subdir,
+        ])
+        .assert()
+        .success();
+
+    fs::write(&file_path, "new-a").unwrap();
+    let new_mtime = SystemTime::UNIX_EPOCH + Duration::from_secs(86400);
+    filetime::set_file_mtime(&subdir, filetime::FileTime::from_system_time(new_mtime)).unwrap();
+
+    (archive_path, file_path)
+}
+
+/// Precondition: Archive contains a file whose content changed without changing its size.
+/// Action: Run diff with `--compare size`.
+/// Expectation: The content difference is not reported, because size was the only selected field.
+#[test]
+fn diff_with_compare_size_ignores_content() {
+    setup();
+    let (archive_path, _) =
+        create_archive_with_resized_file("diff_compare_size_ignores_test", false);
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "diff",
+            "-f",
+            &archive_path,
+            "--compare",
+            "size",
+            "--unstable",
+        ])
+        .assert()
+        .success()
+        .stderr("")
+        .stdout("");
+}
+
+/// Precondition: Archive contains a file that grew on disk.
+/// Action: Run diff with `--compare size`.
+/// Expectation: The size difference is reported.
+#[test]
+fn diff_with_compare_size_detects_size_change() {
+    setup();
+    let (archive_path, _) =
+        create_archive_with_resized_file("diff_compare_size_detects_test", true);
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "diff",
+            "-f",
+            &archive_path,
+            "--compare",
+            "size",
+            "--unstable",
+        ])
+        .assert()
+        .code(1)
+        .stderr("")
+        .stdout(predicate::str::contains("Size differs"));
+}
+
+/// Precondition: Archive contains a file that grew on disk.
+/// Action: Run diff with `--compare content`, leaving size unselected.
+/// Expectation: The difference is reported as a content difference, not a size difference.
+#[test]
+fn diff_with_compare_content_reports_size_change_as_content() {
+    setup();
+    let (archive_path, file_path) =
+        create_archive_with_resized_file("diff_compare_content_substitution_test", true);
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "diff",
+            "-f",
+            &archive_path,
+            "--compare",
+            "content",
+            "--unstable",
+            "--format",
+            "jsonl",
+        ])
+        .assert()
+        .code(1)
+        .stderr("")
+        .stdout(format!(r#"{{"path":"{file_path}","kind":"content"}}"#) + "\n");
+}
+
+/// Precondition: Archive contains a file whose content changed without changing its size.
+/// Action: Run diff with `--compare default`.
+/// Expectation: Output is identical to running diff without `--compare`.
+#[test]
+fn diff_with_compare_default_matches_the_omitted_option() {
+    setup();
+    let (archive_path, _) =
+        create_archive_with_resized_file("diff_compare_default_equivalence_test", false);
+
+    let implicit = cargo_bin_cmd!("pna")
+        .args(["experimental", "diff", "-f", &archive_path])
+        .assert()
+        .code(1)
+        .get_output()
+        .stdout
+        .clone();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "diff",
+            "-f",
+            &archive_path,
+            "--compare",
+            "default",
+            "--unstable",
+        ])
+        .assert()
+        .code(1)
+        .stderr("")
+        .stdout(implicit);
+}
+
+/// Precondition: Archive stores a directory whose mtime changed on disk.
+/// Action: Run diff with `--compare mtime`.
+/// Expectation: The directory mtime difference is reported, which the default profile suppresses.
+#[test]
+fn diff_with_compare_mtime_covers_directories() {
+    setup();
+    let (archive_path, _) =
+        create_archive_with_retimed_directory("diff_compare_directory_mtime_test");
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "diff",
+            "-f",
+            &archive_path,
+            "--compare",
+            "mtime",
+            "--unstable",
+        ])
+        .assert()
+        .code(1)
+        .stderr("")
+        .stdout(predicate::str::contains("Mod time differs"));
+}
+
+/// Precondition: Archive stores a directory whose mtime changed and a file whose content changed.
+/// Action: Run diff with `--compare default,mtime`.
+/// Expectation: The default profile still applies and mtime is compared in addition to it.
+#[test]
+fn diff_with_compare_default_adds_to_the_selected_fields() {
+    setup();
+    let (archive_path, _) =
+        create_archive_with_retimed_directory("diff_compare_default_union_test");
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "diff",
+            "-f",
+            &archive_path,
+            "--compare",
+            "default,mtime",
+            "--unstable",
+        ])
+        .assert()
+        .code(1)
+        .stderr("")
+        .stdout(
+            predicate::str::contains("Contents differ")
+                .and(predicate::str::contains("Mod time differs")),
+        );
+}
+
+/// Precondition: None.
+/// Action: Parse a diff invocation combining `--compare` and `--full-compare`.
+/// Expectation: Parsing fails with a mutual exclusion error.
+#[test]
+fn diff_with_compare_conflicts_with_full_compare() {
+    setup();
+
+    let result = cli::Cli::try_parse_from([
+        "pna",
+        "experimental",
+        "diff",
+        "-f",
+        "dummy.pna",
+        "--compare",
+        "size",
+        "--full-compare",
+        "--unstable",
+    ]);
+
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("cannot be used with"),
+        "expected a mutual exclusion error, got: {err}"
+    );
+}
+
+/// Precondition: None.
+/// Action: Parse a diff invocation using `--compare` without `--unstable`.
+/// Expectation: Parsing fails because the option is gated behind `--unstable`.
+#[test]
+fn diff_with_compare_requires_unstable() {
+    setup();
+
+    let result = cli::Cli::try_parse_from([
+        "pna",
+        "experimental",
+        "diff",
+        "-f",
+        "dummy.pna",
+        "--compare",
+        "size",
+    ]);
+
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("--unstable"),
+        "expected the unstable requirement to be reported, got: {err}"
+    );
+}
+
+/// Precondition: Archive contains a path that no longer exists on disk.
+/// Action: Run diff with `--compare mtime`, which selects neither missing paths nor types.
+/// Expectation: The missing path is still reported, because it is not gated by field selection.
+#[test]
+fn diff_with_compare_still_reports_missing_paths() {
+    setup();
+    let (archive_path, file_path) =
+        create_archive_with_resized_file("diff_compare_missing_test", false);
+    fs::remove_file(&file_path).unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "diff",
+            "-f",
+            &archive_path,
+            "--compare",
+            "mtime",
+            "--unstable",
+        ])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("Cannot stat"));
+}
+
+/// Precondition: Archive contains a file that grew on disk.
+/// Action: Run diff with `--compare uid`, which no non-Unix platform supports.
+/// Expectation: The command fails instead of reporting that nothing differs.
+#[cfg(not(unix))]
+#[test]
+fn diff_with_compare_fails_when_no_field_is_supported() {
+    setup();
+    let (archive_path, _) = create_archive_with_resized_file("diff_compare_unsupported_test", true);
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "diff",
+            "-f",
+            &archive_path,
+            "--compare",
+            "uid",
+            "--unstable",
+        ])
+        .assert()
+        .code(2)
+        .stderr(
+            predicate::str::contains("cannot compare the requested field(s)").and(
+                predicate::str::contains("uid: unsupported on this platform"),
+            ),
+        );
+}
+
+/// Precondition: Archive records no size for its entries, and the files match on disk.
+/// Action: Run diff with `--compare size`.
+/// Expectation: The command fails instead of reporting that nothing differs.
+#[test]
+fn diff_with_compare_size_fails_when_no_size_was_recorded() {
+    setup();
+    let dir = place_archive_without_recorded_sizes("diff_compare_no_recorded_size_test");
+
+    cargo_bin_cmd!("pna")
+        .current_dir(dir)
+        .args([
+            "experimental",
+            "diff",
+            "-f",
+            "store.pna",
+            "--compare",
+            "size",
+            "--unstable",
+        ])
+        .assert()
+        .code(2)
+        .stdout("")
+        .stderr(predicate::str::contains(
+            "size: not recorded in the archive",
+        ));
+}
+
+/// Precondition: Archive records no size for its entries, and the files match on disk.
+/// Action: Run diff without `--compare`.
+/// Expectation: The run succeeds, because the default profile skips what it cannot compare.
+#[test]
+fn diff_without_compare_tolerates_missing_sizes() {
+    setup();
+    let dir = place_archive_without_recorded_sizes("diff_compare_default_tolerates_test");
+
+    cargo_bin_cmd!("pna")
+        .current_dir(dir)
+        .args(["experimental", "diff", "-f", "store.pna"])
+        .assert()
+        .success()
+        .stdout("");
+}
+
+/// Precondition: Archive stores a directory without a modification time.
+/// Action: Run diff with `--compare mtime`.
+/// Expectation: The directory entry is counted as uncomparable, not silently skipped.
+#[test]
+fn diff_with_compare_mtime_fails_on_directory_without_recorded_mtime() {
+    setup();
+    let dir = "diff_compare_directory_no_mtime_test";
+    let _ = fs::remove_dir_all(dir);
+    let subdir = format!("{dir}/subdir");
+    fs::create_dir_all(&subdir).unwrap();
+
+    let archive_path = format!("{dir}/test.pna");
+    cargo_bin_cmd!("pna")
+        .args([
+            "create",
+            "-f",
+            &archive_path,
+            "--overwrite",
+            "--keep-dir",
+            &subdir,
+        ])
+        .assert()
+        .success();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "experimental",
+            "diff",
+            "-f",
+            &archive_path,
+            "--compare",
+            "mtime",
+            "--unstable",
+        ])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains(
+            "mtime: not recorded in the archive",
+        ));
+}
+
+/// Precondition: Archive stores a file's mode, and the file became unreadable on disk.
+/// Action: Run diff without `--compare`, so that reading the contents fails.
+/// Expectation: The mode difference is still reported before the read error aborts the run.
+#[cfg(unix)]
+#[test]
+fn diff_reports_metadata_differences_before_a_read_failure() {
+    use std::os::unix::fs::PermissionsExt;
+
+    setup();
+    // SAFETY: geteuid() only reads the calling process's effective user id.
+    if unsafe { libc::geteuid() } == 0 {
+        return; // root can open a 0o000 file, so the read never fails.
+    }
+
+    let dir = "diff_compare_metadata_before_read_error_test";
+    let _ = fs::remove_dir_all(dir);
+    fs::create_dir_all(dir).unwrap();
+
+    let file_path = format!("{dir}/file.txt");
+    fs::write(&file_path, "content").unwrap();
+    fs::set_permissions(&file_path, fs::Permissions::from_mode(0o644)).unwrap();
+
+    let archive_path = format!("{dir}/test.pna");
+    cargo_bin_cmd!("pna")
+        .args([
+            "create",
+            "-f",
+            &archive_path,
+            "--overwrite",
+            "--keep-permission",
+            &file_path,
+        ])
+        .assert()
+        .success();
+
+    fs::set_permissions(&file_path, fs::Permissions::from_mode(0o000)).unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args(["experimental", "diff", "-f", &archive_path])
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains("Mode differs"));
+}


### PR DESCRIPTION
## Summary
Adds an unstable `--compare` option to `pna diff` that lets users select which fields (size, content, mtime, mode, uid, gid, symlink, hardlink) participate in the comparison, in addition to the existing `--full-compare` flag.

## Notes
- `--compare` requires `--unstable` and conflicts with `--full-compare`.
- Fields unsupported on the current platform (mode/uid/gid outside Unix) are dropped with a warning; if nothing remains to compare, the command errors out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the experimental `--compare` option for selecting diff checks such as size, content, timestamps, permissions, ownership, and links.
  * Added support for combining comparison profiles with individual fields.

* **Bug Fixes**
  * Diff results now explicitly detect mismatched entry types.
  * Missing paths are reported regardless of selected comparison fields.
  * Added validation for unsupported or ineffective selections and conflicts with full comparison mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->