### PR TITLE
:recycle: Drop Send bounds from reader-based extract and update

### DIFF
--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -594,7 +594,7 @@ pub(crate) struct OutputOption<'a> {
 }
 
 pub(crate) fn run_extract_archive_reader<'a, 'p, Provider>(
-    reader: impl IntoIterator<Item = impl Read> + Send,
+    reader: impl IntoIterator<Item = impl Read>,
     files: Vec<String>,
     mut password_provider: Provider,
     args: OutputOption<'a>,
@@ -620,7 +620,7 @@ where
     #[cfg(not(target_family = "wasm"))]
     {
         let (tx, rx) = std::sync::mpsc::channel();
-        rayon::scope_fifo(|s| -> anyhow::Result<()> {
+        rayon::in_place_scope_fifo(|s| -> anyhow::Result<()> {
             if fast_read && !globs.is_empty() {
                 run_process_archive_readers_stoppable(
                     reader,

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -572,7 +572,7 @@ pub(crate) fn run_update_archive<Strategy, W>(
 ) -> anyhow::Result<()>
 where
     Strategy: TransformStrategy,
-    W: io::Write + Send,
+    W: io::Write,
 {
     let (tx, rx) = std::sync::mpsc::channel();
     let context = TransformContext::new(password);
@@ -611,7 +611,7 @@ where
         }
     }
 
-    rayon::scope_fifo(|s| -> anyhow::Result<()> {
+    rayon::in_place_scope_fifo(|s| -> anyhow::Result<()> {
         source.for_each_read_entry(
             |entry| {
                 Strategy::transform(out_archive, &context, entry, |entry| {


### PR DESCRIPTION
## Summary

Drop the `Send` bounds on the archive reader in `run_extract_archive_reader` and the writer in `run_update_archive` by switching their `rayon::scope_fifo` to `rayon::in_place_scope_fifo`. Archive I/O stays on the calling thread; only entry creation is parallel, so neither needs to cross threads.
