### PR TITLE
Add Box<[u8]> support to RawChunk and Entry types

### DIFF
--- a/lib/src/chunk.rs
+++ b/lib/src/chunk.rs
@@ -115,6 +115,13 @@ impl<const N: usize> From<(ChunkType, [u8; N])> for RawChunk<Vec<u8>> {
     }
 }
 
+impl From<(ChunkType, Box<[u8]>)> for RawChunk<Vec<u8>> {
+    #[inline]
+    fn from(value: (ChunkType, Box<[u8]>)) -> Self {
+        RawChunk::<Box<[u8]>>::from(value).into()
+    }
+}
+
 impl<'d> RawChunk<&'d [u8]> {
     pub(crate) fn from_slice(ty: ChunkType, data: &'d [u8]) -> Self {
         let chunk = (ty, data);
@@ -152,6 +159,66 @@ impl<'a> From<RawChunk<&'a [u8]>> for RawChunk<Vec<u8>> {
 }
 
 impl<const N: usize> From<RawChunk<[u8; N]>> for RawChunk<Vec<u8>> {
+    #[inline]
+    fn from(value: RawChunk<[u8; N]>) -> Self {
+        Self {
+            length: value.length,
+            ty: value.ty,
+            data: value.data.into(),
+            crc: value.crc,
+        }
+    }
+}
+
+impl From<RawChunk<Box<[u8]>>> for RawChunk<Vec<u8>> {
+    #[inline]
+    fn from(value: RawChunk<Box<[u8]>>) -> Self {
+        Self {
+            length: value.length,
+            ty: value.ty,
+            data: value.data.into(),
+            crc: value.crc,
+        }
+    }
+}
+
+impl From<RawChunk<Vec<u8>>> for RawChunk<Box<[u8]>> {
+    #[inline]
+    fn from(value: RawChunk<Vec<u8>>) -> Self {
+        Self {
+            length: value.length,
+            ty: value.ty,
+            data: value.data.into(),
+            crc: value.crc,
+        }
+    }
+}
+
+impl<'a> From<RawChunk<Cow<'a, [u8]>>> for RawChunk<Box<[u8]>> {
+    #[inline]
+    fn from(value: RawChunk<Cow<'a, [u8]>>) -> Self {
+        Self {
+            length: value.length,
+            ty: value.ty,
+            data: value.data.into(),
+            crc: value.crc,
+        }
+    }
+}
+
+impl<'a> From<RawChunk<&'a [u8]>> for RawChunk<Box<[u8]>> {
+    #[inline]
+    fn from(value: RawChunk<&'a [u8]>) -> Self {
+        Self {
+            length: value.length,
+            ty: value.ty,
+            data: value.data.into(),
+            crc: value.crc,
+        }
+    }
+}
+
+impl<const N: usize> From<RawChunk<[u8; N]>> for RawChunk<Box<[u8]>> {
     #[inline]
     fn from(value: RawChunk<[u8; N]>) -> Self {
         Self {
@@ -503,6 +570,7 @@ mod tests {
         check_impl::<RawChunk<Cow<[u8]>>>();
         check_impl::<RawChunk<&[u8]>>();
         check_impl::<RawChunk<[u8; 1]>>();
+        check_impl::<RawChunk<Box<[u8]>>>();
     }
 
     #[test]

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -267,6 +267,34 @@ impl<'a> From<RawEntry<&'a [u8]>> for RawEntry<Cow<'a, [u8]>> {
     }
 }
 
+impl From<RawEntry<Vec<u8>>> for RawEntry<Box<[u8]>> {
+    #[inline]
+    fn from(value: RawEntry<Vec<u8>>) -> Self {
+        Self(value.0.into_iter().map(Into::into).collect())
+    }
+}
+
+impl<'a> From<RawEntry<Cow<'a, [u8]>>> for RawEntry<Box<[u8]>> {
+    #[inline]
+    fn from(value: RawEntry<Cow<'a, [u8]>>) -> Self {
+        Self(value.0.into_iter().map(Into::into).collect())
+    }
+}
+
+impl<'a> From<RawEntry<&'a [u8]>> for RawEntry<Box<[u8]>> {
+    #[inline]
+    fn from(value: RawEntry<&'a [u8]>) -> Self {
+        Self(value.0.into_iter().map(Into::into).collect())
+    }
+}
+
+impl From<RawEntry<Box<[u8]>>> for RawEntry<Vec<u8>> {
+    #[inline]
+    fn from(value: RawEntry<Box<[u8]>>) -> Self {
+        Self(value.0.into_iter().map(Into::into).collect())
+    }
+}
+
 /// Reader for Entry data.
 pub struct EntryDataReader<'r>(EntryReader<EncodedDataReader<'r>>);
 
@@ -419,6 +447,46 @@ impl From<ReadEntry<Vec<u8>>> for ReadEntry<Cow<'_, [u8]>> {
 impl<'a> From<ReadEntry<&'a [u8]>> for ReadEntry<Cow<'a, [u8]>> {
     #[inline]
     fn from(value: ReadEntry<&'a [u8]>) -> Self {
+        match value {
+            ReadEntry::Solid(s) => Self::Solid(s.into()),
+            ReadEntry::Normal(r) => Self::Normal(r.into()),
+        }
+    }
+}
+
+impl From<ReadEntry<Vec<u8>>> for ReadEntry<Box<[u8]>> {
+    #[inline]
+    fn from(value: ReadEntry<Vec<u8>>) -> Self {
+        match value {
+            ReadEntry::Solid(s) => Self::Solid(s.into()),
+            ReadEntry::Normal(r) => Self::Normal(r.into()),
+        }
+    }
+}
+
+impl<'a> From<ReadEntry<Cow<'a, [u8]>>> for ReadEntry<Box<[u8]>> {
+    #[inline]
+    fn from(value: ReadEntry<Cow<'a, [u8]>>) -> Self {
+        match value {
+            ReadEntry::Solid(s) => Self::Solid(s.into()),
+            ReadEntry::Normal(r) => Self::Normal(r.into()),
+        }
+    }
+}
+
+impl<'a> From<ReadEntry<&'a [u8]>> for ReadEntry<Box<[u8]>> {
+    #[inline]
+    fn from(value: ReadEntry<&'a [u8]>) -> Self {
+        match value {
+            ReadEntry::Solid(s) => Self::Solid(s.into()),
+            ReadEntry::Normal(r) => Self::Normal(r.into()),
+        }
+    }
+}
+
+impl From<ReadEntry<Box<[u8]>>> for ReadEntry<Vec<u8>> {
+    #[inline]
+    fn from(value: ReadEntry<Box<[u8]>>) -> Self {
         match value {
             ReadEntry::Solid(s) => Self::Solid(s.into()),
             ReadEntry::Normal(r) => Self::Normal(r.into()),
@@ -669,6 +737,54 @@ impl<'a> From<SolidEntry<&'a [u8]>> for SolidEntry<Cow<'a, [u8]>> {
 impl From<SolidEntry<Vec<u8>>> for SolidEntry<Cow<'_, [u8]>> {
     #[inline]
     fn from(value: SolidEntry<Vec<u8>>) -> Self {
+        Self {
+            header: value.header,
+            phsf: value.phsf,
+            data: value.data.into_iter().map(Into::into).collect(),
+            extra: value.extra.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<SolidEntry<Vec<u8>>> for SolidEntry<Box<[u8]>> {
+    #[inline]
+    fn from(value: SolidEntry<Vec<u8>>) -> Self {
+        Self {
+            header: value.header,
+            phsf: value.phsf,
+            data: value.data.into_iter().map(Into::into).collect(),
+            extra: value.extra.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl<'a> From<SolidEntry<Cow<'a, [u8]>>> for SolidEntry<Box<[u8]>> {
+    #[inline]
+    fn from(value: SolidEntry<Cow<'a, [u8]>>) -> Self {
+        Self {
+            header: value.header,
+            phsf: value.phsf,
+            data: value.data.into_iter().map(Into::into).collect(),
+            extra: value.extra.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl<'a> From<SolidEntry<&'a [u8]>> for SolidEntry<Box<[u8]>> {
+    #[inline]
+    fn from(value: SolidEntry<&'a [u8]>) -> Self {
+        Self {
+            header: value.header,
+            phsf: value.phsf,
+            data: value.data.into_iter().map(Into::into).collect(),
+            extra: value.extra.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<SolidEntry<Box<[u8]>>> for SolidEntry<Vec<u8>> {
+    #[inline]
+    fn from(value: SolidEntry<Box<[u8]>>) -> Self {
         Self {
             header: value.header,
             phsf: value.phsf,
@@ -1230,6 +1346,58 @@ impl<'a> From<NormalEntry<&'a [u8]>> for NormalEntry<Cow<'a, [u8]>> {
     }
 }
 
+impl From<NormalEntry<Vec<u8>>> for NormalEntry<Box<[u8]>> {
+    #[inline]
+    fn from(value: NormalEntry<Vec<u8>>) -> Self {
+        Self {
+            header: value.header,
+            phsf: value.phsf,
+            extra: value.extra.into_iter().map(Into::into).collect(),
+            data: value.data.into_iter().map(Into::into).collect(),
+            metadata: value.metadata,
+        }
+    }
+}
+
+impl<'a> From<NormalEntry<Cow<'a, [u8]>>> for NormalEntry<Box<[u8]>> {
+    #[inline]
+    fn from(value: NormalEntry<Cow<'a, [u8]>>) -> Self {
+        Self {
+            header: value.header,
+            phsf: value.phsf,
+            extra: value.extra.into_iter().map(Into::into).collect(),
+            data: value.data.into_iter().map(Into::into).collect(),
+            metadata: value.metadata,
+        }
+    }
+}
+
+impl<'a> From<NormalEntry<&'a [u8]>> for NormalEntry<Box<[u8]>> {
+    #[inline]
+    fn from(value: NormalEntry<&'a [u8]>) -> Self {
+        Self {
+            header: value.header,
+            phsf: value.phsf,
+            extra: value.extra.into_iter().map(Into::into).collect(),
+            data: value.data.into_iter().map(Into::into).collect(),
+            metadata: value.metadata,
+        }
+    }
+}
+
+impl From<NormalEntry<Box<[u8]>>> for NormalEntry<Vec<u8>> {
+    #[inline]
+    fn from(value: NormalEntry<Box<[u8]>>) -> Self {
+        Self {
+            header: value.header,
+            phsf: value.phsf,
+            extra: value.extra.into_iter().map(Into::into).collect(),
+            data: value.data.into_iter().map(Into::into).collect(),
+            metadata: value.metadata,
+        }
+    }
+}
+
 /// A structure representing the split [`Entry`] for archive splitting.
 #[deprecated(since = "TBD", note = "use Archive::write_split_header instead")]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
@@ -1351,21 +1519,25 @@ mod tests {
         check_impl::<NormalEntry<Cow<[u8]>>>();
         check_impl::<NormalEntry<&[u8]>>();
         check_impl::<NormalEntry<[u8; 1]>>();
+        check_impl::<NormalEntry<Box<[u8]>>>();
 
         check_impl::<SolidEntry<Vec<u8>>>();
         check_impl::<SolidEntry<Cow<[u8]>>>();
         check_impl::<SolidEntry<&[u8]>>();
         check_impl::<SolidEntry<[u8; 1]>>();
+        check_impl::<SolidEntry<Box<[u8]>>>();
 
         check_impl::<ReadEntry<Vec<u8>>>();
         check_impl::<ReadEntry<Cow<[u8]>>>();
         check_impl::<ReadEntry<&[u8]>>();
         check_impl::<ReadEntry<[u8; 1]>>();
+        check_impl::<ReadEntry<Box<[u8]>>>();
 
         check_impl::<RawEntry<Vec<u8>>>();
         check_impl::<RawEntry<Cow<[u8]>>>();
         check_impl::<RawEntry<&[u8]>>();
         check_impl::<RawEntry<[u8; 1]>>();
+        check_impl::<RawEntry<Box<[u8]>>>();
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `Box<[u8]>` as a first-class data representation for `RawChunk<T>`, with `From` conversions to/from the existing `Vec<u8>`, `Cow<[u8]>`, `&[u8]`, and `[u8; N]` variants wherever the underlying std `From` exists.
- Extend the same `Box<[u8]>` conversions to the Entry-family generic types (`RawEntry`, `ReadEntry`, `SolidEntry`, `NormalEntry`), matching each type's existing `Vec<u8>`/`Cow`/`&[u8]` conversion set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for boxed byte storage across chunk and entry data types.
  * Added conversions between boxed, owned, borrowed, and copy-on-write byte representations.
  * Preserved chunk metadata, lengths, and CRC values during conversions.
* **Tests**
  * Expanded compatibility checks to cover boxed byte storage for chunks and entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->