### PR TITLE
:construction_worker: Cache the libarchive build in bsdtar compatibility CI

### DIFF
--- a/.github/workflows/bsdtar-compat.yml
+++ b/.github/workflows/bsdtar-compat.yml
@@ -34,7 +34,6 @@ on:
       - '.github/scripts/jsonify-bsdtar-output.py'
 
 env:
-  # Keeps the checkout ref and the build cache key in lockstep.
   LIBARCHIVE_REF: v3.8.5
 
 jobs:
@@ -90,7 +89,7 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: libarchive
-          key: "libarchive-${{ env.LIBARCHIVE_REF }}-${{ matrix.name }}-${{ runner.arch }}-${{ env.ImageVersion }}"
+          key: "libarchive-${{ env.LIBARCHIVE_REF }}-${{ matrix.name }}-${{ runner.arch }}"
 
       - name: Clone libarchive
         if: ${{ steps.libarchive_cache.outputs.cache-hit != 'true' }}
@@ -268,7 +267,7 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: libarchive
-          key: "libarchive-${{ env.LIBARCHIVE_REF }}-${{ matrix.name }}-${{ runner.arch }}-${{ env.ImageVersion }}"
+          key: "libarchive-${{ env.LIBARCHIVE_REF }}-${{ matrix.name }}-${{ runner.arch }}"
 
       - name: Clone libarchive
         if: ${{ steps.libarchive_cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/bsdtar-compat.yml
+++ b/.github/workflows/bsdtar-compat.yml
@@ -33,6 +33,10 @@ on:
       - '.github/workflows/bsdtar-compat.yml'
       - '.github/scripts/jsonify-bsdtar-output.py'
 
+env:
+  # Keeps the checkout ref and the build cache key in lockstep.
+  LIBARCHIVE_REF: v3.8.5
+
 jobs:
   bsdtar-reference:
     name: Verify bsdtar_test passes with bsdtar (${{ matrix.name }})
@@ -81,16 +85,24 @@ jobs:
         run: |
           brew install autoconf automake libtool make pkg-config
 
+      - name: Restore libarchive build
+        id: libarchive_cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: libarchive
+          key: "libarchive-${{ env.LIBARCHIVE_REF }}-${{ matrix.name }}-${{ runner.arch }}-${{ env.ImageVersion }}"
+
       - name: Clone libarchive
+        if: ${{ steps.libarchive_cache.outputs.cache-hit != 'true' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: libarchive/libarchive
-          ref: v3.8.5
+          ref: ${{ env.LIBARCHIVE_REF }}
           path: libarchive
           persist-credentials: false
 
       - name: Build bsdtar and bsdtar_test
-        if: ${{ matrix.name != 'windows' }}
+        if: ${{ steps.libarchive_cache.outputs.cache-hit != 'true' && matrix.name != 'windows' }}
         run: |
           cd libarchive
           JOBS="$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu)"
@@ -104,7 +116,7 @@ jobs:
           "${MAKE}" -j"${JOBS}" bsdtar_test bsdtar
 
       - name: Build bsdtar and bsdtar_test (Windows)
-        if: ${{ matrix.name == 'windows' }}
+        if: ${{ steps.libarchive_cache.outputs.cache-hit != 'true' && matrix.name == 'windows' }}
         shell: cmd
         working-directory: libarchive
         env:
@@ -116,6 +128,13 @@ jobs:
           call build\ci\github_actions\ci.cmd configure
           cd /d "%ROOT%"
           call build\ci\github_actions\ci.cmd build
+
+      - name: Save libarchive build
+        if: ${{ steps.libarchive_cache.outputs.cache-hit != 'true' && github.ref_name == github.event.repository.default_branch }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: libarchive
+          key: "${{ steps.libarchive_cache.outputs.cache-primary-key }}"
 
       - name: Locate built binaries
         run: |
@@ -244,16 +263,24 @@ jobs:
           cargo build --locked --release --all-features -p portable-network-archive
         working-directory: pna
 
+      - name: Restore libarchive build
+        id: libarchive_cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: libarchive
+          key: "libarchive-${{ env.LIBARCHIVE_REF }}-${{ matrix.name }}-${{ runner.arch }}-${{ env.ImageVersion }}"
+
       - name: Clone libarchive
+        if: ${{ steps.libarchive_cache.outputs.cache-hit != 'true' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: libarchive/libarchive
-          ref: v3.8.5
+          ref: ${{ env.LIBARCHIVE_REF }}
           path: libarchive
           persist-credentials: false
 
-      - name: Build bsdtar_test
-        if: ${{ matrix.name != 'windows' }}
+      - name: Build bsdtar and bsdtar_test
+        if: ${{ steps.libarchive_cache.outputs.cache-hit != 'true' && matrix.name != 'windows' }}
         run: |
           cd libarchive
           JOBS="$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu)"
@@ -264,10 +291,10 @@ jobs:
           ./build/autogen.sh
           ./configure --enable-bsdtar --disable-bsdcpio --disable-bsdcat --disable-bsdunzip
           "${MAKE}" tar/test/list.h
-          "${MAKE}" -j"${JOBS}" bsdtar_test
+          "${MAKE}" -j"${JOBS}" bsdtar_test bsdtar
 
-      - name: Build bsdtar_test (Windows)
-        if: ${{ matrix.name == 'windows' }}
+      - name: Build bsdtar and bsdtar_test (Windows)
+        if: ${{ steps.libarchive_cache.outputs.cache-hit != 'true' && matrix.name == 'windows' }}
         shell: cmd
         working-directory: libarchive
         env:
@@ -279,6 +306,13 @@ jobs:
           call build\ci\github_actions\ci.cmd configure
           cd /d "%ROOT%"
           call build\ci\github_actions\ci.cmd build
+
+      - name: Save libarchive build
+        if: ${{ steps.libarchive_cache.outputs.cache-hit != 'true' && github.ref_name == github.event.repository.default_branch }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: libarchive
+          key: "${{ steps.libarchive_cache.outputs.cache-primary-key }}"
 
       - name: Build tar2pna
         if: ${{ matrix.name != 'windows' }}


### PR DESCRIPTION
## Problem

`bsdtar-compat.yml` builds libarchive from source in both of its jobs, on
three runners each. That is six full autotools/MSVC builds of the same pinned
`v3.8.5` tree per workflow run, with no caching.

Measured over 60 recent runs, this workflow accounted for ~144 job-minutes,
almost all of it in those six builds:

| Job | n | median | total |
|---|---:|---:|---:|
| Test pna compat bsdtar with bsdtar_test | 15 | 3.7 min | 88.2 min |
| Verify bsdtar_test passes with bsdtar | 15 | 1.7 min | 55.9 min |

## Change

Restore the built libarchive tree from the actions cache, and skip both the
clone and the build when it hits. The ref is pinned, so the tree is
deterministic for a given runner.

The cache key covers the libarchive ref, the runner and its image version.
The image version matters here because these binaries link against system
libraries (libssl, liblzma, zlib, libacl) that move when the runner image is
updated; without it, a stale binary could fail in a way that looks like a
compatibility regression.

The ref itself moves to a workflow-level `LIBARCHIVE_REF` so the checkout and
the cache key cannot drift apart on the next version bump — a silent drift
there would mean testing against binaries from a different libarchive.

Both jobs now build the same make targets so they share one cache entry per
runner rather than two. `pna-compat-bsdtar` does not invoke `bsdtar` itself,
but building it next to `bsdtar_test` is free once the library is built, and
halving the number of entries matters given the repository is already at its
cache quota.

Saving is restricted to the default branch, matching the existing caches in
`test.yml` and the Rust caches in this workflow. Pull request branches cannot
share cache entries with one another, so saving from them would consume quota
without ever producing a hit for anyone else.

## Coverage

Unchanged. The same libarchive version, the same `bsdtar_test` suite, the same
reference corpus under `libarchive/tar/test` — the binaries are simply not
recompiled on every run. The first run on `main` after this merges populates
the cache; pull requests read it from there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved compatibility build workflows by caching libarchive builds.
  * Skipped redundant setup and compilation when cached builds are available.

* **Compatibility**
  * Enhanced PNA compatibility checks to build and validate both required tools across supported platforms, including Windows.
  * Improved build consistency by using a shared libarchive version across compatibility checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->