### PR TITLE
:recycle: Hand Cow entries from SplitArchiveReader in every build

### DIFF
--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -1694,7 +1694,7 @@ where
 
 // Kept available in memmap builds for non-file sources introduced by the stdio stack.
 #[cfg_attr(feature = "memmap", allow(dead_code))]
-fn run_transform_entries_readers<'p, W, Provider, F, Transform>(
+fn run_transform_entries_readers<'d, 'p, W, Provider, F, Transform>(
     writer: W,
     archives: impl IntoIterator<Item = impl Read>,
     mut password_provider: Provider,
@@ -1704,7 +1704,9 @@ fn run_transform_entries_readers<'p, W, Provider, F, Transform>(
 where
     W: Write,
     Provider: FnMut() -> Option<&'p [u8]>,
-    F: FnMut(io::Result<NormalEntry>) -> io::Result<Option<NormalEntry>>,
+    F: FnMut(
+        io::Result<NormalEntry<Cow<'d, [u8]>>>,
+    ) -> io::Result<Option<NormalEntry<Cow<'d, [u8]>>>>,
     Transform: TransformStrategy,
 {
     let password = password_provider();
@@ -1712,7 +1714,14 @@ where
     let mut out_archive = Archive::write_header(writer)?;
     run_read_entries_readers(
         archives,
-        |entry| Transform::transform(&mut out_archive, &context, entry, &mut processor),
+        |entry| {
+            Transform::transform(
+                &mut out_archive,
+                &context,
+                entry.map(ReadEntry::<Cow<'d, [u8]>>::from),
+                &mut processor,
+            )
+        },
         false,
     )?;
     out_archive.finalize()?;

--- a/cli/src/command/core/archive_source.rs
+++ b/cli/src/command/core/archive_source.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "memmap")]
 use std::borrow::Cow;
 use std::{fs, io};
 
@@ -30,8 +29,8 @@ impl SplitArchiveReader {
     }
 
     #[cfg(not(feature = "memmap"))]
-    pub(crate) fn transform_entries<W, F, S>(
-        &mut self,
+    pub(crate) fn transform_entries<'s, W, F, S>(
+        &'s mut self,
         writer: W,
         password: Option<&[u8]>,
         processor: F,
@@ -39,7 +38,9 @@ impl SplitArchiveReader {
     ) -> anyhow::Result<()>
     where
         W: io::Write,
-        F: FnMut(io::Result<NormalEntry>) -> io::Result<Option<NormalEntry>>,
+        F: FnMut(
+            io::Result<NormalEntry<Cow<'s, [u8]>>>,
+        ) -> io::Result<Option<NormalEntry<Cow<'s, [u8]>>>>,
         S: TransformStrategy,
     {
         super::run_transform_entries_readers(
@@ -76,12 +77,17 @@ impl SplitArchiveReader {
     }
 
     #[cfg(not(feature = "memmap"))]
-    pub(crate) fn for_each_entry(
-        &mut self,
+    pub(crate) fn for_each_entry<'s>(
+        &'s mut self,
         read_options: &ReadOptions,
-        processor: impl FnMut(io::Result<NormalEntry>) -> io::Result<()>,
+        mut processor: impl FnMut(io::Result<NormalEntry<Cow<'s, [u8]>>>) -> io::Result<()>,
     ) -> io::Result<()> {
-        super::run_process_archive_readers(self.files.drain(..), read_options, processor, false)
+        super::run_process_archive_readers(
+            self.files.drain(..),
+            read_options,
+            |entry| processor(entry.map(Into::into)),
+            false,
+        )
     }
 
     #[cfg(feature = "memmap")]
@@ -98,14 +104,14 @@ impl SplitArchiveReader {
     }
 
     #[cfg(not(feature = "memmap"))]
-    pub(crate) fn for_each_read_entry(
-        &mut self,
-        processor: impl FnMut(io::Result<ReadEntry>) -> io::Result<()>,
+    pub(crate) fn for_each_read_entry<'s>(
+        &'s mut self,
+        mut processor: impl FnMut(io::Result<ReadEntry<Cow<'s, [u8]>>>) -> io::Result<()>,
         allow_concatenated_archives: bool,
     ) -> io::Result<()> {
         super::run_read_entries_readers(
             self.files.drain(..),
-            processor,
+            |entry| processor(entry.map(Into::into)),
             allow_concatenated_archives,
         )
     }


### PR DESCRIPTION
## Summary
`SplitArchiveReader::{transform_entries, for_each_entry, for_each_read_entry}` now hand callbacks `NormalEntry<Cow<'s, [u8]>>` / `ReadEntry<Cow<'s, [u8]>>` in both the `memmap` and reader builds, converting reader-sourced entries with the existing move-only `From` impls. Call sites and future trait implementations no longer need feature-dependent entry types.
