### PR TITLE
:white_check_mark: Assert crypto vectors and chunk bytes exactly instead of round-tripping

### DIFF
--- a/lib/src/cipher.rs
+++ b/lib/src/cipher.rs
@@ -6,12 +6,12 @@ mod gcm;
 mod stream;
 
 use crate::util::io::TryIntoInner;
+#[cfg(test)]
+pub(crate) use aead::MAX_SEGMENT_SIZE;
 pub(crate) use aead::{
     DEFAULT_SEGMENT_SIZE, STREAM_HEADER_LEN, SegmentSize, StreamHeader, StreamKey,
     derive_stream_key, key_confirmation,
 };
-#[cfg(test)]
-pub(crate) use aead::{GCM_TAG_LEN, MAX_SEGMENT_SIZE, segment_nonce};
 use aes::Aes256;
 use camellia::Camellia256;
 use cipher::block_padding::Pkcs7;

--- a/lib/src/cipher/aead.rs
+++ b/lib/src/cipher/aead.rs
@@ -211,12 +211,6 @@ pub(crate) fn segment_nonce(nonce_prefix: &[u8; 7], counter: u32, is_final: bool
 mod tests {
     use super::*;
 
-    const OKM_42_BYTES: [u8; 42] = [
-        0x3c, 0xb2, 0x5f, 0x25, 0xfa, 0xac, 0xd5, 0x7a, 0x90, 0x43, 0x4f, 0x64, 0xd0, 0x36, 0x2f,
-        0x2a, 0x2d, 0x2d, 0x0a, 0x90, 0xcf, 0x1a, 0x5a, 0x4c, 0x5d, 0xb0, 0x2d, 0x56, 0xec, 0xc4,
-        0xc5, 0xbf, 0x34, 0x00, 0x72, 0x08, 0xd5, 0xb8, 0x87, 0x18, 0x58, 0x65,
-    ];
-
     const SALT: [u8; 32] = [0x42; 32];
     const PREFIX: [u8; 7] = [0x5A; 7];
     const SEGMENT_SIZE: u32 = 0x01020304;
@@ -234,6 +228,14 @@ mod tests {
         0x43, 0x3a, 0x1f, 0x44, 0x98, 0xd2, 0x2a, 0x59, 0x11, 0x50, 0x7e, 0x68, 0x27, 0x59, 0x0f,
         0xad, 0xb5,
     ]);
+
+    /// `HKDF-SHA-256(ikm = "master_key", salt = ∅, info = "PNA-KC-v1")`, produced
+    /// by an RFC 5869 implementation outside this crate.
+    const K_CONFIRM_MASTER_KEY: [u8; 32] = [
+        0xe4, 0x1a, 0x66, 0x1e, 0x64, 0x9b, 0x11, 0x68, 0x18, 0xf7, 0x16, 0x71, 0x7f, 0x29, 0xe2,
+        0x0c, 0x4e, 0x6b, 0x19, 0xc6, 0xea, 0x3b, 0xd3, 0x79, 0x8f, 0x9a, 0xd1, 0xcc, 0xb1, 0xb2,
+        0x8a, 0x97,
+    ];
 
     fn header() -> StreamHeader {
         header_of(SALT, PREFIX, SEGMENT_SIZE)
@@ -318,30 +320,8 @@ mod tests {
     }
 
     #[test]
-    fn hkdf_sha256_rfc5869_test_case_1() {
-        let ikm = [0x0bu8; 22];
-        let salt: Vec<u8> = (0x00u8..=0x0c).collect();
-        let info: Vec<u8> = (0xf0u8..=0xf9).collect();
-        assert_eq!(
-            hkdf_sha256(&ikm, &salt, &info).as_slice(),
-            &OKM_42_BYTES[..32]
-        );
-    }
-
-    #[test]
-    fn key_confirmation_is_hkdf_with_empty_salt_and_domain_info() {
-        assert_eq!(
-            key_confirmation(b"master_key").0,
-            hkdf_sha256(b"master_key", &[], b"PNA-KC-v1")
-        );
-    }
-
-    #[test]
-    fn key_confirmation_differs_per_k_master() {
-        assert_ne!(
-            key_confirmation(b"master_key_1").0,
-            key_confirmation(b"master_key_2").0
-        );
+    fn key_confirmation_matches_a_fixed_vector() {
+        assert_eq!(key_confirmation(b"master_key").0, K_CONFIRM_MASTER_KEY);
     }
 
     #[test]

--- a/lib/src/cipher/aead.rs
+++ b/lib/src/cipher/aead.rs
@@ -271,16 +271,6 @@ mod tests {
     }
 
     #[test]
-    fn segment_size_rejects_zero() {
-        assert!(SegmentSize::new(0).is_none());
-    }
-
-    #[test]
-    fn segment_size_rejects_oversized() {
-        assert!(SegmentSize::new(MAX_SEGMENT_SIZE + 1).is_none());
-    }
-
-    #[test]
     fn stream_header_rejects_zero_segment_size() {
         let bytes = [0u8; STREAM_HEADER_LEN];
         assert!(matches!(
@@ -364,25 +354,6 @@ mod tests {
         let ctx = entry_context(&header(), ChunkType::SHED, b"test_header", b"test_phsf");
         let expected = Sha256::digest([b"SHED".as_slice(), b"test_header".as_slice()].concat());
         assert_eq!(&ctx[13..45], expected.as_slice());
-    }
-
-    #[test]
-    fn derive_stream_key_ignores_key_confirmation() {
-        let header1 = StreamHeader::new(
-            SALT,
-            PREFIX,
-            SegmentSize::new(SEGMENT_SIZE).unwrap(),
-            KeyConfirmation::from_bytes([0x01; 32]),
-        );
-        let header2 = StreamHeader::new(
-            SALT,
-            PREFIX,
-            SegmentSize::new(SEGMENT_SIZE).unwrap(),
-            KeyConfirmation::from_bytes([0x02; 32]),
-        );
-        let key1 = derive_stream_key(K_MASTER, &header1, ChunkType::FHED, HEADER_DATA, PHSF_DATA);
-        let key2 = derive_stream_key(K_MASTER, &header2, ChunkType::FHED, HEADER_DATA, PHSF_DATA);
-        assert_eq!(key1, key2);
     }
 
     /// Pins every input's contribution and the order they are fed to HKDF. A

--- a/lib/src/cipher/gcm.rs
+++ b/lib/src/cipher/gcm.rs
@@ -327,6 +327,34 @@ mod tests {
     const PREFIX: [u8; 7] = [3u8; 7];
     const SEG: u32 = 4;
 
+    /// AES-256-GCM under key `[7u8; 32]`, nonce = `[3u8; 7] ‖ counter (u32 BE) ‖ final flag`,
+    /// no AAD, segment size 4, 16-byte tag appended per segment; produced by an
+    /// implementation outside this crate. Regenerating these from `GcmEncryptWriter`
+    /// would bless whatever it currently does and lose the only external check.
+    const CT_EMPTY: [u8; 16] = [
+        0x72, 0x8b, 0xbc, 0x7c, 0xcb, 0xd8, 0x69, 0x08, 0xa3, 0x0d, 0x9f, 0xe1, 0x72, 0x49, 0x33,
+        0x36,
+    ];
+    const CT_ABC: [u8; 19] = [
+        0x0c, 0xc6, 0xd0, 0xde, 0x0a, 0x2e, 0xd1, 0x47, 0xec, 0x2b, 0x11, 0x9a, 0x37, 0xdd, 0xcc,
+        0xee, 0x8d, 0x50, 0xaf,
+    ];
+    const CT_ABCD: [u8; 20] = [
+        0x0c, 0xc6, 0xd0, 0x2f, 0x02, 0xa4, 0x64, 0x07, 0x20, 0x2c, 0xea, 0x8f, 0x9d, 0xc9, 0xbe,
+        0x34, 0x43, 0x13, 0x49, 0x2d,
+    ];
+    const CT_ABCDEFGH: [u8; 40] = [
+        0x6c, 0x0b, 0x40, 0x87, 0x21, 0xd8, 0x5e, 0xbb, 0xe5, 0x86, 0x94, 0xd3, 0x2e, 0x44, 0x90,
+        0x6e, 0xf6, 0x22, 0x9f, 0x2f, 0xc3, 0xfc, 0xd2, 0xe6, 0x23, 0x11, 0xff, 0x57, 0xe5, 0x8a,
+        0x52, 0x23, 0x41, 0xe2, 0xa5, 0xb0, 0xf2, 0xc1, 0xad, 0xd6,
+    ];
+    const CT_ABCDEFGHI: [u8; 57] = [
+        0x6c, 0x0b, 0x40, 0x87, 0x21, 0xd8, 0x5e, 0xbb, 0xe5, 0x86, 0x94, 0xd3, 0x2e, 0x44, 0x90,
+        0x6e, 0xf6, 0x22, 0x9f, 0x2f, 0xa5, 0x62, 0x8c, 0x08, 0x20, 0xaa, 0x39, 0x58, 0x9d, 0x6f,
+        0x6d, 0xdd, 0xbe, 0x08, 0x07, 0x80, 0x3c, 0x36, 0x31, 0x24, 0xc0, 0xea, 0x0b, 0xda, 0x83,
+        0x24, 0x2f, 0x7f, 0x71, 0x27, 0xf5, 0x8b, 0xb3, 0xcc, 0x06, 0x23, 0x7c,
+    ];
+
     fn header(segment_size: u32) -> StreamHeader {
         StreamHeader::new(
             [0u8; 32],
@@ -356,31 +384,6 @@ mod tests {
         w.finish().unwrap()
     }
 
-    fn decrypt_stream<C>(plain_len: usize, ciphertext: &[u8]) -> Vec<u8>
-    where
-        AesGcm<C, U12>: KeyInit + Aead + AeadCore<NonceSize = U12>,
-    {
-        let cipher = AesGcm::<C, U12>::new_from_slice(KEY.as_bytes()).unwrap();
-        let non_final = if plain_len == 0 {
-            0
-        } else {
-            (plain_len - 1) / SEG as usize
-        };
-        let mut out = Vec::new();
-        let mut rest = ciphertext;
-        let mut counter = 0u32;
-        for _ in 0..non_final {
-            let nonce = Array::<u8, U12>::from(segment_nonce(&PREFIX, counter, false));
-            let (segment, tail) = rest.split_at(SEG as usize + GCM_TAG_LEN);
-            out.extend_from_slice(&cipher.decrypt(&nonce, segment).unwrap());
-            rest = tail;
-            counter += 1;
-        }
-        let nonce = Array::<u8, U12>::from(segment_nonce(&PREFIX, counter, true));
-        out.extend_from_slice(&cipher.decrypt(&nonce, rest).unwrap());
-        out
-    }
-
     #[derive(Default)]
     struct RecordingWriter {
         bytes: Vec<u8>,
@@ -407,68 +410,43 @@ mod tests {
         let output = writer.finish().unwrap();
 
         assert_eq!(output.write_sizes, [SEG as usize, GCM_TAG_LEN]);
-        assert_eq!(
-            decrypt_stream::<Aes256>(SEG as usize, &output.bytes),
-            b"abcd"
-        );
+        assert_eq!(output.bytes, CT_ABCD);
     }
 
     #[test]
     fn empty_plaintext_emits_single_tag_only_segment() {
-        let ct = encrypt_all::<Aes256>(b"");
-        assert_eq!(ct.len(), GCM_TAG_LEN);
-        assert_eq!(decrypt_stream::<Aes256>(0, &ct).as_slice(), b"");
+        assert_eq!(encrypt_all::<Aes256>(b""), CT_EMPTY);
     }
 
     #[test]
     fn below_segment_size_emits_single_final_segment() {
-        let plain = b"abc";
-        let ct = encrypt_all::<Aes256>(plain);
-        assert_eq!(ct.len(), plain.len() + GCM_TAG_LEN);
-        assert_eq!(decrypt_stream::<Aes256>(plain.len(), &ct).as_slice(), plain);
-    }
-
-    #[test]
-    fn exact_segment_size_has_no_trailing_empty_segment() {
-        let plain = b"abcd";
-        let ct = encrypt_all::<Aes256>(plain);
-        assert_eq!(ct.len(), plain.len() + GCM_TAG_LEN);
-        assert_eq!(decrypt_stream::<Aes256>(plain.len(), &ct).as_slice(), plain);
+        assert_eq!(encrypt_all::<Aes256>(b"abc"), CT_ABC);
     }
 
     #[test]
     fn two_segments_split_into_non_final_and_final() {
-        let plain = b"abcdefgh";
-        let ct = encrypt_all::<Aes256>(plain);
-        assert_eq!(ct.len(), plain.len() + 2 * GCM_TAG_LEN);
-        assert_eq!(decrypt_stream::<Aes256>(plain.len(), &ct).as_slice(), plain);
+        assert_eq!(encrypt_all::<Aes256>(b"abcdefgh"), CT_ABCDEFGH);
     }
 
     #[test]
     fn partial_tail_after_two_full_segments() {
-        let plain = b"abcdefghi";
-        let ct = encrypt_all::<Aes256>(plain);
-        assert_eq!(ct.len(), plain.len() + 3 * GCM_TAG_LEN);
-        assert_eq!(decrypt_stream::<Aes256>(plain.len(), &ct).as_slice(), plain);
+        assert_eq!(encrypt_all::<Aes256>(b"abcdefghi"), CT_ABCDEFGHI);
     }
 
     #[test]
     fn output_independent_of_write_boundaries() {
-        let plain = b"abcdefghi";
-        assert_eq!(
-            encrypt_all::<Aes256>(plain),
-            encrypt_byte_by_byte::<Aes256>(plain)
-        );
+        assert_eq!(encrypt_byte_by_byte::<Aes256>(b"abcdefghi"), CT_ABCDEFGHI);
     }
 
     #[test]
     fn camellia_segments_decrypt_with_the_derived_nonces() {
-        let plain = b"abcdefgh";
-        let ct = encrypt_all::<Camellia256>(plain);
-        assert_eq!(
-            decrypt_stream::<Camellia256>(plain.len(), &ct).as_slice(),
-            plain
-        );
+        let ct = encrypt_all::<Camellia256>(b"abcdefgh");
+        let cipher = AesGcm::<Camellia256, U12>::new_from_slice(KEY.as_bytes()).unwrap();
+        let (seg0, seg1) = ct.split_at(SEG as usize + GCM_TAG_LEN);
+        let nonce0 = Array::<u8, U12>::from([3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0x00]);
+        let nonce1 = Array::<u8, U12>::from([3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 1, 0x01]);
+        assert_eq!(cipher.decrypt(&nonce0, seg0).unwrap(), b"abcd");
+        assert_eq!(cipher.decrypt(&nonce1, seg1).unwrap(), b"efgh");
     }
 
     fn decrypt_all<C>(ciphertext: Vec<u8>) -> io::Result<Vec<u8>>

--- a/lib/src/entry/attr.rs
+++ b/lib/src/entry/attr.rs
@@ -248,16 +248,24 @@ mod tests {
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
+    const NAME_VALUE: [u8; 17] = [
+        0, 0, 0, 4, b'n', b'a', b'm', b'e', 0, 0, 0, 5, b'v', b'a', b'l', b'u', b'e',
+    ];
+
     #[test]
-    fn xattr() {
+    fn xattr_to_bytes_is_length_prefixed_name_then_value() {
         let xattr = ExtendedAttribute::new(
             XattrName::try_from("name").unwrap(),
             XattrValue::try_from(b"value".as_slice()).unwrap(),
         );
-        assert_eq!(
-            xattr,
-            ExtendedAttribute::try_from_bytes(&xattr.to_bytes()).unwrap()
-        );
+        assert_eq!(xattr.to_bytes(), NAME_VALUE);
+    }
+
+    #[test]
+    fn xattr_try_from_bytes_reads_length_prefixed_name_then_value() {
+        let xattr = ExtendedAttribute::try_from_bytes(&NAME_VALUE).unwrap();
+        assert_eq!(xattr.name(), "name");
+        assert_eq!(xattr.value(), b"value");
     }
 
     #[test]

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -949,18 +949,18 @@ mod tests {
         ))));
         let entry = b.build().unwrap();
 
-        // The setter stores the metadata as-is: `permission()` returns what
-        // was set, and the owner facets it never touched stay `None`.
         let m = entry.metadata();
-        assert!(m.permission().is_some());
+        let p = m.permission().unwrap();
+        assert_eq!(
+            (p.uid(), p.uname(), p.gid(), p.gname(), p.permissions()),
+            (7, "legacy", 8, "grp", 0o600)
+        );
         assert_eq!(m.owner_uid(), None);
         assert_eq!(m.owner_gid(), None);
         assert_eq!(m.owner_user_name(), None);
         assert_eq!(m.owner_group_name(), None);
         assert_eq!(m.permission_mode(), None);
 
-        // The chunks this entry writes carry the facets derived from that
-        // permission, and no fPRM.
         let chunks = entry.into_chunks();
         assert!(!chunks.iter().any(|c| c.ty == ChunkType::fPRM));
         assert_eq!(
@@ -1065,16 +1065,14 @@ mod tests {
 
     mod gcm {
         use super::*;
-        use crate::cipher::{
-            GCM_TAG_LEN, STREAM_HEADER_LEN, StreamHeader, StreamKey, derive_stream_key,
-            segment_nonce,
-        };
+        use crate::cipher::{STREAM_HEADER_LEN, StreamHeader, derive_stream_key};
         use crate::{CipherMode, Encryption, HashAlgorithm};
         use aes::Aes256;
         use aes_gcm::AesGcm;
         use aes_gcm::aead::array::Array;
         use aes_gcm::aead::{Aead, AeadCore, KeyInit, consts::U12};
         use camellia::Camellia256;
+        use std::ops::Range;
         // `use super::*` re-imports `test` from the parent's own
         // `#[cfg(...)] use wasm_bindgen_test::... as test;`, but a
         // glob-imported name loses to (rather than shadows) the `#[test]`
@@ -1098,37 +1096,22 @@ mod tests {
             StreamHeader::try_from_bytes(bytes.try_into().unwrap()).unwrap()
         }
 
-        fn gcm_decrypt<C>(
-            k_stream: &StreamKey,
-            nonce_prefix: &[u8; 7],
-            segment_size: u32,
-            ciphertext: &[u8],
-        ) -> Result<Vec<u8>, aes_gcm::aead::Error>
-        where
-            AesGcm<C, U12>: KeyInit + Aead + AeadCore<NonceSize = U12>,
-        {
-            let cipher = AesGcm::<C, U12>::new_from_slice(k_stream.as_bytes()).unwrap();
-            let full = segment_size as usize + GCM_TAG_LEN;
-            let mut out = Vec::new();
-            let mut rest = ciphertext;
-            let mut counter = 0u32;
-            while rest.len() > full {
-                let (segment, tail) = rest.split_at(full);
-                let nonce = Array::<u8, U12>::from(segment_nonce(nonce_prefix, counter, false));
-                out.extend_from_slice(&cipher.decrypt(&nonce, segment)?);
-                rest = tail;
-                counter += 1;
-            }
-            let nonce = Array::<u8, U12>::from(segment_nonce(nonce_prefix, counter, true));
-            out.extend_from_slice(&cipher.decrypt(&nonce, rest)?);
-            Ok(out)
+        fn nonce(prefix: &[u8; 7], counter: u32, final_flag: u8) -> Array<u8, U12> {
+            let mut n = [0u8; 12];
+            n[..7].copy_from_slice(prefix);
+            n[7..11].copy_from_slice(&counter.to_be_bytes());
+            n[11] = final_flag;
+            Array::from(n)
         }
 
-        fn assert_gcm_file_roundtrip<C>(encryption: Encryption, segment_size: u32, plain: &[u8])
-        where
+        fn assert_gcm_file_segments<C>(
+            encryption: Encryption,
+            plain: &[u8],
+            segments: &[(Range<usize>, u32, u8, &[u8])],
+        ) where
             AesGcm<C, U12>: KeyInit + Aead + AeadCore<NonceSize = U12>,
         {
-            let options = gcm_write_options(encryption, segment_size);
+            let options = gcm_write_options(encryption, 4);
             let mut builder =
                 FileEntryBuilder::new_with_options("dir/file".into(), &options).unwrap();
             builder.write_all(plain).unwrap();
@@ -1136,10 +1119,9 @@ mod tests {
 
             let cipher = options.cipher().unwrap();
             assert_eq!(entry.phsf.as_deref(), Some(cipher.derived.phsf.as_str()));
-
             assert_eq!(entry.data[0].len(), STREAM_HEADER_LEN);
             let header = stream_header(&entry.data[0]);
-            assert_eq!(header.segment_size().get(), segment_size);
+            assert_eq!(header.segment_size().get(), 4);
             assert!(header.confirms_key(cipher.derived.key.as_bytes()));
 
             let k_stream = derive_stream_key(
@@ -1149,53 +1131,63 @@ mod tests {
                 &entry.header.to_bytes(),
                 cipher.derived.phsf.as_bytes(),
             );
+            let aead = AesGcm::<C, U12>::new_from_slice(k_stream.as_bytes()).unwrap();
             let ciphertext = entry.data[1..].concat();
-            let decrypted =
-                gcm_decrypt::<C>(&k_stream, &header.nonce_prefix, segment_size, &ciphertext)
-                    .unwrap();
-            assert_eq!(decrypted, plain);
+            assert_eq!(ciphertext.len(), segments.last().unwrap().0.end);
+            for (range, counter, final_flag, expected) in segments {
+                assert_eq!(
+                    aead.decrypt(
+                        &nonce(&header.nonce_prefix, *counter, *final_flag),
+                        &ciphertext[range.clone()]
+                    )
+                    .unwrap(),
+                    *expected,
+                    "segment {counter}"
+                );
+            }
         }
+
+        const HELLO_SEGMENTS: [(Range<usize>, u32, u8, &[u8]); 4] = [
+            (0..20, 0, 0x00, b"hell"),
+            (20..40, 1, 0x00, b"o gc"),
+            (40..60, 2, 0x00, b"m st"),
+            (60..80, 3, 0x01, b"ream"),
+        ];
 
         #[test]
         fn new_file_gcm_aes_decrypts_to_plaintext() {
-            assert_gcm_file_roundtrip::<Aes256>(Encryption::AES, 4, b"hello gcm stream");
+            assert_gcm_file_segments::<Aes256>(
+                Encryption::AES,
+                b"hello gcm stream",
+                &HELLO_SEGMENTS,
+            );
         }
 
         #[test]
         fn new_file_gcm_camellia_decrypts_to_plaintext() {
-            assert_gcm_file_roundtrip::<Camellia256>(Encryption::CAMELLIA, 4, b"hello gcm stream");
+            assert_gcm_file_segments::<Camellia256>(
+                Encryption::CAMELLIA,
+                b"hello gcm stream",
+                &HELLO_SEGMENTS,
+            );
         }
 
         #[test]
         fn new_file_gcm_multiple_segments_decrypts_to_plaintext() {
-            assert_gcm_file_roundtrip::<Aes256>(Encryption::AES, 4, b"0123456789");
+            assert_gcm_file_segments::<Aes256>(
+                Encryption::AES,
+                b"0123456789",
+                &[
+                    (0..20, 0, 0x00, b"0123"),
+                    (20..40, 1, 0x00, b"4567"),
+                    (40..58, 2, 0x01, b"89"),
+                ],
+            );
         }
 
         #[test]
         fn new_file_gcm_empty_plaintext_is_tag_only_segment() {
-            let options = gcm_write_options(Encryption::AES, 4);
-            let mut builder =
-                FileEntryBuilder::new_with_options("dir/file".into(), &options).unwrap();
-            builder.write_all(b"").unwrap();
-            let entry = builder.build().unwrap();
-
-            let ciphertext = entry.data[1..].concat();
-            assert_eq!(ciphertext.len(), GCM_TAG_LEN);
-
-            let cipher = options.cipher().unwrap();
-            let header = stream_header(&entry.data[0]);
-            let k_stream = derive_stream_key(
-                cipher.derived.key.as_bytes(),
-                &header,
-                ChunkType::FHED,
-                &entry.header.to_bytes(),
-                cipher.derived.phsf.as_bytes(),
-            );
-            assert!(
-                gcm_decrypt::<Aes256>(&k_stream, &header.nonce_prefix, 4, &ciphertext)
-                    .unwrap()
-                    .is_empty()
-            );
+            assert_gcm_file_segments::<Aes256>(Encryption::AES, b"", &[(0..16, 0, 0x01, b"")]);
         }
 
         #[test]
@@ -1222,7 +1214,7 @@ mod tests {
 
         #[test]
         fn solid_gcm_decrypts_with_shed_header_type() {
-            let options = gcm_write_options(Encryption::AES, 4);
+            let options = gcm_write_options(Encryption::AES, 1024);
             let mut builder = SolidEntryBuilder::new(&options).unwrap();
             builder
                 .write_file("dir/file".into(), Metadata::new(), |w| {
@@ -1234,7 +1226,6 @@ mod tests {
             let cipher = options.cipher().unwrap();
             let header = stream_header(&entry.data[0]);
             let ciphertext = entry.data[1..].concat();
-
             let solid_key = derive_stream_key(
                 cipher.derived.key.as_bytes(),
                 &header,
@@ -1242,16 +1233,23 @@ mod tests {
                 &entry.header.to_bytes(),
                 cipher.derived.phsf.as_bytes(),
             );
-            assert!(
-                !gcm_decrypt::<Aes256>(
-                    &solid_key,
-                    &header.nonce_prefix,
-                    header.segment_size().get(),
-                    &ciphertext
-                )
+            let aead = AesGcm::<Aes256, U12>::new_from_slice(solid_key.as_bytes()).unwrap();
+            let plain = aead
+                .decrypt(&nonce(&header.nonce_prefix, 0, 0x01), ciphertext.as_slice())
+                .unwrap();
+
+            let mut store_entry =
+                FileEntryBuilder::new_with_options("dir/file".into(), WriteOptions::store())
+                    .unwrap();
+            store_entry.store_file_size(false);
+            store_entry.write_all(b"solid gcm payload").unwrap();
+            let mut expected = Vec::new();
+            store_entry
+                .build()
                 .unwrap()
-                .is_empty()
-            );
+                .write_in(&mut expected)
+                .unwrap();
+            assert_eq!(plain, expected);
         }
     }
 }

--- a/lib/src/entry/header.rs
+++ b/lib/src/entry/header.rs
@@ -311,21 +311,29 @@ mod tests {
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
     #[test]
-    fn entry_header_try_from_bytes() {
-        assert!(EntryHeader::try_from_bytes(&[]).is_err());
+    fn entry_header_to_bytes_follows_fhed_layout() {
+        let header = EntryHeader::for_file(
+            Compression::XZ,
+            Encryption::AES,
+            CipherMode::GCM,
+            "file".into(),
+        );
+        assert_eq!(header.to_bytes(), b"\x00\x00\x00\x04\x01\x02file");
     }
 
     #[test]
-    fn entry_header_to_from_bytes() {
-        let header = EntryHeader::for_file(
-            Compression::ZSTANDARD,
-            Encryption::CAMELLIA,
-            CipherMode::CTR,
-            "file".into(),
+    fn entry_header_try_from_bytes_requires_six_fixed_bytes() {
+        assert_eq!(
+            EntryHeader::try_from_bytes(&[]).unwrap_err().kind(),
+            io::ErrorKind::InvalidData
         );
         assert_eq!(
-            header,
-            EntryHeader::try_from_bytes(&header.to_bytes()).unwrap(),
+            EntryHeader::try_from_bytes(&[0; 5]).unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+        assert_eq!(
+            EntryHeader::try_from_bytes(&[0; 6]).unwrap(),
+            EntryHeader::for_file(Compression::NO, Encryption::NO, CipherMode::CBC, "".into())
         );
     }
 
@@ -348,7 +356,10 @@ mod tests {
 
     #[test]
     fn solid_header_try_from_bytes() {
-        assert!(SolidHeader::try_from_bytes(&[0; 5]).is_ok());
+        assert_eq!(
+            SolidHeader::try_from_bytes(&[0; 5]).unwrap(),
+            SolidHeader::new(Compression::NO, Encryption::NO, CipherMode::CBC)
+        );
         assert_eq!(
             SolidHeader::try_from_bytes(&[0; 4]).unwrap_err().kind(),
             io::ErrorKind::InvalidData,
@@ -360,11 +371,10 @@ mod tests {
     }
 
     #[test]
-    fn solid_header_to_from_bytes() {
-        let header = SolidHeader::new(Compression::ZSTANDARD, Encryption::AES, CipherMode::CBC);
+    fn solid_header_to_bytes_follows_shed_layout() {
         assert_eq!(
-            header,
-            SolidHeader::try_from_bytes(&header.to_bytes()).unwrap(),
+            SolidHeader::new(Compression::ZSTANDARD, Encryption::AES, CipherMode::CBC).to_bytes(),
+            [0x00, 0x00, 0x02, 0x01, 0x00]
         );
     }
 

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -1143,30 +1143,18 @@ mod tests {
     }
 
     #[test]
-    fn link_target_type_roundtrip_unknown() {
-        let ltp = LinkTargetType::Unknown;
-        assert_eq!(
-            Some(ltp),
-            LinkTargetType::try_from_bytes(&ltp.to_bytes()).unwrap()
-        );
-    }
-
-    #[test]
-    fn link_target_type_roundtrip_file() {
-        let ltp = LinkTargetType::File;
-        assert_eq!(
-            Some(ltp),
-            LinkTargetType::try_from_bytes(&ltp.to_bytes()).unwrap()
-        );
-    }
-
-    #[test]
-    fn link_target_type_roundtrip_directory() {
-        let ltp = LinkTargetType::Directory;
-        assert_eq!(
-            Some(ltp),
-            LinkTargetType::try_from_bytes(&ltp.to_bytes()).unwrap()
-        );
+    fn link_target_type_to_bytes_is_the_spec_code() {
+        let cases = [
+            (LinkTargetType::Unknown, 0x00),
+            (LinkTargetType::File, 0x01),
+            (LinkTargetType::Directory, 0x02),
+        ];
+        for (ltp, code) in cases {
+            assert_eq!(ltp.to_bytes(), [code]);
+        }
+        match LinkTargetType::Unknown {
+            LinkTargetType::Unknown | LinkTargetType::File | LinkTargetType::Directory => {}
+        }
     }
 
     #[test]

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -978,7 +978,6 @@ mod tests {
         assert_eq!((over.max(), over.actual()), (255, 256));
         let n = OwnerUserName::new("alice").unwrap();
         assert_eq!(n.to_bytes(), vec![5, b'a', b'l', b'i', b'c', b'e']);
-        assert_eq!(OwnerUserName::try_from_bytes(&n.to_bytes()).unwrap(), n);
         assert_eq!(OwnerUserName::try_from_bytes(&[0]).unwrap().as_str(), "");
         assert_eq!(
             OwnerUserName::try_from_bytes(&[3, b'a', b'b', b'c', 0xFF])
@@ -1009,7 +1008,6 @@ mod tests {
         let u = OwnerUid::from(1000u64);
         assert_eq!(u.get(), 1000);
         assert_eq!(u.to_bytes(), 1000u64.to_be_bytes());
-        assert_eq!(OwnerUid::try_from_bytes(&u.to_bytes()).unwrap(), u);
         assert_eq!(
             OwnerUid::try_from_bytes(&[0, 0, 0]).unwrap_err().kind(),
             io::ErrorKind::InvalidData
@@ -1018,7 +1016,6 @@ mod tests {
         assert_eq!(PermissionMode::from(0o170755u16).get(), 0o0755);
         let m = PermissionMode::from(0o644u16);
         assert_eq!(m.to_bytes(), 0o644u16.to_be_bytes());
-        assert_eq!(PermissionMode::try_from_bytes(&m.to_bytes()).unwrap(), m);
         assert_eq!(
             PermissionMode::try_from_bytes(&0o170644u16.to_be_bytes())
                 .unwrap()

--- a/lib/src/entry/meta.rs
+++ b/lib/src/entry/meta.rs
@@ -971,10 +971,11 @@ mod tests {
 
     #[test]
     fn owner_string_newtype_bound_and_codec() {
-        assert!(OwnerUserName::new("").is_ok());
-        assert!(OwnerUserName::new("alice").is_ok());
-        assert!(OwnerUserName::new("a".repeat(255)).is_ok());
-        assert!(OwnerUserName::new("a".repeat(256)).is_err());
+        assert_eq!(OwnerUserName::new("").unwrap().as_str(), "");
+        assert_eq!(OwnerUserName::new("alice").unwrap().as_str(), "alice");
+        assert_eq!(OwnerUserName::new("a".repeat(255)).unwrap().len(), 255);
+        let over = OwnerUserName::new("a".repeat(256)).unwrap_err();
+        assert_eq!((over.max(), over.actual()), (255, 256));
         let n = OwnerUserName::new("alice").unwrap();
         assert_eq!(n.to_bytes(), vec![5, b'a', b'l', b'i', b'c', b'e']);
         assert_eq!(OwnerUserName::try_from_bytes(&n.to_bytes()).unwrap(), n);
@@ -985,9 +986,22 @@ mod tests {
                 .as_str(),
             "abc"
         );
-        assert!(OwnerUserName::try_from_bytes(&[]).is_err());
-        assert!(OwnerUserName::try_from_bytes(&[5, b'a']).is_err());
-        assert!(OwnerUserName::try_from_bytes(&[1, 0xFF]).is_err());
+        assert_eq!(
+            OwnerUserName::try_from_bytes(&[]).unwrap_err().kind(),
+            io::ErrorKind::UnexpectedEof
+        );
+        assert_eq!(
+            OwnerUserName::try_from_bytes(&[5, b'a'])
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::UnexpectedEof
+        );
+        assert_eq!(
+            OwnerUserName::try_from_bytes(&[1, 0xFF])
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
     }
 
     #[test]
@@ -996,7 +1010,10 @@ mod tests {
         assert_eq!(u.get(), 1000);
         assert_eq!(u.to_bytes(), 1000u64.to_be_bytes());
         assert_eq!(OwnerUid::try_from_bytes(&u.to_bytes()).unwrap(), u);
-        assert!(OwnerUid::try_from_bytes(&[0, 0, 0]).is_err());
+        assert_eq!(
+            OwnerUid::try_from_bytes(&[0, 0, 0]).unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
         assert_eq!(PermissionMode::from(0o7777u16).get(), 0o7777);
         assert_eq!(PermissionMode::from(0o170755u16).get(), 0o0755);
         let m = PermissionMode::from(0o644u16);
@@ -1008,7 +1025,10 @@ mod tests {
                 .get(),
             0o0644
         );
-        assert!(PermissionMode::try_from_bytes(&[0]).is_err());
+        assert_eq!(
+            PermissionMode::try_from_bytes(&[0]).unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
     }
 
     #[test]
@@ -1165,7 +1185,10 @@ mod tests {
 
     #[test]
     fn link_target_type_empty_bytes() {
-        assert!(LinkTargetType::try_from_bytes(&[]).is_err());
+        assert_eq!(
+            LinkTargetType::try_from_bytes(&[]).unwrap_err().kind(),
+            io::ErrorKind::UnexpectedEof
+        );
     }
 
     #[test]
@@ -1179,7 +1202,10 @@ mod tests {
             LinkTargetType::try_from(2u8).unwrap(),
             LinkTargetType::Directory
         );
-        assert!(LinkTargetType::try_from(3u8).is_err());
+        assert_eq!(
+            LinkTargetType::try_from(3u8).unwrap_err().to_string(),
+            "unknown value 3"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Replace test oracles that cannot separate correct behavior from a wrong implementation. HKDF and AES-256-GCM expectations now come from vectors generated outside this crate instead of from the functions under test, and FHED, SHED, xATR and fLTP are asserted as the exact bytes the specification fixes rather than through encode→decode round trips, which a consistently transposed layout survives.

## Notes

- The `CT_*` constants in `gcm.rs` and `K_CONFIRM_MASTER_KEY` in `aead.rs` must not be regenerated from this crate's own code; the recipe for reproducing them externally is in the doc comment above each.
- `SolidEntryBuilder::write_file` streams before the payload size is known, so inner solid entries carry no `fSIZ`. The solid GCM test therefore compares against a store entry built with `store_file_size(false)`. `fSIZ` is an optional hint, so this is legal, but the test now pins it: if inner entries should carry the hint, this is the test to change.
- The `#[cfg(test)]` re-export of `GCM_TAG_LEN` and `segment_nonce` in `cipher.rs` is dropped because it was only reachable from the removed decrypt helper.
- The last commit deletes six tests the exact assertions subsume, with the reasoning in its message: for example, the two fixed HKDF vectors fail under every mutation `key_confirmation_differs_per_k_master` could catch.

## Verification

Each new assertion was checked by introducing the defect it claims to catch — nonce final-flag inversion, counter endianness, transposed fields in encoder and decoder together, swapped error kinds — and confirming the test fails, then reverting.
