### PR TITLE
:sparkles: Read the next archive part from the current stream

### DIFF
--- a/lib/src/archive/read.rs
+++ b/lib/src/archive/read.rs
@@ -12,6 +12,24 @@ use std::{
     mem::swap,
 };
 
+/// Verifies that `next` is the archive that follows `current` as its next part.
+fn verify_next_archive_number(current: &ArchiveHeader, next: &ArchiveHeader) -> io::Result<()> {
+    let expected = current
+        .archive_number
+        .checked_add(1)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "archive number overflow"))?;
+    if expected != next.archive_number {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "next archive number must be {expected} (expected previous + 1, detected: {})",
+                next.archive_number
+            ),
+        ));
+    }
+    Ok(())
+}
+
 impl<R: Read> Archive<R> {
     /// Reads the archive header from the provided reader and returns a new [`Archive`].
     ///
@@ -116,22 +134,32 @@ impl<R: Read> Archive<R> {
     /// Returns an error if an I/O error occurs while reading from the reader.
     #[inline]
     pub fn read_next_archive<OR: Read>(self, reader: OR) -> io::Result<Archive<OR>> {
-        let current_header = self.header;
         let mut next = Archive::<OR>::read_header_with_buffer(reader, self.buf)?;
         next.max_chunk_size = self.max_chunk_size;
-        let next_number = current_header
-            .archive_number
-            .checked_add(1)
-            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "archive number overflow"))?;
-        if next_number != next.header.archive_number {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "next archive number must be {next_number} (expected previous + 1, detected: {})",
-                    next.header.archive_number
-                ),
-            ));
-        }
+        verify_next_archive_number(&self.header, &next.header)?;
+        Ok(next)
+    }
+
+    /// Reads the archive that follows this one on the same reader and returns a new [`Archive`].
+    ///
+    /// Use this when the parts of a split archive arrive on a single stream, such as
+    /// standard input, instead of one reader per part.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an I/O error occurs while reading from the reader.
+    #[inline]
+    pub fn read_next_archive_in_stream(self) -> io::Result<Self> {
+        let Self {
+            inner,
+            header,
+            max_chunk_size,
+            buf,
+            ..
+        } = self;
+        let mut next = Self::read_header_with_buffer(inner, buf)?;
+        next.max_chunk_size = max_chunk_size;
+        verify_next_archive_number(&header, &next.header)?;
         Ok(next)
     }
 }
@@ -511,6 +539,48 @@ mod tests {
         let first = Archive::read_header(&first_bytes[..]).unwrap();
         let next = archive_bytes(ArchiveHeader::new(0, 0, 5));
         let err = first.read_next_archive(&next[..]).err().unwrap();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn read_next_archive_in_stream_reads_the_part_that_follows() {
+        use crate::{Metadata, WriteOptions};
+        use std::{io::Write, num::NonZeroU32};
+
+        let mut bytes = Vec::new();
+        let first = Archive::write_header(&mut bytes).unwrap();
+        let mut second = first.split_to_next_archive(Vec::new()).unwrap();
+        second
+            .write_file(
+                "a".into(),
+                Metadata::new(),
+                WriteOptions::store(),
+                |writer| writer.write_all(b"12345678"),
+            )
+            .unwrap();
+        let second_bytes = second.finalize().unwrap();
+        bytes.extend_from_slice(&second_bytes);
+
+        let mut first = Archive::read_header(&bytes[..]).unwrap();
+        first.set_max_chunk_size(NonZeroU32::new(7).unwrap());
+        assert!(first.entries().next().is_none());
+        assert!(first.has_next_archive());
+
+        let mut second = first.read_next_archive_in_stream().unwrap();
+        assert_eq!(
+            second.entries().next().unwrap().unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    #[test]
+    fn read_next_archive_in_stream_rejects_non_consecutive_number() {
+        let mut bytes = archive_bytes(ArchiveHeader::new(0, 0, 0));
+        bytes.extend_from_slice(&archive_bytes(ArchiveHeader::new(0, 0, 0)));
+
+        let mut first = Archive::read_header(&bytes[..]).unwrap();
+        assert!(first.entries().next().is_none());
+        let err = first.read_next_archive_in_stream().err().unwrap();
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 

--- a/lib/src/archive/read/slice.rs
+++ b/lib/src/archive/read/slice.rs
@@ -1,5 +1,6 @@
 //! Slice-based archive reading for memory-mapped access.
 
+use super::verify_next_archive_number;
 use crate::{
     Archive, Chunk, ChunkType, Entry, NormalEntry, RawChunk, ReadEntry, ReadOptions,
     archive::{ArchiveHeader, read::ExtractSolidEntries},
@@ -140,22 +141,32 @@ impl<'d> Archive<&'d [u8]> {
     /// Returns an error if an I/O error occurs while reading from the bytes.
     #[inline]
     pub fn read_next_archive_from_slice(self, bytes: &[u8]) -> io::Result<Archive<&[u8]>> {
-        let current_header = self.header;
         let mut next = Archive::read_header_from_slice_with_buffer(bytes, self.buf)?;
         next.max_chunk_size = self.max_chunk_size;
-        let next_number = current_header
-            .archive_number
-            .checked_add(1)
-            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "archive number overflow"))?;
-        if next_number != next.header.archive_number {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "next archive number must be {next_number} (expected previous + 1, detected: {})",
-                    next.header.archive_number
-                ),
-            ));
-        }
+        verify_next_archive_number(&self.header, &next.header)?;
+        Ok(next)
+    }
+
+    /// Reads the archive that follows this one in the same bytes and returns a new [`Archive`].
+    ///
+    /// Use this when the parts of a split archive are concatenated in a single byte
+    /// sequence instead of one sequence per part.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an I/O error occurs while reading from the bytes.
+    #[inline]
+    pub fn read_next_archive_in_stream_from_slice(self) -> io::Result<Self> {
+        let Self {
+            inner,
+            header,
+            max_chunk_size,
+            buf,
+            ..
+        } = self;
+        let mut next = Self::read_header_from_slice_with_buffer(inner, buf)?;
+        next.max_chunk_size = max_chunk_size;
+        verify_next_archive_number(&header, &next.header)?;
         Ok(next)
     }
 }
@@ -403,5 +414,53 @@ mod tests {
             second.entries_slice().next().unwrap().unwrap_err().kind(),
             io::ErrorKind::InvalidData
         );
+    }
+
+    #[test]
+    fn next_archive_in_stream_from_slice_reads_the_part_that_follows() {
+        let mut bytes = Vec::new();
+        let first = Archive::write_header(&mut bytes).unwrap();
+        let mut second = first.split_to_next_archive(Vec::new()).unwrap();
+
+        second
+            .write_file(
+                "a".into(),
+                Metadata::new(),
+                WriteOptions::store(),
+                |writer| writer.write_all(b"12345678"),
+            )
+            .unwrap();
+        let second_bytes = second.finalize().unwrap();
+        bytes.extend_from_slice(&second_bytes);
+
+        let mut first = Archive::read_header_from_slice(&bytes).unwrap();
+        first.set_max_chunk_size(NonZeroU32::new(7).unwrap());
+        assert!(first.entries_slice().next().is_none());
+        assert!(first.has_next_archive());
+
+        let mut second = first.read_next_archive_in_stream_from_slice().unwrap();
+        assert_eq!(
+            second.entries_slice().next().unwrap().unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    #[test]
+    fn next_archive_in_stream_from_slice_rejects_non_consecutive_number() {
+        let mut bytes = Vec::new();
+        Archive::write_header(&mut bytes)
+            .unwrap()
+            .finalize()
+            .unwrap();
+        let independent = bytes.clone();
+        bytes.extend_from_slice(&independent);
+
+        let mut first = Archive::read_header_from_slice(&bytes).unwrap();
+        assert!(first.entries_slice().next().is_none());
+        let err = first
+            .read_next_archive_in_stream_from_slice()
+            .err()
+            .unwrap();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 }


### PR DESCRIPTION
`read_next_archive` takes the next part as a separate reader. That covers a split archive stored as one file per part, but not one whose parts arrive back to back on a single stream — standard input, or several parts concatenated into one file. Nothing in the API could advance past the first part in that shape.

## API

```rust
impl<R: Read> Archive<R> {
    pub fn read_next_archive_in_stream(self) -> io::Result<Self>;
}

impl<'d> Archive<&'d [u8]> {
    pub fn read_next_archive_in_stream_from_slice(self) -> io::Result<Self>;
}
```

Both continue past `AEND` into the part that follows, on the reader or in the bytes this archive is already reading. `into_inner` is not a substitute: it yields the remaining input but drops the header this archive was read with and the chunks buffered across the part boundary, so the caller can neither validate the succession nor recover an entry that straddles it.

The slice variant needs its own name because `&[u8]` implements `Read`, so a shared name would make both inherent methods ambiguous on `Archive<&[u8]>`. That is the same reason `read_next_archive_from_slice` exists alongside `read_next_archive`.

## Succession

The consecutive archive number requirement is unchanged, and it is what separates a next part from an unrelated archive: `write_header` stamps number 0, which never matches previous + 1, so an independent archive concatenated after the last part is rejected rather than read as a continuation. No `has_next_archive` gate is needed for that, which keeps the contract identical to `read_next_archive`.

The check moves out of the four entry points into one function in `archive::read`; the error kind and message are unchanged.

## Tests

Per shape, in the module that owns it: continuing to the following part carries the max chunk size over, and a concatenated independent archive is rejected with `InvalidData`.

## Verification

`cargo test --workspace` passes (libpna 498 unit, 125 doc; portable-network-archive 691; pna 25 + 28), as does `cargo test -p portable-network-archive --features memmap` (691). `cargo clippy --workspace --all-targets` and `cargo fmt --all --check` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reading consecutive archive parts directly from the same stream or concatenated data slice.
  * Preserves existing buffering and chunk-size settings when continuing archive reads.

* **Bug Fixes**
  * Added validation to reject archive parts with non-consecutive numbers.
  * Improved handling of chunk-size mismatches, reporting them as invalid data.

* **Tests**
  * Added coverage for consecutive archive reading, number validation, and chunk-size enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->