### PR TITLE
:recycle: Migrate ordinary rewrites to the shared executor

### DIFF
--- a/cli/src/command/acl.rs
+++ b/cli/src/command/acl.rs
@@ -1,14 +1,11 @@
 use crate::{
     chunk::{Ace, AcePlatform, Flag, Identifier, OwnerType, Permission},
-    cli::{
-        ArchiveFileArgs, FileOperands, PasswordArgs, SolidEntriesTransformStrategy,
-        SolidEntriesTransformStrategyArgs,
-    },
+    cli::{ArchiveFileArgs, FileOperands, PasswordArgs, SolidEntriesTransformStrategyArgs},
     command::{
         Command, ask_password,
         core::{
-            SplitArchiveReader, StagedArchive, TransformStrategyKeepSolid,
-            TransformStrategyUnSolid, Umask, collect_split_archives,
+            SplitArchiveReader, Umask, collect_split_archives,
+            rewrite::{EntryTransform, execute_archive_transform},
         },
     },
     ext::{Acls, NormalEntryExt},
@@ -25,6 +22,7 @@ use nom::{
 use pna::{Chunk, NormalEntry, RawChunk, ReadOptions};
 use regex::Regex;
 use std::{
+    borrow::Cow,
     collections::{HashMap, HashSet},
     fs, io,
     path::PathBuf,
@@ -342,7 +340,7 @@ fn archive_get_acl(args: GetAclCommand) -> anyhow::Result<()> {
 fn archive_set_acl(args: SetAclCommand, umask: Umask) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
     let files = args.files.files;
-    let mut set_strategy = if args.restore_from_stdin {
+    let set_strategy = if args.restore_from_stdin {
         SetAclsStrategy::Restore(parse_acl_dump(io::stdin().lock())?)
     } else if let Some(path) = args.restore.as_deref() {
         SetAclsStrategy::Restore(parse_acl_dump(io::BufReader::new(fs::File::open(path)?))?)
@@ -359,32 +357,14 @@ fn archive_set_acl(args: SetAclCommand, umask: Umask) -> anyhow::Result<()> {
         }
     };
 
-    let mut source = SplitArchiveReader::new(collect_split_archives(&args.archive.file)?)?;
-
-    let output_path = args.archive.file.remove_part();
-    let mut staged = StagedArchive::new(output_path, umask)?;
-
-    match args.transform_strategy.strategy() {
-        SolidEntriesTransformStrategy::UnSolid => source.transform_entries(
-            staged.as_file_mut(),
-            password.as_deref(),
-            #[hooq::skip_all]
-            |entry| Ok(Some(set_strategy.transform_entry(entry?))),
-            TransformStrategyUnSolid,
-        ),
-        SolidEntriesTransformStrategy::KeepSolid => source.transform_entries(
-            staged.as_file_mut(),
-            password.as_deref(),
-            #[hooq::skip_all]
-            |entry| Ok(Some(set_strategy.transform_entry(entry?))),
-            TransformStrategyKeepSolid,
-        ),
-    }?;
-
-    drop(source);
-
-    staged.commit(set_strategy.globs())?;
-    Ok(())
+    execute_archive_transform(
+        &args.archive.file,
+        args.archive.file.remove_part(),
+        umask,
+        password.as_deref(),
+        args.transform_strategy.strategy(),
+        set_strategy,
+    )
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -465,6 +445,19 @@ impl SetAclsStrategy<'_> {
                 }
             }
         }
+    }
+}
+
+impl EntryTransform for SetAclsStrategy<'_> {
+    fn transform<'d>(
+        &mut self,
+        entry: NormalEntry<Cow<'d, [u8]>>,
+    ) -> io::Result<Option<NormalEntry<Cow<'d, [u8]>>>> {
+        Ok(Some(self.transform_entry(entry)))
+    }
+
+    fn patterns(&self) -> Option<&GlobPatterns<'_>> {
+        self.globs()
     }
 }
 

--- a/cli/src/command/bsdtar.rs
+++ b/cli/src/command/bsdtar.rs
@@ -1550,7 +1550,7 @@ fn run_update(args: BsdtarCommand, umask: Umask) -> anyhow::Result<()> {
     out_archive.finalize()?;
     drop(source);
 
-    staged.commit(None)?;
+    staged.commit()?;
 
     Ok(())
 }

--- a/cli/src/command/chmod.rs
+++ b/cli/src/command/chmod.rs
@@ -1,13 +1,10 @@
 use crate::{
-    cli::{
-        ArchiveFileArgs, PasswordArgs, SolidEntriesTransformStrategy,
-        SolidEntriesTransformStrategyArgs,
-    },
+    cli::{ArchiveFileArgs, PasswordArgs, SolidEntriesTransformStrategyArgs},
     command::{
         Command, ask_password,
         core::{
-            SplitArchiveReader, StagedArchive, TransformStrategyKeepSolid,
-            TransformStrategyUnSolid, Umask, collect_split_archives,
+            Umask,
+            rewrite::{EntryTransform, execute_archive_transform},
         },
     },
     utils::{GlobPatterns, PathPartExt},
@@ -22,7 +19,7 @@ use nom::{
     multi::{many0, many1, separated_list1},
 };
 use pna::{DataKind, NormalEntry};
-use std::{ops::BitOr, str::FromStr};
+use std::{borrow::Cow, io, ops::BitOr, str::FromStr};
 
 #[derive(Parser, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub(crate) struct ChmodCommand {
@@ -51,48 +48,40 @@ fn archive_chmod(args: ChmodCommand, umask: Umask) -> anyhow::Result<()> {
     if args.files.is_empty() {
         return Ok(());
     }
-    let mut globs = GlobPatterns::new(args.files.iter().map(|p| p.as_str()))?;
+    let globs = GlobPatterns::new(args.files.iter().map(|p| p.as_str()))?;
+    execute_archive_transform(
+        &args.archive.file,
+        args.archive.file.remove_part(),
+        umask,
+        password.as_deref(),
+        args.transform_strategy.strategy(),
+        ChmodTransform {
+            globs,
+            mode: args.mode,
+        },
+    )
+}
 
-    let mut source = SplitArchiveReader::new(collect_split_archives(&args.archive.file)?)?;
+struct ChmodTransform<'g> {
+    globs: GlobPatterns<'g>,
+    mode: Mode,
+}
 
-    let output_path = args.archive.file.remove_part();
-    let mut staged = StagedArchive::new(output_path, umask)?;
+impl EntryTransform for ChmodTransform<'_> {
+    fn transform<'d>(
+        &mut self,
+        entry: NormalEntry<Cow<'d, [u8]>>,
+    ) -> io::Result<Option<NormalEntry<Cow<'d, [u8]>>>> {
+        Ok(Some(if self.globs.matches_any(entry.name()) {
+            transform_entry(entry, &self.mode)
+        } else {
+            entry
+        }))
+    }
 
-    match args.transform_strategy.strategy() {
-        SolidEntriesTransformStrategy::UnSolid => source.transform_entries(
-            staged.as_file_mut(),
-            password.as_deref(),
-            #[hooq::skip_all]
-            |entry| {
-                let entry = entry?;
-                if globs.matches_any(entry.name()) {
-                    Ok(Some(transform_entry(entry, &args.mode)))
-                } else {
-                    Ok(Some(entry))
-                }
-            },
-            TransformStrategyUnSolid,
-        ),
-        SolidEntriesTransformStrategy::KeepSolid => source.transform_entries(
-            staged.as_file_mut(),
-            password.as_deref(),
-            #[hooq::skip_all]
-            |entry| {
-                let entry = entry?;
-                if globs.matches_any(entry.name()) {
-                    Ok(Some(transform_entry(entry, &args.mode)))
-                } else {
-                    Ok(Some(entry))
-                }
-            },
-            TransformStrategyKeepSolid,
-        ),
-    }?;
-
-    drop(source);
-
-    staged.commit(Some(&globs))?;
-    Ok(())
+    fn patterns(&self) -> Option<&GlobPatterns<'_>> {
+        Some(&self.globs)
+    }
 }
 
 #[inline]

--- a/cli/src/command/chown.rs
+++ b/cli/src/command/chown.rs
@@ -1,13 +1,10 @@
 use crate::{
-    cli::{
-        ArchiveFileArgs, PasswordArgs, SolidEntriesTransformStrategy,
-        SolidEntriesTransformStrategyArgs,
-    },
+    cli::{ArchiveFileArgs, PasswordArgs, SolidEntriesTransformStrategyArgs},
     command::{
         Command, ask_password,
         core::{
-            SplitArchiveReader, StagedArchive, TransformStrategyKeepSolid,
-            TransformStrategyUnSolid, Umask, collect_split_archives,
+            Umask,
+            rewrite::{EntryTransform, execute_archive_transform},
         },
     },
     utils::{
@@ -17,7 +14,7 @@ use crate::{
 };
 use clap::{ArgAction, Parser, ValueHint, builder::ArgPredicate};
 use pna::NormalEntry;
-use std::{io, ops::Not, str::FromStr};
+use std::{borrow::Cow, io, ops::Not, str::FromStr};
 
 #[derive(Parser, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub(crate) struct ChownCommand {
@@ -58,52 +55,41 @@ fn archive_chown(args: ChownCommand, umask: Umask) -> anyhow::Result<()> {
     if args.files.is_empty() {
         return Ok(());
     }
-    let mut globs = GlobPatterns::new(args.files.iter().map(|p| p.as_ref()))?;
+    let globs = GlobPatterns::new(args.files.iter().map(|p| p.as_ref()))?;
 
     let owner = args
         .owner
         .lookup_platform_owner(args.numeric_owner, args.owner_lookup)?;
+    execute_archive_transform(
+        &args.archive.file,
+        args.archive.file.remove_part(),
+        umask,
+        password.as_deref(),
+        args.transform_strategy.strategy(),
+        ChownTransform { globs, owner },
+    )
+}
 
-    let mut source = SplitArchiveReader::new(collect_split_archives(&args.archive.file)?)?;
+struct ChownTransform<'g> {
+    globs: GlobPatterns<'g>,
+    owner: Ownership,
+}
 
-    let output_path = args.archive.file.remove_part();
-    let mut staged = StagedArchive::new(output_path, umask)?;
+impl EntryTransform for ChownTransform<'_> {
+    fn transform<'d>(
+        &mut self,
+        entry: NormalEntry<Cow<'d, [u8]>>,
+    ) -> io::Result<Option<NormalEntry<Cow<'d, [u8]>>>> {
+        Ok(Some(if self.globs.matches_any(entry.name()) {
+            transform_entry(entry, &self.owner)
+        } else {
+            entry
+        }))
+    }
 
-    match args.transform_strategy.strategy() {
-        SolidEntriesTransformStrategy::UnSolid => source.transform_entries(
-            staged.as_file_mut(),
-            password.as_deref(),
-            #[hooq::skip_all]
-            |entry| {
-                let entry = entry?;
-                if globs.matches_any(entry.name()) {
-                    Ok(Some(transform_entry(entry, &owner)))
-                } else {
-                    Ok(Some(entry))
-                }
-            },
-            TransformStrategyUnSolid,
-        ),
-        SolidEntriesTransformStrategy::KeepSolid => source.transform_entries(
-            staged.as_file_mut(),
-            password.as_deref(),
-            #[hooq::skip_all]
-            |entry| {
-                let entry = entry?;
-                if globs.matches_any(entry.name()) {
-                    Ok(Some(transform_entry(entry, &owner)))
-                } else {
-                    Ok(Some(entry))
-                }
-            },
-            TransformStrategyKeepSolid,
-        ),
-    }?;
-
-    drop(source);
-
-    staged.commit(Some(&globs))?;
-    Ok(())
+    fn patterns(&self) -> Option<&GlobPatterns<'_>> {
+        Some(&self.globs)
+    }
 }
 
 #[inline]

--- a/cli/src/command/core/rewrite.rs
+++ b/cli/src/command/core/rewrite.rs
@@ -53,5 +53,97 @@ pub(crate) fn execute_archive_transform(
         ),
     }?;
     drop(source);
-    staged.commit(transform.patterns())
+    if let Some(patterns) = transform.patterns() {
+        patterns.ensure_all_matched()?;
+    }
+    staged.commit()?;
+    Ok(())
+}
+
+#[cfg(test)]
+#[cfg(not(target_family = "wasm"))]
+mod tests {
+    use super::*;
+    use pna::{Archive, FileEntryBuilder};
+    use std::fs;
+
+    /// Drops every entry so a committed rewrite is distinguishable from the original bytes.
+    struct DropAll<'s>(GlobPatterns<'s>);
+
+    impl EntryTransform for DropAll<'_> {
+        fn transform<'d>(
+            &mut self,
+            entry: NormalEntry<Cow<'d, [u8]>>,
+        ) -> io::Result<Option<NormalEntry<Cow<'d, [u8]>>>> {
+            self.0.matches_any(entry.name());
+            Ok(None)
+        }
+
+        fn patterns(&self) -> Option<&GlobPatterns<'_>> {
+            Some(&self.0)
+        }
+    }
+
+    fn test_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join("pna_rewrite_test").join(name);
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write_archive(path: &Path) -> Vec<u8> {
+        let mut archive = Archive::write_header(Vec::new()).unwrap();
+        archive
+            .add_entry(
+                FileEntryBuilder::new("present.txt".into())
+                    .unwrap()
+                    .build()
+                    .unwrap(),
+            )
+            .unwrap();
+        let bytes = archive.finalize().unwrap();
+        fs::write(path, &bytes).unwrap();
+        bytes
+    }
+
+    fn entries_beside(dir: &Path, archive: &str) -> Vec<String> {
+        fs::read_dir(dir)
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name().to_string_lossy().into_owned())
+            .filter(|name| name != archive)
+            .collect()
+    }
+
+    fn rewrite(archive: &Path, pattern: &str) -> anyhow::Result<()> {
+        execute_archive_transform(
+            archive,
+            archive.to_path_buf(),
+            Umask::new(0o022),
+            None,
+            SolidEntriesTransformStrategy::UnSolid,
+            DropAll(GlobPatterns::new([pattern]).unwrap()),
+        )
+    }
+
+    #[test]
+    fn unmatched_pattern_refuses_the_rewrite_and_keeps_the_original() {
+        let dir = test_dir("unmatched");
+        let archive = dir.join("archive.pna");
+        let original = write_archive(&archive);
+
+        assert!(rewrite(&archive, "absent").is_err());
+        assert_eq!(fs::read(&archive).unwrap(), original);
+        assert!(entries_beside(&dir, "archive.pna").is_empty());
+    }
+
+    #[test]
+    fn matched_pattern_replaces_the_original() {
+        let dir = test_dir("matched");
+        let archive = dir.join("archive.pna");
+        let original = write_archive(&archive);
+
+        rewrite(&archive, "present.txt").unwrap();
+        assert_ne!(fs::read(&archive).unwrap(), original);
+        assert!(entries_beside(&dir, "archive.pna").is_empty());
+    }
 }

--- a/cli/src/command/core/staged_archive.rs
+++ b/cli/src/command/core/staged_archive.rs
@@ -1,5 +1,4 @@
 use crate::command::core::{SafeWriter, Umask};
-use crate::utils::GlobPatterns;
 use std::{fs, io, path::PathBuf};
 
 /// An archive rewrite held in a temp file until the checks that must precede it have passed.
@@ -49,15 +48,9 @@ impl StagedArchive {
     }
 
     /// Puts the staged archive in place of the original.
-    ///
-    /// `patterns` holds the patterns the run was asked to match, or is `None` for commands
-    /// that take none. A pattern that matched nothing aborts the commit.
     #[inline]
     #[cfg_attr(not(unix), allow(unused_mut))]
-    pub(crate) fn commit(mut self, patterns: Option<&GlobPatterns>) -> anyhow::Result<()> {
-        if let Some(patterns) = patterns {
-            patterns.ensure_all_matched()?;
-        }
+    pub(crate) fn commit(mut self) -> io::Result<()> {
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -127,24 +120,9 @@ mod tests {
 
         let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022)).unwrap();
         staged.as_file_mut().write_all(b"rewritten").unwrap();
-        staged.commit(None).unwrap();
+        staged.commit().unwrap();
 
         assert_eq!(fs::read(&output).unwrap(), b"rewritten");
-        assert!(entries_beside(&dir, "archive.pna").is_empty());
-    }
-
-    #[test]
-    fn commit_is_refused_when_a_pattern_matched_nothing() {
-        let dir = test_dir("unmatched");
-        let output = dir.join("archive.pna");
-        fs::write(&output, b"original").unwrap();
-
-        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022)).unwrap();
-        staged.as_file_mut().write_all(b"rewritten").unwrap();
-        let patterns = GlobPatterns::new(["absent"]).unwrap();
-
-        assert!(staged.commit(Some(&patterns)).is_err());
-        assert_eq!(fs::read(&output).unwrap(), b"original");
         assert!(entries_beside(&dir, "archive.pna").is_empty());
     }
 
@@ -165,7 +143,7 @@ mod tests {
 
         let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022)).unwrap();
         staged.as_file_mut().write_all(b"rewritten").unwrap();
-        staged.commit(None).unwrap();
+        staged.commit().unwrap();
 
         assert_eq!(mode_of(&output), 0o666);
     }
@@ -181,7 +159,7 @@ mod tests {
 
         let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022)).unwrap();
         staged.as_file_mut().write_all(b"rewritten").unwrap();
-        staged.commit(None).unwrap();
+        staged.commit().unwrap();
 
         assert_eq!(mode_of(&output), 0o755);
     }
@@ -194,7 +172,7 @@ mod tests {
 
         let mut staged = StagedArchive::new(output.clone(), Umask::new(0o007)).unwrap();
         staged.as_file_mut().write_all(b"written").unwrap();
-        staged.commit(None).unwrap();
+        staged.commit().unwrap();
 
         assert_eq!(mode_of(&output), 0o660);
     }
@@ -210,7 +188,7 @@ mod tests {
 
         let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022)).unwrap();
         staged.as_file_mut().write_all(b"written").unwrap();
-        staged.commit(None).unwrap();
+        staged.commit().unwrap();
 
         assert!(output.is_file());
         assert_eq!(mode_of(&output), 0o644);
@@ -229,7 +207,7 @@ mod tests {
 
         let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022)).unwrap();
         staged.as_file_mut().write_all(b"written").unwrap();
-        staged.commit(None).unwrap();
+        staged.commit().unwrap();
 
         assert_eq!(fs::read(&output).unwrap(), b"written");
         assert_eq!(mode_of(&output), 0o644);
@@ -254,7 +232,7 @@ mod tests {
 
         let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022)).unwrap();
         staged.as_file_mut().write_all(b"written").unwrap();
-        staged.commit(None).unwrap();
+        staged.commit().unwrap();
 
         assert_eq!(fs::read(&output).unwrap(), b"written");
     }

--- a/cli/src/command/delete.rs
+++ b/cli/src/command/delete.rs
@@ -1,20 +1,17 @@
 use crate::{
-    cli::{
-        ArchiveFileArgs, FileOperands, PasswordArgs, SolidEntriesTransformStrategy,
-        SolidEntriesTransformStrategyArgs,
-    },
+    cli::{ArchiveFileArgs, FileOperands, PasswordArgs, SolidEntriesTransformStrategyArgs},
     command::{
         Command, ask_password,
         core::{
-            PathFilter, SplitArchiveReader, StagedArchive, TransformStrategyKeepSolid,
-            TransformStrategyUnSolid, Umask, collect_split_archives, read_paths, read_paths_stdin,
+            PathFilter, Umask, read_paths, read_paths_stdin,
+            rewrite::{EntryTransform, execute_archive_transform},
         },
     },
     utils::{GlobPatterns, PathPartExt, VCS_FILES},
 };
 use clap::{ArgGroup, Parser, ValueHint};
 use pna::NormalEntry;
-use std::path::PathBuf;
+use std::{borrow::Cow, io, path::PathBuf};
 
 #[derive(Parser, Clone, Eq, PartialEq, Hash, Debug)]
 #[command(
@@ -109,7 +106,7 @@ fn delete_file_from_archive(args: DeleteCommand, umask: Umask) -> anyhow::Result
     } else if let Some(path) = args.files_from {
         files.extend(read_paths(path, args.null)?);
     }
-    let mut globs = GlobPatterns::new(files.iter().map(|it| it.as_str()))?;
+    let globs = GlobPatterns::new(files.iter().map(|it| it.as_str()))?;
 
     let mut exclude = args.exclude;
     if let Some(p) = args.exclude_from {
@@ -125,34 +122,35 @@ fn delete_file_from_archive(args: DeleteCommand, umask: Umask) -> anyhow::Result
         exclude.iter().map(|s| s.as_str()).chain(vcs_patterns),
     );
 
-    let mut source = SplitArchiveReader::new(collect_split_archives(&args.archive.file)?)?;
-
     let output_path = args
         .output
         .unwrap_or_else(|| args.archive.file.remove_part());
-    let mut staged = StagedArchive::new(output_path, umask)?;
+    execute_archive_transform(
+        &args.archive.file,
+        output_path,
+        umask,
+        password.as_deref(),
+        args.transform_strategy.strategy(),
+        DeleteTransform { globs, filter },
+    )
+}
 
-    match args.transform_strategy.strategy() {
-        SolidEntriesTransformStrategy::UnSolid => source.transform_entries(
-            staged.as_file_mut(),
-            password.as_deref(),
-            #[hooq::skip_all]
-            |entry| Ok(filter_entry(&mut globs, &filter, entry?)),
-            TransformStrategyUnSolid,
-        ),
-        SolidEntriesTransformStrategy::KeepSolid => source.transform_entries(
-            staged.as_file_mut(),
-            password.as_deref(),
-            #[hooq::skip_all]
-            |entry| Ok(filter_entry(&mut globs, &filter, entry?)),
-            TransformStrategyKeepSolid,
-        ),
-    }?;
+struct DeleteTransform<'g, 'f> {
+    globs: GlobPatterns<'g>,
+    filter: PathFilter<'f>,
+}
 
-    drop(source);
+impl EntryTransform for DeleteTransform<'_, '_> {
+    fn transform<'d>(
+        &mut self,
+        entry: NormalEntry<Cow<'d, [u8]>>,
+    ) -> io::Result<Option<NormalEntry<Cow<'d, [u8]>>>> {
+        Ok(filter_entry(&mut self.globs, &self.filter, entry))
+    }
 
-    staged.commit(Some(&globs))?;
-    Ok(())
+    fn patterns(&self) -> Option<&GlobPatterns<'_>> {
+        Some(&self.globs)
+    }
 }
 
 #[inline]

--- a/cli/src/command/sort.rs
+++ b/cli/src/command/sort.rs
@@ -189,7 +189,7 @@ fn sort_archive(args: SortCommand, umask: Umask) -> anyhow::Result<()> {
 
     drop(source);
 
-    staged.commit(None)?;
+    staged.commit()?;
 
     Ok(())
 }

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -552,7 +552,7 @@ fn update_archive(args: UpdateCommand, umask: Umask) -> anyhow::Result<()> {
     out_archive.finalize()?;
     drop(source);
 
-    staged.commit(None)?;
+    staged.commit()?;
 
     Ok(())
 }

--- a/cli/src/command/xattr.rs
+++ b/cli/src/command/xattr.rs
@@ -1,13 +1,10 @@
 use crate::{
-    cli::{
-        ArchiveFileArgs, FileOperands, PasswordArgs, SolidEntriesTransformStrategy,
-        SolidEntriesTransformStrategyArgs,
-    },
+    cli::{ArchiveFileArgs, FileOperands, PasswordArgs, SolidEntriesTransformStrategyArgs},
     command::{
         Command, ask_password,
         core::{
-            SplitArchiveReader, StagedArchive, TransformStrategyKeepSolid,
-            TransformStrategyUnSolid, Umask, collect_split_archives,
+            SplitArchiveReader, Umask, collect_split_archives,
+            rewrite::{EntryTransform, execute_archive_transform},
         },
     },
     utils::{GlobPatterns, PathPartExt},
@@ -19,6 +16,7 @@ use indexmap::IndexMap;
 use pna::{NormalEntry, ReadOptions};
 use regex::Regex;
 use std::{
+    borrow::Cow,
     collections::HashMap,
     fmt::{self, Display, Formatter, Write},
     fs, io,
@@ -249,7 +247,7 @@ fn archive_get_xattr(args: GetXattrCommand) -> anyhow::Result<()> {
 fn archive_set_xattr(args: SetXattrCommand, umask: Umask) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
     let files = args.files.files;
-    let mut set_strategy = if args.restore_from_stdin {
+    let set_strategy = if args.restore_from_stdin {
         SetAttrStrategy::Restore(parse_dump(io::stdin().lock())?)
     } else if let Some(path) = args.restore.as_deref() {
         if path.as_os_str() == "-" {
@@ -273,32 +271,14 @@ fn archive_set_xattr(args: SetXattrCommand, umask: Umask) -> anyhow::Result<()> 
         }
     };
 
-    let mut source = SplitArchiveReader::new(collect_split_archives(&args.archive.file)?)?;
-
-    let output_path = args.archive.file.remove_part();
-    let mut staged = StagedArchive::new(output_path, umask)?;
-
-    match args.transform_strategy.strategy() {
-        SolidEntriesTransformStrategy::UnSolid => source.transform_entries(
-            staged.as_file_mut(),
-            password.as_deref(),
-            #[hooq::skip_all]
-            |entry| Ok(Some(set_strategy.transform_entry(entry?)?)),
-            TransformStrategyUnSolid,
-        ),
-        SolidEntriesTransformStrategy::KeepSolid => source.transform_entries(
-            staged.as_file_mut(),
-            password.as_deref(),
-            #[hooq::skip_all]
-            |entry| Ok(Some(set_strategy.transform_entry(entry?)?)),
-            TransformStrategyKeepSolid,
-        ),
-    }?;
-
-    drop(source);
-
-    staged.commit(set_strategy.globs())?;
-    Ok(())
+    execute_archive_transform(
+        &args.archive.file,
+        args.archive.file.remove_part(),
+        umask,
+        password.as_deref(),
+        args.transform_strategy.strategy(),
+        set_strategy,
+    )
 }
 
 enum SetAttrStrategy<'s> {
@@ -366,6 +346,19 @@ impl SetAttrStrategy<'_> {
                 }
             }
         }
+    }
+}
+
+impl EntryTransform for SetAttrStrategy<'_> {
+    fn transform<'d>(
+        &mut self,
+        entry: NormalEntry<Cow<'d, [u8]>>,
+    ) -> io::Result<Option<NormalEntry<Cow<'d, [u8]>>>> {
+        self.transform_entry(entry).map(Some)
+    }
+
+    fn patterns(&self) -> Option<&GlobPatterns<'_>> {
+        self.globs()
     }
 }
 


### PR DESCRIPTION
## Summary
Move chmod, chown, delete, ACL set, and xattr set onto `execute_archive_transform`, removing the duplicated unsolid/keep-solid closures from each command. Selector validation now happens once next to the executor's commit, so `StagedArchive::commit` no longer takes patterns.

Stacked on #3492.
