### PR TITLE
:fire: Remove duplicated tests and share chunk byte fixtures

### DIFF
--- a/cli/tests/cli/chunk/list/option_type.rs
+++ b/cli/tests/cli/chunk/list/option_type.rs
@@ -241,24 +241,3 @@ fn chunk_list_with_invalid_type_chars() {
         "unexpected error message: {err}"
     );
 }
-
-/// Precondition: An empty PNA archive exists.
-/// Action: Run `pna experimental chunk list -f <archive>` without type filters.
-/// Expectation: All chunks are listed as before.
-#[test]
-fn chunk_list_without_type_filter() {
-    setup();
-    TestResources::extract_in("empty.pna", "chunk_list_no_type_filter/").unwrap();
-
-    cargo_bin_cmd!("pna")
-        .args([
-            "experimental",
-            "chunk",
-            "list",
-            "-f",
-            "chunk_list_no_type_filter/empty.pna",
-        ])
-        .assert()
-        .success()
-        .stdout(concat!(" 1  AHED  8  0x0008 \n", " 2  AEND  0  0x001c \n",));
-}

--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -1185,16 +1185,6 @@ mod tests {
         }
 
         #[test]
-        fn chunk_split_default() {
-            let options = gcm_options(Encryption::AES, Compression::NO, 4);
-            let archived = per_entry_archive(&options, REPRESENTATIVE, None);
-            assert_eq!(
-                read_per_entry(&archived, Some("password")).unwrap(),
-                REPRESENTATIVE
-            );
-        }
-
-        #[test]
         fn chunk_split_one_byte() {
             let options = gcm_options(Encryption::AES, Compression::NO, 4);
             let archived = per_entry_archive(&options, REPRESENTATIVE, Some(1));

--- a/lib/src/bytes.rs
+++ b/lib/src/bytes.rs
@@ -113,6 +113,7 @@ pub fn skip_chunk(bytes: &[u8]) -> io::Result<(ChunkType, &[u8])> {
 mod tests {
     use super::*;
     use crate::Chunk;
+    use crate::chunk::test_support::{raw_chunk_bytes, valid_chunk_bytes};
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
@@ -137,24 +138,6 @@ mod tests {
             read_signature(b"xxxxxxxx").unwrap_err().kind(),
             io::ErrorKind::InvalidData
         );
-    }
-
-    fn valid_chunk_bytes() -> Vec<u8> {
-        vec![
-            0x00, 0x00, 0x00, 0x04, // chunk length
-            b'F', b'D', b'A', b'T', // chunk type
-            0xAA, 0xBB, 0xCC, 0xDD, // chunk data
-            0x47, 0xF3, 0x2B, 0x10, // CRC-32
-        ]
-    }
-
-    fn raw_chunk_bytes(ty: [u8; 4], data: &[u8]) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(data.len() + 12);
-        bytes.extend_from_slice(&(data.len() as u32).to_be_bytes());
-        bytes.extend_from_slice(&ty);
-        bytes.extend_from_slice(data);
-        bytes.extend_from_slice(&crate::format::chunk_crc(&ty, data).to_be_bytes());
-        bytes
     }
 
     #[test]

--- a/lib/src/chunk.rs
+++ b/lib/src/chunk.rs
@@ -587,3 +587,24 @@ mod tests {
         assert!(chunks.next().is_none());
     }
 }
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    pub(crate) fn valid_chunk_bytes() -> Vec<u8> {
+        vec![
+            0x00, 0x00, 0x00, 0x04, // chunk length
+            b'F', b'D', b'A', b'T', // chunk type
+            0xAA, 0xBB, 0xCC, 0xDD, // chunk data
+            0x47, 0xF3, 0x2B, 0x10, // CRC-32
+        ]
+    }
+
+    pub(crate) fn raw_chunk_bytes(ty: [u8; 4], data: &[u8]) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(data.len() + 12);
+        bytes.extend_from_slice(&(data.len() as u32).to_be_bytes());
+        bytes.extend_from_slice(&ty);
+        bytes.extend_from_slice(data);
+        bytes.extend_from_slice(&crate::format::chunk_crc(&ty, data).to_be_bytes());
+        bytes
+    }
+}

--- a/lib/src/entry/options.rs
+++ b/lib/src/entry/options.rs
@@ -1520,22 +1520,6 @@ mod tests {
         let _ = WriteOptions::builder().encryption(Encryption::AES).build();
     }
 
-    #[test]
-    fn cipher_mode_2_from_byte_returns_gcm() {
-        assert_eq!(CipherMode::from_byte(2), CipherMode::GCM);
-    }
-
-    #[test]
-    fn cipher_mode_gcm_to_byte_is_2() {
-        assert_eq!(CipherMode::GCM.to_byte(), 2);
-    }
-
-    #[test]
-    fn cipher_mode_gcm_roundtrips_through_byte() {
-        let byte = CipherMode::GCM.to_byte();
-        assert_eq!(CipherMode::from_byte(byte), CipherMode::GCM);
-    }
-
     fn test_output(byte: u8) -> Output {
         Output::new(&[byte; 32]).unwrap()
     }
@@ -1816,6 +1800,8 @@ mod tests {
     fn cipher_mode_known_constants_map_to_spec_bytes() {
         assert_eq!(CipherMode::CBC.to_byte(), 0);
         assert_eq!(CipherMode::CTR.to_byte(), 1);
+        assert_eq!(CipherMode::GCM.to_byte(), 2);
+        assert_eq!(CipherMode::from_byte(2), CipherMode::GCM);
     }
 
     #[test]

--- a/lib/src/io.rs
+++ b/lib/src/io.rs
@@ -237,6 +237,7 @@ pub fn skip_chunk<R: io::Read + io::Seek + ?Sized>(reader: &mut R) -> io::Result
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::chunk::test_support::{raw_chunk_bytes, valid_chunk_bytes};
     use crate::{Chunk, util::io::tests::PartialReader};
     use std::io::{Read, Seek};
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
@@ -273,24 +274,6 @@ mod tests {
             read_signature(&mut reader).unwrap_err().kind(),
             io::ErrorKind::InvalidData
         );
-    }
-
-    fn valid_chunk_bytes() -> Vec<u8> {
-        vec![
-            0x00, 0x00, 0x00, 0x04, // chunk length
-            b'F', b'D', b'A', b'T', // chunk type
-            0xAA, 0xBB, 0xCC, 0xDD, // chunk data
-            0x47, 0xF3, 0x2B, 0x10, // CRC-32
-        ]
-    }
-
-    fn raw_chunk_bytes(ty: [u8; 4], data: &[u8]) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(data.len() + 12);
-        bytes.extend_from_slice(&(data.len() as u32).to_be_bytes());
-        bytes.extend_from_slice(&ty);
-        bytes.extend_from_slice(data);
-        bytes.extend_from_slice(&crate::format::chunk_crc(&ty, data).to_be_bytes());
-        bytes
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Delete three tests whose claim is already made elsewhere, and move the chunk byte fixtures that `bytes.rs` and `io.rs` each defined separately into one shared `#[cfg(test)]` module in `chunk.rs`.

## Notes

- `cipher_mode_known_constants_map_to_spec_bytes` now pins `CipherMode::GCM` alongside CBC and CTR, which is what the three deleted GCM tests asserted between them.
- `chunk_list_without_type_filter` repeated `chunk/list/basic.rs`; the solid GCM round trip in `archive.rs` repeated the per-entry compression/encryption matrix in the same module.
