### PR TITLE
:construction_worker: Use self-repository syntax for local actions

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y libacl1-dev
-      - uses: ./.github/actions/setup-rust
+      - uses: $/.github/actions/setup-rust
         with:
           channel: nightly
       - name: Run rust-bench
@@ -95,7 +95,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: ./.github/actions/setup-rust
+      - uses: $/.github/actions/setup-rust
       - name: Install dependencies
         run: |
           sudo apt update

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Rust
-        uses: ./.github/actions/setup-rust
+        uses: $/.github/actions/setup-rust
 
       - name: Generate CLI documentation
         run: cargo xtask docgen --output docs/cli-reference.md

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
-      - uses: ./.github/actions/label_by_message
+      - uses: $/.github/actions/label_by_message
         with:
           pr_number: ${{ github.event.pull_request.number }}
           message_contains: ':boom:'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           submodules: true
           persist-credentials: false
-      - uses: ./.github/actions/setup-rust
+      - uses: $/.github/actions/setup-rust
       - name: install dependencies
         run: |
           sudo apt update

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: ./.github/actions/setup-rust
+      - uses: $/.github/actions/setup-rust
       - name: Install dependencies (Linux)
         if: startsWith(matrix.os, 'ubuntu')
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           persist-credentials: false
       - id: install_rust
-        uses: ./.github/actions/setup-rust
+        uses: $/.github/actions/setup-rust
         with:
           channel: ${{ matrix.rust }}
       - name: Install cargo-hack from crates.io
@@ -151,7 +151,7 @@ jobs:
         with:
           persist-credentials: false
       - id: install_rust
-        uses: ./.github/actions/setup-rust
+        uses: $/.github/actions/setup-rust
         with:
           channel: ${{ matrix.rust }}
           target: ${{ matrix.target }}
@@ -197,7 +197,7 @@ jobs:
         with:
           persist-credentials: false
       - id: install_rust
-        uses: ./.github/actions/setup-rust
+        uses: $/.github/actions/setup-rust
         with:
           channel: ${{ matrix.rust }}
       - name: Install cargo-hack from crates.io


### PR DESCRIPTION
## Summary

- Replace workspace-relative local action references with GitHub self-repository syntax ($/...) in CI workflows.
- Update all nine local action references across six workflow files.

## Validation

- zizmor 1.29.0: passed with no findings.
- YAML parsing and git diff checks: passed.
- actionlint 1.7.11: expected failure because the installed parser predates the $/ syntax; no local ignore configuration was included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected automated workflow configuration across benchmarking, documentation, labeling, publishing, linting, and testing processes.
  - Improved reliability of Rust setup and workflow-specific automation by ensuring internal actions are referenced correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->