### PR TITLE
:recycle: Take the archive writer factory as FnOnce

### DIFF
--- a/cli/src/command/create.rs
+++ b/cli/src/command/create.rs
@@ -575,7 +575,7 @@ pub(crate) struct CreationContext {
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn create_archive_file<W, F>(
-    mut get_writer: F,
+    get_writer: F,
     CreationContext {
         write_option,
         keep_options,
@@ -591,7 +591,7 @@ pub(crate) fn create_archive_file<W, F>(
 ) -> anyhow::Result<()>
 where
     W: Write,
-    F: FnMut() -> io::Result<W> + Send,
+    F: FnOnce() -> io::Result<W>,
 {
     let option = if solid {
         WriteOptions::store()


### PR DESCRIPTION
## Summary
`create_archive_file` invokes its writer factory exactly once, so the bound is now `FnOnce() -> io::Result<W>` instead of `FnMut() -> io::Result<W> + Send`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Simplified archive creation configuration by allowing a one-time writer setup.
  - Removed unnecessary requirements for writer factories, improving compatibility with more integrations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->