### PR TITLE
:zap: Use zlib-rs as the default deflate backend

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -24,7 +24,7 @@ cipher = { version = "0.5.2", features = ["alloc", "block-padding", "stream-wrap
 crc32fast = "1.5.0"
 crypto-common = { version = "0.2.1", default-features = false }
 ctr = "0.10.1"
-flate2 = "1.1.9"
+flate2 = { version = "1.1.9", default-features = false, features = ["zlib-rs"] }
 futures-io = { version = "0.3.32", optional = true }
 futures-util = { version = "0.3.32", features = ["io"], optional = true }
 hkdf = "0.12.4"


### PR DESCRIPTION
## Summary

- Configure libpna to use zlib-rs as flate2's default Deflate backend.
- Keep the existing zlib-ng feature available as an explicit backend selection.

The existing `lib/benches/create_extract.rs` Deflate benchmark was run with identical Criterion settings (1 s warm-up, 3 s measurement, 30 samples):

| Benchmark | miniz_oxide | zlib-rs |
| --- | ---: | ---: |
| write_deflate_archive | 11.58 us | 7.99 us |
| read_deflate_archive | 6.81 us | 1.76 us |
| read_deflate_archive_from_slice | 6.57 us | 1.60 us |

The benchmark uses a small fixed input, so these numbers are directional rather than representative of every workload.

## Test

- `cargo fmt --all -- --check`
- `cargo test -p libpna --locked`
- `cargo test -p libpna --locked --all-features`
- `cargo test --workspace --locked --all-features`
- `cargo clippy --workspace --locked --all-targets --all-features -- -D warnings`
