### PR TITLE
:recycle: Centralize archive rewrite execution

### DIFF
--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -9,6 +9,7 @@ pub(crate) mod path_lock;
 mod path_transformer;
 pub(crate) mod permission;
 pub(crate) mod re;
+pub(crate) mod rewrite;
 pub(crate) mod safe_writer;
 mod staged_archive;
 pub(crate) mod time_filter;

--- a/cli/src/command/core/rewrite.rs
+++ b/cli/src/command/core/rewrite.rs
@@ -1,0 +1,57 @@
+use super::{
+    SplitArchiveReader, StagedArchive, TransformStrategyKeepSolid, TransformStrategyUnSolid, Umask,
+    collect_split_archives,
+};
+use crate::{cli::SolidEntriesTransformStrategy, utils::GlobPatterns};
+use pna::NormalEntry;
+use std::{
+    borrow::Cow,
+    io,
+    path::{Path, PathBuf},
+};
+
+/// The per-entry step of a command that rewrites an archive.
+///
+/// Returning `None` drops the entry from the output.
+pub(crate) trait EntryTransform {
+    fn transform<'d>(
+        &mut self,
+        entry: NormalEntry<Cow<'d, [u8]>>,
+    ) -> io::Result<Option<NormalEntry<Cow<'d, [u8]>>>>;
+
+    /// The patterns the run was asked to match, when the command takes any.
+    /// A pattern that matched nothing aborts the rewrite before the original is replaced.
+    fn patterns(&self) -> Option<&GlobPatterns<'_>>;
+}
+
+/// Rewrites `archive` into `output` through `transform`, one entry at a time.
+#[hooq::hooq(anyhow)]
+pub(crate) fn execute_archive_transform(
+    archive: &Path,
+    output: PathBuf,
+    umask: Umask,
+    password: Option<&[u8]>,
+    strategy: SolidEntriesTransformStrategy,
+    mut transform: impl EntryTransform,
+) -> anyhow::Result<()> {
+    let mut source = SplitArchiveReader::new(collect_split_archives(archive)?)?;
+    let mut staged = StagedArchive::new(output, umask)?;
+    match strategy {
+        SolidEntriesTransformStrategy::UnSolid => source.transform_entries(
+            staged.as_file_mut(),
+            password,
+            #[hooq::skip_all]
+            |entry| transform.transform(entry?),
+            TransformStrategyUnSolid,
+        ),
+        SolidEntriesTransformStrategy::KeepSolid => source.transform_entries(
+            staged.as_file_mut(),
+            password,
+            #[hooq::skip_all]
+            |entry| transform.transform(entry?),
+            TransformStrategyKeepSolid,
+        ),
+    }?;
+    drop(source);
+    staged.commit(transform.patterns())
+}

--- a/cli/src/command/migrate.rs
+++ b/cli/src/command/migrate.rs
@@ -1,20 +1,18 @@
 use crate::{
-    cli::{
-        ArchiveFileArgs, PasswordArgs, SolidEntriesTransformStrategy,
-        SolidEntriesTransformStrategyArgs,
-    },
+    cli::{ArchiveFileArgs, PasswordArgs, SolidEntriesTransformStrategyArgs},
     command::{
         Command, ask_password,
         core::{
-            SplitArchiveReader, StagedArchive, TransformStrategyKeepSolid,
-            TransformStrategyUnSolid, Umask, collect_split_archives,
+            Umask,
+            rewrite::{EntryTransform, execute_archive_transform},
         },
     },
     ext::*,
+    utils::GlobPatterns,
 };
 use clap::{Parser, ValueHint};
 use pna::{NormalEntry, RawChunk, prelude::*};
-use std::{io, path::PathBuf};
+use std::{borrow::Cow, io, path::PathBuf};
 
 #[derive(Parser, Clone, Eq, PartialEq, Hash, Debug)]
 pub(crate) struct MigrateCommand {
@@ -38,33 +36,29 @@ impl Command for MigrateCommand {
 #[hooq::hooq(anyhow)]
 fn migrate_metadata(args: MigrateCommand, umask: Umask) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
+    execute_archive_transform(
+        &args.archive.file,
+        args.output,
+        umask,
+        password.as_deref(),
+        args.transform_strategy.strategy(),
+        MigrateTransform,
+    )
+}
 
-    let mut source = SplitArchiveReader::new(collect_split_archives(&args.archive.file)?)?;
+struct MigrateTransform;
 
-    let output_path = args.output;
-    let mut staged = StagedArchive::new(output_path, umask)?;
+impl EntryTransform for MigrateTransform {
+    fn transform<'d>(
+        &mut self,
+        entry: NormalEntry<Cow<'d, [u8]>>,
+    ) -> io::Result<Option<NormalEntry<Cow<'d, [u8]>>>> {
+        convert_entry_to_owner_facet(entry).map(Some)
+    }
 
-    match args.transform_strategy.strategy() {
-        SolidEntriesTransformStrategy::UnSolid => source.transform_entries(
-            staged.as_file_mut(),
-            password.as_deref(),
-            #[hooq::skip_all]
-            |entry| Ok(Some(convert_entry_to_owner_facet(entry?)?)),
-            TransformStrategyUnSolid,
-        ),
-        SolidEntriesTransformStrategy::KeepSolid => source.transform_entries(
-            staged.as_file_mut(),
-            password.as_deref(),
-            #[hooq::skip_all]
-            |entry| Ok(Some(convert_entry_to_owner_facet(entry?)?)),
-            TransformStrategyKeepSolid,
-        ),
-    }?;
-
-    drop(source);
-
-    staged.commit(None)?;
-    Ok(())
+    fn patterns(&self) -> Option<&GlobPatterns<'_>> {
+        None
+    }
 }
 
 #[inline]

--- a/cli/src/command/strip.rs
+++ b/cli/src/command/strip.rs
@@ -1,20 +1,20 @@
 use crate::{
     cli::{
         ArchiveFileArgs, FileOperands, PasswordArgs, PrivateChunkType,
-        SolidEntriesTransformStrategy, SolidEntriesTransformStrategyArgs,
+        SolidEntriesTransformStrategyArgs,
     },
     command::{
         Command, ask_password,
         core::{
-            SplitArchiveReader, StagedArchive, TransformStrategyKeepSolid,
-            TransformStrategyUnSolid, Umask, collect_split_archives,
+            Umask,
+            rewrite::{EntryTransform, execute_archive_transform},
         },
     },
-    utils::PathPartExt,
+    utils::{GlobPatterns, PathPartExt},
 };
 use clap::{Args, Parser, ValueHint};
 use pna::{Metadata, NormalEntry, RawChunk, prelude::*};
-use std::path::PathBuf;
+use std::{borrow::Cow, io, path::PathBuf};
 
 #[derive(Args, Clone, Eq, PartialEq, Hash, Debug)]
 pub(crate) struct StripOptions {
@@ -73,32 +73,30 @@ impl Command for StripCommand {
 fn strip_metadata(args: StripCommand, umask: Umask) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
     let archive = args.archive.file;
-    let mut source = SplitArchiveReader::new(collect_split_archives(&archive)?)?;
-
     let output_path = args.output.unwrap_or_else(|| archive.remove_part());
-    let mut staged = StagedArchive::new(output_path, umask)?;
+    execute_archive_transform(
+        &archive,
+        output_path,
+        umask,
+        password.as_deref(),
+        args.transform_strategy.strategy(),
+        StripTransform(args.strip_options),
+    )
+}
 
-    match args.transform_strategy.strategy() {
-        SolidEntriesTransformStrategy::UnSolid => source.transform_entries(
-            staged.as_file_mut(),
-            password.as_deref(),
-            #[hooq::skip_all]
-            |entry| Ok(Some(strip_entry_metadata(entry?, &args.strip_options))),
-            TransformStrategyUnSolid,
-        ),
-        SolidEntriesTransformStrategy::KeepSolid => source.transform_entries(
-            staged.as_file_mut(),
-            password.as_deref(),
-            #[hooq::skip_all]
-            |entry| Ok(Some(strip_entry_metadata(entry?, &args.strip_options))),
-            TransformStrategyKeepSolid,
-        ),
-    }?;
+struct StripTransform(StripOptions);
 
-    drop(source);
+impl EntryTransform for StripTransform {
+    fn transform<'d>(
+        &mut self,
+        entry: NormalEntry<Cow<'d, [u8]>>,
+    ) -> io::Result<Option<NormalEntry<Cow<'d, [u8]>>>> {
+        Ok(Some(strip_entry_metadata(entry, &self.0)))
+    }
 
-    staged.commit(None)?;
-    Ok(())
+    fn patterns(&self) -> Option<&GlobPatterns<'_>> {
+        None
+    }
 }
 
 #[inline]


### PR DESCRIPTION
## Summary
Add `EntryTransform` and `execute_archive_transform` in `core/rewrite.rs`: one executor opens the split archive, stages the rewrite, dispatches the solid strategy, and commits only after the transform and its selector validation succeed. Commands express just their per-entry step; strip and migrate are migrated first.

Stacked on #3488, whose `Cow` entry types let the trait take `NormalEntry<Cow<'_, [u8]>>` directly instead of a generic `T` with chunk bounds.
