### PR TITLE
:white_check_mark: Remove conditional passes from tests and enforce precondition skips

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,7 @@ jobs:
           cargo hack test --locked --release --feature-powerset --exclude-features wasm --exclude portable-network-archive-fuzz --exclude xtask -- --test-threads=1
         env:
           RUST_BACKTRACE: 1
+          PNA_TEST_REQUIRE: ${{ startsWith(matrix.os, 'windows') && 'birthtime,mtime_nanos' || 'birthtime,mtime_nanos,xattr,nodump,chmod,setuid,unprivileged' }}
       - name: Save rust build cache
         if: github.ref_name == github.event.repository.default_branch && matrix.rust == 'stable' && steps.restore-rust-build-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -219,6 +220,7 @@ jobs:
         env:
           CRATE: ${{ matrix.crate }}
           RUST_BACKTRACE: 1
+          PNA_TEST_REQUIRE: birthtime,mtime_nanos,xattr,nodump,chmod,setuid,unprivileged
       - name: Save rust build cache
         if: github.ref_name == github.event.repository.default_branch && steps.restore-rust-build-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -99,6 +99,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 50
     name: Test on FreeBSD
+    env:
+      # This job exists to exercise POSIX.1e ACLs and extended attributes on
+      # the UFS image mounted below, so a skip for want of xattr means that
+      # mount stopped delivering them.
+      PNA_TEST_REQUIRE: root,xattr
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/vm.yml
+++ b/.github/workflows/vm.yml
@@ -31,6 +31,8 @@ permissions:
 
 env:
   RUST_BACKTRACE: 1
+  # These VMs run the suite as root, so a skip for want of privilege is a defect.
+  PNA_TEST_REQUIRE: root
 
 jobs:
   solaris-test:
@@ -45,7 +47,7 @@ jobs:
         id: test
         uses: vmactions/solaris-vm@315163f088b66e55bbcc45928bd224d4973b2312 # v1.3.8
         with:
-          envs: "RUST_BACKTRACE"
+          envs: "RUST_BACKTRACE PNA_TEST_REQUIRE"
           copyback: false
           disable-cache: true
           usesh: true
@@ -75,7 +77,7 @@ jobs:
         id: test
         uses: vmactions/NetBSD-vm@00081e82b14bc40114eb97f32b4455306828516b # v1.4.6
         with:
-          envs: "RUST_BACKTRACE"
+          envs: "RUST_BACKTRACE PNA_TEST_REQUIRE"
           copyback: false
           disable-cache: true
           usesh: true
@@ -105,7 +107,7 @@ jobs:
         id: test
         uses: vmactions/freebsd-vm@d0518f912576ae759075aa00fb9fe27037940271 # v1.5.4
         with:
-          envs: "RUST_BACKTRACE"
+          envs: "RUST_BACKTRACE PNA_TEST_REQUIRE"
           copyback: false
           disable-cache: true
           usesh: true
@@ -167,7 +169,7 @@ jobs:
         id: test
         uses: vmactions/OpenBSD-vm@e6c68b637a12e83519688d115d57d5b0b53923cd # v1.4.6
         with:
-          envs: "RUST_BACKTRACE"
+          envs: "RUST_BACKTRACE PNA_TEST_REQUIRE"
           copyback: false
           disable-cache: true
           usesh: true
@@ -221,7 +223,7 @@ jobs:
         id: test
         uses: vmactions/omnios-vm@f777b9ef6bf644b6c9a33e018bd158b5b1982f06 # v1.3.5
         with:
-          envs: "RUST_BACKTRACE"
+          envs: "RUST_BACKTRACE PNA_TEST_REQUIRE"
           copyback: false
           disable-cache: true
           usesh: true

--- a/cli/tests/cli/append.rs
+++ b/cli/tests/cli/append.rs
@@ -8,11 +8,13 @@ mod option_exclude_vcs;
 mod option_newer_ctime;
 mod option_newer_ctime_than;
 mod option_newer_mtime;
+#[cfg(not(target_family = "wasm"))]
 mod option_newer_mtime_than;
 #[cfg(any(windows, target_os = "macos"))]
 mod option_older_ctime;
 mod option_older_ctime_than;
 mod option_older_mtime;
+#[cfg(not(target_family = "wasm"))]
 mod option_older_mtime_than;
 
 use crate::utils::{EmbedExt, TestResources, diff::assert_dirs_equal, setup};

--- a/cli/tests/cli/append/option_newer_ctime_than.rs
+++ b/cli/tests/cli/append/option_newer_ctime_than.rs
@@ -1,7 +1,10 @@
-use crate::utils::{archive, setup, time::ensure_ctime_order};
+use crate::utils::{
+    archive, setup,
+    time::{birth_time, birth_time_recorded, create_file_born_after},
+};
 use clap::Parser;
 use portable_network_archive::cli;
-use std::{collections::HashSet, fs, thread, time::Duration};
+use std::{collections::HashSet, fs};
 
 /// Precondition: An archive exists with an older file, and the source tree contains a reference file and a newer file.
 /// Action: Run `pna append` with `--newer-ctime-than` pointing to the reference file.
@@ -14,19 +17,11 @@ fn append_with_newer_ctime_than() {
     let older_file = "append_newer_ctime_than/older.txt";
     let newer_file = "append_newer_ctime_than/newer.txt";
 
-    // Create directory
     fs::create_dir_all("append_newer_ctime_than").unwrap();
-
-    // Create the older file
     fs::write(older_file, "older file content").unwrap();
 
-    // Check if creation time is available on this filesystem
-    if fs::metadata(older_file).unwrap().created().is_err() {
-        eprintln!("Skipping test: creation time (birth time) is not supported on this filesystem");
-        return;
-    }
+    skip_unless!("birthtime", birth_time_recorded(older_file));
 
-    // Create an archive with the older file
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -40,24 +35,13 @@ fn append_with_newer_ctime_than() {
     .execute()
     .unwrap();
 
-    // Wait to ensure distinct ctime
-    thread::sleep(Duration::from_millis(10));
+    let reference_ctime = create_file_born_after(
+        reference_file,
+        "reference time marker",
+        birth_time(older_file),
+    );
+    create_file_born_after(newer_file, "newer file content", reference_ctime);
 
-    // Create the reference file
-    fs::write(reference_file, "reference time marker").unwrap();
-
-    // Wait to ensure the next file has a newer ctime
-    thread::sleep(Duration::from_millis(10));
-
-    // Create the newer file
-    fs::write(newer_file, "newer file content").unwrap();
-    let reference_ctime = fs::metadata(reference_file).unwrap().created().unwrap();
-    if !ensure_ctime_order(older_file, newer_file, reference_ctime) {
-        eprintln!("Skipping test: unable to produce strict ctime ordering on this filesystem");
-        return;
-    }
-
-    // Append to the archive with the `--newer-ctime-than` option
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -76,36 +60,14 @@ fn append_with_newer_ctime_than() {
     .execute()
     .unwrap();
 
-    // Verify archive contents
     let mut seen = HashSet::new();
     archive::for_each_entry("append_newer_ctime_than/test.pna", |entry| {
         seen.insert(entry.header().path().to_string());
     })
     .unwrap();
 
-    // older_file should be included (from original archive creation)
-    assert!(
-        seen.contains(older_file),
-        "older file should be in archive from initial creation: {older_file}"
-    );
-
-    // reference_file should NOT be included (ctime == reference)
-    assert!(
-        !seen.contains(reference_file),
-        "reference file should NOT be appended: {reference_file}"
-    );
-
-    // newer_file should be included (appended because ctime > reference)
-    assert!(
-        seen.contains(newer_file),
-        "newer file should be appended: {newer_file}"
-    );
-
-    // Verify that exactly two entries exist
     assert_eq!(
-        seen.len(),
-        2,
-        "Expected exactly 2 entries, but found {}: {seen:?}",
-        seen.len()
+        seen,
+        HashSet::from([older_file.to_string(), newer_file.to_string()])
     );
 }

--- a/cli/tests/cli/append/option_newer_mtime_than.rs
+++ b/cli/tests/cli/append/option_newer_mtime_than.rs
@@ -1,7 +1,10 @@
-use crate::utils::{archive, setup, time::ensure_mtime_order};
+use crate::utils::{
+    archive, setup,
+    time::{DURATION_24_HOURS, set_mtime},
+};
 use clap::Parser;
 use portable_network_archive::cli;
-use std::{collections::HashSet, fs, thread, time::Duration};
+use std::{collections::HashSet, fs, time::SystemTime};
 
 /// Precondition: An archive exists with an older file, and the source tree contains a reference file and a newer file.
 /// Action: Run `pna append` with `--newer-mtime-than` pointing to the reference file.
@@ -13,13 +16,9 @@ fn append_with_newer_mtime_than() {
     let older_file = "append_newer_mtime_than/older.txt";
     let newer_file = "append_newer_mtime_than/newer.txt";
 
-    // Create directory
     fs::create_dir_all("append_newer_mtime_than").unwrap();
-
-    // Create the older file
     fs::write(older_file, "older file content").unwrap();
 
-    // Create an archive with the older file
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -33,24 +32,13 @@ fn append_with_newer_mtime_than() {
     .execute()
     .unwrap();
 
-    // Wait to ensure distinct mtime
-    thread::sleep(Duration::from_millis(10));
-
-    // Create the reference file
+    let now = SystemTime::now();
     fs::write(reference_file, "reference time marker").unwrap();
-
-    // Wait to ensure the next file has a newer mtime
-    thread::sleep(Duration::from_millis(10));
-
-    // Create the newer file
     fs::write(newer_file, "newer file content").unwrap();
-    let reference_mtime = fs::metadata(reference_file).unwrap().modified().unwrap();
-    if !ensure_mtime_order(older_file, newer_file, reference_mtime) {
-        eprintln!("Skipping test: unable to produce strict mtime ordering on this filesystem");
-        return;
-    }
+    set_mtime(older_file, now - 2 * DURATION_24_HOURS);
+    set_mtime(reference_file, now - DURATION_24_HOURS);
+    set_mtime(newer_file, now);
 
-    // Append to the archive with the `--newer-mtime-than` option
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -68,36 +56,14 @@ fn append_with_newer_mtime_than() {
     .execute()
     .unwrap();
 
-    // Verify archive contents
     let mut seen = HashSet::new();
     archive::for_each_entry("append_newer_mtime_than/test.pna", |entry| {
         seen.insert(entry.header().path().to_string());
     })
     .unwrap();
 
-    // older_file should be included (from original archive creation)
-    assert!(
-        seen.contains(older_file),
-        "older file should be in archive from initial creation: {older_file}"
-    );
-
-    // reference_file should NOT be included (mtime == reference)
-    assert!(
-        !seen.contains(reference_file),
-        "reference file should NOT be appended: {reference_file}"
-    );
-
-    // newer_file should be included (appended because mtime > reference)
-    assert!(
-        seen.contains(newer_file),
-        "newer file should be appended: {newer_file}"
-    );
-
-    // Verify that exactly two entries exist
     assert_eq!(
-        seen.len(),
-        2,
-        "Expected exactly 2 entries, but found {}: {seen:?}",
-        seen.len()
+        seen,
+        HashSet::from([older_file.to_string(), newer_file.to_string()])
     );
 }

--- a/cli/tests/cli/append/option_older_ctime_than.rs
+++ b/cli/tests/cli/append/option_older_ctime_than.rs
@@ -1,10 +1,10 @@
 use crate::utils::{
     archive, setup,
-    time::{confirm_time_older_than, wait_until_time_newer_than},
+    time::{birth_time, birth_time_recorded, create_file_born_after},
 };
 use clap::Parser;
 use portable_network_archive::cli;
-use std::{collections::HashSet, fs, thread, time::Duration};
+use std::{collections::HashSet, fs};
 
 /// Precondition: An archive exists with an older file, and the source tree contains a reference file and a newer file.
 /// Action: Run `pna append` with `--older-ctime-than` pointing to the reference file.
@@ -22,12 +22,8 @@ fn append_with_older_ctime_than() {
     fs::create_dir_all(base_dir).unwrap();
     fs::write(&older_file, "older file content").unwrap();
 
-    if fs::metadata(&older_file).unwrap().created().is_err() {
-        eprintln!("Skipping test: creation time (birth time) is not supported on this filesystem");
-        return;
-    }
+    skip_unless!("birthtime", birth_time_recorded(&older_file));
 
-    // Create the initial archive containing only the older file.
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -41,21 +37,12 @@ fn append_with_older_ctime_than() {
     .execute()
     .unwrap();
 
-    thread::sleep(Duration::from_millis(10));
-    fs::write(&reference_file, "reference content").unwrap();
-    let reference_ctime = fs::metadata(&reference_file).unwrap().created().unwrap();
-
-    thread::sleep(Duration::from_millis(10));
-    fs::write(&newer_file, "newer content").unwrap();
-
-    if !confirm_time_older_than(&older_file, reference_ctime, |m| m.created().ok())
-        || !wait_until_time_newer_than(&newer_file, reference_ctime, |m| m.created().ok())
-    {
-        eprintln!(
-            "Skipping test: unable to establish required creation time ordering on this filesystem"
-        );
-        return;
-    }
+    let reference_ctime = create_file_born_after(
+        &reference_file,
+        "reference content",
+        birth_time(&older_file),
+    );
+    create_file_born_after(&newer_file, "newer content", reference_ctime);
 
     cli::Cli::try_parse_from([
         "pna",
@@ -80,22 +67,5 @@ fn append_with_older_ctime_than() {
     })
     .unwrap();
 
-    assert!(
-        seen.contains(&older_file),
-        "older file should remain from initial archive: {older_file}"
-    );
-    assert!(
-        !seen.contains(&reference_file),
-        "reference file should NOT be appended: {reference_file}"
-    );
-    assert!(
-        !seen.contains(&newer_file),
-        "newer file should NOT be appended: {newer_file}"
-    );
-    assert_eq!(
-        seen.len(),
-        1,
-        "Expected exactly 1 entry (older only) but found {}: {seen:?}",
-        seen.len()
-    );
+    assert_eq!(seen, HashSet::from([older_file]));
 }

--- a/cli/tests/cli/append/option_older_mtime_than.rs
+++ b/cli/tests/cli/append/option_older_mtime_than.rs
@@ -1,10 +1,10 @@
 use crate::utils::{
     archive, setup,
-    time::{confirm_time_older_than, wait_until_time_newer_than},
+    time::{DURATION_24_HOURS, set_mtime},
 };
 use clap::Parser;
 use portable_network_archive::cli;
-use std::{collections::HashSet, fs, thread, time::Duration};
+use std::{collections::HashSet, fs, time::SystemTime};
 
 /// Precondition: An archive exists with an older file, and the source tree contains a reference file and a newer file.
 /// Action: Run `pna append` with `--older-mtime-than` pointing to the reference file.
@@ -34,21 +34,12 @@ fn append_with_older_mtime_than() {
     .execute()
     .unwrap();
 
-    thread::sleep(Duration::from_millis(10));
+    let now = SystemTime::now();
     fs::write(&reference_file, "reference mtime content").unwrap();
-    let reference_mtime = fs::metadata(&reference_file).unwrap().modified().unwrap();
-
-    thread::sleep(Duration::from_millis(10));
     fs::write(&newer_file, "newer mtime content").unwrap();
-
-    if !confirm_time_older_than(&older_file, reference_mtime, |m| m.modified().ok())
-        || !wait_until_time_newer_than(&newer_file, reference_mtime, |m| m.modified().ok())
-    {
-        eprintln!(
-            "Skipping test: unable to establish required modification time ordering on this filesystem"
-        );
-        return;
-    }
+    set_mtime(&older_file, now - 2 * DURATION_24_HOURS);
+    set_mtime(&reference_file, now - DURATION_24_HOURS);
+    set_mtime(&newer_file, now);
 
     cli::Cli::try_parse_from([
         "pna",
@@ -73,22 +64,5 @@ fn append_with_older_mtime_than() {
     })
     .unwrap();
 
-    assert!(
-        seen.contains(&older_file),
-        "older file should remain from initial archive: {older_file}"
-    );
-    assert!(
-        !seen.contains(&reference_file),
-        "reference file should NOT be appended: {reference_file}"
-    );
-    assert!(
-        !seen.contains(&newer_file),
-        "newer file should NOT be appended: {newer_file}"
-    );
-    assert_eq!(
-        seen.len(),
-        1,
-        "Expected exactly 1 entry (older only) but found {}: {seen:?}",
-        seen.len()
-    );
+    assert_eq!(seen, HashSet::from([older_file]));
 }

--- a/cli/tests/cli/bsdtar/option_chroot.rs
+++ b/cli/tests/cli/bsdtar/option_chroot.rs
@@ -8,10 +8,7 @@ use std::fs;
 /// Expectation: Absolute output path is resolved relative to chroot root, not filesystem root.
 #[test]
 fn compat_bsdtar_extract_chroot() {
-    // chroot needs root privileges.
-    if !nix::unistd::Uid::effective().is_root() {
-        return;
-    }
+    skip_unless!("root", nix::unistd::Uid::effective().is_root());
     setup();
     TestResources::extract_in("zstd.pna", "extract_chroot/").unwrap();
 

--- a/cli/tests/cli/bsdtar/option_same_permissions.rs
+++ b/cli/tests/cli/bsdtar/option_same_permissions.rs
@@ -8,28 +8,14 @@
 use crate::utils::archive;
 #[cfg(unix)]
 use crate::utils::pna_cmd_with_umask;
+#[cfg(unix)]
+use crate::utils::set_mode;
 use crate::utils::setup;
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::predicate;
 use std::fs;
 #[cfg(unix)]
-use std::io::ErrorKind;
-#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
-
-#[cfg(unix)]
-macro_rules! set_permissions_or_skip {
-    ($path:expr, $mode:expr) => {
-        match fs::set_permissions($path, fs::Permissions::from_mode($mode)) {
-            Ok(()) => {}
-            Err(e) if e.kind() == ErrorKind::PermissionDenied => {
-                eprintln!("Skipping test: insufficient permissions: {}", e);
-                return;
-            }
-            Err(e) => panic!("Failed to set permissions: {}", e),
-        }
-    };
-}
 
 // =============================================================================
 // Flag Validation Tests
@@ -233,7 +219,7 @@ fn bsdtar_extract_with_same_permissions_and_same_owner() {
 
     let file = format!("{base}/test.txt");
     fs::write(&file, "test content").unwrap();
-    set_permissions_or_skip!(&file, 0o751);
+    skip_unless!("chmod", set_mode(&file, 0o751));
 
     let mut create_cmd = cargo_bin_cmd!("pna");
     let create_output = create_cmd
@@ -318,7 +304,7 @@ fn bsdtar_extract_same_permissions_with_no_acls() {
 
     let file = format!("{base}/test.txt");
     fs::write(&file, "test content").unwrap();
-    set_permissions_or_skip!(&file, 0o752);
+    skip_unless!("chmod", set_mode(&file, 0o752));
 
     let mut create_cmd = cargo_bin_cmd!("pna");
     let create_output = create_cmd
@@ -403,7 +389,7 @@ fn bsdtar_extract_with_long_same_permissions_flag() {
 
     let file = format!("{base}/test.txt");
     fs::write(&file, "test content").unwrap();
-    set_permissions_or_skip!(&file, 0o755);
+    skip_unless!("chmod", set_mode(&file, 0o755));
 
     let mut create_cmd = cargo_bin_cmd!("pna");
     let create_output = create_cmd
@@ -486,7 +472,7 @@ fn bsdtar_extract_with_preserve_permissions_alias() {
 
     let file = format!("{base}/test.txt");
     fs::write(&file, "test content").unwrap();
-    set_permissions_or_skip!(&file, 0o754);
+    skip_unless!("chmod", set_mode(&file, 0o754));
 
     let mut create_cmd = cargo_bin_cmd!("pna");
     let create_output = create_cmd
@@ -573,7 +559,7 @@ fn bsdtar_extract_same_permissions_overridden_by_no_same_permissions() {
 
     let file = format!("{base}/test.txt");
     fs::write(&file, "test content").unwrap();
-    set_permissions_or_skip!(&file, 0o755);
+    skip_unless!("chmod", set_mode(&file, 0o755));
 
     let mut create_cmd = cargo_bin_cmd!("pna");
     let create_output = create_cmd
@@ -658,10 +644,7 @@ fn bsdtar_extract_no_same_permissions_with_keep_xattr() {
     let base = "bsdtar_no_same_p_keep_xattr";
     fs::create_dir_all(base).unwrap();
 
-    if !xattr_supported(base) {
-        eprintln!("Skipping test: xattr not supported on this filesystem");
-        return;
-    }
+    skip_unless!("xattr", xattr_supported(base));
 
     let file = format!("{base}/test.txt");
     fs::write(&file, "test content").unwrap();
@@ -786,10 +769,7 @@ fn bsdtar_extract_no_same_permissions_alone() {
 #[test]
 #[cfg(unix)]
 fn bsdtar_extract_without_p_masks_permissions() {
-    if nix::unistd::Uid::effective().is_root() {
-        eprintln!("Skipping: test requires non-root user (root defaults to preserve mode)");
-        return;
-    }
+    skip_unless!("unprivileged", !nix::unistd::Uid::effective().is_root());
     setup();
     let base = "bsdtar_extract_no_p_perm";
     fs::create_dir_all(base).unwrap();
@@ -797,7 +777,7 @@ fn bsdtar_extract_without_p_masks_permissions() {
     // Create file with executable permission
     let file = format!("{}/test.txt", base);
     fs::write(&file, "test content").unwrap();
-    set_permissions_or_skip!(&file, 0o755);
+    skip_unless!("chmod", set_mode(&file, 0o755));
 
     // Verify source file has expected permission
     let src_meta = fs::symlink_metadata(&file).unwrap();
@@ -859,7 +839,7 @@ fn bsdtar_extract_with_p_preserves_permissions() {
     // Create file with executable permission
     let file = format!("{}/test.txt", base);
     fs::write(&file, "test content").unwrap();
-    set_permissions_or_skip!(&file, 0o755);
+    skip_unless!("chmod", set_mode(&file, 0o755));
 
     // Create archive via bsdtar (stores mode+owner by default)
     let mut create_cmd = cargo_bin_cmd!("pna");
@@ -913,7 +893,7 @@ fn bsdtar_create_stores_permissions_by_default() {
     // Create file with executable permission
     let file = format!("{}/test.txt", base);
     fs::write(&file, "test content").unwrap();
-    set_permissions_or_skip!(&file, 0o755);
+    skip_unless!("chmod", set_mode(&file, 0o755));
 
     // Create archive via bsdtar and write to file
     let archive_path = format!("{}/archive.pna", base);
@@ -977,7 +957,7 @@ fn bsdtar_create_with_no_same_owner_omits_permission() {
     // Create file
     let file = format!("{}/test.txt", base);
     fs::write(&file, "test content").unwrap();
-    set_permissions_or_skip!(&file, 0o644);
+    skip_unless!("chmod", set_mode(&file, 0o644));
 
     // Create archive with --no-same-owner
     let archive_path = format!("{}/archive.pna", base);
@@ -1054,10 +1034,7 @@ fn bsdtar_extract_with_p_restores_xattr() {
     let base = "bsdtar_extract_p_xattr";
     fs::create_dir_all(base).unwrap();
 
-    if !xattr_supported(base) {
-        eprintln!("Skipping test: xattr not supported on this filesystem");
-        return;
-    }
+    skip_unless!("xattr", xattr_supported(base));
 
     // Create file with xattr
     let file = format!("{}/test.txt", base);
@@ -1123,17 +1100,14 @@ fn bsdtar_extract_with_p_restores_xattr() {
 #[test]
 #[cfg(unix)]
 fn bsdtar_extract_no_same_permissions_applies_mask() {
-    if nix::unistd::Uid::effective().is_root() {
-        eprintln!("Skipping: test requires non-root user");
-        return;
-    }
+    skip_unless!("unprivileged", !nix::unistd::Uid::effective().is_root());
     setup();
     let base = "bsdtar_extract_no_same_p_applies_mask";
     fs::create_dir_all(base).unwrap();
 
     let file = format!("{}/test.txt", base);
     fs::write(&file, "test content").unwrap();
-    set_permissions_or_skip!(&file, 0o755);
+    skip_unless!("chmod", set_mode(&file, 0o755));
 
     let mut create_cmd = cargo_bin_cmd!("pna");
     let create_output = create_cmd
@@ -1186,13 +1160,10 @@ fn bsdtar_extract_with_p_preserves_special_bits() {
 
     let file = format!("{}/setuid_file.txt", base);
     fs::write(&file, "test content").unwrap();
-    set_permissions_or_skip!(&file, 0o4755);
+    skip_unless!("chmod", set_mode(&file, 0o4755));
 
     let src_meta = fs::symlink_metadata(&file).unwrap();
-    if src_meta.permissions().mode() & 0o7777 != 0o4755 {
-        eprintln!("Skipping: filesystem doesn't support setuid bit");
-        return;
-    }
+    skip_unless!("setuid", src_meta.permissions().mode() & 0o7777 == 0o4755);
 
     let mut create_cmd = cargo_bin_cmd!("pna");
     let create_output = create_cmd
@@ -1237,17 +1208,14 @@ fn bsdtar_extract_with_p_preserves_special_bits() {
 #[test]
 #[cfg(unix)]
 fn bsdtar_extract_root_default_preserves_permissions() {
-    if !nix::unistd::Uid::effective().is_root() {
-        eprintln!("Skipping: test requires root user");
-        return;
-    }
+    skip_unless!("root", nix::unistd::Uid::effective().is_root());
     setup();
     let base = "bsdtar_extract_root_default";
     fs::create_dir_all(base).unwrap();
 
     let file = format!("{}/test.txt", base);
     fs::write(&file, "test content").unwrap();
-    set_permissions_or_skip!(&file, 0o755);
+    skip_unless!("chmod", set_mode(&file, 0o755));
 
     let mut create_cmd = cargo_bin_cmd!("pna");
     let create_output = create_cmd
@@ -1291,17 +1259,14 @@ fn bsdtar_extract_root_default_preserves_permissions() {
 #[test]
 #[cfg(unix)]
 fn bsdtar_extract_root_with_no_same_permissions_masks() {
-    if !nix::unistd::Uid::effective().is_root() {
-        eprintln!("Skipping: test requires root user");
-        return;
-    }
+    skip_unless!("root", nix::unistd::Uid::effective().is_root());
     setup();
     let base = "bsdtar_extract_root_no_same_p";
     fs::create_dir_all(base).unwrap();
 
     let file = format!("{}/test.txt", base);
     fs::write(&file, "test content").unwrap();
-    set_permissions_or_skip!(&file, 0o755);
+    skip_unless!("chmod", set_mode(&file, 0o755));
 
     let mut create_cmd = cargo_bin_cmd!("pna");
     let create_output = create_cmd
@@ -1350,10 +1315,7 @@ fn bsdtar_extract_without_p_does_not_restore_xattr() {
     let base = "bsdtar_extract_no_p_xattr";
     fs::create_dir_all(base).unwrap();
 
-    if !xattr_supported(base) {
-        eprintln!("Skipping test: xattr not supported on this filesystem");
-        return;
-    }
+    skip_unless!("xattr", xattr_supported(base));
 
     // Create file with xattr
     let file = format!("{}/test.txt", base);

--- a/cli/tests/cli/chmod.rs
+++ b/cli/tests/cli/chmod.rs
@@ -80,17 +80,10 @@ fn archive_chmod() {
     .execute()
     .unwrap();
 
-    archive::for_each_entry("chmod.pna", |entry| {
-        if entry.header().path() == ENTRY_PATH {
-            let mode = entry
-                .metadata()
-                .permission_mode()
-                .expect("entry should have permission mode metadata")
-                .get();
-            assert_eq!(mode & 0o777, 0o666, "-x on 0o777 should yield 0o666");
-        }
-    })
-    .unwrap();
+    assert_eq!(
+        archive::modes_by_entry("chmod.pna"),
+        vec![(ENTRY_PATH.to_string(), Some(0o666))]
+    );
 }
 
 /// Precondition: An archive entry carries legacy fPRM metadata.

--- a/cli/tests/cli/chmod/glob_pattern.rs
+++ b/cli/tests/cli/chmod/glob_pattern.rs
@@ -50,18 +50,15 @@ fn chmod_glob_pattern_txt_files() {
     .execute()
     .unwrap();
 
-    archive::for_each_entry("chmod_glob_txt.pna", |entry| {
-        let path = entry.header().path();
-        let path_str = path.as_str();
-        if let Some(pm) = entry.metadata().permission_mode() {
-            if path_str.ends_with(".txt") {
-                assert_eq!(pm.get() & 0o777, 0o755, "{} should be 755", path_str);
-            } else if path_str.ends_with(".png") {
-                assert_eq!(pm.get() & 0o777, 0o600, "icon.png should remain 600");
-            }
-        }
-    })
-    .unwrap();
+    assert_eq!(
+        archive::modes_by_entry("chmod_glob_txt.pna"),
+        vec![
+            ("dir/text.txt".to_string(), Some(0o755)),
+            ("dir/empty.txt".to_string(), Some(0o755)),
+            ("dir/sub/child.txt".to_string(), Some(0o755)),
+            ("dir/images/icon.png".to_string(), Some(0o600)),
+        ]
+    );
 }
 
 /// Precondition: An archive contains files in nested directories.
@@ -107,16 +104,12 @@ fn chmod_glob_pattern_subdirectory() {
     .execute()
     .unwrap();
 
-    archive::for_each_entry("chmod_glob_subdir.pna", |entry| {
-        let path = entry.header().path();
-        let path_str = path.as_str();
-        if let Some(pm) = entry.metadata().permission_mode() {
-            if path_str.contains("/images/") {
-                assert_eq!(pm.get() & 0o777, 0o755, "{} should be 755", path_str);
-            } else if path_str.ends_with(".txt") {
-                assert_eq!(pm.get() & 0o777, 0o644, "text.txt should remain 644");
-            }
-        }
-    })
-    .unwrap();
+    assert_eq!(
+        archive::modes_by_entry("chmod_glob_subdir.pna"),
+        vec![
+            ("dir/images/icon.png".to_string(), Some(0o755)),
+            ("dir/images/icon.svg".to_string(), Some(0o755)),
+            ("dir/text.txt".to_string(), Some(0o644)),
+        ]
+    );
 }

--- a/cli/tests/cli/create.rs
+++ b/cli/tests/cli/create.rs
@@ -16,12 +16,14 @@ mod option_include;
 mod option_newer_ctime;
 mod option_newer_ctime_than;
 mod option_newer_mtime;
+#[cfg(not(target_family = "wasm"))]
 mod option_newer_mtime_than;
 mod option_no_recursive;
 #[cfg(any(windows, target_os = "macos"))]
 mod option_older_ctime;
 mod option_older_ctime_than;
 mod option_older_mtime;
+#[cfg(not(target_family = "wasm"))]
 mod option_older_mtime_than;
 #[cfg(unix)]
 mod option_one_file_system;

--- a/cli/tests/cli/create/option_newer_ctime_than.rs
+++ b/cli/tests/cli/create/option_newer_ctime_than.rs
@@ -1,10 +1,10 @@
 use crate::utils::{
     archive, setup,
-    time::{confirm_time_older_than, wait_until_time_newer_than},
+    time::{birth_time, birth_time_recorded, create_file_born_after},
 };
 use clap::Parser;
 use portable_network_archive::cli;
-use std::{collections::HashSet, fs, thread, time::Duration};
+use std::{collections::HashSet, fs};
 
 /// Precondition: The source tree contains files with strictly ordered creation times and a reference file.
 /// Action: Run `pna create` with `--newer-ctime-than` pointing to the reference file.
@@ -17,36 +17,18 @@ fn create_with_newer_ctime_than() {
     let older_file = "create_newer_ctime_than/older.txt";
     let newer_file = "create_newer_ctime_than/newer.txt";
 
-    // Create the older file first
     fs::create_dir_all("create_newer_ctime_than").unwrap();
     fs::write(older_file, "older file content").unwrap();
 
-    // Check if creation time is available on this filesystem
-    if fs::metadata(older_file).unwrap().created().is_err() {
-        eprintln!("Skipping test: creation time (birth time) is not supported on this filesystem");
-        return;
-    }
+    skip_unless!("birthtime", birth_time_recorded(older_file));
 
-    // Wait to ensure distinct ctime
-    thread::sleep(Duration::from_millis(10));
+    let reference_ctime = create_file_born_after(
+        reference_file,
+        "reference time marker",
+        birth_time(older_file),
+    );
+    create_file_born_after(newer_file, "newer file content", reference_ctime);
 
-    // Create the reference file
-    fs::write(reference_file, "reference time marker").unwrap();
-    let reference_ctime = fs::metadata(reference_file).unwrap().created().unwrap();
-
-    // Wait to ensure the next file has a newer ctime
-    thread::sleep(Duration::from_millis(10));
-
-    // Create the newer file
-    fs::write(newer_file, "newer file content").unwrap();
-    if !wait_until_time_newer_than(newer_file, reference_ctime, |m| m.created().ok())
-        || !confirm_time_older_than(older_file, reference_ctime, |m| m.created().ok())
-    {
-        eprintln!("Skipping test: unable to produce distinct creation times on this filesystem");
-        return;
-    }
-
-    // Create an archive with the `--newer-ctime-than` option
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -66,36 +48,11 @@ fn create_with_newer_ctime_than() {
     .execute()
     .unwrap();
 
-    // Verify archive contents
     let mut seen = HashSet::new();
     archive::for_each_entry("create_newer_ctime_than/test.pna", |entry| {
         seen.insert(entry.header().path().to_string());
     })
     .unwrap();
 
-    // newer_file should be included (ctime > reference)
-    assert!(
-        seen.contains(newer_file),
-        "newer file should be included: {newer_file}"
-    );
-
-    // reference_file should NOT be included (ctime == reference)
-    assert!(
-        !seen.contains(reference_file),
-        "reference file should NOT be included: {reference_file}"
-    );
-
-    // older_file should NOT be included (ctime < reference)
-    assert!(
-        !seen.contains(older_file),
-        "older file should NOT be included: {older_file}"
-    );
-
-    // Verify that exactly one entry exists (newer only)
-    assert_eq!(
-        seen.len(),
-        1,
-        "Expected exactly 1 entry, but found {}: {seen:?}",
-        seen.len()
-    );
+    assert_eq!(seen, HashSet::from([newer_file.to_string()]));
 }

--- a/cli/tests/cli/create/option_newer_mtime_than.rs
+++ b/cli/tests/cli/create/option_newer_mtime_than.rs
@@ -1,7 +1,10 @@
-use crate::utils::{archive, setup, time::ensure_mtime_order};
+use crate::utils::{
+    archive, setup,
+    time::{DURATION_24_HOURS, set_mtime},
+};
 use clap::Parser;
 use portable_network_archive::cli;
-use std::{collections::HashSet, fs, thread, time::Duration};
+use std::{collections::HashSet, fs, time::SystemTime};
 
 /// Precondition: The source tree contains files with strictly ordered modification times and a reference file.
 /// Action: Run `pna create` with `--newer-mtime-than` pointing to the reference file.
@@ -13,28 +16,15 @@ fn create_with_newer_mtime_than() {
     let older_file = "create_newer_mtime_than/older.txt";
     let newer_file = "create_newer_mtime_than/newer.txt";
 
-    // Create the older file first
+    let now = SystemTime::now();
     fs::create_dir_all("create_newer_mtime_than").unwrap();
     fs::write(older_file, "older file content").unwrap();
-
-    // Wait to ensure distinct mtime
-    thread::sleep(Duration::from_millis(10));
-
-    // Create the reference file
     fs::write(reference_file, "reference time marker").unwrap();
-
-    // Wait to ensure the next file has a newer mtime
-    thread::sleep(Duration::from_millis(10));
-
-    // Create the newer file
     fs::write(newer_file, "newer file content").unwrap();
-    let reference_mtime = fs::metadata(reference_file).unwrap().modified().unwrap();
-    if !ensure_mtime_order(older_file, newer_file, reference_mtime) {
-        eprintln!("Skipping test: unable to produce strict mtime ordering on this filesystem");
-        return;
-    }
+    set_mtime(older_file, now - 2 * DURATION_24_HOURS);
+    set_mtime(reference_file, now - DURATION_24_HOURS);
+    set_mtime(newer_file, now);
 
-    // Create an archive with the `--newer-mtime-than` option
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -53,36 +43,11 @@ fn create_with_newer_mtime_than() {
     .execute()
     .unwrap();
 
-    // Verify archive contents
     let mut seen = HashSet::new();
     archive::for_each_entry("create_newer_mtime_than/test.pna", |entry| {
         seen.insert(entry.header().path().to_string());
     })
     .unwrap();
 
-    // newer_file should be included (mtime > reference)
-    assert!(
-        seen.contains(newer_file),
-        "newer file should be included: {newer_file}"
-    );
-
-    // reference_file should NOT be included (mtime == reference)
-    assert!(
-        !seen.contains(reference_file),
-        "reference file should NOT be included: {reference_file}"
-    );
-
-    // older_file should NOT be included (mtime < reference)
-    assert!(
-        !seen.contains(older_file),
-        "older file should NOT be included: {older_file}"
-    );
-
-    // Verify that exactly one entry exists (newer only)
-    assert_eq!(
-        seen.len(),
-        1,
-        "Expected exactly 1 entry, but found {}: {seen:?}",
-        seen.len()
-    );
+    assert_eq!(seen, HashSet::from([newer_file.to_string()]));
 }

--- a/cli/tests/cli/create/option_older_ctime_than.rs
+++ b/cli/tests/cli/create/option_older_ctime_than.rs
@@ -1,7 +1,10 @@
-use crate::utils::{archive, setup, time::ensure_ctime_order};
+use crate::utils::{
+    archive, setup,
+    time::{birth_time, birth_time_recorded, create_file_born_after},
+};
 use clap::Parser;
 use portable_network_archive::cli;
-use std::{collections::HashSet, fs, thread, time::Duration};
+use std::{collections::HashSet, fs};
 
 /// Precondition: The source tree contains files with strictly ordered creation times and a reference file.
 /// Action: Run `pna create` with `--older-ctime-than` pointing to the reference file.
@@ -17,24 +20,14 @@ fn create_with_older_ctime_than() {
     fs::create_dir_all("create_older_ctime_than").unwrap();
     fs::write(older_file, "older file content").unwrap();
 
-    if fs::metadata(older_file).unwrap().created().is_err() {
-        eprintln!("Skipping test: creation time (birth time) not supported on this filesystem");
-        return;
-    }
+    skip_unless!("birthtime", birth_time_recorded(older_file));
 
-    thread::sleep(Duration::from_millis(10));
-    fs::write(reference_file, "reference file content").unwrap();
-    let reference_ctime = fs::metadata(reference_file).unwrap().created().unwrap();
-
-    thread::sleep(Duration::from_millis(10));
-    fs::write(newer_file, "newer file content").unwrap();
-
-    if !ensure_ctime_order(older_file, newer_file, reference_ctime) {
-        eprintln!(
-            "Skipping test: unable to establish strict creation time ordering on this filesystem"
-        );
-        return;
-    }
+    let reference_ctime = create_file_born_after(
+        reference_file,
+        "reference file content",
+        birth_time(older_file),
+    );
+    create_file_born_after(newer_file, "newer file content", reference_ctime);
 
     cli::Cli::try_parse_from([
         "pna",
@@ -61,22 +54,5 @@ fn create_with_older_ctime_than() {
     })
     .unwrap();
 
-    assert!(
-        seen.contains(older_file),
-        "older file should be included: {older_file}"
-    );
-    assert!(
-        !seen.contains(reference_file),
-        "reference file should NOT be included: {reference_file}"
-    );
-    assert!(
-        !seen.contains(newer_file),
-        "newer file should NOT be included: {newer_file}"
-    );
-    assert_eq!(
-        seen.len(),
-        1,
-        "Expected exactly 1 entry, but found {}: {seen:?}",
-        seen.len()
-    );
+    assert_eq!(seen, HashSet::from([older_file.to_string()]));
 }

--- a/cli/tests/cli/create/option_older_mtime_than.rs
+++ b/cli/tests/cli/create/option_older_mtime_than.rs
@@ -1,10 +1,10 @@
 use crate::utils::{
     archive, setup,
-    time::{confirm_time_older_than, wait_until_time_newer_than},
+    time::{DURATION_24_HOURS, set_mtime},
 };
 use clap::Parser;
 use portable_network_archive::cli;
-use std::{collections::HashSet, fs, thread, time::Duration};
+use std::{collections::HashSet, fs, time::SystemTime};
 
 /// Precondition: The source tree contains files with strictly ordered modification times and a reference file.
 /// Action: Run `pna create` with `--older-mtime-than` pointing to the reference file.
@@ -16,24 +16,14 @@ fn create_with_older_mtime_than() {
     let older_file = "create_older_mtime_than/older.txt";
     let newer_file = "create_older_mtime_than/newer.txt";
 
+    let now = SystemTime::now();
     fs::create_dir_all("create_older_mtime_than").unwrap();
     fs::write(older_file, "older file content").unwrap();
-
-    thread::sleep(Duration::from_millis(10));
     fs::write(reference_file, "reference file content").unwrap();
-    let reference_mtime = fs::metadata(reference_file).unwrap().modified().unwrap();
-
-    thread::sleep(Duration::from_millis(10));
     fs::write(newer_file, "newer file content").unwrap();
-
-    if !confirm_time_older_than(older_file, reference_mtime, |m| m.modified().ok())
-        || !wait_until_time_newer_than(newer_file, reference_mtime, |m| m.modified().ok())
-    {
-        eprintln!(
-            "Skipping test: unable to establish strict modification time ordering on this filesystem"
-        );
-        return;
-    }
+    set_mtime(older_file, now - 2 * DURATION_24_HOURS);
+    set_mtime(reference_file, now - DURATION_24_HOURS);
+    set_mtime(newer_file, now);
 
     cli::Cli::try_parse_from([
         "pna",
@@ -60,22 +50,5 @@ fn create_with_older_mtime_than() {
     })
     .unwrap();
 
-    assert!(
-        seen.contains(older_file),
-        "older file should be included: {older_file}"
-    );
-    assert!(
-        !seen.contains(reference_file),
-        "reference file should NOT be included: {reference_file}"
-    );
-    assert!(
-        !seen.contains(newer_file),
-        "newer file should NOT be included: {newer_file}"
-    );
-    assert_eq!(
-        seen.len(),
-        1,
-        "Expected exactly 1 entry, but found {}: {seen:?}",
-        seen.len()
-    );
+    assert_eq!(seen, HashSet::from([older_file.to_string()]));
 }

--- a/cli/tests/cli/create/option_one_file_system.rs
+++ b/cli/tests/cli/create/option_one_file_system.rs
@@ -38,10 +38,7 @@ mod platform {
     #[test]
     fn create_with_one_file_system() {
         setup();
-        if !can_mount_tmpfs() {
-            eprintln!("Skipping test: cannot create tmpfs mount (requires root)");
-            return;
-        }
+        skip_unless!("mount", can_mount_tmpfs());
 
         let _ = fs::remove_dir_all("option_one_file_system_mount");
         fs::create_dir_all("option_one_file_system_mount/in/subdir").unwrap();
@@ -63,10 +60,10 @@ mod platform {
             ])
             .status()
             .expect("failed to execute mount");
-        if !mount_status.success() {
-            eprintln!("Skipping test: failed to mount tmpfs");
-            return;
-        }
+        assert!(
+            mount_status.success(),
+            "mount failed after can_mount_tmpfs() probe succeeded"
+        );
 
         fs::write(
             "option_one_file_system_mount/in/subdir/tmpfs_file.txt",

--- a/cli/tests/cli/diff/metadata.rs
+++ b/cli/tests/cli/diff/metadata.rs
@@ -206,14 +206,14 @@ fn diff_ignores_subsecond_when_archive_has_whole_second_mtime() {
 
     let with_nanos = whole_second + Duration::from_nanos(123_456_789);
     filetime::set_file_mtime(&file_path, filetime::FileTime::from_system_time(with_nanos)).unwrap();
-    if fs::symlink_metadata(&file_path)
-        .unwrap()
-        .modified()
-        .unwrap()
-        != with_nanos
-    {
-        return;
-    }
+    skip_unless!(
+        "mtime_nanos",
+        fs::symlink_metadata(&file_path)
+            .unwrap()
+            .modified()
+            .unwrap()
+            == with_nanos
+    );
 
     cargo_bin_cmd!("pna")
         .args(["experimental", "diff", "-f", &archive_path])
@@ -244,14 +244,14 @@ fn diff_detects_subsecond_difference_when_archive_stores_nanoseconds() {
         filetime::FileTime::from_system_time(archived_time),
     )
     .unwrap();
-    if fs::symlink_metadata(&file_path)
-        .unwrap()
-        .modified()
-        .unwrap()
-        != archived_time
-    {
-        return;
-    }
+    skip_unless!(
+        "mtime_nanos",
+        fs::symlink_metadata(&file_path)
+            .unwrap()
+            .modified()
+            .unwrap()
+            == archived_time
+    );
 
     let archive_path = format!("{dir}/test.pna");
     cargo_bin_cmd!("pna")
@@ -272,14 +272,14 @@ fn diff_detects_subsecond_difference_when_archive_stores_nanoseconds() {
         filetime::FileTime::from_system_time(different_nanos),
     )
     .unwrap();
-    if fs::symlink_metadata(&file_path)
-        .unwrap()
-        .modified()
-        .unwrap()
-        != different_nanos
-    {
-        return;
-    }
+    skip_unless!(
+        "mtime_nanos",
+        fs::symlink_metadata(&file_path)
+            .unwrap()
+            .modified()
+            .unwrap()
+            == different_nanos
+    );
 
     cargo_bin_cmd!("pna")
         .args(["experimental", "diff", "-f", &archive_path])
@@ -310,14 +310,14 @@ fn diff_accepts_exact_nanosecond_roundtrip() {
         filetime::FileTime::from_system_time(archived_time),
     )
     .unwrap();
-    if fs::symlink_metadata(&file_path)
-        .unwrap()
-        .modified()
-        .unwrap()
-        != archived_time
-    {
-        return;
-    }
+    skip_unless!(
+        "mtime_nanos",
+        fs::symlink_metadata(&file_path)
+            .unwrap()
+            .modified()
+            .unwrap()
+            == archived_time
+    );
 
     let archive_path = format!("{dir}/test.pna");
     cargo_bin_cmd!("pna")
@@ -380,14 +380,14 @@ fn diff_ignores_end_of_second_when_archive_has_whole_second_mtime() {
         filetime::FileTime::from_system_time(end_of_second),
     )
     .unwrap();
-    if fs::symlink_metadata(&file_path)
-        .unwrap()
-        .modified()
-        .unwrap()
-        != end_of_second
-    {
-        return;
-    }
+    skip_unless!(
+        "mtime_nanos",
+        fs::symlink_metadata(&file_path)
+            .unwrap()
+            .modified()
+            .unwrap()
+            == end_of_second
+    );
 
     cargo_bin_cmd!("pna")
         .args(["experimental", "diff", "-f", &archive_path])

--- a/cli/tests/cli/extract/option_keep_permission.rs
+++ b/cli/tests/cli/extract/option_keep_permission.rs
@@ -1,5 +1,5 @@
 #[cfg(unix)]
-use crate::utils::{EmbedExt, TestResources, archive, setup};
+use crate::utils::{EmbedExt, TestResources, archive, set_mode, setup};
 #[cfg(unix)]
 use clap::Parser;
 #[cfg(unix)]
@@ -7,27 +7,7 @@ use portable_network_archive::cli;
 #[cfg(unix)]
 use std::fs;
 #[cfg(unix)]
-use std::io::ErrorKind;
-#[cfg(unix)]
 use std::os::unix::prelude::*;
-
-/// Helper macro to set permissions, skipping the test if permission denied.
-#[cfg(unix)]
-macro_rules! set_permissions_or_skip {
-    ($path:expr, $mode:expr) => {
-        match fs::set_permissions($path, fs::Permissions::from_mode($mode)) {
-            Ok(()) => {}
-            Err(e) if e.kind() == ErrorKind::PermissionDenied => {
-                eprintln!(
-                    "Skipping test: insufficient permissions to set file permissions: {}",
-                    e
-                );
-                return;
-            }
-            Err(e) => panic!("Failed to set permissions: {}", e),
-        }
-    };
-}
 
 /// Recursively remove a directory, restoring write permissions on files if needed.
 /// This is necessary because files with 0o000 permissions cannot be overwritten.
@@ -69,7 +49,7 @@ fn extract_preserves_executable_permission() {
     setup();
     TestResources::extract_in("raw/", "extract_perm_755/in/").unwrap();
 
-    set_permissions_or_skip!("extract_perm_755/in/raw/text.txt", 0o755);
+    skip_unless!("chmod", set_mode("extract_perm_755/in/raw/text.txt", 0o755));
 
     cli::Cli::try_parse_from([
         "pna",
@@ -130,7 +110,7 @@ fn extract_preserves_readonly_permission() {
     setup();
     TestResources::extract_in("raw/", "extract_perm_644/in/").unwrap();
 
-    set_permissions_or_skip!("extract_perm_644/in/raw/text.txt", 0o644);
+    skip_unless!("chmod", set_mode("extract_perm_644/in/raw/text.txt", 0o644));
 
     cli::Cli::try_parse_from([
         "pna",
@@ -191,7 +171,7 @@ fn extract_preserves_private_permission() {
     setup();
     TestResources::extract_in("raw/", "extract_perm_600/in/").unwrap();
 
-    set_permissions_or_skip!("extract_perm_600/in/raw/text.txt", 0o600);
+    skip_unless!("chmod", set_mode("extract_perm_600/in/raw/text.txt", 0o600));
 
     cli::Cli::try_parse_from([
         "pna",
@@ -255,11 +235,13 @@ fn extract_preserves_no_permission() {
     let _ = force_remove_dir_all("extract_perm_000");
     TestResources::extract_in("raw/", "extract_perm_000/in/").unwrap();
 
-    set_permissions_or_skip!("extract_perm_000/in/raw/text.txt", 0o000);
+    skip_unless!("chmod", set_mode("extract_perm_000/in/raw/text.txt", 0o000));
+    skip_unless!(
+        "root",
+        fs::File::open("extract_perm_000/in/raw/text.txt").is_ok()
+    );
 
-    // Creating an archive of a file with 0o000 permissions requires root
-    // privileges to read the file. Skip the test if we can't read the file.
-    let result = cli::Cli::try_parse_from([
+    cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "c",
@@ -270,20 +252,8 @@ fn extract_preserves_no_permission() {
         "--keep-permission",
     ])
     .unwrap()
-    .execute();
-
-    if let Err(e) = &result {
-        // Check if the error is permission-related (use {:#} to include full error chain)
-        let full_error = format!("{:#}", e);
-        if full_error.contains("Permission denied") || full_error.contains("permission denied") {
-            eprintln!(
-                "Skipping test: insufficient permissions to read file with 0o000 mode: {}",
-                e
-            );
-            return;
-        }
-    }
-    result.unwrap();
+    .execute()
+    .unwrap();
 
     cli::Cli::try_parse_from([
         "pna",
@@ -319,7 +289,7 @@ fn extract_preserves_full_permission() {
     setup();
     TestResources::extract_in("raw/", "extract_perm_777/in/").unwrap();
 
-    set_permissions_or_skip!("extract_perm_777/in/raw/text.txt", 0o777);
+    skip_unless!("chmod", set_mode("extract_perm_777/in/raw/text.txt", 0o777));
 
     cli::Cli::try_parse_from([
         "pna",
@@ -380,10 +350,12 @@ fn extract_preserves_mixed_permissions() {
     setup();
     TestResources::extract_in("raw/", "extract_perm_mixed/in/").unwrap();
 
-    // Set different permissions for different files
-    set_permissions_or_skip!("extract_perm_mixed/in/raw/text.txt", 0o755);
-    set_permissions_or_skip!("extract_perm_mixed/in/raw/empty.txt", 0o644);
-    set_permissions_or_skip!("extract_perm_mixed/in/raw/images/icon.png", 0o600);
+    skip_unless!(
+        "chmod",
+        set_mode("extract_perm_mixed/in/raw/text.txt", 0o755)
+            && set_mode("extract_perm_mixed/in/raw/empty.txt", 0o644)
+            && set_mode("extract_perm_mixed/in/raw/images/icon.png", 0o600)
+    );
 
     cli::Cli::try_parse_from([
         "pna",
@@ -481,7 +453,7 @@ fn extract_preserves_directory_permission() {
     setup();
     TestResources::extract_in("raw/", "extract_dir_perm/in/").unwrap();
 
-    set_permissions_or_skip!("extract_dir_perm/in/raw/images", 0o750);
+    skip_unless!("chmod", set_mode("extract_dir_perm/in/raw/images", 0o750));
 
     cli::Cli::try_parse_from([
         "pna",
@@ -541,7 +513,10 @@ fn extract_encrypted_gcm_without_keep_permission_drops_setuid() {
     setup();
     TestResources::extract_in("raw/", "extract_gcm_setuid/in/").unwrap();
 
-    set_permissions_or_skip!("extract_gcm_setuid/in/raw/text.txt", 0o4755);
+    skip_unless!(
+        "chmod",
+        set_mode("extract_gcm_setuid/in/raw/text.txt", 0o4755)
+    );
 
     cli::Cli::try_parse_from([
         "pna",

--- a/cli/tests/cli/main.rs
+++ b/cli/tests/cli/main.rs
@@ -1,4 +1,6 @@
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
+#[macro_use]
+pub mod utils;
 mod acl;
 mod append;
 #[cfg(not(target_family = "wasm"))]
@@ -35,7 +37,6 @@ mod sort;
 mod split;
 mod strip;
 mod update;
-pub mod utils;
 #[cfg(not(target_family = "wasm"))]
 mod verify;
 mod xattr;

--- a/cli/tests/cli/nodump.rs
+++ b/cli/tests/cli/nodump.rs
@@ -87,10 +87,7 @@ mod platform {
     #[test]
     fn create_nodump() {
         setup();
-        if !is_nodump_supported() {
-            eprintln!("Skipping test: nodump not supported on this system");
-            return;
-        }
+        skip_unless!("nodump", is_nodump_supported());
 
         let _ = fs::remove_dir_all("nodump_create");
         fs::create_dir_all("nodump_create").unwrap();
@@ -121,10 +118,7 @@ mod platform {
     #[test]
     fn append_nodump() {
         setup();
-        if !is_nodump_supported() {
-            eprintln!("Skipping test: nodump not supported on this system");
-            return;
-        }
+        skip_unless!("nodump", is_nodump_supported());
 
         let _ = fs::remove_dir_all("nodump_append");
         fs::create_dir_all("nodump_append").unwrap();

--- a/cli/tests/cli/restore_acl.rs
+++ b/cli/tests/cli/restore_acl.rs
@@ -19,7 +19,10 @@ struct RestoreAclCase {
     acl_entry: &'static str,
 }
 
-fn current_platform() -> &'static str {
+/// `""` on platforms with no ACL implementation to restore through (OpenBSD,
+/// Solaris, …). The archive still carries its ACL metadata there, so only the
+/// archive-side assertions apply.
+const fn current_platform() -> &'static str {
     if cfg!(windows) {
         "windows"
     } else if cfg!(target_os = "macos") {
@@ -97,12 +100,6 @@ fn assert_extracted_payload_matches_baseline(baseline_path: &Path, keep_acl_path
 
 fn assert_current_platform_acl_roundtrip(case: &RestoreAclCase, out_dir: &Path) {
     let current_platform = current_platform();
-    if current_platform.is_empty() {
-        return;
-    }
-    if case.platform != current_platform && !case.platform.is_empty() {
-        return;
-    }
 
     let roundtrip_archive = out_dir.parent().unwrap().join("roundtrip.pna");
     cargo_bin_cmd!("pna")
@@ -226,7 +223,11 @@ fn assert_restore_acl(case: RestoreAclCase) {
     let baseline_path = Path::new(&baseline_dir).join(case.entry);
     let keep_acl_path = Path::new(&keep_acl_dir).join(case.entry);
     assert_extracted_payload_matches_baseline(&baseline_path, &keep_acl_path);
-    assert_current_platform_acl_roundtrip(&case, Path::new(&keep_acl_dir));
+
+    let platform = current_platform();
+    if !platform.is_empty() && (case.platform.is_empty() || case.platform == platform) {
+        assert_current_platform_acl_roundtrip(&case, Path::new(&keep_acl_dir));
+    }
 }
 
 /// Precondition: A Windows ACL fixture archive is available.

--- a/cli/tests/cli/update.rs
+++ b/cli/tests/cli/update.rs
@@ -20,10 +20,12 @@ mod option_mtime;
 mod option_newer_ctime;
 mod option_newer_ctime_than;
 mod option_newer_mtime;
+#[cfg(not(target_family = "wasm"))]
 mod option_newer_mtime_than;
 mod option_older_ctime;
 mod option_older_ctime_than;
 mod option_older_mtime;
+#[cfg(not(target_family = "wasm"))]
 mod option_older_mtime_than;
 mod option_output;
 mod option_recursive;

--- a/cli/tests/cli/update/mtime_stored_precision.rs
+++ b/cli/tests/cli/update/mtime_stored_precision.rs
@@ -49,9 +49,14 @@ fn update_keeps_entry_when_only_subsecond_differs() {
 
     let with_nanos = whole_second + Duration::from_nanos(123_456_700);
     filetime::set_file_mtime(&file_path, filetime::FileTime::from_system_time(with_nanos)).unwrap();
-    if fs::metadata(&file_path).unwrap().modified().unwrap() != with_nanos {
-        return;
-    }
+    skip_unless!(
+        "mtime_nanos",
+        fs::symlink_metadata(&file_path)
+            .unwrap()
+            .modified()
+            .unwrap()
+            == with_nanos
+    );
 
     cli::Cli::try_parse_from([
         "pna",

--- a/cli/tests/cli/update/option_newer_ctime.rs
+++ b/cli/tests/cli/update/option_newer_ctime.rs
@@ -1,7 +1,14 @@
-use crate::utils::{archive, setup};
+use crate::utils::{
+    archive, setup,
+    time::{birth_time, birth_time_recorded, create_file_born_after},
+};
 use clap::Parser;
 use portable_network_archive::cli;
-use std::{collections::HashSet, fs, thread, time};
+use std::{
+    collections::HashSet,
+    fs,
+    time::{Duration, SystemTime},
+};
 
 /// Precondition: An archive contains a file.
 /// Action: Recreate files with different ctimes, run `pna experimental update` with `--newer-ctime`.
@@ -10,23 +17,16 @@ use std::{collections::HashSet, fs, thread, time};
 #[test]
 fn update_with_newer_ctime() {
     setup();
-    // Clean up any leftover files from previous test runs
     let _ = fs::remove_dir_all("update_newer_ctime");
     fs::create_dir_all("update_newer_ctime").unwrap();
 
-    // Create initial file
     let file_to_keep = "update_newer_ctime/file_to_keep.txt";
     let file_to_update = "update_newer_ctime/file_to_update.txt";
 
     fs::write(file_to_keep, "original content").unwrap();
 
-    // Check if creation time is available on this filesystem
-    if fs::metadata(file_to_keep).unwrap().created().is_err() {
-        eprintln!("Skipping test: creation time (birth time) is not supported on this filesystem");
-        return;
-    }
+    skip_unless!("birthtime", birth_time_recorded(file_to_keep));
 
-    // Create initial archive with file_to_keep
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -40,76 +40,54 @@ fn update_with_newer_ctime() {
     .execute()
     .unwrap();
 
-    // Wait and record threshold time
-    thread::sleep(time::Duration::from_millis(10));
     let threshold_file = "update_newer_ctime/threshold.txt";
-    fs::write(threshold_file, "threshold marker").unwrap();
-    let threshold_ctime = fs::metadata(threshold_file).unwrap().created().unwrap();
+    let threshold_ctime =
+        create_file_born_after(threshold_file, "threshold marker", birth_time(file_to_keep));
 
-    // Wait, then create a new file that should be added (newer ctime)
-    thread::sleep(time::Duration::from_millis(10));
-    fs::write(file_to_update, "new content").unwrap();
+    // `--newer-ctime @secs` truncates to whole seconds, so round the boundary
+    // up to the next second: threshold_file's own sub-second ctime then falls
+    // strictly before it (excluded) while file_to_update, created after the
+    // boundary, falls strictly after it (included).
+    let boundary_secs = threshold_ctime
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        + 1;
+    create_file_born_after(
+        file_to_update,
+        "new content",
+        SystemTime::UNIX_EPOCH + Duration::from_secs(boundary_secs),
+    );
 
-    // Wait until the new file has ctime after threshold
-    if !wait_until_ctime_after(file_to_update, threshold_ctime) {
-        eprintln!(
-            "Skipping test: creation time did not advance beyond threshold on this filesystem"
-        );
-        return;
-    }
-
-    // Run update with --newer-ctime
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "experimental",
         "update",
         "--newer-ctime",
-        &format!(
-            "@{}",
-            threshold_ctime
-                .duration_since(time::SystemTime::UNIX_EPOCH)
-                .unwrap()
-                .as_secs()
-        ),
+        &format!("@{boundary_secs}"),
         "-f",
         "update_newer_ctime/archive.pna",
         file_to_keep,
         file_to_update,
+        threshold_file,
         "--unstable",
     ])
     .unwrap()
     .execute()
     .unwrap();
 
-    // Verify archive contents
     let mut seen = HashSet::new();
     archive::for_each_entry("update_newer_ctime/archive.pna", |entry| {
         seen.insert(entry.header().path().to_string());
     })
     .unwrap();
 
-    // file_to_keep should be in archive (from initial creation)
-    assert!(
-        seen.contains(file_to_keep),
-        "file_to_keep should be in the archive: {file_to_keep}"
-    );
-
-    // file_to_update should be in archive (added because ctime > threshold)
-    assert!(
-        seen.contains(file_to_update),
-        "file_to_update should be added to archive: {file_to_update}"
-    );
-
-    // Verify exactly 2 entries
     assert_eq!(
-        seen.len(),
-        2,
-        "Expected exactly 2 entries, but found {}: {seen:?}",
-        seen.len()
+        seen,
+        HashSet::from([file_to_keep.to_string(), file_to_update.to_string()])
     );
 
-    // Extract and verify content
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -130,21 +108,4 @@ fn update_with_newer_ctime() {
         updated_content, "new content",
         "file_to_update should have the new content"
     );
-}
-
-fn wait_until_ctime_after(path: &str, baseline: time::SystemTime) -> bool {
-    const MAX_ATTEMPTS: usize = 200;
-    const SLEEP_MS: u64 = 10;
-    for _ in 0..MAX_ATTEMPTS {
-        if fs::metadata(path)
-            .ok()
-            .and_then(|meta| meta.created().ok())
-            .map(|ctime| ctime > baseline)
-            .unwrap_or(false)
-        {
-            return true;
-        }
-        thread::sleep(time::Duration::from_millis(SLEEP_MS));
-    }
-    false
 }

--- a/cli/tests/cli/update/option_newer_ctime_than.rs
+++ b/cli/tests/cli/update/option_newer_ctime_than.rs
@@ -1,11 +1,10 @@
-use crate::utils::{archive, setup};
+use crate::utils::{
+    archive, setup,
+    time::{birth_time, birth_time_recorded, create_file_born_after},
+};
 use clap::Parser;
 use portable_network_archive::cli;
-use std::{
-    collections::HashSet,
-    fs, thread,
-    time::{Duration, SystemTime},
-};
+use std::{collections::HashSet, fs};
 
 /// Precondition: An archive exists with files to update, and the source tree contains a reference file and files with varying creation times.
 /// Action: Run `pna experimental update` with `--newer-ctime-than` pointing to the reference file.
@@ -18,17 +17,11 @@ fn update_with_newer_ctime_than() {
     let file_to_update = "update_newer_ctime_than/file_to_update.txt";
     let file_to_add = "update_newer_ctime_than/file_to_add.txt";
 
-    // Create directory
     fs::create_dir_all("update_newer_ctime_than").unwrap();
-
-    // 1. Create the initial file and archive it.
     fs::write(file_to_update, "initial content").unwrap();
 
-    // Check if creation time is available on this filesystem
-    if fs::metadata(file_to_update).unwrap().created().is_err() {
-        eprintln!("Skipping test: creation time (birth time) is not supported on this filesystem");
-        return;
-    }
+    skip_unless!("birthtime", birth_time_recorded(file_to_update));
+
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -42,28 +35,11 @@ fn update_with_newer_ctime_than() {
     .execute()
     .unwrap();
 
-    // 2. Wait and create a reference file to set a timestamp benchmark.
-    thread::sleep(Duration::from_millis(10));
-    fs::write(reference_file, "time reference").unwrap();
-    let reference_ctime = fs::metadata(reference_file).unwrap().created().unwrap();
+    let reference_ctime =
+        create_file_born_after(reference_file, "time reference", birth_time(file_to_update));
+    create_file_born_after(file_to_update, "updated content", reference_ctime);
+    create_file_born_after(file_to_add, "new file content", reference_ctime);
 
-    // 3. Wait, then recreate the existing file (to ensure both ctime/birth time move
-    //    forward) and create the new file so that both are newer than the reference.
-    thread::sleep(Duration::from_millis(10));
-    fs::remove_file(file_to_update).unwrap();
-    fs::write(file_to_update, "updated content").unwrap();
-    fs::write(file_to_add, "new file content").unwrap();
-    if !wait_until_ctime_after(file_to_update, reference_ctime)
-        || !wait_until_ctime_after(file_to_add, reference_ctime)
-    {
-        eprintln!(
-            "Skipping test: creation time did not advance beyond reference on this filesystem"
-        );
-        return;
-    }
-
-    // 4. Run the update command, targeting the files to be updated/added,
-    //    filtered by the ctime of the reference file.
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -73,6 +49,7 @@ fn update_with_newer_ctime_than() {
         "update_newer_ctime_than/test.pna",
         file_to_update,
         file_to_add,
+        reference_file,
         "--unstable",
         "--newer-ctime-than",
         reference_file,
@@ -81,34 +58,17 @@ fn update_with_newer_ctime_than() {
     .execute()
     .unwrap();
 
-    // 5. Verify archive contents
     let mut seen = HashSet::new();
     archive::for_each_entry("update_newer_ctime_than/test.pna", |entry| {
         seen.insert(entry.header().path().to_string());
     })
     .unwrap();
 
-    // file_to_update should be present (updated because ctime > reference)
-    assert!(
-        seen.contains(file_to_update),
-        "updated file should be in archive: {file_to_update}"
-    );
-
-    // file_to_add should be present (added because ctime > reference)
-    assert!(
-        seen.contains(file_to_add),
-        "new file should be added: {file_to_add}"
-    );
-
-    // Verify that exactly two entries exist
     assert_eq!(
-        seen.len(),
-        2,
-        "Expected exactly 2 entries, but found {}: {seen:?}",
-        seen.len()
+        seen,
+        HashSet::from([file_to_update.to_string(), file_to_add.to_string()])
     );
 
-    // 6. Extract and verify the content of the updated file.
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -131,21 +91,4 @@ fn update_with_newer_ctime_than() {
         updated_content, "updated content",
         "The updated file did not contain the correct content"
     );
-}
-
-fn wait_until_ctime_after(path: &str, baseline: SystemTime) -> bool {
-    const MAX_ATTEMPTS: usize = 200;
-    const SLEEP_MS: u64 = 10;
-    for _ in 0..MAX_ATTEMPTS {
-        if fs::metadata(path)
-            .ok()
-            .and_then(|meta| meta.created().ok())
-            .map(|ctime| ctime > baseline)
-            .unwrap_or(false)
-        {
-            return true;
-        }
-        thread::sleep(Duration::from_millis(SLEEP_MS));
-    }
-    false
 }

--- a/cli/tests/cli/update/option_newer_mtime_than.rs
+++ b/cli/tests/cli/update/option_newer_mtime_than.rs
@@ -1,7 +1,10 @@
-use crate::utils::{archive, setup};
+use crate::utils::{
+    archive, setup,
+    time::{DURATION_24_HOURS, set_mtime},
+};
 use clap::Parser;
 use portable_network_archive::cli;
-use std::{collections::HashSet, fs, thread, time};
+use std::{collections::HashSet, fs, time::SystemTime};
 
 /// Precondition: An archive exists with files to update, and the source tree contains a reference file and files with varying modification times.
 /// Action: Run `pna experimental update` with `--newer-mtime-than` pointing to the reference file.
@@ -13,10 +16,7 @@ fn update_with_newer_mtime_than() {
     let file_to_update = "update_newer_mtime_than/file_to_update.txt";
     let file_to_add = "update_newer_mtime_than/file_to_add.txt";
 
-    // Create directory
     fs::create_dir_all("update_newer_mtime_than").unwrap();
-
-    // 1. Create the initial file and archive it.
     fs::write(file_to_update, "initial content").unwrap();
     cli::Cli::try_parse_from([
         "pna",
@@ -31,27 +31,14 @@ fn update_with_newer_mtime_than() {
     .execute()
     .unwrap();
 
-    // 2. Wait and create a reference file to set a timestamp benchmark.
-    thread::sleep(time::Duration::from_millis(10));
+    let now = SystemTime::now();
     fs::write(reference_file, "time reference").unwrap();
-
-    // 3. Wait, then update the existing file and create the new file to ensure they
-    //    have a `mtime` newer than the reference file.
-    thread::sleep(time::Duration::from_millis(10));
     fs::write(file_to_update, "updated content").unwrap();
     fs::write(file_to_add, "new file content").unwrap();
-    let reference_mtime = fs::metadata(reference_file).unwrap().modified().unwrap();
-    let update_mtime = fs::metadata(file_to_update).unwrap().modified().unwrap();
-    let add_mtime = fs::metadata(file_to_add).unwrap().modified().unwrap();
-    if update_mtime <= reference_mtime || add_mtime <= reference_mtime {
-        eprintln!(
-            "Skipping test: unable to ensure updated files have mtime > reference on this filesystem"
-        );
-        return;
-    }
+    set_mtime(reference_file, now - DURATION_24_HOURS);
+    set_mtime(file_to_update, now);
+    set_mtime(file_to_add, now);
 
-    // 4. Run the update command, targeting the files to be updated/added,
-    //    filtered by the mtime of the reference file.
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -61,6 +48,7 @@ fn update_with_newer_mtime_than() {
         "update_newer_mtime_than/test.pna",
         file_to_update,
         file_to_add,
+        reference_file,
         "--unstable",
         "--newer-mtime-than",
         reference_file,
@@ -69,34 +57,17 @@ fn update_with_newer_mtime_than() {
     .execute()
     .unwrap();
 
-    // 5. Verify archive contents
     let mut seen = HashSet::new();
     archive::for_each_entry("update_newer_mtime_than/test.pna", |entry| {
         seen.insert(entry.header().path().to_string());
     })
     .unwrap();
 
-    // file_to_update should be present (updated because mtime > reference)
-    assert!(
-        seen.contains(file_to_update),
-        "updated file should be in archive: {file_to_update}"
-    );
-
-    // file_to_add should be present (added because mtime > reference)
-    assert!(
-        seen.contains(file_to_add),
-        "new file should be added: {file_to_add}"
-    );
-
-    // Verify that exactly two entries exist
     assert_eq!(
-        seen.len(),
-        2,
-        "Expected exactly 2 entries, but found {}: {seen:?}",
-        seen.len()
+        seen,
+        HashSet::from([file_to_update.to_string(), file_to_add.to_string()])
     );
 
-    // 6. Extract and verify the content of the updated file.
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",

--- a/cli/tests/cli/update/option_older_ctime.rs
+++ b/cli/tests/cli/update/option_older_ctime.rs
@@ -1,7 +1,14 @@
-use crate::utils::{archive, setup};
+use crate::utils::{
+    archive, setup,
+    time::{birth_time, birth_time_recorded, create_file_born_after},
+};
 use clap::Parser;
 use portable_network_archive::cli;
-use std::{collections::HashSet, fs, thread, time};
+use std::{
+    collections::HashSet,
+    fs,
+    time::{Duration, SystemTime},
+};
 
 /// Precondition: An archive contains a file.
 /// Action: Create files with different ctimes, run `pna experimental update` with `--older-ctime`.
@@ -10,23 +17,16 @@ use std::{collections::HashSet, fs, thread, time};
 #[test]
 fn update_with_older_ctime() {
     setup();
-    // Clean up any leftover files from previous test runs
     let _ = fs::remove_dir_all("update_older_ctime");
     fs::create_dir_all("update_older_ctime").unwrap();
 
-    // Create initial file (will have older ctime)
     let file_to_update = "update_older_ctime/file_to_update.txt";
     let file_to_skip = "update_older_ctime/file_to_skip.txt";
 
     fs::write(file_to_update, "initial content").unwrap();
 
-    // Check if creation time is available on this filesystem
-    if fs::metadata(file_to_update).unwrap().created().is_err() {
-        eprintln!("Skipping test: creation time (birth time) is not supported on this filesystem");
-        return;
-    }
+    skip_unless!("birthtime", birth_time_recorded(file_to_update));
 
-    // Create initial archive
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -40,62 +40,44 @@ fn update_with_older_ctime() {
     .execute()
     .unwrap();
 
-    // Update file_to_update content (keeps same ctime on most filesystems)
     fs::write(file_to_update, "updated content").unwrap();
-    let file_to_update_ctime = fs::metadata(file_to_update).unwrap().created().unwrap();
+    let file_to_update_ctime = birth_time(file_to_update);
 
-    // Wait until we're in the next second to ensure threshold_file has a different second
-    // This is necessary because --older-ctime uses seconds precision
-    wait_until_next_second(file_to_update_ctime);
-
-    // Create threshold file (now guaranteed to be in a later second)
     let threshold_file = "update_older_ctime/threshold.txt";
-    fs::write(threshold_file, "threshold marker").unwrap();
-    let threshold_ctime = fs::metadata(threshold_file).unwrap().created().unwrap();
+    let threshold_ctime = create_file_born_after(
+        threshold_file,
+        "threshold marker",
+        file_to_update_ctime + Duration::from_secs(1) - Duration::from_nanos(1),
+    );
 
-    // Verify file_to_update has ctime < threshold (in seconds)
     let file_to_update_secs = file_to_update_ctime
-        .duration_since(time::SystemTime::UNIX_EPOCH)
+        .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap()
         .as_secs();
     let threshold_secs = threshold_ctime
-        .duration_since(time::SystemTime::UNIX_EPOCH)
+        .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap()
         .as_secs();
-    if file_to_update_secs >= threshold_secs {
-        eprintln!(
-            "Skipping test: file_to_update ctime ({}) is not older than threshold ({}) in seconds",
-            file_to_update_secs, threshold_secs
-        );
-        return;
-    }
+    assert!(file_to_update_secs < threshold_secs);
 
-    // Wait until next second and create file_to_skip (will have newer ctime than threshold)
-    wait_until_next_second(threshold_ctime);
-    fs::write(file_to_skip, "skip content").unwrap();
-    let file_to_skip_ctime = fs::metadata(file_to_skip).unwrap().created().unwrap();
+    let file_to_skip_ctime = create_file_born_after(
+        file_to_skip,
+        "skip content",
+        threshold_ctime + Duration::from_secs(1) - Duration::from_nanos(1),
+    );
     let file_to_skip_secs = file_to_skip_ctime
-        .duration_since(time::SystemTime::UNIX_EPOCH)
+        .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap()
         .as_secs();
+    assert!(file_to_skip_secs >= threshold_secs);
 
-    // Verify file_to_skip has ctime >= threshold (in seconds)
-    if file_to_skip_secs < threshold_secs {
-        eprintln!(
-            "Skipping test: file_to_skip ctime ({}) is not newer than threshold ({}) in seconds",
-            file_to_skip_secs, threshold_secs
-        );
-        return;
-    }
-
-    // Run update with --older-ctime
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "experimental",
         "update",
         "--older-ctime",
-        &format!("@{}", threshold_secs),
+        &format!("@{threshold_secs}"),
         "-f",
         "update_older_ctime/archive.pna",
         file_to_update,
@@ -106,34 +88,14 @@ fn update_with_older_ctime() {
     .execute()
     .unwrap();
 
-    // Verify archive contents
     let mut seen = HashSet::new();
     archive::for_each_entry("update_older_ctime/archive.pna", |entry| {
         seen.insert(entry.header().path().to_string());
     })
     .unwrap();
 
-    // file_to_update should be in archive (ctime <= threshold)
-    assert!(
-        seen.contains(file_to_update),
-        "file_to_update should be in the archive: {file_to_update}"
-    );
+    assert_eq!(seen, HashSet::from([file_to_update.to_string()]));
 
-    // file_to_skip should NOT be in archive (ctime > threshold)
-    assert!(
-        !seen.contains(file_to_skip),
-        "file_to_skip should NOT be added to archive: {file_to_skip}"
-    );
-
-    // Verify exactly 1 entry
-    assert_eq!(
-        seen.len(),
-        1,
-        "Expected exactly 1 entry, but found {}: {seen:?}",
-        seen.len()
-    );
-
-    // Extract and verify content
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -155,28 +117,8 @@ fn update_with_older_ctime() {
         "file_to_update should have the updated content"
     );
 
-    // Verify file_to_skip was not extracted
     assert!(
         !std::path::Path::new(&format!("update_older_ctime/out/{file_to_skip}")).exists(),
         "file_to_skip should not exist in extracted output"
     );
-}
-
-/// Wait until the current second changes from the baseline second.
-/// This is needed because the CLI uses seconds precision for timestamps.
-fn wait_until_next_second(baseline: time::SystemTime) {
-    let baseline_secs = baseline
-        .duration_since(time::SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
-    loop {
-        let now_secs = time::SystemTime::now()
-            .duration_since(time::SystemTime::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-        if now_secs > baseline_secs {
-            break;
-        }
-        thread::sleep(time::Duration::from_millis(10));
-    }
 }

--- a/cli/tests/cli/update/option_older_ctime_than.rs
+++ b/cli/tests/cli/update/option_older_ctime_than.rs
@@ -1,10 +1,10 @@
 use crate::utils::{
     archive, setup,
-    time::{confirm_time_older_than, wait_until_time_newer_than},
+    time::{birth_time, birth_time_recorded, create_file_born_after},
 };
 use clap::Parser;
 use portable_network_archive::cli;
-use std::{collections::HashSet, fs, thread, time::Duration};
+use std::{collections::HashSet, fs};
 
 /// Precondition: An archive exists with files to update, and the source tree contains a reference file and files with varying creation times.
 /// Action: Run `pna experimental update` with `--older-ctime-than` pointing to the reference file.
@@ -22,10 +22,7 @@ fn update_with_older_ctime_than() {
     fs::create_dir_all(base_dir).unwrap();
     fs::write(&file_to_update, "initial content").unwrap();
 
-    if fs::metadata(&file_to_update).unwrap().created().is_err() {
-        eprintln!("Skipping test: creation time (birth time) not supported on this filesystem");
-        return;
-    }
+    skip_unless!("birthtime", birth_time_recorded(&file_to_update));
 
     cli::Cli::try_parse_from([
         "pna",
@@ -40,25 +37,14 @@ fn update_with_older_ctime_than() {
     .execute()
     .unwrap();
 
-    // Recreate the file with updated content *before* creating the reference so its ctime stays older.
-    thread::sleep(Duration::from_millis(10));
     fs::write(&file_to_update, "updated content").unwrap();
 
-    thread::sleep(Duration::from_millis(10));
-    fs::write(&reference_file, "reference marker").unwrap();
-    let reference_ctime = fs::metadata(&reference_file).unwrap().created().unwrap();
-
-    thread::sleep(Duration::from_millis(10));
-    fs::write(&file_to_skip, "skip content").unwrap();
-
-    if !confirm_time_older_than(&file_to_update, reference_ctime, |m| m.created().ok())
-        || !wait_until_time_newer_than(&file_to_skip, reference_ctime, |m| m.created().ok())
-    {
-        eprintln!(
-            "Skipping test: unable to create deterministic creation times on this filesystem"
-        );
-        return;
-    }
+    let reference_ctime = create_file_born_after(
+        &reference_file,
+        "reference marker",
+        birth_time(&file_to_update),
+    );
+    create_file_born_after(&file_to_skip, "skip content", reference_ctime);
 
     cli::Cli::try_parse_from([
         "pna",
@@ -83,10 +69,7 @@ fn update_with_older_ctime_than() {
     })
     .unwrap();
 
-    assert!(
-        !seen.contains(&file_to_skip),
-        "file newer than reference should not have been added: {file_to_skip}"
-    );
+    assert_eq!(seen, HashSet::from([file_to_update.clone()]));
 
     cli::Cli::try_parse_from([
         "pna",

--- a/cli/tests/cli/update/option_older_mtime_than.rs
+++ b/cli/tests/cli/update/option_older_mtime_than.rs
@@ -1,7 +1,10 @@
-use crate::utils::{archive, setup, time::wait_until_time_newer_than};
+use crate::utils::{
+    archive, setup,
+    time::{DURATION_24_HOURS, set_mtime},
+};
 use clap::Parser;
 use portable_network_archive::cli;
-use std::{collections::HashSet, fs, thread, time::Duration};
+use std::{collections::HashSet, fs, time::SystemTime};
 
 /// Precondition: An archive exists with files to update, and the source tree contains a reference file and files with varying modification times.
 /// Action: Run `pna experimental update` with `--older-mtime-than` pointing to the reference file.
@@ -31,30 +34,13 @@ fn update_with_older_mtime_than() {
     .execute()
     .unwrap();
 
-    thread::sleep(Duration::from_millis(10));
+    let now = SystemTime::now();
     fs::write(&file_to_update, "updated content").unwrap();
-    let updated_mtime = fs::metadata(&file_to_update).unwrap().modified().unwrap();
-
-    thread::sleep(Duration::from_millis(10));
     fs::write(&reference_file, "reference marker").unwrap();
-    let reference_mtime = fs::metadata(&reference_file).unwrap().modified().unwrap();
-
-    if updated_mtime >= reference_mtime {
-        eprintln!(
-            "Skipping test: unable to ensure updated file mtime < reference on this filesystem"
-        );
-        return;
-    }
-
-    thread::sleep(Duration::from_millis(10));
     fs::write(&file_to_skip, "skip content").unwrap();
-
-    if !wait_until_time_newer_than(&file_to_skip, reference_mtime, |m| m.modified().ok()) {
-        eprintln!(
-            "Skipping test: unable to ensure skip file is newer than reference on this filesystem"
-        );
-        return;
-    }
+    set_mtime(&file_to_update, now - DURATION_24_HOURS);
+    set_mtime(&reference_file, now);
+    set_mtime(&file_to_skip, now + DURATION_24_HOURS);
 
     cli::Cli::try_parse_from([
         "pna",
@@ -79,10 +65,7 @@ fn update_with_older_mtime_than() {
     })
     .unwrap();
 
-    assert!(
-        !seen.contains(&file_to_skip),
-        "file newer than reference should not have been added: {file_to_skip}"
-    );
+    assert_eq!(seen, HashSet::from([file_to_update.clone()]));
 
     cli::Cli::try_parse_from([
         "pna",

--- a/cli/tests/cli/utils.rs
+++ b/cli/tests/cli/utils.rs
@@ -73,6 +73,38 @@ pub fn setup() {
     std::env::set_current_dir(env!("CARGO_TARGET_TMPDIR")).expect("Failed to set current dir");
 }
 
+/// Environment variable listing capabilities (comma-separated) whose absence
+/// is a failure rather than a skip. CI sets it per job so that a precondition
+/// which should hold on that runner cannot silently turn a test green.
+pub const REQUIRE_ENV: &str = "PNA_TEST_REQUIRE";
+
+pub fn is_required(list: &str, capability: &str) -> bool {
+    list.split(',').map(str::trim).any(|c| c == capability)
+}
+
+#[track_caller]
+pub fn skip_or_fail(capability: &str, condition: &str) {
+    let list = std::env::var(REQUIRE_ENV).unwrap_or_default();
+    if is_required(&list, capability) {
+        panic!("{REQUIRE_ENV} lists `{capability}` but `{condition}` is false");
+    }
+    eprintln!("skipped: `{capability}` unavailable (`{condition}` is false)");
+}
+
+/// Leaves the current test when a runtime-only precondition is unmet.
+/// Capability names are the vocabulary of `PNA_TEST_REQUIRE`; keep them
+/// stable: `birthtime`, `mtime_nanos`, `xattr`, `nodump`, `chmod`, `setuid`,
+/// `root`, `unprivileged`, `mount`.
+#[allow(unused_macros)]
+macro_rules! skip_unless {
+    ($capability:literal, $cond:expr) => {
+        if !$cond {
+            $crate::utils::skip_or_fail($capability, stringify!($cond));
+            return;
+        }
+    };
+}
+
 /// Spawns the `pna` binary under `mask` without touching this test process's
 /// own umask, which `libc::umask` would otherwise change process-wide (it is
 /// not thread-local) and race with unrelated tests running concurrently in
@@ -151,4 +183,27 @@ pub fn remove_with_empty_parents(path: impl AsRef<Path>) -> io::Result<()> {
         Ok(())
     }
     inner(path.as_ref())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_required;
+
+    #[test]
+    fn is_required_matches_whole_comma_separated_items() {
+        let cases = [
+            ("", "xattr", false),
+            ("xattr", "xattr", true),
+            ("birthtime, xattr ,root", "xattr", true),
+            ("xattrs", "xattr", false),
+            ("xattr", "xattrs", false),
+        ];
+        for (list, capability, expected) in cases {
+            assert_eq!(
+                is_required(list, capability),
+                expected,
+                "{list:?} / {capability}"
+            );
+        }
+    }
 }

--- a/cli/tests/cli/utils.rs
+++ b/cli/tests/cli/utils.rs
@@ -95,7 +95,6 @@ pub fn skip_or_fail(capability: &str, condition: &str) {
 /// Capability names are the vocabulary of `PNA_TEST_REQUIRE`; keep them
 /// stable: `birthtime`, `mtime_nanos`, `xattr`, `nodump`, `chmod`, `setuid`,
 /// `root`, `unprivileged`, `mount`.
-#[allow(unused_macros)]
 macro_rules! skip_unless {
     ($capability:literal, $cond:expr) => {
         if !$cond {
@@ -103,6 +102,34 @@ macro_rules! skip_unless {
             return;
         }
     };
+}
+
+/// `false` only when the OS refuses the change; any other error is a test bug.
+#[cfg(unix)]
+#[track_caller]
+pub fn set_mode(path: impl AsRef<Path>, mode: u32) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    match fs::set_permissions(path, fs::Permissions::from_mode(mode)) {
+        Ok(()) => true,
+        Err(e) if e.kind() == io::ErrorKind::PermissionDenied => false,
+        Err(e) => panic!("set_permissions: {e}"),
+    }
+}
+
+/// Non-mutating probe: reading an absent attribute is `Ok(None)` on a
+/// filesystem with xattr support and `Unsupported` otherwise.
+///
+/// Ask this rather than `xattr::SUPPORTED_PLATFORM`, which is a compile-time
+/// constant and stays true on FreeBSD and NetBSD whether or not the mounted
+/// file system carries extended attributes.
+#[cfg(unix)]
+#[track_caller]
+pub fn fs_supports_xattr(path: impl AsRef<Path>) -> bool {
+    match xattr::get(path, "user.pna_test_probe") {
+        Ok(_) => true,
+        Err(e) if e.kind() == io::ErrorKind::Unsupported => false,
+        Err(e) => panic!("xattr::get: {e}"),
+    }
 }
 
 /// Spawns the `pna` binary under `mask` without touching this test process's

--- a/cli/tests/cli/utils/archive.rs
+++ b/cli/tests/cli/utils/archive.rs
@@ -153,6 +153,26 @@ where
     Ok(())
 }
 
+/// Entries that carry at least one xattr, sorted by entry path (directory
+/// traversal order differs between filesystems).
+pub fn xattrs_by_entry(
+    path: impl AsRef<Path>,
+    password: Option<&str>,
+) -> Vec<(String, Vec<pna::ExtendedAttribute>)> {
+    let mut out = Vec::new();
+    for_each_entry_with_password(path, password, |e| {
+        if !e.metadata().xattrs().is_empty() {
+            out.push((
+                e.header().path().to_string(),
+                e.metadata().xattrs().to_vec(),
+            ));
+        }
+    })
+    .unwrap();
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    out
+}
+
 pub fn read_symlink_target(entry: &pna::NormalEntry) -> String {
     let pna::EntryContent::SymbolicLink(target) = entry
         .content(pna::ReadOptions::with_password::<&[u8]>(None))

--- a/cli/tests/cli/utils/archive.rs
+++ b/cli/tests/cli/utils/archive.rs
@@ -173,6 +173,20 @@ pub fn xattrs_by_entry(
     out
 }
 
+/// Permission mode (low 12 bits) of every entry, in archive order. A `Vec`
+/// rather than a map so that a duplicated entry is visible.
+pub fn modes_by_entry(path: impl AsRef<Path>) -> Vec<(String, Option<u16>)> {
+    let mut out = Vec::new();
+    for_each_entry(path, |e| {
+        out.push((
+            e.header().path().to_string(),
+            e.metadata().permission_mode().map(|m| m.get() & 0o7777),
+        ));
+    })
+    .unwrap();
+    out
+}
+
 pub fn read_symlink_target(entry: &pna::NormalEntry) -> String {
     let pna::EntryContent::SymbolicLink(target) = entry
         .content(pna::ReadOptions::with_password::<&[u8]>(None))

--- a/cli/tests/cli/utils/archive.rs
+++ b/cli/tests/cli/utils/archive.rs
@@ -153,8 +153,12 @@ where
     Ok(())
 }
 
-/// Entries that carry at least one xattr, sorted by entry path (directory
-/// traversal order differs between filesystems).
+/// Entries that carry at least one xattr, keyed by the name as stored in FHED
+/// and sorted by it (directory traversal order differs between filesystems).
+///
+/// The stored name rather than `header().path()`, which sanitizes away a
+/// leading `/`, `./` and unresolved `..` — the corruption an archive rewrite
+/// can introduce. `pna xattr set` matches entries on the stored name too.
 pub fn xattrs_by_entry(
     path: impl AsRef<Path>,
     password: Option<&str>,
@@ -162,10 +166,7 @@ pub fn xattrs_by_entry(
     let mut out = Vec::new();
     for_each_entry_with_password(path, password, |e| {
         if !e.metadata().xattrs().is_empty() {
-            out.push((
-                e.header().path().to_string(),
-                e.metadata().xattrs().to_vec(),
-            ));
+            out.push((e.name().to_string(), e.metadata().xattrs().to_vec()));
         }
     })
     .unwrap();

--- a/cli/tests/cli/utils/time.rs
+++ b/cli/tests/cli/utils/time.rs
@@ -5,55 +5,60 @@ use std::{
 
 pub const DURATION_24_HOURS: Duration = Duration::from_secs(24 * 60 * 60);
 
-/// Waits until the file at `path` has a timestamp newer than `baseline`.
-/// The `get_time` function extracts the relevant timestamp from metadata.
-pub fn wait_until_time_newer_than<F>(path: &str, baseline: SystemTime, get_time: F) -> bool
-where
-    F: Fn(&fs::Metadata) -> Option<SystemTime>,
-{
-    const MAX_ATTEMPTS: usize = 500;
-    const SLEEP_MS: u64 = 10;
-    for _ in 0..MAX_ATTEMPTS {
-        if fs::metadata(path)
-            .ok()
-            .and_then(|meta| get_time(&meta))
-            .map(|time| time > baseline)
-            .unwrap_or(false)
-        {
-            return true;
-        }
-        thread::sleep(Duration::from_millis(SLEEP_MS));
-    }
-    false
+#[cfg(not(target_family = "wasm"))]
+#[track_caller]
+pub fn set_mtime(path: &str, at: SystemTime) {
+    filetime::set_file_mtime(path, filetime::FileTime::from_system_time(at)).unwrap();
 }
 
-/// Confirms that the file at `path` has a timestamp older than `baseline`.
-/// The `get_time` function extracts the relevant timestamp from metadata.
-pub fn confirm_time_older_than<F>(path: &str, baseline: SystemTime, get_time: F) -> bool
-where
-    F: Fn(&fs::Metadata) -> Option<SystemTime>,
-{
+#[track_caller]
+pub fn birth_time(path: &str) -> SystemTime {
+    fs::metadata(path).unwrap().created().unwrap()
+}
+
+/// `created()` also succeeds on file systems that keep no birth time and answer
+/// with the epoch for every file (OpenBSD FFS), where no amount of re-creating
+/// can order two files. Such a value means the capability is absent, not that a
+/// file predates the epoch.
+#[track_caller]
+pub fn birth_time_recorded(path: &str) -> bool {
     fs::metadata(path)
-        .ok()
-        .and_then(|meta| get_time(&meta))
-        .map(|time| time < baseline)
-        .unwrap_or(false)
+        .unwrap()
+        .created()
+        .is_ok_and(|born| born > SystemTime::UNIX_EPOCH)
 }
 
-/// Ensures that `older` file has a ctime older than `reference` and
-/// `newer` file has a ctime newer than `reference`.
-pub fn ensure_ctime_order(older: &str, newer: &str, reference: SystemTime) -> bool {
-    if !confirm_time_older_than(older, reference, |m| m.created().ok()) {
-        return false;
+/// Birth time cannot be set, only observed, and it is fixed at creation, so
+/// ordering against `baseline` is obtained by re-creating the file until its
+/// birth time is strictly later.
+///
+/// Each attempt is written to a fresh path rather than `path` itself: on NTFS,
+/// re-creating the same name within roughly 15 seconds of deleting it restores
+/// the original creation time (file-system tunneling), so retrying in place
+/// would observe the same birth time forever. The winning attempt is renamed
+/// onto `path`, which preserves its creation time on both NTFS and Unix; the
+/// birth time is read back afterwards because tunneling applies to the
+/// destination name too when `path` already existed.
+#[track_caller]
+pub fn create_file_born_after(path: &str, content: &str, baseline: SystemTime) -> SystemTime {
+    const MAX_ATTEMPTS: usize = 300;
+    for attempt in 0..MAX_ATTEMPTS {
+        let attempt_path = format!("{path}.attempt{attempt}");
+        fs::write(&attempt_path, content).unwrap();
+        let born = birth_time(&attempt_path);
+        if born > baseline {
+            fs::rename(&attempt_path, path).unwrap();
+            let renamed = birth_time(path);
+            assert!(
+                renamed > baseline,
+                "{path}: renaming onto an existing name reverted the birth time to {renamed:?}"
+            );
+            return renamed;
+        }
+        fs::remove_file(&attempt_path).unwrap();
+        thread::sleep(Duration::from_millis(10));
     }
-    wait_until_time_newer_than(newer, reference, |m| m.created().ok())
-}
-
-/// Ensures that `older` file has an mtime older than `reference` and
-/// `newer` file has an mtime newer than `reference`.
-pub fn ensure_mtime_order(older: &str, newer: &str, reference: SystemTime) -> bool {
-    if !confirm_time_older_than(older, reference, |m| m.modified().ok()) {
-        return false;
-    }
-    wait_until_time_newer_than(newer, reference, |m| m.modified().ok())
+    panic!(
+        "{path}: could not obtain a birth time later than {baseline:?} in {MAX_ATTEMPTS} attempts"
+    );
 }

--- a/cli/tests/cli/xattr/set/basic.rs
+++ b/cli/tests/cli/xattr/set/basic.rs
@@ -29,23 +29,13 @@ fn archive_xattr_set() {
     .execute()
     .unwrap();
 
-    archive::for_each_entry("xattr_set/zstd.pna", |entry| {
-        if entry.name() == "raw/empty.txt" {
-            assert_eq!(
-                entry.metadata().xattrs(),
-                &[archive::xattr("user.name", b"pna developers!")]
-            );
-        } else {
-            // Non-target entries should remain unaffected (no xattrs)
-            assert!(
-                entry.metadata().xattrs().is_empty(),
-                "Entry {} should have no xattrs but has {:?}",
-                entry.name(),
-                entry.metadata().xattrs()
-            );
-        }
-    })
-    .unwrap();
+    assert_eq!(
+        archive::xattrs_by_entry("xattr_set/zstd.pna", None),
+        vec![(
+            "raw/empty.txt".to_string(),
+            vec![archive::xattr("user.name", b"pna developers!")]
+        )]
+    );
 }
 
 /// Precondition: An archive with multiple entries exists.
@@ -91,26 +81,16 @@ fn xattr_long_key_value() {
     .execute()
     .unwrap();
 
-    archive::for_each_entry("xattr_long/zstd.pna", |entry| {
-        if entry.name() == "raw/empty.txt" {
-            assert_eq!(
-                entry.metadata().xattrs(),
-                &[
-                    archive::xattr(long_name.as_str(), long_value.as_bytes()),
-                    archive::xattr("user.special", "\0\n\r\x7f\u{1F600}".as_bytes()),
-                ]
-            );
-        } else {
-            // Non-target entries should remain unaffected (no xattrs)
-            assert!(
-                entry.metadata().xattrs().is_empty(),
-                "Entry {} should have no xattrs but has {:?}",
-                entry.name(),
-                entry.metadata().xattrs()
-            );
-        }
-    })
-    .unwrap();
+    assert_eq!(
+        archive::xattrs_by_entry("xattr_long/zstd.pna", None),
+        vec![(
+            "raw/empty.txt".to_string(),
+            vec![
+                archive::xattr(long_name.as_str(), long_value.as_bytes()),
+                archive::xattr("user.special", "\0\n\r\x7f\u{1F600}".as_bytes()),
+            ]
+        )]
+    );
 }
 
 /// Precondition: An archive with multiple entries exists.
@@ -138,20 +118,13 @@ fn xattr_empty_key() {
     .execute()
     .unwrap();
 
-    archive::for_each_entry("xattr_empty_key/zstd.pna", |entry| {
-        if entry.name() == "raw/empty.txt" {
-            assert_eq!(entry.metadata().xattrs(), &[archive::xattr("", b"value")]);
-        } else {
-            // Non-target entries should remain unaffected (no xattrs)
-            assert!(
-                entry.metadata().xattrs().is_empty(),
-                "Entry {} should have no xattrs but has {:?}",
-                entry.name(),
-                entry.metadata().xattrs()
-            );
-        }
-    })
-    .unwrap();
+    assert_eq!(
+        archive::xattrs_by_entry("xattr_empty_key/zstd.pna", None),
+        vec![(
+            "raw/empty.txt".to_string(),
+            vec![archive::xattr("", b"value")]
+        )]
+    );
 }
 
 /// Precondition: An archive with multiple entries exists.
@@ -179,23 +152,13 @@ fn xattr_empty_value() {
     .execute()
     .unwrap();
 
-    archive::for_each_entry("xattr_empty_value/zstd.pna", |entry| {
-        if entry.name() == "raw/empty.txt" {
-            assert_eq!(
-                entry.metadata().xattrs(),
-                &[archive::xattr("user.empty", b"")]
-            );
-        } else {
-            // Non-target entries should remain unaffected (no xattrs)
-            assert!(
-                entry.metadata().xattrs().is_empty(),
-                "Entry {} should have no xattrs but has {:?}",
-                entry.name(),
-                entry.metadata().xattrs()
-            );
-        }
-    })
-    .unwrap();
+    assert_eq!(
+        archive::xattrs_by_entry("xattr_empty_value/zstd.pna", None),
+        vec![(
+            "raw/empty.txt".to_string(),
+            vec![archive::xattr("user.empty", b"")]
+        )]
+    );
 }
 
 /// Precondition: An archive with multiple entries exists.
@@ -223,18 +186,13 @@ fn xattr_set_preserved_in_archive() {
     .execute()
     .unwrap();
 
-    let mut found = false;
-    archive::for_each_entry("xattr_set_preserved/zstd.pna", |entry| {
-        if entry.name() == "raw/empty.txt" {
-            found = true;
-            assert_eq!(
-                entry.metadata().xattrs(),
-                &[archive::xattr("user.roundtrip", b"preserved_value")]
-            );
-        }
-    })
-    .unwrap();
-    assert!(found, "raw/empty.txt entry not found in archive");
+    assert_eq!(
+        archive::xattrs_by_entry("xattr_set_preserved/zstd.pna", None),
+        vec![(
+            "raw/empty.txt".to_string(),
+            vec![archive::xattr("user.roundtrip", b"preserved_value")]
+        )]
+    );
 }
 
 /// Precondition: An archive entry has extended attributes set.
@@ -300,20 +258,17 @@ fn xattr_round_trip_preservation() {
     .execute()
     .unwrap();
 
-    let mut found = false;
-    archive::for_each_entry("xattr_roundtrip/roundtrip.pna", |entry| {
-        if entry.name().as_str().ends_with("raw/empty.txt") {
-            found = true;
-            assert!(
-                entry
-                    .metadata()
-                    .xattrs()
-                    .contains(&archive::xattr("user.roundtrip", b"preserved_value")),
-                "round-tripped entry is missing user.roundtrip xattr: {:?}",
-                entry.metadata().xattrs()
-            );
-        }
-    })
-    .unwrap();
-    assert!(found, "raw/empty.txt entry not found in round-trip archive");
+    let mut xattrs_by_entry = archive::xattrs_by_entry("xattr_roundtrip/roundtrip.pna", None);
+    for (_, xattrs) in &mut xattrs_by_entry {
+        xattrs.retain(|x| x.name() != "com.apple.provenance");
+    }
+    xattrs_by_entry.retain(|(_, xattrs)| !xattrs.is_empty());
+
+    assert_eq!(
+        xattrs_by_entry,
+        vec![(
+            "xattr_roundtrip/out/raw/empty.txt".to_string(),
+            vec![archive::xattr("user.roundtrip", b"preserved_value")]
+        )]
+    );
 }

--- a/cli/tests/cli/xattr/set/basic.rs
+++ b/cli/tests/cli/xattr/set/basic.rs
@@ -1,3 +1,5 @@
+#[cfg(unix)]
+use crate::utils::fs_supports_xattr;
 use crate::utils::{EmbedExt, TestResources, archive, setup};
 use clap::Parser;
 use portable_network_archive::cli;
@@ -242,11 +244,8 @@ fn xattr_set_preserved_in_archive() {
 #[cfg(unix)]
 fn xattr_round_trip_preservation() {
     setup();
-    if !xattr::SUPPORTED_PLATFORM {
-        eprintln!("Skipping xattr_round_trip_preservation: platform does not support xattr");
-        return;
-    }
     TestResources::extract_in("zstd.pna", "xattr_roundtrip/").unwrap();
+    skip_unless!("xattr", fs_supports_xattr("xattr_roundtrip/zstd.pna"));
 
     cli::Cli::try_parse_from([
         "pna",
@@ -280,16 +279,12 @@ fn xattr_round_trip_preservation() {
     .execute()
     .unwrap();
 
-    // If the filesystem does not support xattrs, the extract above could not
-    // have preserved them; skip the round-trip verification.
-    match xattr::get("xattr_roundtrip/out/raw/empty.txt", "user.roundtrip") {
-        Ok(Some(_)) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::Unsupported => {
-            eprintln!("Skipping xattr round-trip verification: filesystem does not support xattrs");
-            return;
-        }
-        other => panic!("Unexpected xattr::get result: {:?}", other),
-    }
+    assert_eq!(
+        xattr::get("xattr_roundtrip/out/raw/empty.txt", "user.roundtrip")
+            .unwrap()
+            .as_deref(),
+        Some(b"preserved_value".as_slice())
+    );
 
     cli::Cli::try_parse_from([
         "pna",

--- a/cli/tests/cli/xattr/set/multipart.rs
+++ b/cli/tests/cli/xattr/set/multipart.rs
@@ -10,7 +10,6 @@ fn xattr_set_on_multipart_archive() {
     setup();
     TestResources::extract_in("raw/", "xattr_multipart/in/").unwrap();
 
-    // Create a regular archive first
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -24,7 +23,6 @@ fn xattr_set_on_multipart_archive() {
     .execute()
     .unwrap();
 
-    // Split the archive into multiple parts
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -41,7 +39,6 @@ fn xattr_set_on_multipart_archive() {
     .execute()
     .unwrap();
 
-    // Set xattr on an entry in the multipart archive (consolidates to archive.pna)
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -59,16 +56,13 @@ fn xattr_set_on_multipart_archive() {
     .execute()
     .unwrap();
 
-    // Verify xattr was applied in the consolidated output (archive.pna, not archive.part1.pna)
-    archive::for_each_entry("xattr_multipart/split/archive.pna", |entry| {
-        if entry.name() == "xattr_multipart/in/raw/empty.txt" {
-            let xattrs = entry.metadata().xattrs();
-            assert_eq!(xattrs.len(), 1, "entry should have exactly one xattr");
-            assert_eq!(xattrs[0].name(), "user.multipart");
-            assert_eq!(xattrs[0].value(), b"from_split");
-        }
-    })
-    .unwrap();
+    assert_eq!(
+        archive::xattrs_by_entry("xattr_multipart/split/archive.pna", None),
+        vec![(
+            "xattr_multipart/in/raw/empty.txt".to_string(),
+            vec![archive::xattr("user.multipart", b"from_split")]
+        )]
+    );
 }
 
 /// Precondition: A multipart archive exists with multiple entries across parts.
@@ -79,7 +73,6 @@ fn xattr_set_multiple_entries_multipart() {
     setup();
     TestResources::extract_in("raw/", "xattr_multipart_multi/in/").unwrap();
 
-    // Create and split archive
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -109,7 +102,6 @@ fn xattr_set_multiple_entries_multipart() {
     .execute()
     .unwrap();
 
-    // Set xattr on all .txt files using glob pattern (consolidates to archive.pna)
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -127,28 +119,28 @@ fn xattr_set_multiple_entries_multipart() {
     .execute()
     .unwrap();
 
-    // Verify xattr was applied to all matching entries in consolidated archive
-    let mut txt_count = 0;
-    archive::for_each_entry("xattr_multipart_multi/split/archive.pna", |entry| {
-        let path = entry.name();
-        if path.as_str().ends_with(".txt") {
-            txt_count += 1;
-            let xattrs = entry.metadata().xattrs();
-            assert_eq!(
-                xattrs.len(),
-                1,
-                "txt file {path} should have exactly one xattr"
-            );
-            assert_eq!(xattrs[0].name(), "user.filetype");
-            assert_eq!(xattrs[0].value(), b"text");
-        } else {
-            assert!(
-                entry.metadata().xattrs().is_empty(),
-                "non-txt file {path} should have no xattrs"
-            );
-        }
-    })
-    .unwrap();
-
-    assert!(txt_count > 0, "should have found at least one .txt file");
+    let mut applied_sorted_by_name =
+        archive::xattrs_by_entry("xattr_multipart_multi/split/archive.pna", None);
+    applied_sorted_by_name.sort_by(|a, b| a.0.cmp(&b.0));
+    assert_eq!(
+        applied_sorted_by_name,
+        vec![
+            (
+                "xattr_multipart_multi/in/raw/empty.txt".to_string(),
+                vec![archive::xattr("user.filetype", b"text")]
+            ),
+            (
+                "xattr_multipart_multi/in/raw/first/second/third/pna.txt".to_string(),
+                vec![archive::xattr("user.filetype", b"text")]
+            ),
+            (
+                "xattr_multipart_multi/in/raw/parent/child.txt".to_string(),
+                vec![archive::xattr("user.filetype", b"text")]
+            ),
+            (
+                "xattr_multipart_multi/in/raw/text.txt".to_string(),
+                vec![archive::xattr("user.filetype", b"text")]
+            ),
+        ]
+    );
 }

--- a/cli/tests/cli/xattr/set/option_base64.rs
+++ b/cli/tests/cli/xattr/set/option_base64.rs
@@ -10,7 +10,6 @@ fn xattr_set_base64() {
     setup();
     TestResources::extract_in("zstd.pna", "xattr_set_base64/").unwrap();
 
-    // Set base64 encoded value (must start with 0s)
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -21,29 +20,18 @@ fn xattr_set_base64() {
         "--name",
         "user.base64",
         "--value",
-        "0sSGVsbG8gV29ybGQ=", // "Hello World" in base64
+        "0sSGVsbG8gV29ybGQ=",
         "raw/empty.txt",
     ])
     .unwrap()
     .execute()
     .unwrap();
 
-    // Verify the value was set correctly (decoded value)
-    archive::for_each_entry("xattr_set_base64/zstd.pna", |entry| {
-        if entry.name() == "raw/empty.txt" {
-            assert_eq!(
-                entry.metadata().xattrs(),
-                &[archive::xattr("user.base64", b"Hello World")]
-            );
-        } else {
-            // Non-target entries should remain unaffected (no xattrs)
-            assert!(
-                entry.metadata().xattrs().is_empty(),
-                "Entry {} should have no xattrs but has {:?}",
-                entry.name(),
-                entry.metadata().xattrs()
-            );
-        }
-    })
-    .unwrap();
+    assert_eq!(
+        archive::xattrs_by_entry("xattr_set_base64/zstd.pna", None),
+        vec![(
+            "raw/empty.txt".to_string(),
+            vec![archive::xattr("user.base64", b"Hello World")]
+        )]
+    );
 }

--- a/cli/tests/cli/xattr/set/option_hex.rs
+++ b/cli/tests/cli/xattr/set/option_hex.rs
@@ -10,7 +10,6 @@ fn xattr_set_hex() {
     setup();
     TestResources::extract_in("zstd.pna", "xattr_set_hex/").unwrap();
 
-    // Set hex encoded value
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -21,29 +20,18 @@ fn xattr_set_hex() {
         "--name",
         "user.hex",
         "--value",
-        "0x48656c6c6f20576f726c64", // "Hello World" in hex
+        "0x48656c6c6f20576f726c64",
         "raw/empty.txt",
     ])
     .unwrap()
     .execute()
     .unwrap();
 
-    // Verify the value was set correctly
-    archive::for_each_entry("xattr_set_hex/zstd.pna", |entry| {
-        if entry.name() == "raw/empty.txt" {
-            assert_eq!(
-                entry.metadata().xattrs(),
-                &[archive::xattr("user.hex", b"Hello World")]
-            );
-        } else {
-            // Non-target entries should remain unaffected (no xattrs)
-            assert!(
-                entry.metadata().xattrs().is_empty(),
-                "Entry {} should have no xattrs but has {:?}",
-                entry.name(),
-                entry.metadata().xattrs()
-            );
-        }
-    })
-    .unwrap();
+    assert_eq!(
+        archive::xattrs_by_entry("xattr_set_hex/zstd.pna", None),
+        vec![(
+            "raw/empty.txt".to_string(),
+            vec![archive::xattr("user.hex", b"Hello World")]
+        )]
+    );
 }

--- a/cli/tests/cli/xattr/set/option_password.rs
+++ b/cli/tests/cli/xattr/set/option_password.rs
@@ -8,7 +8,6 @@ use portable_network_archive::cli;
 #[test]
 fn xattr_set_with_password() {
     setup();
-    // Use pre-generated encrypted archive (password: "password")
     TestResources::extract_in("zstd_aes_ctr.pna", "xattr_password/").unwrap();
 
     cli::Cli::try_parse_from([
@@ -30,23 +29,13 @@ fn xattr_set_with_password() {
     .execute()
     .unwrap();
 
-    archive::for_each_entry_with_password("xattr_password/zstd_aes_ctr.pna", "password", |entry| {
-        if entry.name() == "raw/empty.txt" {
-            let xattrs = entry.metadata().xattrs();
-            assert_eq!(xattrs.len(), 1, "entry should have exactly one xattr");
-            assert_eq!(xattrs[0].name(), "user.author");
-            assert_eq!(xattrs[0].value(), b"pna developers");
-        } else {
-            // Non-target entries should remain unaffected (no xattrs)
-            assert!(
-                entry.metadata().xattrs().is_empty(),
-                "Entry {} should have no xattrs but has {:?}",
-                entry.name(),
-                entry.metadata().xattrs()
-            );
-        }
-    })
-    .unwrap();
+    assert_eq!(
+        archive::xattrs_by_entry("xattr_password/zstd_aes_ctr.pna", Some("password")),
+        vec![(
+            "raw/empty.txt".to_string(),
+            vec![archive::xattr("user.author", b"pna developers")]
+        )]
+    );
 }
 
 /// Precondition: A pre-generated encrypted archive exists and a password file contains the password.
@@ -55,7 +44,6 @@ fn xattr_set_with_password() {
 #[test]
 fn xattr_set_with_password_file() {
     setup();
-    // Use pre-generated encrypted archive (password: "password")
     TestResources::extract_in("zstd_aes_ctr.pna", "xattr_password_file/").unwrap();
 
     let password = "password";
@@ -80,39 +68,26 @@ fn xattr_set_with_password_file() {
     .execute()
     .unwrap();
 
-    archive::for_each_entry_with_password(
-        "xattr_password_file/zstd_aes_ctr.pna",
-        password,
-        |entry| {
-            if entry.name() == "raw/empty.txt" {
-                let xattrs = entry.metadata().xattrs();
-                assert_eq!(xattrs.len(), 1, "entry should have exactly one xattr");
-                assert_eq!(xattrs[0].name(), "user.version");
-                assert_eq!(xattrs[0].value(), b"1.0.0");
-            } else {
-                // Non-target entries should remain unaffected (no xattrs)
-                assert!(
-                    entry.metadata().xattrs().is_empty(),
-                    "Entry {} should have no xattrs but has {:?}",
-                    entry.name(),
-                    entry.metadata().xattrs()
-                );
-            }
-        },
-    )
-    .unwrap();
+    assert_eq!(
+        archive::xattrs_by_entry("xattr_password_file/zstd_aes_ctr.pna", Some(password)),
+        vec![(
+            "raw/empty.txt".to_string(),
+            vec![archive::xattr("user.version", b"1.0.0")]
+        )]
+    );
 }
 
 /// Precondition: A pre-generated encrypted archive exists.
 /// Action: Run `pna xattr set` with correct password, then with incorrect password.
-/// Expectation: The xattr set with wrong password does not affect the entry.
+/// Expectation: Xattrs are plaintext metadata chunks, so the wrong-password command still
+/// applies its xattr; only the encrypted file content requires the correct password. The
+/// archive is CTR (unauthenticated), so the wrong-password command's own result is
+/// unconstrained — only the postcondition is asserted.
 #[test]
-fn xattr_set_wrong_password_no_effect() {
+fn xattr_set_wrong_password_updates_metadata_only() {
     setup();
-    // Use pre-generated encrypted archive (password: "password")
     TestResources::extract_in("zstd_aes_ctr.pna", "xattr_wrong_password/").unwrap();
 
-    // Set an xattr with the correct password first
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -132,9 +107,7 @@ fn xattr_set_wrong_password_no_effect() {
     .execute()
     .unwrap();
 
-    // Attempt to set xattr with wrong password — may succeed or fail,
-    // but must not corrupt the archive or alter existing xattrs.
-    let _result = cli::Cli::try_parse_from([
+    let _ = cli::Cli::try_parse_from([
         "pna",
         "--quiet",
         "xattr",
@@ -152,30 +125,14 @@ fn xattr_set_wrong_password_no_effect() {
     .unwrap()
     .execute();
 
-    // Verify with correct password - original xattr should still be there
-    archive::for_each_entry_with_password(
-        "xattr_wrong_password/zstd_aes_ctr.pna",
-        "password",
-        |entry| {
-            if entry.name() == "raw/empty.txt" {
-                let xattrs = entry.metadata().xattrs();
-                // Original xattr should exist
-                assert!(
-                    xattrs
-                        .iter()
-                        .any(|x| x.name() == "user.original" && x.value() == b"original_value"),
-                    "original xattr should be preserved"
-                );
-            } else {
-                // Non-target entries should remain unaffected (no xattrs)
-                assert!(
-                    entry.metadata().xattrs().is_empty(),
-                    "Entry {} should have no xattrs but has {:?}",
-                    entry.name(),
-                    entry.metadata().xattrs()
-                );
-            }
-        },
-    )
-    .unwrap();
+    assert_eq!(
+        archive::xattrs_by_entry("xattr_wrong_password/zstd_aes_ctr.pna", Some("password")),
+        vec![(
+            "raw/empty.txt".to_string(),
+            vec![
+                archive::xattr("user.original", b"original_value"),
+                archive::xattr("user.wrong", b"wrong_value"),
+            ]
+        )]
+    );
 }

--- a/cli/tests/cli/xattr/set/option_remove.rs
+++ b/cli/tests/cli/xattr/set/option_remove.rs
@@ -1,6 +1,6 @@
 use crate::utils::{
     EmbedExt, TestResources,
-    archive::{for_each_entry, xattr},
+    archive::{get_archive_entry_names, xattr, xattrs_by_entry},
     setup,
 };
 use clap::Parser;
@@ -42,23 +42,14 @@ fn archive_xattr_remove() {
     .execute()
     .unwrap();
 
-    for_each_entry("xattr_remove/xattr_remove.pna", |entry| {
-        if entry.name() == "xattr_remove/in/raw/empty.txt" {
-            assert_eq!(
-                entry.metadata().xattrs(),
-                &[xattr("user.name", b"pna developers!")],
-            );
-        } else {
-            // Non-target entries should have no xattrs
-            assert!(
-                entry.metadata().xattrs().is_empty(),
-                "Entry {} should have no xattrs but has {:?}",
-                entry.name(),
-                entry.metadata().xattrs()
-            );
-        }
-    })
-    .unwrap();
+    assert_eq!(
+        xattrs_by_entry("xattr_remove/xattr_remove.pna", None),
+        vec![(
+            "xattr_remove/in/raw/empty.txt".to_string(),
+            vec![xattr("user.name", b"pna developers!")]
+        )]
+    );
+    let entries = get_archive_entry_names("xattr_remove/xattr_remove.pna");
 
     cli::Cli::try_parse_from([
         "pna",
@@ -75,14 +66,12 @@ fn archive_xattr_remove() {
     .execute()
     .unwrap();
 
-    for_each_entry("xattr_remove/xattr_remove.pna", |entry| {
-        // After removal, all entries should have no xattrs
-        assert!(
-            entry.metadata().xattrs().is_empty(),
-            "Entry {} should have no xattrs after removal but has {:?}",
-            entry.name(),
-            entry.metadata().xattrs()
-        );
-    })
-    .unwrap();
+    assert_eq!(
+        xattrs_by_entry("xattr_remove/xattr_remove.pna", None),
+        vec![]
+    );
+    assert_eq!(
+        get_archive_entry_names("xattr_remove/xattr_remove.pna"),
+        entries
+    );
 }

--- a/cli/tests/cli/xattr/set/option_restore.rs
+++ b/cli/tests/cli/xattr/set/option_restore.rs
@@ -24,7 +24,6 @@ fn xattr_restore_from_file() {
     .execute()
     .unwrap();
 
-    // Write the dump content to a file
     fs::write(
         "xattr_restore_file/xattrs.dump",
         concat!(
@@ -38,7 +37,6 @@ fn xattr_restore_from_file() {
     )
     .unwrap();
 
-    // Restore xattrs from file
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -53,35 +51,25 @@ fn xattr_restore_from_file() {
     .execute()
     .unwrap();
 
-    // Verify xattrs were restored
-    archive::for_each_entry("xattr_restore_file/archive.pna", |entry| {
-        match entry.name().as_str() {
-            "xattr_restore_file/in/raw/empty.txt" => {
-                let xattrs = entry.metadata().xattrs();
-                assert_eq!(xattrs.len(), 2);
-                assert!(
-                    xattrs
-                        .iter()
-                        .any(|x| x.name() == "user.author" && x.value() == b"pna team")
-                );
-                assert!(
-                    xattrs
-                        .iter()
-                        .any(|x| x.name() == "user.version" && x.value() == b"1.0")
-                );
-            }
-            "xattr_restore_file/in/raw/text.txt" => {
-                let xattrs = entry.metadata().xattrs();
-                assert_eq!(xattrs.len(), 1);
-                assert_eq!(xattrs[0].name(), "user.description");
-                assert_eq!(xattrs[0].value(), b"sample text file");
-            }
-            _ => {
-                assert!(entry.metadata().xattrs().is_empty());
-            }
-        }
-    })
-    .unwrap();
+    let mut applied_sorted_by_name =
+        archive::xattrs_by_entry("xattr_restore_file/archive.pna", None);
+    applied_sorted_by_name.sort_by(|a, b| a.0.cmp(&b.0));
+    assert_eq!(
+        applied_sorted_by_name,
+        vec![
+            (
+                "xattr_restore_file/in/raw/empty.txt".to_string(),
+                vec![
+                    archive::xattr("user.author", b"pna team"),
+                    archive::xattr("user.version", b"1.0"),
+                ]
+            ),
+            (
+                "xattr_restore_file/in/raw/text.txt".to_string(),
+                vec![archive::xattr("user.description", b"sample text file")]
+            ),
+        ]
+    );
 }
 
 /// Precondition: An archive exists and a dump file contains hex-encoded xattr values.
@@ -105,7 +93,6 @@ fn xattr_restore_from_file_with_encodings() {
     .execute()
     .unwrap();
 
-    // Write dump with different encodings
     fs::write(
         "xattr_restore_enc/xattrs.dump",
         concat!(
@@ -131,28 +118,17 @@ fn xattr_restore_from_file_with_encodings() {
     .execute()
     .unwrap();
 
-    archive::for_each_entry("xattr_restore_enc/archive.pna", |entry| {
-        if entry.name() == "xattr_restore_enc/in/raw/empty.txt" {
-            let xattrs = entry.metadata().xattrs();
-            assert_eq!(xattrs.len(), 3);
-            assert!(
-                xattrs
-                    .iter()
-                    .any(|x| x.name() == "user.text" && x.value() == b"hello world")
-            );
-            assert!(
-                xattrs
-                    .iter()
-                    .any(|x| x.name() == "user.hex" && x.value() == b"HELLO")
-            );
-            assert!(
-                xattrs
-                    .iter()
-                    .any(|x| x.name() == "user.base64" && x.value() == b"Hello")
-            );
-        }
-    })
-    .unwrap();
+    assert_eq!(
+        archive::xattrs_by_entry("xattr_restore_enc/archive.pna", None),
+        vec![(
+            "xattr_restore_enc/in/raw/empty.txt".to_string(),
+            vec![
+                archive::xattr("user.text", b"hello world"),
+                archive::xattr("user.hex", b"HELLO"),
+                archive::xattr("user.base64", b"Hello"),
+            ]
+        )]
+    );
 }
 
 /// Precondition: An archive entry already has xattrs, and a dump file defines additional ones.
@@ -176,7 +152,6 @@ fn xattr_restore_from_file_merge() {
     .execute()
     .unwrap();
 
-    // Set initial xattrs
     for (name, value) in [
         ("user.existing", "original"),
         ("user.overwrite", "old_value"),
@@ -199,7 +174,6 @@ fn xattr_restore_from_file_merge() {
         .unwrap();
     }
 
-    // Write dump with new and overlapping xattrs
     fs::write(
         "xattr_restore_merge/xattrs.dump",
         concat!(
@@ -224,29 +198,15 @@ fn xattr_restore_from_file_merge() {
     .execute()
     .unwrap();
 
-    archive::for_each_entry("xattr_restore_merge/archive.pna", |entry| {
-        if entry.name() == "xattr_restore_merge/in/raw/empty.txt" {
-            let xattrs = entry.metadata().xattrs();
-            assert_eq!(xattrs.len(), 3, "should have 3 xattrs after merge");
-            assert!(
-                xattrs
-                    .iter()
-                    .any(|x| x.name() == "user.existing" && x.value() == b"original"),
-                "existing xattr should be preserved"
-            );
-            assert!(
-                xattrs
-                    .iter()
-                    .any(|x| x.name() == "user.new" && x.value() == b"added"),
-                "new xattr should be added"
-            );
-            assert!(
-                xattrs
-                    .iter()
-                    .any(|x| x.name() == "user.overwrite" && x.value() == b"new_value"),
-                "overlapping xattr should be overwritten"
-            );
-        }
-    })
-    .unwrap();
+    assert_eq!(
+        archive::xattrs_by_entry("xattr_restore_merge/archive.pna", None),
+        vec![(
+            "xattr_restore_merge/in/raw/empty.txt".to_string(),
+            vec![
+                archive::xattr("user.existing", b"original"),
+                archive::xattr("user.overwrite", b"new_value"),
+                archive::xattr("user.new", b"added"),
+            ]
+        )]
+    );
 }

--- a/cli/tests/cli/xattr/set/option_restore_from_stdin.rs
+++ b/cli/tests/cli/xattr/set/option_restore_from_stdin.rs
@@ -1,4 +1,6 @@
-use crate::utils::{EmbedExt, TestResources, diff::assert_dirs_equal, setup};
+#[cfg(unix)]
+use crate::utils::fs_supports_xattr;
+use crate::utils::{EmbedExt, TestResources, archive, diff::assert_dirs_equal, setup};
 use assert_cmd::cargo::cargo_bin_cmd;
 use predicates::prelude::*;
 
@@ -84,22 +86,35 @@ fn xattr_set_restore() {
 
     assert_dirs_equal("xattr_set_restore/in/", "xattr_set_restore/out/");
 
-    #[cfg(unix)]
-    if xattr::SUPPORTED_PLATFORM {
-        // Check if xattr is supported on this filesystem
-        match xattr::get("xattr_set_restore/out/raw/empty.txt", "user.name") {
-            Ok(Some(value)) => {
-                assert_eq!(value, b"pna");
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::Unsupported => {
-                eprintln!(
-                    "Skipping xattr verification: filesystem does not support extended attributes"
-                );
-                return;
-            }
-            other => panic!("Unexpected result: {:?}", other),
-        }
+    assert_eq!(
+        archive::xattrs_by_entry("xattr_set_restore/xattr_set_restore.pna", None),
+        vec![
+            (
+                "xattr_set_restore/in/raw/empty.txt".to_string(),
+                vec![
+                    archive::xattr("user.name", b"pna"),
+                    archive::xattr("user.value", b"inspired by png data structure"),
+                ],
+            ),
+            (
+                "xattr_set_restore/in/raw/parent/child.txt".to_string(),
+                vec![archive::xattr("user.meta", &[1, 2, 3, 4, 5])],
+            ),
+        ]
+    );
 
+    #[cfg(unix)]
+    {
+        skip_unless!(
+            "xattr",
+            fs_supports_xattr("xattr_set_restore/out/raw/empty.txt")
+        );
+        assert_eq!(
+            xattr::get("xattr_set_restore/out/raw/empty.txt", "user.name")
+                .unwrap()
+                .as_deref(),
+            Some(b"pna".as_slice())
+        );
         assert_eq!(
             xattr::get("xattr_set_restore/out/raw/empty.txt", "user.value")
                 .unwrap()

--- a/cli/tests/cli/xattr/set/overwrite.rs
+++ b/cli/tests/cli/xattr/set/overwrite.rs
@@ -43,21 +43,11 @@ fn xattr_overwrite() {
     .execute()
     .unwrap();
 
-    archive::for_each_entry("xattr_overwrite/zstd.pna", |entry| {
-        if entry.name() == "raw/empty.txt" {
-            assert_eq!(
-                entry.metadata().xattrs(),
-                &[archive::xattr("user.name", b"second")]
-            );
-        } else {
-            // Non-target entries should remain unaffected (no xattrs)
-            assert!(
-                entry.metadata().xattrs().is_empty(),
-                "Entry {} should have no xattrs but has {:?}",
-                entry.name(),
-                entry.metadata().xattrs()
-            );
-        }
-    })
-    .unwrap();
+    assert_eq!(
+        archive::xattrs_by_entry("xattr_overwrite/zstd.pna", None),
+        vec![(
+            "raw/empty.txt".to_string(),
+            vec![archive::xattr("user.name", b"second")]
+        )]
+    );
 }

--- a/cli/tests/cli/xattr/set/set_and_remove.rs
+++ b/cli/tests/cli/xattr/set/set_and_remove.rs
@@ -10,7 +10,6 @@ fn xattr_multiple_set_and_remove() {
     setup();
     TestResources::extract_in("zstd.pna", "xattr_multi/").unwrap();
 
-    // Set multiple xattrs
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -44,7 +43,6 @@ fn xattr_multiple_set_and_remove() {
     .execute()
     .unwrap();
 
-    // Remove one xattr
     cli::Cli::try_parse_from([
         "pna",
         "--quiet",
@@ -60,18 +58,11 @@ fn xattr_multiple_set_and_remove() {
     .execute()
     .unwrap();
 
-    archive::for_each_entry("xattr_multi/zstd.pna", |entry| {
-        if entry.name() == "raw/empty.txt" {
-            assert_eq!(entry.metadata().xattrs(), &[archive::xattr("user.b", b"B")]);
-        } else {
-            // Non-target entries should remain unaffected (no xattrs)
-            assert!(
-                entry.metadata().xattrs().is_empty(),
-                "Entry {} should have no xattrs but has {:?}",
-                entry.name(),
-                entry.metadata().xattrs()
-            );
-        }
-    })
-    .unwrap();
+    assert_eq!(
+        archive::xattrs_by_entry("xattr_multi/zstd.pna", None),
+        vec![(
+            "raw/empty.txt".to_string(),
+            vec![archive::xattr("user.b", b"B")]
+        )]
+    );
 }

--- a/lib/src/archive/header.rs
+++ b/lib/src/archive/header.rs
@@ -91,13 +91,4 @@ mod tests {
         assert!(ArchiveHeader::try_from_bytes(&[0u8; 8]).is_ok());
         assert!(ArchiveHeader::try_from_bytes(&[0u8; 9]).is_err());
     }
-
-    #[test]
-    fn header_to_from_bytes() {
-        let bytes = [1u8, 2, 0, 0, 0, 0, 0, 3];
-        assert_eq!(
-            ArchiveHeader::from_bytes(&bytes),
-            ArchiveHeader::from_bytes(&ArchiveHeader::from_bytes(&bytes).to_bytes()),
-        );
-    }
 }

--- a/lib/src/cipher.rs
+++ b/lib/src/cipher.rs
@@ -295,17 +295,19 @@ mod tests {
     fn aes256_cbc_wrong_key_does_not_recover_plaintext() {
         let ct = encrypt_aes256_cbc(&KAT_KEY, &KAT_IV, KAT_PLAINTEXT).unwrap();
         let wrong_key = [0x99u8; 32];
-        if let Ok(recovered) = decrypt_aes256_cbc(&wrong_key, &ct) {
-            assert_ne!(recovered.as_slice(), KAT_PLAINTEXT.as_slice())
-        }
+        assert_ne!(
+            decrypt_aes256_cbc(&wrong_key, &ct).ok().as_deref(),
+            Some(KAT_PLAINTEXT.as_slice())
+        );
     }
 
     #[test]
     fn camellia256_cbc_wrong_key_does_not_recover_plaintext() {
         let ct = encrypt_camellia256_cbc(&KAT_KEY, &KAT_IV, KAT_PLAINTEXT).unwrap();
         let wrong_key = [0x99u8; 32];
-        if let Ok(recovered) = decrypt_camellia256_cbc(&wrong_key, &ct) {
-            assert_ne!(recovered.as_slice(), KAT_PLAINTEXT.as_slice())
-        }
+        assert_ne!(
+            decrypt_camellia256_cbc(&wrong_key, &ct).ok().as_deref(),
+            Some(KAT_PLAINTEXT.as_slice())
+        );
     }
 }

--- a/lib/tests/extract_compatibility.rs
+++ b/lib/tests/extract_compatibility.rs
@@ -1,12 +1,21 @@
 use libpna::{Archive, DataKind, ReadOptions};
-use std::io;
+use std::{collections::BTreeSet, io};
+
+/// Whether a fixture's file entries carry the optional fSIZ chunk.
+#[derive(Clone, Copy)]
+enum RawFileSize {
+    Stored,
+    Absent,
+}
 
 /// Reads every entry of a fixture and compares it against the original file.
 ///
-/// Counts what it checked: without that, a fixture that lost its entries would
-/// leave the loop body unexecuted and the test would still pass.
-fn extract_all(bytes: &[u8], password: Option<&[u8]>) {
+/// Counts what it checked and collects the exact path set: without that, a
+/// fixture that lost or renamed an entry would leave that arm's assertions
+/// unexecuted and the test would still pass.
+fn extract_all(bytes: &[u8], password: Option<&[u8]>, raw_file_size: RawFileSize) {
     let mut n = 0;
+    let mut paths = BTreeSet::new();
     let mut archive_reader = Archive::read_header(bytes).unwrap();
     for entry in archive_reader.entries().skip_solid() {
         let item = entry.unwrap();
@@ -15,76 +24,48 @@ fn extract_all(bytes: &[u8], password: Option<&[u8]>) {
         }
         n += 1;
         let path = item.header().path().as_str();
+        paths.insert(path.to_string());
         let mut dist = Vec::new();
         let mut reader = item.reader(ReadOptions::with_password(password)).unwrap();
         io::copy(&mut reader, &mut dist).unwrap();
-        match path {
+        let bytes: &[u8] = match path {
             "raw/first/second/third/pna.txt" => {
-                let bytes = include_bytes!("../../resources/test/raw/first/second/third/pna.txt");
-                assert_eq!(dist.as_slice(), bytes);
-                if let Some(size) = item.metadata().raw_file_size() {
-                    assert_eq!(size, bytes.len() as u128);
-                }
+                include_bytes!("../../resources/test/raw/first/second/third/pna.txt")
             }
-            "raw/images/icon.bmp" => {
-                let bytes = include_bytes!("../../resources/test/raw/images/icon.bmp");
-                assert_eq!(dist.as_slice(), bytes);
-                if let Some(size) = item.metadata().raw_file_size() {
-                    assert_eq!(size, bytes.len() as u128);
-                }
-            }
-            "raw/images/icon.png" => {
-                let bytes = include_bytes!("../../resources/test/raw/images/icon.png");
-                assert_eq!(dist.as_slice(), bytes);
-                if let Some(size) = item.metadata().raw_file_size() {
-                    assert_eq!(size, bytes.len() as u128);
-                }
-            }
-            "raw/images/icon.svg" => {
-                let bytes = include_bytes!("../../resources/test/raw/images/icon.svg");
-                assert_eq!(dist.as_slice(), bytes);
-                if let Some(size) = item.metadata().raw_file_size() {
-                    assert_eq!(size, bytes.len() as u128);
-                }
-            }
-            "raw/parent/child.txt" => {
-                let bytes = include_bytes!("../../resources/test/raw/parent/child.txt");
-                assert_eq!(dist.as_slice(), bytes);
-                if let Some(size) = item.metadata().raw_file_size() {
-                    assert_eq!(size, bytes.len() as u128);
-                }
-            }
-            "raw/pna/empty.pna" => {
-                let bytes = include_bytes!("../../resources/test/raw/pna/empty.pna");
-                assert_eq!(dist.as_slice(), bytes);
-                if let Some(size) = item.metadata().raw_file_size() {
-                    assert_eq!(size, bytes.len() as u128);
-                }
-            }
-            "raw/pna/nest.pna" => {
-                let bytes = include_bytes!("../../resources/test/raw/pna/nest.pna");
-                assert_eq!(dist.as_slice(), bytes);
-                if let Some(size) = item.metadata().raw_file_size() {
-                    assert_eq!(size, bytes.len() as u128);
-                }
-            }
-            "raw/empty.txt" => {
-                let bytes = include_bytes!("../../resources/test/raw/empty.txt");
-                assert_eq!(dist.as_slice(), bytes);
-                if let Some(size) = item.metadata().raw_file_size() {
-                    assert_eq!(size, bytes.len() as u128);
-                }
-            }
-            "raw/text.txt" => {
-                let bytes = include_bytes!("../../resources/test/raw/text.txt");
-                assert_eq!(dist.as_slice(), bytes);
-                if let Some(size) = item.metadata().raw_file_size() {
-                    assert_eq!(size, bytes.len() as u128);
-                }
-            }
+            "raw/images/icon.bmp" => include_bytes!("../../resources/test/raw/images/icon.bmp"),
+            "raw/images/icon.png" => include_bytes!("../../resources/test/raw/images/icon.png"),
+            "raw/images/icon.svg" => include_bytes!("../../resources/test/raw/images/icon.svg"),
+            "raw/parent/child.txt" => include_bytes!("../../resources/test/raw/parent/child.txt"),
+            "raw/pna/empty.pna" => include_bytes!("../../resources/test/raw/pna/empty.pna"),
+            "raw/pna/nest.pna" => include_bytes!("../../resources/test/raw/pna/nest.pna"),
+            "raw/empty.txt" => include_bytes!("../../resources/test/raw/empty.txt"),
+            "raw/text.txt" => include_bytes!("../../resources/test/raw/text.txt"),
             a => panic!("Unexpected entry name {a}"),
-        }
+        };
+        assert_eq!(dist.as_slice(), bytes);
+        let expected = match raw_file_size {
+            RawFileSize::Stored => Some(bytes.len() as u128),
+            RawFileSize::Absent => None,
+        };
+        assert_eq!(item.metadata().raw_file_size(), expected, "{path}");
     }
+    assert_eq!(
+        paths,
+        BTreeSet::from(
+            [
+                "raw/first/second/third/pna.txt",
+                "raw/images/icon.bmp",
+                "raw/images/icon.png",
+                "raw/images/icon.svg",
+                "raw/parent/child.txt",
+                "raw/pna/empty.pna",
+                "raw/pna/nest.pna",
+                "raw/empty.txt",
+                "raw/text.txt",
+            ]
+            .map(String::from)
+        )
+    );
     assert_eq!(n, 9);
 }
 
@@ -99,22 +80,38 @@ fn empty() {
 
 #[test]
 fn store() {
-    extract_all(include_bytes!("../../resources/test/store.pna"), None);
+    extract_all(
+        include_bytes!("../../resources/test/store.pna"),
+        None,
+        RawFileSize::Absent,
+    );
 }
 
 #[test]
 fn deflate() {
-    extract_all(include_bytes!("../../resources/test/deflate.pna"), None);
+    extract_all(
+        include_bytes!("../../resources/test/deflate.pna"),
+        None,
+        RawFileSize::Absent,
+    );
 }
 
 #[test]
 fn zstd() {
-    extract_all(include_bytes!("../../resources/test/zstd.pna"), None);
+    extract_all(
+        include_bytes!("../../resources/test/zstd.pna"),
+        None,
+        RawFileSize::Absent,
+    );
 }
 
 #[test]
 fn xz() {
-    extract_all(include_bytes!("../../resources/test/xz.pna"), None);
+    extract_all(
+        include_bytes!("../../resources/test/xz.pna"),
+        None,
+        RawFileSize::Absent,
+    );
 }
 
 #[test]
@@ -122,6 +119,7 @@ fn zstd_aes_cbc() {
     extract_all(
         include_bytes!("../../resources/test/zstd_aes_cbc.pna"),
         Some(b"password"),
+        RawFileSize::Absent,
     );
 }
 
@@ -130,6 +128,7 @@ fn zstd_aes_ctr() {
     extract_all(
         include_bytes!("../../resources/test/zstd_aes_ctr.pna"),
         Some(b"password"),
+        RawFileSize::Absent,
     );
 }
 
@@ -138,6 +137,7 @@ fn zstd_camellia_cbc() {
     extract_all(
         include_bytes!("../../resources/test/zstd_camellia_cbc.pna"),
         Some(b"password"),
+        RawFileSize::Absent,
     );
 }
 
@@ -146,6 +146,7 @@ fn zstd_camellia_ctr() {
     extract_all(
         include_bytes!("../../resources/test/zstd_camellia_ctr.pna"),
         Some(b"password"),
+        RawFileSize::Absent,
     );
 }
 
@@ -154,6 +155,7 @@ fn zstd_aes_gcm() {
     extract_all(
         include_bytes!("../../resources/test/zstd_aes_gcm.pna"),
         Some(b"password"),
+        RawFileSize::Stored,
     );
 }
 
@@ -162,6 +164,7 @@ fn zstd_camellia_gcm() {
     extract_all(
         include_bytes!("../../resources/test/zstd_camellia_gcm.pna"),
         Some(b"password"),
+        RawFileSize::Stored,
     );
 }
 
@@ -170,6 +173,7 @@ fn keep_permission() {
     extract_all(
         include_bytes!("../../resources/test/zstd_keep_permission.pna"),
         None,
+        RawFileSize::Absent,
     );
 }
 
@@ -178,6 +182,7 @@ fn keep_timestamp() {
     extract_all(
         include_bytes!("../../resources/test/zstd_keep_timestamp.pna"),
         None,
+        RawFileSize::Absent,
     );
 }
 
@@ -186,6 +191,7 @@ fn keep_timestamp_with_nanos() {
     extract_all(
         include_bytes!("../../resources/test/zstd_keep_timestamp_with_nanos.pna"),
         None,
+        RawFileSize::Stored,
     );
 }
 
@@ -194,6 +200,7 @@ fn keep_xattr() {
     extract_all(
         include_bytes!("../../resources/test/zstd_keep_xattr.pna"),
         None,
+        RawFileSize::Stored,
     );
 }
 
@@ -202,6 +209,7 @@ fn keep_dir() {
     extract_all(
         include_bytes!("../../resources/test/zstd_keep_dir.pna"),
         None,
+        RawFileSize::Absent,
     );
 }
 
@@ -210,5 +218,6 @@ fn zstd_with_raw_file_size() {
     extract_all(
         include_bytes!("../../resources/test/zstd_with_raw_file_size.pna"),
         None,
+        RawFileSize::Stored,
     );
 }

--- a/lib/tests/extract_multipart_compatibility.rs
+++ b/lib/tests/extract_multipart_compatibility.rs
@@ -1,9 +1,10 @@
 use libpna::{Archive, DataKind, ReadOptions};
 use std::io;
 
-fn extract_all(follows: &[&[u8]], password: Option<&str>) {
+fn extract_all(follows: &[&[u8]], password: Option<&str>, expected_entries: usize) {
     let mut idx = 0;
     let mut archive_reader = Archive::read_header(follows[idx]).unwrap();
+    let mut n = 0;
     loop {
         idx += 1;
         for entry in archive_reader.entries().skip_solid() {
@@ -22,6 +23,7 @@ fn extract_all(follows: &[&[u8]], password: Option<&str>) {
                 ),
                 a => panic!("Unexpected entry name {a}"),
             }
+            n += 1;
         }
         if archive_reader.has_next_archive() {
             archive_reader = archive_reader.read_next_archive(follows[idx]).unwrap();
@@ -29,6 +31,7 @@ fn extract_all(follows: &[&[u8]], password: Option<&str>) {
             break;
         }
     }
+    assert_eq!(n, expected_entries);
 }
 
 #[test]
@@ -39,5 +42,6 @@ fn extract_multipart_archive() {
             include_bytes!("../../resources/test/multipart.part2.pna"),
         ],
         None,
+        1,
     );
 }

--- a/pna/src/ext/time.rs
+++ b/pna/src/ext/time.rs
@@ -226,16 +226,4 @@ mod tests {
         let s = saturating_duration_to_system_time(Duration::MIN);
         assert!(s <= SystemTime::UNIX_EPOCH);
     }
-
-    #[test]
-    fn saturating_duration_to_system_time_clamp_targets_are_deterministic() {
-        assert_eq!(
-            saturating_duration_to_system_time(Duration::MAX),
-            saturating_duration_to_system_time(Duration::MAX)
-        );
-        assert_eq!(
-            saturating_duration_to_system_time(Duration::MIN),
-            saturating_duration_to_system_time(Duration::MIN)
-        );
-    }
 }


### PR DESCRIPTION
## Summary

Tests that returned early, asserted inside a callback that might never run, or compared a value against the expression that produced it no longer pass without checking anything. Runtime preconditions (birth time, xattr, chmod, …) exit through a `skip_unless!` macro that prints the skip and panics when `PNA_TEST_REQUIRE` lists that capability, and the workflows set the variable per job, so a capability the runner does have can no longer be skipped silently.

## Notes

- `PNA_TEST_REQUIRE` is a comma-separated capability list read in `cli/tests/cli/utils.rs`. Windows jobs require `birthtime,mtime_nanos`; the other hosted jobs also require `xattr,nodump,chmod,setuid,unprivileged`; the VM jobs require `root`, which they hold. Still skipped on CI: `root` and `mount` on the hosted Linux and macOS runners.
- A capability probe has to reject the sentinel answers, not only the error: OpenBSD returns `Ok(UNIX_EPOCH)` from `created()` for every file, and `current_platform()` returns `""` where no ACL implementation exists. Both are treated as absent.
- Time-filter tests set timestamps with `filetime` instead of sleeping. `set_mtime` and the six `option_*_mtime_than` modules are gated on `#[cfg(not(target_family = "wasm"))]` because `filetime` is not a dependency there.
- Birth time cannot be set, so `create_file_born_after` creates each attempt at a fresh path and reads the time back after the rename: NTFS tunneling restores the previous creation time both for a re-created name and for the destination of a rename.
- `xattr_set_wrong_password_no_effect` asserted a postcondition that does not hold. Xattrs are plaintext metadata chunks, so `xattr set` with a wrong password does apply its xattr to a CTR (unauthenticated) normal-mode archive. Renamed to `xattr_set_wrong_password_updates_metadata_only`, with the actual contract in the doc comment.

## Verification

Setting `PNA_TEST_REQUIRE=root` on a runner without privilege makes the affected tests fail instead of skipping, confirming the variable is honored.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved archive extraction checks for complete entry sets, file contents, and metadata.
  * Made timestamp, permission, extended-attribute, and encryption tests more deterministic and comprehensive.
  * Added consistent capability-based test handling across supported platforms and CI environments.
  * Limited unsupported timestamp tests to non-Wasm platforms.
  * Clarified wrong-password extended-attribute behavior: plaintext metadata updates still apply.
  * Strengthened archive permission and extended-attribute verification.
  * Expanded CI validation for supported metadata capabilities and required privileges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->