### PR TITLE
:sparkles: Continue split archives that arrive on a single stream

### DIFF
--- a/cli/src/command/bsdtar.rs
+++ b/cli/src/command/bsdtar.rs
@@ -1137,7 +1137,7 @@ fn run_extract_archive(ctx: &GlobalContext, args: BsdtarCommand) -> anyhow::Resu
         )
     } else {
         run_extract_archive_reader(
-            std::iter::repeat_with(|| io::stdin().lock()),
+            std::iter::once_with(|| io::stdin().lock()),
             files,
             || password.as_deref(),
             out_option,
@@ -1227,7 +1227,7 @@ fn run_list_archive(args: BsdtarCommand) -> anyhow::Result<()> {
         )
     } else {
         crate::command::list::run_list_archive(
-            std::iter::repeat_with(|| io::stdin().lock()),
+            std::iter::once_with(|| io::stdin().lock()),
             password.as_deref(),
             files_globs,
             filter,

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -1343,6 +1343,47 @@ impl TransformStrategy for TransformStrategyKeepSolid {
     }
 }
 
+/// Reports a stream that ends at a part boundary as a missing subsequent archive.
+fn map_missing_next_archive(e: io::Error) -> io::Error {
+    if e.kind() == io::ErrorKind::UnexpectedEof {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            "Archive is split, but no subsequent archives are found",
+        )
+    } else {
+        e
+    }
+}
+
+/// Advances a split archive to its next part, continuing on the current reader
+/// when the provider has no further archive to hand out.
+fn next_archive_part_reader<R: Read>(
+    archive: Archive<R>,
+    next: Option<R>,
+) -> io::Result<Archive<R>> {
+    match next {
+        Some(reader) => archive.read_next_archive(reader),
+        None => archive
+            .read_next_archive_in_stream()
+            .map_err(map_missing_next_archive),
+    }
+}
+
+/// Advances a split archive to its next part, continuing in the current bytes
+/// when the provider has no further archive to hand out.
+#[cfg(feature = "memmap")]
+fn next_archive_part_bytes<'d>(
+    archive: Archive<&'d [u8]>,
+    next: Option<&'d [u8]>,
+) -> io::Result<Archive<&'d [u8]>> {
+    match next {
+        Some(bytes) => archive.read_next_archive_from_slice(bytes),
+        None => archive
+            .read_next_archive_in_stream_from_slice()
+            .map_err(map_missing_next_archive),
+    }
+}
+
 pub(crate) fn run_across_archive_readers<R, F>(
     provider: impl IntoIterator<Item = R>,
     mut processor: F,
@@ -1357,13 +1398,7 @@ where
     loop {
         processor(&mut archive)?;
         if archive.has_next_archive() {
-            let next_reader = iter.next().ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::NotFound,
-                    "Archive is split, but no subsequent archives are found",
-                )
-            })?;
-            archive = archive.read_next_archive(next_reader)?;
+            archive = next_archive_part_reader(archive, iter.next())?;
             continue;
         }
         if !allow_concatenated_archives {
@@ -1395,13 +1430,7 @@ where
             break;
         }
         if archive.has_next_archive() {
-            let next_reader = iter.next().ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::NotFound,
-                    "Archive is split, but no subsequent archives are found",
-                )
-            })?;
-            archive = archive.read_next_archive(next_reader)?;
+            archive = next_archive_part_reader(archive, iter.next())?;
             continue;
         }
         if !allow_concatenated_archives {
@@ -1478,13 +1507,7 @@ where
     loop {
         processor(&mut archive)?;
         if archive.has_next_archive() {
-            let next_reader = iter.next().ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::NotFound,
-                    "Archive is split, but no subsequent archives are found",
-                )
-            })?;
-            archive = archive.read_next_archive_from_slice(next_reader)?;
+            archive = next_archive_part_bytes(archive, iter.next())?;
             continue;
         }
         if !allow_concatenated_archives {
@@ -1553,13 +1576,7 @@ where
             break;
         }
         if archive.has_next_archive() {
-            let next_reader = iter.next().ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::NotFound,
-                    "Archive is split, but no subsequent archives are found",
-                )
-            })?;
-            archive = archive.read_next_archive_from_slice(next_reader)?;
+            archive = next_archive_part_bytes(archive, iter.next())?;
             continue;
         }
         if !allow_concatenated_archives {

--- a/cli/tests/cli/bsdtar.rs
+++ b/cli/tests/cli/bsdtar.rs
@@ -29,6 +29,7 @@ mod option_update;
 mod option_update_strip_components;
 mod option_version;
 mod path_traversal;
+mod split_archive_stdin;
 mod strip_components;
 mod symlink;
 mod unlink_first;

--- a/cli/tests/cli/bsdtar/split_archive_stdin.rs
+++ b/cli/tests/cli/bsdtar/split_archive_stdin.rs
@@ -1,0 +1,96 @@
+#![cfg(not(target_family = "wasm"))]
+
+use crate::utils::setup;
+use assert_cmd::cargo::cargo_bin_cmd;
+use pna::{Archive, Compression, Metadata, WriteOptions};
+use std::cell::RefCell;
+use std::fs;
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::rc::Rc;
+
+/// A part writer that appends to one shared buffer, so the parts of a split
+/// archive land in it back to back, as they do when piped in order.
+#[derive(Clone, Default)]
+struct SharedBuf(Rc<RefCell<Vec<u8>>>);
+
+impl Write for SharedBuf {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.borrow_mut().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Builds a split archive holding `content` under `name`, with the entry data
+/// spanning several parts, and returns every part concatenated in order.
+fn split_archive_stream(name: &str, content: &[u8]) -> Vec<u8> {
+    let buf = SharedBuf::default();
+    let mut archive = Archive::write_split_header(300, {
+        let buf = buf.clone();
+        move |_| Ok(buf.clone())
+    })
+    .unwrap();
+    let options = WriteOptions::builder().compression(Compression::NO).build();
+    archive
+        .write_file(name.into(), Metadata::new(), options, |w| {
+            w.write_all(content)
+        })
+        .unwrap();
+    let parts = archive.finalize().unwrap().parts();
+    assert!(
+        parts > 1,
+        "expected the archive to be split into several parts"
+    );
+    buf.0.borrow().clone()
+}
+
+/// Precondition: Every part of a split archive is piped through stdin, one
+///   after another.
+/// Action: Run bsdtar-compat list reading from stdin.
+/// Expectation: The entry spanning the part boundary is listed, so the reader
+///   walked past the first part instead of stopping at it.
+#[test]
+fn bsdtar_list_reads_split_archive_from_stdin() {
+    setup();
+    let stream = split_archive_stream("split.txt", &[b'x'; 4096]);
+
+    cargo_bin_cmd!("pna")
+        .write_stdin(stream)
+        .args(["compat", "bsdtar", "--unstable", "-tf", "-"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("split.txt"));
+}
+
+/// Precondition: Every part of a split archive is piped through stdin, one
+///   after another.
+/// Action: Run bsdtar-compat extract reading from stdin.
+/// Expectation: The entry spanning the part boundary is restored whole.
+#[test]
+fn bsdtar_extract_reads_split_archive_from_stdin() {
+    setup();
+    let stream = split_archive_stream("split.txt", &[b'x'; 4096]);
+    let base = PathBuf::from("bsdtar_extract_split_archive_from_stdin");
+    fs::create_dir_all(&base).unwrap();
+
+    cargo_bin_cmd!("pna")
+        .write_stdin(stream)
+        .args([
+            "compat",
+            "bsdtar",
+            "--unstable",
+            "--no-xattrs",
+            "--cd",
+            base.to_str().unwrap(),
+            "-xf",
+            "-",
+        ])
+        .assert()
+        .success();
+
+    assert_eq!(fs::read(base.join("split.txt")).unwrap(), vec![b'x'; 4096]);
+}

--- a/cli/tests/cli/multipart.rs
+++ b/cli/tests/cli/multipart.rs
@@ -1,6 +1,7 @@
 use crate::utils::{EmbedExt, TestResources, diff::assert_dirs_equal, setup};
 use clap::Parser;
 use portable_network_archive::cli;
+use std::fs;
 
 #[test]
 fn multipart_archive() {
@@ -38,4 +39,61 @@ fn multipart_archive() {
     .unwrap();
 
     assert_dirs_equal("./multipart_archive/in/", "./multipart_archive/out/");
+}
+
+/// Reads every part of the split archive named `base`, concatenated in order.
+fn concatenated_parts(base: &str) -> Vec<u8> {
+    let mut parts = 0;
+    let mut bytes = Vec::new();
+    while let Ok(part) = fs::read(format!("{base}.part{}.pna", parts + 1)) {
+        bytes.extend(part);
+        parts += 1;
+    }
+    assert!(parts > 1, "expected {base} to be split into several parts");
+    bytes
+}
+
+#[test]
+fn multipart_archive_joined_into_single_file() {
+    setup();
+    TestResources::extract_in("multipart_test.txt", "./multipart_joined/in/").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "./multipart_joined/multipart.pna",
+        "--overwrite",
+        "./multipart_joined/in/multipart_test.txt",
+        "--unstable",
+        "--split",
+        "110",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    fs::write(
+        "./multipart_joined/joined.pna",
+        concatenated_parts("./multipart_joined/multipart"),
+    )
+    .unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "x",
+        "-f",
+        "./multipart_joined/joined.pna",
+        "--overwrite",
+        "--out-dir",
+        "./multipart_joined/out/",
+        "--strip-components",
+        "2",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    assert_dirs_equal("./multipart_joined/in/", "./multipart_joined/out/");
 }


### PR DESCRIPTION
Stacked on #3489, which adds the `read_next_archive_in_stream` pair this uses. Review that one first; the diff here is against it.

Reading a split archive whose parts arrive on one stream failed with `Archive is split, but no subsequent archives are found`, because every traversal took the next part from the archive provider and treated an exhausted provider as a missing part. Piping a split archive into `pna` was therefore impossible, and so was extracting one whose parts had been concatenated into a single file.

## Fallback

When the provider has no further archive to hand out, the traversal now continues in the current stream instead of failing. If the stream really does end at a part boundary, the continuation reports `UnexpectedEof` and that is mapped back to the original `NotFound` message, so a genuinely missing part reads the same as before.

The four traversals — reader and memmap byte, each in its plain and stoppable form — share the two helpers this adds rather than repeating the branch.

## bsdtar stdin

`--extract` and `--list` reading from stdin handed out the same `StdinLock` repeatedly (`repeat_with`) so that each part read would land back on the same stream. That is what the fallback now does properly, so they take stdin once. `once_with` rather than `once`: `run_extract_archive_reader` requires a `Send` provider, and a materialized `StdinLock` is not `Send`.

## Tests

`bsdtar/split_archive_stdin.rs` covers the two call sites this changes: every part of a split archive piped in order, listed with `-tf -` and extracted with `-xf -`, with the entry data spanning a part boundary in both. The fixture writes each part into one shared buffer, so what it returns is the byte sequence a pipe delivers.

`multipart.rs` covers the other shape: parts concatenated into a single file and extracted with `pna x -f`. Under `memmap` that file is a single mmap, which is the only path through the byte traversal's fallback — stdin cannot be mapped.

Each test was checked against the traversal restored to its previous form: all three fail there with `Archive is split, but no subsequent archives are found`, the bsdtar pair under default features and the concatenated-file one under both feature sets.

## Verification

`cargo test --workspace` passes (portable-network-archive 691; libpna 498 unit, 125 doc; pna 25 + 28), as does `cargo test -p portable-network-archive --features memmap` (691). `cargo clippy --workspace --all-targets` and `cargo fmt --all --check` are clean.
