### PR TITLE
Drop into_chunks() from tests in favor of the wire format

### DIFF
--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -1516,11 +1516,25 @@ pub(crate) mod test_support {
             .expect("writing to a Vec is infallible");
         buf
     }
+
+    /// Serializes `entry` and parses the wire bytes back into chunks.
+    pub(crate) fn entry_chunks(entry: impl SealedEntryExt) -> Vec<RawChunk> {
+        let bytes = entry_bytes(entry);
+        let mut reader = io::Cursor::new(&bytes[..]);
+        let mut chunks = Vec::new();
+        while (reader.position() as usize) < bytes.len() {
+            chunks.push(
+                crate::io::read_chunk(&mut reader, u32::MAX).expect("entry bytes must parse"),
+            );
+        }
+        chunks
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::entry::test_support::entry_chunks;
     use std::io::Write;
     use std::sync::LazyLock;
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
@@ -2156,7 +2170,7 @@ mod tests {
         let mut builder = FileEntryBuilder::new("f".into()).unwrap();
         builder.metadata(Metadata::new().with_xattrs(vec![xattr.clone()]));
         let entry = builder.build().unwrap();
-        let restored = NormalEntry::try_from(RawEntry(entry.into_chunks())).unwrap();
+        let restored = NormalEntry::try_from(RawEntry(entry_chunks(entry))).unwrap();
         assert_eq!(restored.metadata().xattrs(), &[xattr]);
     }
 

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -2177,7 +2177,7 @@ mod tests {
     #[test]
     fn empty_xattrs_emit_no_xatr_chunk() {
         let entry = FileEntryBuilder::new("f".into()).unwrap().build().unwrap();
-        assert!(entry.into_chunks().iter().all(|c| c.ty != ChunkType::xATR));
+        assert!(entry_chunks(entry).iter().all(|c| c.ty != ChunkType::xATR));
     }
 
     #[allow(deprecated)]
@@ -2201,7 +2201,7 @@ mod tests {
         );
         builder.write_all(b"data").unwrap();
         let entry = builder.build().unwrap();
-        let chunks = entry.into_chunks();
+        let chunks = entry_chunks(entry);
 
         let fdat_pos = chunks.iter().position(|c| c.ty == ChunkType::FDAT).unwrap();
         for ty in [ChunkType::cTIM, ChunkType::fMOd, ChunkType::xATR] {

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -1505,6 +1505,20 @@ fn u128_from_be_bytes_last(bytes: &[u8]) -> u128 {
 }
 
 #[cfg(test)]
+pub(crate) mod test_support {
+    use super::*;
+
+    /// Serializes `entry` through the production writer and returns the wire bytes.
+    pub(crate) fn entry_bytes(entry: impl SealedEntryExt) -> Vec<u8> {
+        let mut buf = Vec::new();
+        entry
+            .write_in(&mut buf)
+            .expect("writing to a Vec is infallible");
+        buf
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use std::io::Write;

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -625,7 +625,7 @@ mod tests {
     use crate::chunk::Chunk;
     use crate::entry::RawEntry;
     use crate::entry::private::SealedEntryExt;
-    use crate::entry::test_support::entry_bytes;
+    use crate::entry::test_support::{entry_bytes, entry_chunks};
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
@@ -650,9 +650,7 @@ mod tests {
             SymlinkEntryBuilder::new("link_name".into(), "target_dir".into()).unwrap();
         builder.metadata(Metadata::new().with_link_target_type(Some(LinkTargetType::Directory)));
         let entry = builder.build().unwrap();
-        let chunks = entry.into_chunks();
-        let raw = RawEntry(chunks);
-        let restored = NormalEntry::try_from(raw).unwrap();
+        let restored = NormalEntry::try_from(RawEntry(entry_chunks(entry))).unwrap();
         assert_eq!(
             restored.metadata().link_target_type(),
             Some(LinkTargetType::Directory)
@@ -665,9 +663,7 @@ mod tests {
             HardLinkEntryBuilder::new("dir_hardlink".into(), "target_dir".into()).unwrap();
         builder.metadata(Metadata::new().with_link_target_type(Some(LinkTargetType::Directory)));
         let entry = builder.build().unwrap();
-        let chunks = entry.into_chunks();
-        let raw = RawEntry(chunks);
-        let restored = NormalEntry::try_from(raw).unwrap();
+        let restored = NormalEntry::try_from(RawEntry(entry_chunks(entry))).unwrap();
         assert_eq!(
             restored.metadata().link_target_type(),
             Some(LinkTargetType::Directory)
@@ -678,9 +674,7 @@ mod tests {
     fn fltp_absent_returns_none() {
         let builder = SymlinkEntryBuilder::new("link_name".into(), "target".into()).unwrap();
         let entry = builder.build().unwrap();
-        let chunks = entry.into_chunks();
-        let raw = RawEntry(chunks);
-        let restored = NormalEntry::try_from(raw).unwrap();
+        let restored = NormalEntry::try_from(RawEntry(entry_chunks(entry))).unwrap();
         assert_eq!(restored.metadata().link_target_type(), None);
     }
 
@@ -689,9 +683,7 @@ mod tests {
         let mut builder = FileEntryBuilder::new("regular.txt".into()).unwrap();
         builder.metadata(Metadata::new().with_link_target_type(Some(LinkTargetType::File)));
         let entry = builder.build().unwrap();
-        let chunks = entry.into_chunks();
-        let raw = RawEntry(chunks);
-        let restored = NormalEntry::try_from(raw).unwrap();
+        let restored = NormalEntry::try_from(RawEntry(entry_chunks(entry))).unwrap();
         assert_eq!(
             restored.metadata().link_target_type(),
             Some(LinkTargetType::File)
@@ -704,8 +696,7 @@ mod tests {
         b.write_all(b"content").unwrap();
         b.metadata(Metadata::new().with_modified(Some(Duration::seconds(42))));
         let entry = b.build().unwrap();
-        let raw = RawEntry(entry.into_chunks());
-        let restored = NormalEntry::try_from(raw).unwrap();
+        let restored = NormalEntry::try_from(RawEntry(entry_chunks(entry))).unwrap();
         assert_eq!(restored.header().data_kind(), DataKind::FILE);
         assert_eq!(restored.metadata().modified(), Some(Duration::seconds(42)));
         assert_eq!(restored.metadata().raw_file_size(), Some(7));
@@ -738,8 +729,7 @@ mod tests {
         let mut b = DirEntryBuilder::new("d/".into());
         b.metadata(Metadata::new().with_permission_mode(Some(PermissionMode::from(0o755))));
         let entry = b.build().unwrap();
-        let raw = RawEntry(entry.into_chunks());
-        let restored = NormalEntry::try_from(raw).unwrap();
+        let restored = NormalEntry::try_from(RawEntry(entry_chunks(entry))).unwrap();
         assert_eq!(restored.header().data_kind(), DataKind::DIRECTORY);
         assert_eq!(
             restored.metadata().permission_mode(),
@@ -869,8 +859,7 @@ mod tests {
         let mut b = OpaqueEntryBuilder::new("custom".into(), kind).unwrap();
         b.write_all(b"opaque bytes").unwrap();
         let entry = b.build().unwrap();
-        let raw = RawEntry(entry.into_chunks());
-        let restored = NormalEntry::try_from(raw).unwrap();
+        let restored = NormalEntry::try_from(RawEntry(entry_chunks(entry))).unwrap();
         assert_eq!(restored.header().data_kind(), kind);
         match restored.content(ReadOptions::builder().build()).unwrap() {
             crate::EntryContent::Unknown(k, mut r) => {

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -773,15 +773,12 @@ mod tests {
         let b = SymlinkEntryBuilder::new_with_options("link".into(), "secret/target".into(), opt)
             .unwrap();
         let entry = b.build().unwrap();
-        for chunk in entry.clone().into_chunks() {
-            assert!(
-                !chunk
-                    .data()
-                    .windows(b"secret/target".len())
-                    .any(|w| w == b"secret/target"),
-                "link target must not appear in plaintext"
-            );
-        }
+        assert!(
+            !entry_bytes(entry.clone())
+                .windows(b"secret/target".len())
+                .any(|w| w == b"secret/target"),
+            "link target must not appear in plaintext"
+        );
         match entry
             .content(ReadOptions::with_password(Some("pass")))
             .unwrap()
@@ -799,9 +796,7 @@ mod tests {
         let b = SymlinkEntryBuilder::new_with_options("link".into(), "target".into(), opt).unwrap();
         let entry = b.build().unwrap();
         assert_eq!(entry.header().compression(), crate::Compression::ZSTANDARD);
-        let data_chunk = entry
-            .clone()
-            .into_chunks()
+        let data_chunk = entry_chunks(entry.clone())
             .into_iter()
             .find(|c| c.ty() == ChunkType::FDAT)
             .unwrap();
@@ -835,15 +830,12 @@ mod tests {
         let b =
             HardLinkEntryBuilder::new_with_options("link".into(), "secret".into(), opt).unwrap();
         let entry = b.build().unwrap();
-        for chunk in entry.clone().into_chunks() {
-            assert!(
-                !chunk
-                    .data()
-                    .windows(b"secret".len())
-                    .any(|w| w == b"secret"),
-                "link target must not appear in plaintext"
-            );
-        }
+        assert!(
+            !entry_bytes(entry.clone())
+                .windows(b"secret".len())
+                .any(|w| w == b"secret"),
+            "link target must not appear in plaintext"
+        );
         match entry
             .content(ReadOptions::with_password(Some("pass")))
             .unwrap()
@@ -952,7 +944,7 @@ mod tests {
         assert_eq!(m.owner_group_name(), None);
         assert_eq!(m.permission_mode(), None);
 
-        let chunks = entry.into_chunks();
+        let chunks = entry_chunks(entry);
         assert!(!chunks.iter().any(|c| c.ty == ChunkType::fPRM));
         assert_eq!(
             chunks

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -625,6 +625,7 @@ mod tests {
     use crate::chunk::Chunk;
     use crate::entry::RawEntry;
     use crate::entry::private::SealedEntryExt;
+    use crate::entry::test_support::entry_bytes;
     #[cfg(all(target_family = "wasm", target_os = "unknown"))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
@@ -888,9 +889,10 @@ mod tests {
         a.write_all(b"data").unwrap();
         let mut b = FileEntryBuilder::new("f".into()).unwrap();
         b.write_all(b"data").unwrap();
-        let ac: Vec<_> = a.build().unwrap().into_chunks();
-        let bc: Vec<_> = b.build().unwrap().into_chunks();
-        assert_eq!(ac, bc);
+        assert_eq!(
+            entry_bytes(a.build().unwrap()),
+            entry_bytes(b.build().unwrap())
+        );
     }
 
     #[test]
@@ -1018,7 +1020,7 @@ mod tests {
         new.write_all(b"data").unwrap();
         let new = new.build().unwrap();
 
-        assert_eq!(old.into_chunks(), new.into_chunks());
+        assert_eq!(entry_bytes(old), entry_bytes(new));
     }
 
     #[allow(deprecated)]
@@ -1032,7 +1034,7 @@ mod tests {
             .unwrap()
             .build()
             .unwrap();
-        assert_eq!(old.into_chunks(), new.into_chunks());
+        assert_eq!(entry_bytes(old), entry_bytes(new));
     }
 
     #[allow(deprecated)]
@@ -1046,7 +1048,7 @@ mod tests {
             .unwrap()
             .build()
             .unwrap();
-        assert_eq!(old.into_chunks(), new.into_chunks());
+        assert_eq!(entry_bytes(old), entry_bytes(new));
     }
 
     #[allow(deprecated)]
@@ -1060,7 +1062,7 @@ mod tests {
         new.metadata(Metadata::new().with_permission_mode(Some(PermissionMode::from(0o755))));
         let new = new.build().unwrap();
 
-        assert_eq!(old.into_chunks(), new.into_chunks());
+        assert_eq!(entry_bytes(old), entry_bytes(new));
     }
 
     mod gcm {


### PR DESCRIPTION
## Summary
Replace every test use of `SealedEntryExt::into_chunks()` with serialization through the production writer (`write_in`), so tests assert against the real wire format instead of an intermediate chunk list. Two `#[cfg(test)]` helpers in `lib/src/entry.rs` cover all call sites: `entry_bytes` returns the wire bytes, `entry_chunks` parses them back.

This is the first step toward retiring `into_chunks()`. Its `Into<RawChunk>` requirement is what forces `EntryChunkSink::write_chunk` to carry a `Into<RawChunk>` bound, which in turn pins entry data to `Vec<u8>` on every write. `EntryChunkWriter` only needs `C: Chunk`; the bound exists solely for `RawChunkCollector`, which backs `into_chunks()`. After this change the only remaining caller is the deprecated `EntryPart`.

## Notes
Two assertions get stricter as a side effect:
- The `deprecated_*`/`opaque_*` wire-equality tests now compare serialized bytes, so length prefixes, chunk types, and CRCs are covered.
- The link-target secrecy checks now scan the whole entry rather than chunk bodies only, so framing bytes are covered too.

## Verification
Each rewritten assertion was mutation-checked to confirm it still fails on a real regression: flipping a permission mode, an expected link-target type, and the encryption option each produced the expected failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for entry serialization and deserialization.
  * Added round-trip validation to ensure entries can be reconstructed correctly.
  * Strengthened checks that plaintext is not exposed in serialized output.
  * Updated wire-format comparisons to validate the exact serialized bytes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->