### PR TITLE
:bug: Honor file operands in strip

### DIFF
--- a/cli/src/command/strip.rs
+++ b/cli/src/command/strip.rs
@@ -74,28 +74,50 @@ fn strip_metadata(args: StripCommand, umask: Umask) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
     let archive = args.archive.file;
     let output_path = args.output.unwrap_or_else(|| archive.remove_part());
+    let globs = if args.files.files.is_empty() {
+        None
+    } else {
+        Some(GlobPatterns::new(
+            args.files.files.iter().map(String::as_str),
+        )?)
+    };
     execute_archive_transform(
         &archive,
         output_path,
         umask,
         password.as_deref(),
         args.transform_strategy.strategy(),
-        StripTransform(args.strip_options),
+        StripTransform {
+            options: args.strip_options,
+            globs,
+        },
     )
 }
 
-struct StripTransform(StripOptions);
+struct StripTransform<'g> {
+    options: StripOptions,
+    /// `None` selects every entry.
+    globs: Option<GlobPatterns<'g>>,
+}
 
-impl EntryTransform for StripTransform {
+impl EntryTransform for StripTransform<'_> {
     fn transform<'d>(
         &mut self,
         entry: NormalEntry<Cow<'d, [u8]>>,
     ) -> io::Result<Option<NormalEntry<Cow<'d, [u8]>>>> {
-        Ok(Some(strip_entry_metadata(entry, &self.0)))
+        let selected = match &mut self.globs {
+            Some(globs) => globs.matches_any(entry.name()),
+            None => true,
+        };
+        Ok(Some(if selected {
+            strip_entry_metadata(entry, &self.options)
+        } else {
+            entry
+        }))
     }
 
     fn patterns(&self) -> Option<&GlobPatterns<'_>> {
-        None
+        self.globs.as_ref()
     }
 }
 

--- a/cli/tests/cli/strip.rs
+++ b/cli/tests/cli/strip.rs
@@ -1,3 +1,8 @@
+mod file_operands;
+mod keep_solid;
+mod missing_file;
+mod unsolid;
+
 use crate::utils::{EmbedExt, TestResources, archive, setup};
 use clap::Parser;
 use pna::Duration;

--- a/cli/tests/cli/strip/file_operands.rs
+++ b/cli/tests/cli/strip/file_operands.rs
@@ -1,0 +1,49 @@
+use crate::utils::{archive, archive::FileEntryDef, setup};
+use clap::Parser;
+use portable_network_archive::cli;
+
+/// Precondition: An archive holds several entries carrying permission metadata.
+/// Action: Run `pna strip` naming only some of the entries.
+/// Expectation: The named entries lose their metadata; the others keep it and every entry survives.
+#[test]
+fn strip_only_named_entries() {
+    setup();
+    let path = "strip_file_operands.pna";
+    archive::create_archive_with_permissions(
+        path,
+        &[
+            FileEntryDef {
+                path: "keep.txt",
+                content: b"keep",
+                permission: 0o644,
+            },
+            FileEntryDef {
+                path: "strip.txt",
+                content: b"strip",
+                permission: 0o644,
+            },
+        ],
+    )
+    .unwrap();
+
+    cli::Cli::try_parse_from(["pna", "--quiet", "strip", "-f", path, "strip.txt"])
+        .unwrap()
+        .execute()
+        .unwrap();
+
+    let mut entries = Vec::new();
+    archive::for_each_entry(path, |entry| {
+        entries.push((
+            entry.header().path().to_string(),
+            entry.metadata().permission_mode().map(|m| m.get()),
+        ));
+    })
+    .unwrap();
+    assert_eq!(
+        entries,
+        [
+            ("keep.txt".to_string(), Some(0o644)),
+            ("strip.txt".to_string(), None),
+        ]
+    );
+}

--- a/cli/tests/cli/strip/keep_solid.rs
+++ b/cli/tests/cli/strip/keep_solid.rs
@@ -1,0 +1,65 @@
+use crate::utils::{archive, archive::FileEntryDef, setup};
+use clap::Parser;
+use pna::prelude::*;
+use portable_network_archive::cli;
+
+/// Precondition: A solid archive holds several entries carrying permission metadata.
+/// Action: Run `pna strip --keep-solid` naming only some of the entries.
+/// Expectation: Only the named entries lose their metadata and the archive stays solid.
+#[test]
+fn strip_keep_solid_only_named_entries() {
+    setup();
+    let path = "strip_keep_solid.pna";
+    archive::create_solid_archive_with_permissions(
+        path,
+        &[
+            FileEntryDef {
+                path: "keep.txt",
+                content: b"keep",
+                permission: 0o644,
+            },
+            FileEntryDef {
+                path: "strip.txt",
+                content: b"strip",
+                permission: 0o644,
+            },
+        ],
+    )
+    .unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "strip",
+        "--keep-solid",
+        "-f",
+        path,
+        "strip.txt",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut archive = pna::Archive::open(path).unwrap();
+    let layout = archive
+        .entries()
+        .map(|entry| matches!(entry.unwrap(), pna::ReadEntry::Solid(_)))
+        .collect::<Vec<_>>();
+    assert_eq!(layout, [true]);
+
+    let mut entries = Vec::new();
+    archive::for_each_entry(path, |entry| {
+        entries.push((
+            entry.header().path().to_string(),
+            entry.metadata().permission_mode().map(|m| m.get()),
+        ));
+    })
+    .unwrap();
+    assert_eq!(
+        entries,
+        [
+            ("keep.txt".to_string(), Some(0o644)),
+            ("strip.txt".to_string(), None),
+        ]
+    );
+}

--- a/cli/tests/cli/strip/missing_file.rs
+++ b/cli/tests/cli/strip/missing_file.rs
@@ -1,0 +1,42 @@
+use crate::utils::{archive, archive::FileEntryDef, setup};
+use clap::Parser;
+use portable_network_archive::cli;
+use std::fs;
+
+/// Precondition: An archive holds entries, and one named operand matches none of them.
+/// Action: Run `pna strip` naming an existing and a missing entry.
+/// Expectation: The command fails and the archive is left byte-for-byte unchanged.
+#[test]
+fn fail_with_missing_file() {
+    setup();
+    let path = "strip_missing_file.pna";
+    archive::create_archive_with_permissions(
+        path,
+        &[FileEntryDef {
+            path: "present.txt",
+            content: b"present",
+            permission: 0o644,
+        }],
+    )
+    .unwrap();
+    let before = fs::read(path).unwrap();
+
+    let result = cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "strip",
+        "-f",
+        path,
+        "present.txt",
+        "not_found.txt",
+    ])
+    .unwrap()
+    .execute();
+
+    assert!(result.is_err());
+    assert_eq!(
+        fs::read(path).unwrap(),
+        before,
+        "the archive must be left unchanged"
+    );
+}

--- a/cli/tests/cli/strip/unsolid.rs
+++ b/cli/tests/cli/strip/unsolid.rs
@@ -1,0 +1,65 @@
+use crate::utils::{archive, archive::FileEntryDef, setup};
+use clap::Parser;
+use pna::prelude::*;
+use portable_network_archive::cli;
+
+/// Precondition: A solid archive holds several entries carrying permission metadata.
+/// Action: Run `pna strip --unsolid` naming only some of the entries.
+/// Expectation: Only the named entries lose their metadata and every entry becomes a normal entry.
+#[test]
+fn strip_unsolid_only_named_entries() {
+    setup();
+    let path = "strip_unsolid.pna";
+    archive::create_solid_archive_with_permissions(
+        path,
+        &[
+            FileEntryDef {
+                path: "keep.txt",
+                content: b"keep",
+                permission: 0o644,
+            },
+            FileEntryDef {
+                path: "strip.txt",
+                content: b"strip",
+                permission: 0o644,
+            },
+        ],
+    )
+    .unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "strip",
+        "--unsolid",
+        "-f",
+        path,
+        "strip.txt",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let mut archive = pna::Archive::open(path).unwrap();
+    let layout = archive
+        .entries()
+        .map(|entry| matches!(entry.unwrap(), pna::ReadEntry::Solid(_)))
+        .collect::<Vec<_>>();
+    assert_eq!(layout, [false, false]);
+
+    let mut entries = Vec::new();
+    archive::for_each_entry(path, |entry| {
+        entries.push((
+            entry.header().path().to_string(),
+            entry.metadata().permission_mode().map(|m| m.get()),
+        ));
+    })
+    .unwrap();
+    assert_eq!(
+        entries,
+        [
+            ("keep.txt".to_string(), Some(0o644)),
+            ("strip.txt".to_string(), None),
+        ]
+    );
+}


### PR DESCRIPTION
## Summary
`pna strip` accepted and documented `[FILES]...` but never read them, so every entry was stripped regardless. The operands now select entries as glob patterns, the same way `chmod` and `chown` do; with no operand every entry is still stripped.

## Notes
- A pattern that matches nothing aborts the run before the archive is replaced.
- Entries not selected are written back with their metadata intact.
