### PR TITLE
:sparkles: Add --overwrite option to transform subcommands to guard --output clobbering

### DIFF
--- a/cli/src/command/acl.rs
+++ b/cli/src/command/acl.rs
@@ -4,14 +4,14 @@ use crate::{
     command::{
         Command, ask_password,
         core::{
-            SplitArchiveReader, Umask, collect_split_archives,
+            SplitArchiveReader, Umask, collect_split_archives, resolve_rewrite_output,
             rewrite::{EntryTransform, execute_archive_transform},
         },
     },
     ext::{Acls, NormalEntryExt},
-    utils::{GlobPatterns, PathPartExt},
+    utils::GlobPatterns,
 };
-use clap::{ArgGroup, Parser, ValueHint};
+use clap::{ArgAction, ArgGroup, Parser, ValueHint};
 use nom::{
     Parser as _,
     branch::alt,
@@ -119,6 +119,20 @@ pub(crate) struct SetAclCommand {
     restore_from_stdin: bool,
     #[arg(long, help = "Output file path", value_hint = ValueHint::FilePath)]
     output: Option<PathBuf>,
+    #[arg(
+        long,
+        conflicts_with = "no_overwrite",
+        requires = "output",
+        help = "Overwrite output file"
+    )]
+    overwrite: bool,
+    #[arg(
+        long,
+        action = ArgAction::SetTrue,
+        help = "Do not overwrite output file. This is the inverse option of --overwrite",
+        requires = "output"
+    )]
+    no_overwrite: (),
     #[command(flatten)]
     transform_strategy: SolidEntriesTransformStrategyArgs,
     #[command(flatten)]
@@ -359,10 +373,10 @@ fn archive_set_acl(args: SetAclCommand, umask: Umask) -> anyhow::Result<()> {
         }
     };
 
+    let destination = resolve_rewrite_output(&args.archive.file, args.output, args.overwrite)?;
     execute_archive_transform(
         &args.archive.file,
-        args.output
-            .unwrap_or_else(|| args.archive.file.remove_part()),
+        destination,
         umask,
         password.as_deref(),
         args.transform_strategy.strategy(),

--- a/cli/src/command/acl.rs
+++ b/cli/src/command/acl.rs
@@ -122,8 +122,7 @@ pub(crate) struct SetAclCommand {
     #[arg(
         long,
         conflicts_with = "no_overwrite",
-        requires = "output",
-        help = "Overwrite output file"
+        help = "Overwrite the output file (rewrite in place when --output is omitted)"
     )]
     overwrite: bool,
     #[arg(

--- a/cli/src/command/bsdtar.rs
+++ b/cli/src/command/bsdtar.rs
@@ -1531,7 +1531,7 @@ fn run_update(args: BsdtarCommand, umask: Umask) -> anyhow::Result<()> {
 
     let archives = collect_split_archives(&archive_path)?;
 
-    let mut staged = StagedArchive::new(archive_path.remove_part(), umask)?;
+    let mut staged = StagedArchive::new(archive_path.remove_part(), umask, true)?;
     let mut out_archive = Archive::write_header(staged.as_file_mut())?;
 
     let mut source = SplitArchiveReader::new(archives)?;

--- a/cli/src/command/chmod.rs
+++ b/cli/src/command/chmod.rs
@@ -3,14 +3,14 @@ use crate::{
     command::{
         Command, ask_password,
         core::{
-            Umask,
+            Umask, resolve_rewrite_output,
             rewrite::{EntryTransform, execute_archive_transform},
         },
     },
-    utils::{GlobPatterns, PathPartExt},
+    utils::GlobPatterns,
 };
 use bitflags::bitflags;
-use clap::{Parser, ValueHint};
+use clap::{ArgAction, Parser, ValueHint};
 use nom::{
     Parser as _,
     branch::alt,
@@ -31,6 +31,20 @@ pub(crate) struct ChmodCommand {
     files: Vec<String>,
     #[arg(long, help = "Output file path", value_hint = ValueHint::FilePath)]
     output: Option<PathBuf>,
+    #[arg(
+        long,
+        conflicts_with = "no_overwrite",
+        requires = "output",
+        help = "Overwrite output file"
+    )]
+    overwrite: bool,
+    #[arg(
+        long,
+        action = ArgAction::SetTrue,
+        help = "Do not overwrite output file. This is the inverse option of --overwrite",
+        requires = "output"
+    )]
+    no_overwrite: (),
     #[command(flatten)]
     transform_strategy: SolidEntriesTransformStrategyArgs,
     #[command(flatten)]
@@ -51,12 +65,10 @@ fn archive_chmod(args: ChmodCommand, umask: Umask) -> anyhow::Result<()> {
         return Ok(());
     }
     let globs = GlobPatterns::new(args.files.iter().map(|p| p.as_str()))?;
-    let output_path = args
-        .output
-        .unwrap_or_else(|| args.archive.file.remove_part());
+    let destination = resolve_rewrite_output(&args.archive.file, args.output, args.overwrite)?;
     execute_archive_transform(
         &args.archive.file,
-        output_path,
+        destination,
         umask,
         password.as_deref(),
         args.transform_strategy.strategy(),

--- a/cli/src/command/chmod.rs
+++ b/cli/src/command/chmod.rs
@@ -34,8 +34,7 @@ pub(crate) struct ChmodCommand {
     #[arg(
         long,
         conflicts_with = "no_overwrite",
-        requires = "output",
-        help = "Overwrite output file"
+        help = "Overwrite the output file (rewrite in place when --output is omitted)"
     )]
     overwrite: bool,
     #[arg(

--- a/cli/src/command/chown.rs
+++ b/cli/src/command/chown.rs
@@ -3,12 +3,12 @@ use crate::{
     command::{
         Command, ask_password,
         core::{
-            Umask,
+            Umask, resolve_rewrite_output,
             rewrite::{EntryTransform, execute_archive_transform},
         },
     },
     utils::{
-        GlobPatterns, PathPartExt,
+        GlobPatterns,
         fs::{Group, User},
     },
 };
@@ -38,6 +38,20 @@ pub(crate) struct ChownCommand {
     files: Vec<String>,
     #[arg(long, help = "Output file path", value_hint = ValueHint::FilePath)]
     output: Option<PathBuf>,
+    #[arg(
+        long,
+        conflicts_with = "no_overwrite",
+        requires = "output",
+        help = "Overwrite output file"
+    )]
+    overwrite: bool,
+    #[arg(
+        long,
+        action = ArgAction::SetTrue,
+        help = "Do not overwrite output file. This is the inverse option of --overwrite",
+        requires = "output"
+    )]
+    no_overwrite: (),
     #[command(flatten)]
     transform_strategy: SolidEntriesTransformStrategyArgs,
     #[command(flatten)]
@@ -62,12 +76,10 @@ fn archive_chown(args: ChownCommand, umask: Umask) -> anyhow::Result<()> {
     let owner = args
         .owner
         .lookup_platform_owner(args.numeric_owner, args.owner_lookup)?;
-    let output_path = args
-        .output
-        .unwrap_or_else(|| args.archive.file.remove_part());
+    let destination = resolve_rewrite_output(&args.archive.file, args.output, args.overwrite)?;
     execute_archive_transform(
         &args.archive.file,
-        output_path,
+        destination,
         umask,
         password.as_deref(),
         args.transform_strategy.strategy(),

--- a/cli/src/command/chown.rs
+++ b/cli/src/command/chown.rs
@@ -41,8 +41,7 @@ pub(crate) struct ChownCommand {
     #[arg(
         long,
         conflicts_with = "no_overwrite",
-        requires = "output",
-        help = "Overwrite output file"
+        help = "Overwrite the output file (rewrite in place when --output is omitted)"
     )]
     overwrite: bool,
     #[arg(

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -364,6 +364,49 @@ pub(crate) enum ArchiveSource {
     Stdin,
 }
 
+/// Resolved `--output` of a rewrite subcommand.
+///
+/// `None` keeps the historical in-place behavior and always replaces the input.
+/// An explicit `--output` without `--overwrite` is refused at commit time when
+/// occupied, so `--output` naming the input itself still requires `--overwrite`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct RewriteDestination {
+    pub(crate) path: PathBuf,
+    /// Whether the destination may replace an existing entry.
+    pub(crate) overwrite: bool,
+}
+
+/// Resolves `--output`/`--overwrite` into a [`RewriteDestination`].
+///
+/// The existence check only fails fast; the commit enforces the guard.
+/// `symlink_metadata` (not `exists()`) is used so a dangling symlink is also
+/// refused and unexpected I/O errors propagate.
+pub(crate) fn resolve_rewrite_output(
+    archive: &Path,
+    output: Option<PathBuf>,
+    overwrite: bool,
+) -> anyhow::Result<RewriteDestination> {
+    match output {
+        Some(path) => {
+            if !overwrite {
+                match fs::symlink_metadata(&path) {
+                    Ok(_) => anyhow::bail!(
+                        "{} already exists (use --overwrite to replace it)",
+                        path.display()
+                    ),
+                    Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+                    Err(e) => return Err(e.into()),
+                }
+            }
+            Ok(RewriteDestination { path, overwrite })
+        }
+        None => Ok(RewriteDestination {
+            path: archive.remove_part(),
+            overwrite: true,
+        }),
+    }
+}
+
 impl fmt::Display for ArchiveSource {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -2807,6 +2850,59 @@ mod tests {
 
     mod item_source_parse {
         use super::*;
+
+        #[test]
+        #[cfg(not(target_family = "wasm"))]
+        fn rewrite_destination_resolves_the_contract_matrix() {
+            let dir = std::env::temp_dir().join("pna_rewrite_destination_test");
+            let _ = fs::remove_dir_all(&dir);
+            fs::create_dir_all(&dir).unwrap();
+            let existing = dir.join("existing.pna");
+            fs::write(&existing, b"sentinel").unwrap();
+            let missing = dir.join("missing.pna");
+            let _ = fs::remove_file(&missing);
+            let archive = dir.join("input.pna");
+
+            // Omitted output always rewrites in place, regardless of --overwrite.
+            for overwrite in [false, true] {
+                let destination = resolve_rewrite_output(&archive, None, overwrite).unwrap();
+                assert_eq!(
+                    destination,
+                    RewriteDestination {
+                        path: archive.clone(),
+                        overwrite: true,
+                    }
+                );
+            }
+
+            // Explicit output without --overwrite arms the commit-time guard,
+            // and refuses an existing destination up front.
+            let destination =
+                resolve_rewrite_output(&archive, Some(missing.clone()), false).unwrap();
+            assert_eq!(
+                destination,
+                RewriteDestination {
+                    path: missing.clone(),
+                    overwrite: false,
+                }
+            );
+            let error =
+                resolve_rewrite_output(&archive, Some(existing.clone()), false).unwrap_err();
+            assert!(error.to_string().contains("already exists"));
+
+            // Explicit output with --overwrite replaces unconditionally.
+            let destination =
+                resolve_rewrite_output(&archive, Some(existing.clone()), true).unwrap();
+            assert_eq!(
+                destination,
+                RewriteDestination {
+                    path: existing.clone(),
+                    overwrite: true,
+                }
+            );
+
+            let _ = fs::remove_dir_all(&dir);
+        }
 
         #[test]
         fn at_alone_is_stdin() {

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -378,6 +378,10 @@ pub(crate) struct RewriteDestination {
 
 /// Resolves `--output`/`--overwrite` into a [`RewriteDestination`].
 ///
+/// An omitted `--output` without `--overwrite` keeps the historical in-place
+/// behavior but emits a deprecation warning (a future release will write to
+/// standard output instead); passing `--overwrite` selects in-place
+/// explicitly and stays silent.
 /// The existence check only fails fast; the commit enforces the guard.
 /// `symlink_metadata` (not `exists()`) is used so a dangling symlink is also
 /// refused and unexpected I/O errors propagate.
@@ -400,10 +404,19 @@ pub(crate) fn resolve_rewrite_output(
             }
             Ok(RewriteDestination { path, overwrite })
         }
-        None => Ok(RewriteDestination {
-            path: archive.remove_part(),
-            overwrite: true,
-        }),
+        None => {
+            let path = archive.remove_part();
+            if !overwrite {
+                log::warn!(
+                    "omitting `--output` is deprecated and will write to standard output instead of rewriting '{}' in place in a future release; specify `--output` explicitly, or pass `--overwrite` to keep rewriting in place",
+                    path.display()
+                );
+            }
+            Ok(RewriteDestination {
+                path,
+                overwrite: true,
+            })
+        }
     }
 }
 

--- a/cli/src/command/core/rewrite.rs
+++ b/cli/src/command/core/rewrite.rs
@@ -1,14 +1,10 @@
 use super::{
-    SplitArchiveReader, StagedArchive, TransformStrategyKeepSolid, TransformStrategyUnSolid, Umask,
-    collect_split_archives,
+    RewriteDestination, SplitArchiveReader, StagedArchive, TransformStrategyKeepSolid,
+    TransformStrategyUnSolid, Umask, collect_split_archives,
 };
 use crate::{cli::SolidEntriesTransformStrategy, utils::GlobPatterns};
 use pna::NormalEntry;
-use std::{
-    borrow::Cow,
-    io,
-    path::{Path, PathBuf},
-};
+use std::{borrow::Cow, io, path::Path};
 
 /// The per-entry step of a command that rewrites an archive.
 ///
@@ -24,18 +20,21 @@ pub(crate) trait EntryTransform {
     fn patterns(&self) -> Option<&GlobPatterns<'_>>;
 }
 
-/// Rewrites `archive` into `output` through `transform`, one entry at a time.
+/// Rewrites `archive` into `destination` through `transform`, one entry at a time.
+///
+/// A destination resolved without `--overwrite` refuses at commit time to replace
+/// an existing file instead of renaming over it.
 #[hooq::hooq(anyhow)]
 pub(crate) fn execute_archive_transform(
     archive: &Path,
-    output: PathBuf,
+    destination: RewriteDestination,
     umask: Umask,
     password: Option<&[u8]>,
     strategy: SolidEntriesTransformStrategy,
     mut transform: impl EntryTransform,
 ) -> anyhow::Result<()> {
     let mut source = SplitArchiveReader::new(collect_split_archives(archive)?)?;
-    let mut staged = StagedArchive::new(output, umask)?;
+    let mut staged = StagedArchive::new(destination.path, umask, destination.overwrite)?;
     match strategy {
         SolidEntriesTransformStrategy::UnSolid => source.transform_entries(
             staged.as_file_mut(),
@@ -65,7 +64,7 @@ pub(crate) fn execute_archive_transform(
 mod tests {
     use super::*;
     use pna::{Archive, FileEntryBuilder};
-    use std::fs;
+    use std::{fs, path::PathBuf};
 
     /// Drops every entry so a committed rewrite is distinguishable from the original bytes.
     struct DropAll<'s>(GlobPatterns<'s>);
@@ -117,7 +116,10 @@ mod tests {
     fn rewrite(archive: &Path, pattern: &str) -> anyhow::Result<()> {
         execute_archive_transform(
             archive,
-            archive.to_path_buf(),
+            RewriteDestination {
+                path: archive.to_path_buf(),
+                overwrite: true,
+            },
             Umask::new(0o022),
             None,
             SolidEntriesTransformStrategy::UnSolid,

--- a/cli/src/command/core/safe_writer.rs
+++ b/cli/src/command/core/safe_writer.rs
@@ -1,3 +1,4 @@
+use crate::utils::fs::rename_no_overwrite;
 use std::{
     fs, io,
     path::{Path, PathBuf},
@@ -27,6 +28,7 @@ pub(crate) struct SafeWriter {
     temp_path: Option<PathBuf>,
     final_path: PathBuf,
     file: fs::File,
+    overwrite: bool,
 }
 
 impl SafeWriter {
@@ -37,10 +39,13 @@ impl SafeWriter {
     /// Creates a new temp file with pattern `.pna.{random}` in the same directory as
     /// `final_path`, which keeps [`persist()`](Self::persist)'s rename within one filesystem.
     ///
+    /// When `overwrite` is false, [`persist()`](Self::persist) atomically refuses to
+    /// replace an existing destination instead of renaming over it.
+    ///
     /// # Errors
     ///
     /// Returns an error if the parent directory doesn't exist or temp file creation fails.
-    pub(crate) fn new(final_path: impl AsRef<Path>) -> io::Result<Self> {
+    pub(crate) fn new(final_path: impl AsRef<Path>, overwrite: bool) -> io::Result<Self> {
         let final_path = final_path.as_ref().to_path_buf();
         let parent = final_path.parent().unwrap_or(Path::new("."));
 
@@ -65,6 +70,7 @@ impl SafeWriter {
             temp_path: Some(temp_path),
             final_path,
             file,
+            overwrite,
         })
     }
 
@@ -78,6 +84,9 @@ impl SafeWriter {
     ///
     /// On failure, the temp file is cleaned up automatically via `Drop`.
     ///
+    /// When created with `overwrite` set to false, an occupied destination is
+    /// refused instead of replaced; the filesystem enforces this at publish time.
+    ///
     /// # Errors
     ///
     /// Returns an error if:
@@ -85,8 +94,21 @@ impl SafeWriter {
     /// - A non-empty directory exists at the destination path
     /// - The destination path cannot be accessed (permission denied, I/O error)
     /// - The rename operation fails
+    /// - The destination is already occupied and overwriting was not allowed
     pub(crate) fn persist(mut self) -> io::Result<()> {
         self.file.sync_all()?;
+
+        if !self.overwrite {
+            let temp_path = self
+                .temp_path
+                .as_deref()
+                .expect("persist called on already-persisted SafeWriter")
+                .to_path_buf();
+            rename_no_overwrite(&temp_path, &self.final_path)?;
+            self.temp_path = None;
+            return Ok(());
+        }
+
         self.prepare_destination()?;
 
         let temp_path = self
@@ -155,7 +177,7 @@ mod tests {
     fn safe_writer_creates_temp_in_same_directory() {
         let dir = test_dir();
         let target = dir.join("target.txt");
-        let writer = SafeWriter::new(&target).unwrap();
+        let writer = SafeWriter::new(&target, true).unwrap();
 
         let temp_path = writer.temp_path.as_ref().unwrap();
         // Temp file should be in same directory
@@ -184,7 +206,7 @@ mod tests {
 
         let dir = test_dir();
         let target = dir.join("mode_test.txt");
-        let writer = SafeWriter::new(&target).unwrap();
+        let writer = SafeWriter::new(&target, true).unwrap();
         let temp_path = writer.temp_path.as_ref().unwrap().clone();
 
         let mode = fs::metadata(&temp_path).unwrap().permissions().mode();
@@ -199,7 +221,7 @@ mod tests {
         let target = dir.join("persist_test.txt");
         let _ = fs::remove_file(&target);
 
-        let mut writer = SafeWriter::new(&target).unwrap();
+        let mut writer = SafeWriter::new(&target, true).unwrap();
         let temp_path = writer.temp_path.as_ref().unwrap().clone();
 
         write!(writer.as_file_mut(), "test content").unwrap();
@@ -223,7 +245,7 @@ mod tests {
         let temp_path;
 
         {
-            let writer = SafeWriter::new(&target).unwrap();
+            let writer = SafeWriter::new(&target, true).unwrap();
             temp_path = writer.temp_path.as_ref().unwrap().clone();
             assert!(temp_path.exists());
             // Drop without persist
@@ -245,7 +267,7 @@ mod tests {
         assert_eq!(fs::read_to_string(&target).unwrap(), "old content");
 
         // Create SafeWriter and persist new content
-        let mut writer = SafeWriter::new(&target).unwrap();
+        let mut writer = SafeWriter::new(&target, true).unwrap();
         write!(writer.as_file_mut(), "new content").unwrap();
         writer.persist().unwrap();
 
@@ -266,7 +288,7 @@ mod tests {
         let target = dir.join("rename_failure_test.txt");
         fs::write(&target, "old content").unwrap();
 
-        let mut writer = SafeWriter::new(&target).unwrap();
+        let mut writer = SafeWriter::new(&target, true).unwrap();
         let temp_path = writer.temp_path.as_ref().unwrap().clone();
         write!(writer.as_file_mut(), "new content").unwrap();
 
@@ -296,7 +318,7 @@ mod tests {
         assert!(target.is_dir());
 
         // Create SafeWriter and persist - should replace directory with file
-        let mut writer = SafeWriter::new(&target).unwrap();
+        let mut writer = SafeWriter::new(&target, true).unwrap();
         write!(writer.as_file_mut(), "file content").unwrap();
         writer.persist().unwrap();
 
@@ -307,7 +329,6 @@ mod tests {
         // Cleanup
         let _ = fs::remove_file(&target);
     }
-
     #[test]
     fn safe_writer_fails_on_non_empty_directory() {
         let dir = test_dir();
@@ -320,7 +341,7 @@ mod tests {
         assert!(target.is_dir());
 
         // Create SafeWriter and try to persist - should fail
-        let mut writer = SafeWriter::new(&target).unwrap();
+        let mut writer = SafeWriter::new(&target, true).unwrap();
         write!(writer.as_file_mut(), "file content").unwrap();
         let result = writer.persist();
 
@@ -332,5 +353,59 @@ mod tests {
 
         // Cleanup
         let _ = fs::remove_dir_all(&target);
+    }
+
+    #[test]
+    fn persist_without_overwrite_publishes_when_the_destination_is_absent() {
+        let dir = test_dir();
+        let target = dir.join("noclobber_absent.txt");
+        let _ = fs::remove_file(&target);
+
+        let mut writer = SafeWriter::new(&target, false).unwrap();
+        let temp_path = writer.temp_path.as_ref().unwrap().clone();
+        write!(writer.as_file_mut(), "new content").unwrap();
+        writer.persist().unwrap();
+
+        assert_eq!(fs::read_to_string(&target).unwrap(), "new content");
+        assert!(!temp_path.exists());
+
+        let _ = fs::remove_file(&target);
+    }
+
+    #[test]
+    fn persist_without_overwrite_refuses_an_existing_file_atomically() {
+        let dir = test_dir();
+        let target = dir.join("noclobber_existing.txt");
+        fs::write(&target, "original").unwrap();
+
+        let mut writer = SafeWriter::new(&target, false).unwrap();
+        write!(writer.as_file_mut(), "replacement").unwrap();
+        let error = writer.persist().unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
+        assert!(error.to_string().contains("already exists"));
+        // The original is untouched.
+        assert_eq!(fs::read_to_string(&target).unwrap(), "original");
+
+        let _ = fs::remove_file(&target);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn persist_without_overwrite_refuses_a_dangling_symlink() {
+        let dir = test_dir();
+        let target = dir.join("noclobber_dangling.txt");
+        let _ = fs::remove_file(&target);
+        std::os::unix::fs::symlink("missing-target", &target).unwrap();
+
+        let mut writer = SafeWriter::new(&target, false).unwrap();
+        write!(writer.as_file_mut(), "replacement").unwrap();
+        let error = writer.persist().unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
+        // The symlink itself is preserved, not replaced.
+        assert!(fs::symlink_metadata(&target).unwrap().is_symlink());
+
+        let _ = fs::remove_file(&target);
     }
 }

--- a/cli/src/command/core/staged_archive.rs
+++ b/cli/src/command/core/staged_archive.rs
@@ -16,9 +16,12 @@ impl StagedArchive {
     ///
     /// On unix, the commit gives the archive the permission bits of the regular file it
     /// replaces, or what `umask` leaves of `0666` when there is no such file.
+    ///
+    /// When `overwrite` is false, [`commit()`](Self::commit) atomically refuses to
+    /// replace an existing destination instead of renaming over it.
     #[inline]
     #[cfg_attr(not(unix), allow(unused_variables))]
-    pub(crate) fn new(output: PathBuf, umask: Umask) -> io::Result<Self> {
+    pub(crate) fn new(output: PathBuf, umask: Umask, overwrite: bool) -> io::Result<Self> {
         if let Some(parent) = output.parent() {
             fs::create_dir_all(parent)?;
         }
@@ -35,7 +38,7 @@ impl StagedArchive {
             }
         };
         Ok(Self {
-            writer: SafeWriter::new(output)?,
+            writer: SafeWriter::new(output, overwrite)?,
             #[cfg(unix)]
             mode,
         })
@@ -92,7 +95,7 @@ mod tests {
         let output = dir.join("archive.pna");
         fs::write(&output, b"original").unwrap();
 
-        let staged = StagedArchive::new(output, Umask::new(0o022)).unwrap();
+        let staged = StagedArchive::new(output, Umask::new(0o022), true).unwrap();
 
         assert_eq!(entries_beside(&dir, "archive.pna").len(), 1);
         drop(staged);
@@ -104,7 +107,7 @@ mod tests {
         let output = dir.join("archive.pna");
         fs::write(&output, b"original").unwrap();
 
-        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022)).unwrap();
+        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022), true).unwrap();
         staged.as_file_mut().write_all(b"rewritten").unwrap();
         drop(staged);
 
@@ -118,7 +121,7 @@ mod tests {
         let output = dir.join("archive.pna");
         fs::write(&output, b"original").unwrap();
 
-        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022)).unwrap();
+        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022), true).unwrap();
         staged.as_file_mut().write_all(b"rewritten").unwrap();
         staged.commit().unwrap();
 
@@ -141,7 +144,7 @@ mod tests {
         fs::write(&output, b"original").unwrap();
         fs::set_permissions(&output, fs::Permissions::from_mode(0o666)).unwrap();
 
-        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022)).unwrap();
+        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022), true).unwrap();
         staged.as_file_mut().write_all(b"rewritten").unwrap();
         staged.commit().unwrap();
 
@@ -157,7 +160,7 @@ mod tests {
         fs::write(&output, b"original").unwrap();
         fs::set_permissions(&output, fs::Permissions::from_mode(0o4755)).unwrap();
 
-        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022)).unwrap();
+        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022), true).unwrap();
         staged.as_file_mut().write_all(b"rewritten").unwrap();
         staged.commit().unwrap();
 
@@ -170,7 +173,7 @@ mod tests {
         let dir = test_dir("new_mode");
         let output = dir.join("archive.pna");
 
-        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o007)).unwrap();
+        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o007), true).unwrap();
         staged.as_file_mut().write_all(b"written").unwrap();
         staged.commit().unwrap();
 
@@ -186,7 +189,7 @@ mod tests {
         fs::create_dir(&output).unwrap();
         fs::set_permissions(&output, fs::Permissions::from_mode(0o755)).unwrap();
 
-        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022)).unwrap();
+        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022), true).unwrap();
         staged.as_file_mut().write_all(b"written").unwrap();
         staged.commit().unwrap();
 
@@ -205,7 +208,7 @@ mod tests {
         fs::set_permissions(&target, fs::Permissions::from_mode(0o600)).unwrap();
         std::os::unix::fs::symlink(&target, &output).unwrap();
 
-        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022)).unwrap();
+        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022), true).unwrap();
         staged.as_file_mut().write_all(b"written").unwrap();
         staged.commit().unwrap();
 
@@ -221,7 +224,7 @@ mod tests {
         let dir = test_dir("unreadable_mode");
         let output = dir.join("a".repeat(300));
 
-        assert!(StagedArchive::new(output, Umask::new(0o022)).is_err());
+        assert!(StagedArchive::new(output, Umask::new(0o022), true).is_err());
         assert!(fs::read_dir(&dir).unwrap().next().is_none());
     }
 
@@ -230,10 +233,37 @@ mod tests {
         let dir = test_dir("missing_parent");
         let output = dir.join("nested").join("archive.pna");
 
-        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022)).unwrap();
+        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022), true).unwrap();
         staged.as_file_mut().write_all(b"written").unwrap();
         staged.commit().unwrap();
 
         assert_eq!(fs::read(&output).unwrap(), b"written");
+    }
+
+    #[test]
+    fn noclobber_commit_refuses_an_existing_archive() {
+        let dir = test_dir("noclobber");
+        let output = dir.join("archive.pna");
+        fs::write(&output, b"original").unwrap();
+        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022), false).unwrap();
+        staged.as_file_mut().write_all(b"replacement").unwrap();
+        let error = staged.commit().unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
+        assert_eq!(fs::read(&output).unwrap(), b"original");
+        assert!(entries_beside(&dir, "archive.pna").is_empty());
+    }
+
+    #[test]
+    fn noclobber_commit_publishes_when_the_archive_is_absent() {
+        let dir = test_dir("noclobber_absent");
+        let output = dir.join("archive.pna");
+        let _ = fs::remove_file(&output);
+        let mut staged = StagedArchive::new(output.clone(), Umask::new(0o022), false).unwrap();
+        staged.as_file_mut().write_all(b"written").unwrap();
+        staged.commit().unwrap();
+
+        assert_eq!(fs::read(&output).unwrap(), b"written");
+        assert!(entries_beside(&dir, "archive.pna").is_empty());
     }
 }

--- a/cli/src/command/delete.rs
+++ b/cli/src/command/delete.rs
@@ -3,13 +3,13 @@ use crate::{
     command::{
         Command, ask_password,
         core::{
-            PathFilter, Umask, read_paths, read_paths_stdin,
+            PathFilter, Umask, read_paths, read_paths_stdin, resolve_rewrite_output,
             rewrite::{EntryTransform, execute_archive_transform},
         },
     },
-    utils::{GlobPatterns, PathPartExt, VCS_FILES},
+    utils::{GlobPatterns, VCS_FILES},
 };
-use clap::{ArgGroup, Parser, ValueHint};
+use clap::{ArgAction, ArgGroup, Parser, ValueHint};
 use pna::NormalEntry;
 use std::{borrow::Cow, io, path::PathBuf};
 
@@ -26,6 +26,20 @@ use std::{borrow::Cow, io, path::PathBuf};
 pub(crate) struct DeleteCommand {
     #[arg(long, help = "Output file path", value_hint = ValueHint::FilePath)]
     output: Option<PathBuf>,
+    #[arg(
+        long,
+        conflicts_with = "no_overwrite",
+        requires = "output",
+        help = "Overwrite output file"
+    )]
+    overwrite: bool,
+    #[arg(
+        long,
+        action = ArgAction::SetTrue,
+        help = "Do not overwrite output file. This is the inverse option of --overwrite",
+        requires = "output"
+    )]
+    no_overwrite: (),
     #[arg(
         long,
         value_name = "FILE",
@@ -122,12 +136,10 @@ fn delete_file_from_archive(args: DeleteCommand, umask: Umask) -> anyhow::Result
         exclude.iter().map(|s| s.as_str()).chain(vcs_patterns),
     );
 
-    let output_path = args
-        .output
-        .unwrap_or_else(|| args.archive.file.remove_part());
+    let destination = resolve_rewrite_output(&args.archive.file, args.output, args.overwrite)?;
     execute_archive_transform(
         &args.archive.file,
-        output_path,
+        destination,
         umask,
         password.as_deref(),
         args.transform_strategy.strategy(),

--- a/cli/src/command/delete.rs
+++ b/cli/src/command/delete.rs
@@ -29,8 +29,7 @@ pub(crate) struct DeleteCommand {
     #[arg(
         long,
         conflicts_with = "no_overwrite",
-        requires = "output",
-        help = "Overwrite output file"
+        help = "Overwrite the output file (rewrite in place when --output is omitted)"
     )]
     overwrite: bool,
     #[arg(

--- a/cli/src/command/extract.rs
+++ b/cli/src/command/extract.rs
@@ -1339,7 +1339,7 @@ where
     };
 
     if *safe_writes {
-        let mut safe_writer = SafeWriter::new(&path)?;
+        let mut safe_writer = SafeWriter::new(&path, true)?;
         {
             let mut writer = io::BufWriter::with_capacity(64 * 1024, safe_writer.as_file_mut());
             let mut reader = item.reader(read_options)?;

--- a/cli/src/command/migrate.rs
+++ b/cli/src/command/migrate.rs
@@ -3,14 +3,14 @@ use crate::{
     command::{
         Command, ask_password,
         core::{
-            Umask,
+            Umask, resolve_rewrite_output,
             rewrite::{EntryTransform, execute_archive_transform},
         },
     },
     ext::*,
     utils::GlobPatterns,
 };
-use clap::{Parser, ValueHint};
+use clap::{ArgAction, Parser, ValueHint};
 use pna::{NormalEntry, RawChunk, prelude::*};
 use std::{borrow::Cow, io, path::PathBuf};
 
@@ -24,6 +24,20 @@ pub(crate) struct MigrateCommand {
     archive: ArchiveFileArgs,
     #[arg(long, help = "Output file path", value_hint = ValueHint::AnyPath)]
     output: PathBuf,
+    #[arg(
+        long,
+        conflicts_with = "no_overwrite",
+        requires = "output",
+        help = "Overwrite output file"
+    )]
+    overwrite: bool,
+    #[arg(
+        long,
+        action = ArgAction::SetTrue,
+        help = "Do not overwrite output file. This is the inverse option of --overwrite",
+        requires = "output"
+    )]
+    no_overwrite: (),
 }
 
 impl Command for MigrateCommand {
@@ -36,9 +50,11 @@ impl Command for MigrateCommand {
 #[hooq::hooq(anyhow)]
 fn migrate_metadata(args: MigrateCommand, umask: Umask) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
+    let destination =
+        resolve_rewrite_output(&args.archive.file, Some(args.output), args.overwrite)?;
     execute_archive_transform(
         &args.archive.file,
-        args.output,
+        destination,
         umask,
         password.as_deref(),
         args.transform_strategy.strategy(),

--- a/cli/src/command/migrate.rs
+++ b/cli/src/command/migrate.rs
@@ -27,8 +27,7 @@ pub(crate) struct MigrateCommand {
     #[arg(
         long,
         conflicts_with = "no_overwrite",
-        requires = "output",
-        help = "Overwrite output file"
+        help = "Overwrite the output file (rewrite in place when --output is omitted)"
     )]
     overwrite: bool,
     #[arg(

--- a/cli/src/command/sort.rs
+++ b/cli/src/command/sort.rs
@@ -2,11 +2,13 @@ use crate::{
     cli::{ArchiveFileArgs, PasswordArgs},
     command::{
         Command, ask_password,
-        core::{SplitArchiveReader, StagedArchive, Umask, collect_split_archives},
+        core::{
+            SplitArchiveReader, StagedArchive, Umask, collect_split_archives,
+            resolve_rewrite_output,
+        },
     },
-    utils::PathPartExt,
 };
-use clap::{Parser, ValueHint};
+use clap::{ArgAction, Parser, ValueHint};
 use pna::{Archive, NormalEntry, ReadOptions};
 use std::{
     fmt::{self, Display, Formatter},
@@ -125,6 +127,20 @@ pub(crate) struct SortCommand {
     #[arg(long, help = "Output archive file path", value_hint = ValueHint::FilePath)]
     output: Option<PathBuf>,
     #[arg(
+        long,
+        conflicts_with = "no_overwrite",
+        requires = "output",
+        help = "Overwrite output file"
+    )]
+    overwrite: bool,
+    #[arg(
+        long,
+        action = ArgAction::SetTrue,
+        help = "Do not overwrite output file. This is the inverse option of --overwrite",
+        requires = "output"
+    )]
+    no_overwrite: (),
+    #[arg(
         long = "by",
         value_name = "KEY",
         num_args = 1..,
@@ -177,10 +193,8 @@ fn sort_archive(args: SortCommand, umask: Umask) -> anyhow::Result<()> {
         std::cmp::Ordering::Equal
     });
 
-    let output = args
-        .output
-        .unwrap_or_else(|| args.archive.file.remove_part());
-    let mut staged = StagedArchive::new(output, umask)?;
+    let destination = resolve_rewrite_output(&args.archive.file, args.output, args.overwrite)?;
+    let mut staged = StagedArchive::new(destination.path, umask, destination.overwrite)?;
     let mut archive = Archive::write_header(staged.as_file_mut())?;
     for entry in entries {
         archive.add_entry(entry)?;

--- a/cli/src/command/sort.rs
+++ b/cli/src/command/sort.rs
@@ -129,8 +129,7 @@ pub(crate) struct SortCommand {
     #[arg(
         long,
         conflicts_with = "no_overwrite",
-        requires = "output",
-        help = "Overwrite output file"
+        help = "Overwrite the output file (rewrite in place when --output is omitted)"
     )]
     overwrite: bool,
     #[arg(

--- a/cli/src/command/strip.rs
+++ b/cli/src/command/strip.rs
@@ -6,13 +6,13 @@ use crate::{
     command::{
         Command, ask_password,
         core::{
-            Umask,
+            Umask, resolve_rewrite_output,
             rewrite::{EntryTransform, execute_archive_transform},
         },
     },
-    utils::{GlobPatterns, PathPartExt},
+    utils::GlobPatterns,
 };
-use clap::{Args, Parser, ValueHint};
+use clap::{ArgAction, Args, Parser, ValueHint};
 use pna::{Metadata, NormalEntry, RawChunk, prelude::*};
 use std::{borrow::Cow, io, path::PathBuf};
 
@@ -54,6 +54,20 @@ pub(crate) struct StripCommand {
     transform_strategy: SolidEntriesTransformStrategyArgs,
     #[arg(long, help = "Output file path", value_hint = ValueHint::AnyPath)]
     pub(crate) output: Option<PathBuf>,
+    #[arg(
+        long,
+        conflicts_with = "no_overwrite",
+        requires = "output",
+        help = "Overwrite output file"
+    )]
+    overwrite: bool,
+    #[arg(
+        long,
+        action = ArgAction::SetTrue,
+        help = "Do not overwrite output file. This is the inverse option of --overwrite",
+        requires = "output"
+    )]
+    no_overwrite: (),
     #[command(flatten)]
     pub(crate) password: PasswordArgs,
     #[command(flatten)]
@@ -73,7 +87,7 @@ impl Command for StripCommand {
 fn strip_metadata(args: StripCommand, umask: Umask) -> anyhow::Result<()> {
     let password = ask_password(args.password)?;
     let archive = args.archive.file;
-    let output_path = args.output.unwrap_or_else(|| archive.remove_part());
+    let destination = resolve_rewrite_output(&archive, args.output, args.overwrite)?;
     let globs = if args.files.files.is_empty() {
         None
     } else {
@@ -83,7 +97,7 @@ fn strip_metadata(args: StripCommand, umask: Umask) -> anyhow::Result<()> {
     };
     execute_archive_transform(
         &archive,
-        output_path,
+        destination,
         umask,
         password.as_deref(),
         args.transform_strategy.strategy(),

--- a/cli/src/command/strip.rs
+++ b/cli/src/command/strip.rs
@@ -57,8 +57,7 @@ pub(crate) struct StripCommand {
     #[arg(
         long,
         conflicts_with = "no_overwrite",
-        requires = "output",
-        help = "Overwrite output file"
+        help = "Overwrite the output file (rewrite in place when --output is omitted)"
     )]
     overwrite: bool,
     #[arg(

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -16,10 +16,10 @@ use crate::{
             create_entry, entry_option,
             iter::ReorderByIndex,
             re::{bsd::SubstitutionRule, gnu::TransformRule},
-            read_paths, read_paths_stdin,
+            read_paths, read_paths_stdin, resolve_rewrite_output,
         },
     },
-    utils::{PathPartExt, VCS_FILES, fs::HardlinkResolver},
+    utils::{VCS_FILES, fs::HardlinkResolver},
 };
 use clap::{ArgAction, ArgGroup, Parser, ValueHint, builder::ArgPredicate};
 use indexmap::IndexMap;
@@ -55,6 +55,20 @@ use std::{
 pub(crate) struct UpdateCommand {
     #[arg(long, help = "Output file path", value_hint = ValueHint::FilePath)]
     output: Option<PathBuf>,
+    #[arg(
+        long,
+        conflicts_with = "no_overwrite",
+        requires = "output",
+        help = "Overwrite output file"
+    )]
+    overwrite: bool,
+    #[arg(
+        long,
+        action = ArgAction::SetTrue,
+        help = "Do not overwrite output file. This is the inverse option of --overwrite",
+        requires = "output"
+    )]
+    no_overwrite: (),
     #[arg(
         long,
         requires = "unstable",
@@ -518,8 +532,8 @@ fn update_archive(args: UpdateCommand, umask: Umask) -> anyhow::Result<()> {
     let mut resolver = HardlinkResolver::new(collect_options.follow_links);
     let target_items = collect_items_from_paths(&files, &collect_options, &mut resolver)?;
 
-    let output_path = args.output.unwrap_or_else(|| archive_path.remove_part());
-    let mut staged = StagedArchive::new(output_path, umask)?;
+    let destination = resolve_rewrite_output(archive_path, args.output, args.overwrite)?;
+    let mut staged = StagedArchive::new(destination.path, umask, destination.overwrite)?;
     let mut out_archive = Archive::write_header(staged.as_file_mut())?;
 
     let mut source = SplitArchiveReader::new(archives)?;

--- a/cli/src/command/update.rs
+++ b/cli/src/command/update.rs
@@ -58,8 +58,7 @@ pub(crate) struct UpdateCommand {
     #[arg(
         long,
         conflicts_with = "no_overwrite",
-        requires = "output",
-        help = "Overwrite output file"
+        help = "Overwrite the output file (rewrite in place when --output is omitted)"
     )]
     overwrite: bool,
     #[arg(

--- a/cli/src/command/xattr.rs
+++ b/cli/src/command/xattr.rs
@@ -3,15 +3,15 @@ use crate::{
     command::{
         Command, ask_password,
         core::{
-            SplitArchiveReader, Umask, collect_split_archives,
+            SplitArchiveReader, Umask, collect_split_archives, resolve_rewrite_output,
             rewrite::{EntryTransform, execute_archive_transform},
         },
     },
-    utils::{GlobPatterns, PathPartExt},
+    utils::GlobPatterns,
 };
 use base64::Engine;
 use bstr::{ByteSlice, io::BufReadExt};
-use clap::{ArgGroup, Parser, ValueEnum, ValueHint};
+use clap::{ArgAction, ArgGroup, Parser, ValueEnum, ValueHint};
 use indexmap::IndexMap;
 use pna::{NormalEntry, ReadOptions};
 use regex::Regex;
@@ -120,6 +120,20 @@ pub(crate) struct SetXattrCommand {
     restore_from_stdin: bool,
     #[arg(long, help = "Output file path", value_hint = ValueHint::FilePath)]
     output: Option<PathBuf>,
+    #[arg(
+        long,
+        conflicts_with = "no_overwrite",
+        requires = "output",
+        help = "Overwrite output file"
+    )]
+    overwrite: bool,
+    #[arg(
+        long,
+        action = ArgAction::SetTrue,
+        help = "Do not overwrite output file. This is the inverse option of --overwrite",
+        requires = "output"
+    )]
+    no_overwrite: (),
     #[command(flatten)]
     transform_strategy: SolidEntriesTransformStrategyArgs,
     #[command(flatten)]
@@ -273,10 +287,10 @@ fn archive_set_xattr(args: SetXattrCommand, umask: Umask) -> anyhow::Result<()> 
         }
     };
 
+    let destination = resolve_rewrite_output(&args.archive.file, args.output, args.overwrite)?;
     execute_archive_transform(
         &args.archive.file,
-        args.output
-            .unwrap_or_else(|| args.archive.file.remove_part()),
+        destination,
         umask,
         password.as_deref(),
         args.transform_strategy.strategy(),

--- a/cli/src/command/xattr.rs
+++ b/cli/src/command/xattr.rs
@@ -123,8 +123,7 @@ pub(crate) struct SetXattrCommand {
     #[arg(
         long,
         conflicts_with = "no_overwrite",
-        requires = "output",
-        help = "Overwrite output file"
+        help = "Overwrite the output file (rewrite in place when --output is omitted)"
     )]
     overwrite: bool,
     #[arg(

--- a/cli/src/utils/fs.rs
+++ b/cli/src/utils/fs.rs
@@ -132,3 +132,25 @@ pub(crate) fn file_create(path: impl AsRef<Path>, overwrite: bool) -> io::Result
         fs::File::create_new(path)
     }
 }
+
+/// Atomically renames `src` onto `dst`, failing when anything already occupies `dst`.
+///
+/// Unlike [`fs::rename`], which silently replaces an existing file on Unix, the
+/// filesystem itself refuses the link when the destination name is taken, so no
+/// check-then-act race exists. A dangling symlink is never replaced either.
+pub(crate) fn rename_no_overwrite(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
+    let (src, dst) = (src.as_ref(), dst.as_ref());
+    if let Err(error) = fs::hard_link(src, dst) {
+        // The link itself is the atomic guard; this lookup only selects the message.
+        let message = if fs::symlink_metadata(dst).is_ok() {
+            format!(
+                "{} already exists (use --overwrite to replace it)",
+                dst.display()
+            )
+        } else {
+            format!("failed to publish {}: {error}", dst.display())
+        };
+        return Err(io::Error::new(error.kind(), message));
+    }
+    fs::remove_file(src)
+}

--- a/cli/tests/cli/acl/set/option_output.rs
+++ b/cli/tests/cli/acl/set/option_output.rs
@@ -3,6 +3,7 @@ use assert_cmd::cargo::cargo_bin_cmd;
 use clap::Parser;
 use portable_network_archive::cli;
 use predicates::prelude::*;
+use std::fs;
 
 /// Precondition: A pre-built archive (zstd.pna) is available.
 /// Action: Set user ACL with `--output` to a new path.
@@ -10,6 +11,7 @@ use predicates::prelude::*;
 #[test]
 fn acl_set_output() {
     setup();
+    let _ = std::fs::remove_file("acl_set_output/out.pna");
     TestResources::extract_in("zstd.pna", "acl_set_output/").unwrap();
 
     cli::Cli::try_parse_from([
@@ -52,6 +54,98 @@ fn acl_set_output() {
             "get",
             "-f",
             "acl_set_output/zstd.pna",
+            "raw/text.txt",
+        ])
+        .assert()
+        .success()
+        .stdout(
+            predicate::str::contains(":u:")
+                .not()
+                .and(predicate::str::contains(":g:").not()),
+        );
+}
+
+/// Precondition: An archive and a pre-existing output file exist.
+/// Action: Run `pna acl set` with `--output` pointing at the existing file.
+/// Expectation: The command fails without touching either file.
+#[test]
+fn acl_set_output_without_overwrite_refuses_to_clobber() {
+    setup();
+    TestResources::extract_in("zstd.pna", "acl_overwrite/").unwrap();
+    fs::write("acl_overwrite/out.pna", b"sentinel").unwrap();
+
+    let error = cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "acl",
+        "set",
+        "-f",
+        "acl_overwrite/zstd.pna",
+        "--output",
+        "acl_overwrite/out.pna",
+        "raw/text.txt",
+        "-m",
+        "u:test:r,w,x",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap_err();
+
+    assert!(format!("{error:?}").contains("already exists"));
+    assert_eq!(fs::read("acl_overwrite/out.pna").unwrap(), b"sentinel");
+}
+
+/// Precondition: An archive and a pre-existing output file exist.
+/// Action: Run the same set with `--overwrite`.
+/// Expectation: The output holds the ACL; the original does not.
+#[test]
+fn acl_set_output_with_overwrite_replaces() {
+    setup();
+    TestResources::extract_in("zstd.pna", "acl_overwrite_ok/").unwrap();
+    fs::write("acl_overwrite_ok/out.pna", b"sentinel").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "acl",
+        "set",
+        "-f",
+        "acl_overwrite_ok/zstd.pna",
+        "--output",
+        "acl_overwrite_ok/out.pna",
+        "--overwrite",
+        "raw/text.txt",
+        "-m",
+        "u:test:r,w,x",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "acl",
+            "get",
+            "-f",
+            "acl_overwrite_ok/out.pna",
+            "raw/text.txt",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(":u:test:allow:r|w|x"));
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "--quiet",
+            "experimental",
+            "acl",
+            "get",
+            "-f",
+            "acl_overwrite_ok/zstd.pna",
             "raw/text.txt",
         ])
         .assert()

--- a/cli/tests/cli/chmod/option_output.rs
+++ b/cli/tests/cli/chmod/option_output.rs
@@ -1,6 +1,7 @@
 use crate::utils::{archive, archive::FileEntryDef, setup};
 use clap::Parser;
 use portable_network_archive::cli;
+use std::fs;
 
 /// Precondition: An archive contains a file with permission 0o777.
 /// Action: Run `pna experimental chmod` with `--output` to a new path.
@@ -8,6 +9,7 @@ use portable_network_archive::cli;
 #[test]
 fn chmod_output() {
     setup();
+    let _ = std::fs::remove_file("chmod_output_out.pna");
 
     archive::create_archive_with_permissions(
         "chmod_output.pna",
@@ -42,6 +44,93 @@ fn chmod_output() {
     );
     assert_eq!(
         archive::modes_by_entry("chmod_output_out.pna"),
+        vec![("test.txt".to_string(), Some(0o666))]
+    );
+}
+
+/// Precondition: An archive and a pre-existing output file exist.
+/// Action: Run `pna experimental chmod` with `--output` pointing at the existing file.
+/// Expectation: The command fails without touching either file.
+#[test]
+fn chmod_output_without_overwrite_refuses_to_clobber() {
+    setup();
+    archive::create_archive_with_permissions(
+        "chmod_overwrite.pna",
+        &[FileEntryDef {
+            path: "test.txt",
+            content: b"test content",
+            permission: 0o777,
+        }],
+    )
+    .unwrap();
+    fs::write("chmod_overwrite_out.pna", b"sentinel").unwrap();
+
+    let error = cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "chmod",
+        "-f",
+        "chmod_overwrite.pna",
+        "--output",
+        "chmod_overwrite_out.pna",
+        "--",
+        "-x",
+        "test.txt",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap_err();
+
+    assert!(format!("{error:?}").contains("already exists"));
+    assert_eq!(fs::read("chmod_overwrite_out.pna").unwrap(), b"sentinel");
+    assert_eq!(
+        archive::modes_by_entry("chmod_overwrite.pna"),
+        vec![("test.txt".to_string(), Some(0o777))]
+    );
+}
+
+/// Precondition: An archive and a pre-existing output file exist.
+/// Action: Run the same chmod with `--overwrite`.
+/// Expectation: The output holds the updated mode; the original is untouched.
+#[test]
+fn chmod_output_with_overwrite_replaces() {
+    setup();
+    archive::create_archive_with_permissions(
+        "chmod_overwrite_ok.pna",
+        &[FileEntryDef {
+            path: "test.txt",
+            content: b"test content",
+            permission: 0o777,
+        }],
+    )
+    .unwrap();
+    fs::write("chmod_overwrite_ok_out.pna", b"sentinel").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "chmod",
+        "-f",
+        "chmod_overwrite_ok.pna",
+        "--output",
+        "chmod_overwrite_ok_out.pna",
+        "--overwrite",
+        "--",
+        "-x",
+        "test.txt",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    assert_eq!(
+        archive::modes_by_entry("chmod_overwrite_ok.pna"),
+        vec![("test.txt".to_string(), Some(0o777))]
+    );
+    assert_eq!(
+        archive::modes_by_entry("chmod_overwrite_ok_out.pna"),
         vec![("test.txt".to_string(), Some(0o666))]
     );
 }

--- a/cli/tests/cli/chown/option_output.rs
+++ b/cli/tests/cli/chown/option_output.rs
@@ -1,6 +1,16 @@
 use crate::utils::{archive, archive::FileEntryDef, setup};
 use clap::Parser;
 use portable_network_archive::cli;
+use std::fs;
+
+fn uname_of(path: &str) -> String {
+    let mut uname = String::new();
+    archive::for_each_entry(path, |entry| {
+        uname = entry.metadata().owner_user_name().unwrap().to_string();
+    })
+    .unwrap();
+    uname
+}
 
 /// Precondition: An archive contains entries with permission metadata.
 /// Action: Run `pna experimental chown` with `--output` to a new path.
@@ -8,6 +18,7 @@ use portable_network_archive::cli;
 #[test]
 fn chown_output() {
     setup();
+    let _ = std::fs::remove_file("chown_output_out.pna");
 
     archive::create_archive_with_permissions(
         "chown_output.pna",
@@ -47,4 +58,82 @@ fn chown_output() {
 
     assert_eq!(uname_of("chown_output.pna"), "user");
     assert_eq!(uname_of("chown_output_out.pna"), "new_user");
+}
+
+/// Precondition: An archive and a pre-existing output file exist.
+/// Action: Run `pna experimental chown` with `--output` pointing at the existing file.
+/// Expectation: The command fails without touching either file.
+#[test]
+fn chown_output_without_overwrite_refuses_to_clobber() {
+    setup();
+    archive::create_archive_with_permissions(
+        "chown_overwrite.pna",
+        &[FileEntryDef {
+            path: "target.txt",
+            content: b"target",
+            permission: 0o644,
+        }],
+    )
+    .unwrap();
+    fs::write("chown_overwrite_out.pna", b"sentinel").unwrap();
+
+    let error = cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "chown",
+        "-f",
+        "chown_overwrite.pna",
+        "--output",
+        "chown_overwrite_out.pna",
+        "new_user",
+        "target.txt",
+        "--no-owner-lookup",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap_err();
+
+    assert!(format!("{error:?}").contains("already exists"));
+    assert_eq!(fs::read("chown_overwrite_out.pna").unwrap(), b"sentinel");
+    assert_eq!(uname_of("chown_overwrite.pna"), "user");
+}
+
+/// Precondition: An archive and a pre-existing output file exist.
+/// Action: Run the same chown with `--overwrite`.
+/// Expectation: The output holds the updated owner; the original is untouched.
+#[test]
+fn chown_output_with_overwrite_replaces() {
+    setup();
+    archive::create_archive_with_permissions(
+        "chown_overwrite_ok.pna",
+        &[FileEntryDef {
+            path: "target.txt",
+            content: b"target",
+            permission: 0o644,
+        }],
+    )
+    .unwrap();
+    fs::write("chown_overwrite_ok_out.pna", b"sentinel").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "chown",
+        "-f",
+        "chown_overwrite_ok.pna",
+        "--output",
+        "chown_overwrite_ok_out.pna",
+        "--overwrite",
+        "new_user",
+        "target.txt",
+        "--no-owner-lookup",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    assert_eq!(uname_of("chown_overwrite_ok.pna"), "user");
+    assert_eq!(uname_of("chown_overwrite_ok_out.pna"), "new_user");
 }

--- a/cli/tests/cli/delete/multipart.rs
+++ b/cli/tests/cli/delete/multipart.rs
@@ -9,6 +9,7 @@ use std::collections::HashSet;
 #[test]
 fn delete_from_multipart_archive() {
     setup();
+    let _ = std::fs::remove_file("delete_multipart/deleted.pna");
     TestResources::extract_in("raw/", "delete_multipart/in/").unwrap();
 
     // Create a regular archive first

--- a/cli/tests/cli/delete/option_exclude.rs
+++ b/cli/tests/cli/delete/option_exclude.rs
@@ -10,6 +10,7 @@ use std::collections::HashSet;
 #[test]
 fn delete_with_exclude() {
     setup();
+    let _ = std::fs::remove_file("delete_output_exclude/delete_excluded.pna");
     TestResources::extract_in("raw/", "delete_output_exclude/in/").unwrap();
     cli::Cli::try_parse_from([
         "pna",

--- a/cli/tests/cli/delete/option_output.rs
+++ b/cli/tests/cli/delete/option_output.rs
@@ -2,6 +2,7 @@ use crate::utils::{EmbedExt, TestResources, archive, setup};
 use clap::Parser;
 use portable_network_archive::cli;
 use std::collections::HashSet;
+use std::fs;
 
 /// Precondition: The source tree contains both files and directories.
 /// Action: Run `pna create` to build an archive, then delete entries from the archive
@@ -11,6 +12,7 @@ use std::collections::HashSet;
 #[test]
 fn delete_output() {
     setup();
+    let _ = std::fs::remove_file("delete_output/deleted.pna");
     TestResources::extract_in("raw/", "delete_output/in/").unwrap();
     cli::Cli::try_parse_from([
         "pna",
@@ -84,4 +86,143 @@ fn delete_output() {
         );
     }
     assert!(seen.is_empty(), "unexpected entries found: {seen:?}");
+}
+
+/// Precondition: An archive and a pre-existing output file exist.
+/// Action: Run `pna experimental delete` with `--output` pointing at the existing file.
+/// Expectation: The command fails without touching either file.
+#[test]
+fn delete_output_without_overwrite_refuses_to_clobber() {
+    setup();
+    fs::create_dir_all("delete_ow_guard/in").unwrap();
+    fs::write("delete_ow_guard/in/file.txt", b"data").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "delete_ow_guard/archive.pna",
+        "--overwrite",
+        "delete_ow_guard/in/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    fs::write("delete_ow_guard/out.pna", b"sentinel").unwrap();
+
+    let error = cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "delete",
+        "-f",
+        "delete_ow_guard/archive.pna",
+        "delete_ow_guard/in/file.txt",
+        "--output",
+        "delete_ow_guard/out.pna",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap_err();
+
+    assert!(format!("{error:?}").contains("already exists"));
+    assert_eq!(fs::read("delete_ow_guard/out.pna").unwrap(), b"sentinel");
+    let mut seen = HashSet::new();
+    archive::for_each_entry("delete_ow_guard/archive.pna", |entry| {
+        seen.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+    assert!(!seen.is_empty(), "original archive must be untouched");
+}
+
+/// Precondition: An archive and a pre-existing output file exist.
+/// Action: Run the same delete with `--overwrite`.
+/// Expectation: The output is replaced with the filtered archive; the original is untouched.
+#[test]
+fn delete_output_with_overwrite_replaces() {
+    setup();
+    fs::create_dir_all("delete_ow_guard_ok/in").unwrap();
+    fs::write("delete_ow_guard_ok/in/file.txt", b"data").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "delete_ow_guard_ok/archive.pna",
+        "--overwrite",
+        "delete_ow_guard_ok/in/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    fs::write("delete_ow_guard_ok/out.pna", b"sentinel").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "delete",
+        "-f",
+        "delete_ow_guard_ok/archive.pna",
+        "delete_ow_guard_ok/in/file.txt",
+        "--output",
+        "delete_ow_guard_ok/out.pna",
+        "--overwrite",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    assert_ne!(fs::read("delete_ow_guard_ok/out.pna").unwrap(), b"sentinel");
+}
+
+/// Precondition: An archive exists.
+/// Action: Run `pna experimental delete` with `--output` naming the input itself.
+/// Expectation: Without `--overwrite` the command fails even though the destination
+/// is the in-place target; with `--overwrite` it rewrites the input.
+#[test]
+fn delete_output_naming_the_input_requires_overwrite() {
+    setup();
+    fs::create_dir_all("delete_ow_guard_self/in").unwrap();
+    fs::write("delete_ow_guard_self/in/file.txt", b"data").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        "delete_ow_guard_self/archive.pna",
+        "--overwrite",
+        "delete_ow_guard_self/in/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let error = cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "delete",
+        "-f",
+        "delete_ow_guard_self/archive.pna",
+        "delete_ow_guard_self/in/file.txt",
+        "--output",
+        "delete_ow_guard_self/archive.pna",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap_err();
+    assert!(format!("{error:?}").contains("already exists"));
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "delete",
+        "-f",
+        "delete_ow_guard_self/archive.pna",
+        "delete_ow_guard_self/in/file.txt",
+        "--output",
+        "delete_ow_guard_self/archive.pna",
+        "--overwrite",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
 }

--- a/cli/tests/cli/migrate.rs
+++ b/cli/tests/cli/migrate.rs
@@ -1,2 +1,3 @@
 mod acl_0_19_1;
 mod fprm_0_33_0;
+mod option_output;

--- a/cli/tests/cli/migrate/acl_0_19_1.rs
+++ b/cli/tests/cli/migrate/acl_0_19_1.rs
@@ -20,6 +20,7 @@ fn assert_migrated_acl(platform: &str, acl_entries: &[&str]) {
     let source = format!("0.19.1/{platform}_acl.pna");
     let migrated = format!("migrate_{platform}_acl/migrated.pna");
     TestResources::extract_in(&source, ".").unwrap();
+    let _ = std::fs::remove_file(&migrated);
 
     cli::Cli::try_parse_from([
         "pna", "--quiet", "migrate", "-f", &source, "--output", &migrated,

--- a/cli/tests/cli/migrate/fprm_0_33_0.rs
+++ b/cli/tests/cli/migrate/fprm_0_33_0.rs
@@ -26,6 +26,7 @@ struct Captured {
 fn migrate_converts_fprm_to_owner_facet() {
     setup();
     TestResources::extract_in("0.33.0/zstd_keep_all.pna", "migrate_fprm_0_33_0/").unwrap();
+    let _ = std::fs::remove_file("migrate_fprm_0_33_0/migrated.pna");
 
     let mut pre: BTreeMap<String, Captured> = BTreeMap::new();
     archive::for_each_entry(LEGACY_FIXTURE, |entry| {

--- a/cli/tests/cli/migrate/option_output.rs
+++ b/cli/tests/cli/migrate/option_output.rs
@@ -1,0 +1,67 @@
+use crate::utils::{EmbedExt, TestResources, archive, setup};
+use clap::Parser;
+use portable_network_archive::cli;
+use std::fs;
+
+const FIXTURE: &str = "migrate_overwrite/0.33.0/zstd_keep_all.pna";
+
+/// Precondition: A legacy archive and a pre-existing output file exist.
+/// Action: Run `pna migrate` with `--output` pointing at the existing file.
+/// Expectation: The command fails without touching either file.
+#[test]
+#[allow(deprecated)]
+fn migrate_output_without_overwrite_refuses_to_clobber() {
+    setup();
+    TestResources::extract_in("0.33.0/zstd_keep_all.pna", "migrate_overwrite/").unwrap();
+    fs::write("migrate_overwrite/out.pna", b"sentinel").unwrap();
+
+    let error = cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "migrate",
+        "-f",
+        FIXTURE,
+        "--output",
+        "migrate_overwrite/out.pna",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap_err();
+
+    assert!(format!("{error:?}").contains("already exists"));
+    assert_eq!(fs::read("migrate_overwrite/out.pna").unwrap(), b"sentinel");
+}
+
+/// Precondition: A legacy archive and a pre-existing output file exist.
+/// Action: Run the same migrate with `--overwrite`.
+/// Expectation: The output is replaced with the migrated archive.
+#[test]
+#[allow(deprecated)]
+fn migrate_output_with_overwrite_replaces() {
+    setup();
+    TestResources::extract_in("0.33.0/zstd_keep_all.pna", "migrate_overwrite_ok/").unwrap();
+    let fixture = "migrate_overwrite_ok/0.33.0/zstd_keep_all.pna";
+    fs::write("migrate_overwrite_ok/out.pna", b"sentinel").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "migrate",
+        "-f",
+        fixture,
+        "--output",
+        "migrate_overwrite_ok/out.pna",
+        "--overwrite",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    assert_ne!(
+        fs::read("migrate_overwrite_ok/out.pna").unwrap(),
+        b"sentinel"
+    );
+    let mut count = 0usize;
+    archive::for_each_entry("migrate_overwrite_ok/out.pna", |_| count += 1).unwrap();
+    assert!(count > 0, "migrated archive should contain entries");
+}

--- a/cli/tests/cli/sort.rs
+++ b/cli/tests/cli/sort.rs
@@ -4,4 +4,5 @@ mod by_mtime;
 mod by_name;
 mod by_name_desc;
 mod multiple_keys;
+mod option_output;
 mod order_combination;

--- a/cli/tests/cli/sort/option_output.rs
+++ b/cli/tests/cli/sort/option_output.rs
@@ -1,0 +1,86 @@
+use crate::utils::{archive::for_each_entry, setup};
+use clap::Parser;
+use pna::{Archive, FileEntryBuilder};
+use portable_network_archive::cli;
+use std::fs;
+
+fn write_unsorted(path: &str) {
+    let parent = std::path::Path::new(path).parent().unwrap();
+    fs::create_dir_all(parent).unwrap();
+    let file = fs::File::create(path).unwrap();
+    let mut archive = Archive::write_header(file).unwrap();
+    let entry_b = FileEntryBuilder::new("b.txt".into()).unwrap();
+    archive.add_entry(entry_b.build().unwrap()).unwrap();
+    let entry_a = FileEntryBuilder::new("a.txt".into()).unwrap();
+    archive.add_entry(entry_a.build().unwrap()).unwrap();
+    archive.finalize().unwrap();
+}
+
+fn entry_names(path: &str) -> Vec<String> {
+    let mut names = Vec::new();
+    for_each_entry(path, |e| {
+        names.push(e.header().path().as_str().to_string());
+    })
+    .unwrap();
+    names
+}
+
+/// Precondition: An archive and a pre-existing output file exist.
+/// Action: Run `pna sort` with `--output` pointing at the existing file.
+/// Expectation: The command fails without touching either file.
+#[test]
+fn sort_output_without_overwrite_refuses_to_clobber() {
+    setup();
+    write_unsorted("sort_overwrite/unsorted.pna");
+    fs::write("sort_overwrite/out.pna", b"sentinel").unwrap();
+
+    let error = cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "sort",
+        "-f",
+        "sort_overwrite/unsorted.pna",
+        "--output",
+        "sort_overwrite/out.pna",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap_err();
+
+    assert!(format!("{error:?}").contains("already exists"));
+    assert_eq!(fs::read("sort_overwrite/out.pna").unwrap(), b"sentinel");
+    assert_eq!(
+        entry_names("sort_overwrite/unsorted.pna"),
+        ["b.txt", "a.txt"]
+    );
+}
+
+/// Precondition: An archive and a pre-existing output file exist.
+/// Action: Run the same sort with `--overwrite`.
+/// Expectation: The output holds sorted entries; the original keeps its order.
+#[test]
+fn sort_output_with_overwrite_replaces() {
+    setup();
+    write_unsorted("sort_overwrite_ok/unsorted.pna");
+    fs::write("sort_overwrite_ok/out.pna", b"sentinel").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "sort",
+        "-f",
+        "sort_overwrite_ok/unsorted.pna",
+        "--output",
+        "sort_overwrite_ok/out.pna",
+        "--overwrite",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    assert_eq!(entry_names("sort_overwrite_ok/out.pna"), ["a.txt", "b.txt"]);
+    assert_eq!(
+        entry_names("sort_overwrite_ok/unsorted.pna"),
+        ["b.txt", "a.txt"]
+    );
+}

--- a/cli/tests/cli/strip.rs
+++ b/cli/tests/cli/strip.rs
@@ -1,6 +1,7 @@
 mod file_operands;
 mod keep_solid;
 mod missing_file;
+mod option_output;
 mod unsolid;
 
 use crate::utils::{EmbedExt, TestResources, archive, setup};

--- a/cli/tests/cli/strip/option_output.rs
+++ b/cli/tests/cli/strip/option_output.rs
@@ -1,0 +1,82 @@
+use crate::utils::{archive, archive::FileEntryDef, setup};
+use clap::Parser;
+use portable_network_archive::cli;
+use std::fs;
+
+/// Precondition: An archive and a pre-existing output file exist.
+/// Action: Run `pna strip` with `--output` pointing at the existing file.
+/// Expectation: The command fails without touching either file.
+#[test]
+fn strip_output_without_overwrite_refuses_to_clobber() {
+    setup();
+    let path = "strip_overwrite.pna";
+    archive::create_archive_with_permissions(
+        path,
+        &[FileEntryDef {
+            path: "strip.txt",
+            content: b"strip",
+            permission: 0o644,
+        }],
+    )
+    .unwrap();
+    fs::write("strip_overwrite_out.pna", b"sentinel").unwrap();
+
+    let error = cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "strip",
+        "-f",
+        path,
+        "--output",
+        "strip_overwrite_out.pna",
+        "strip.txt",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap_err();
+
+    assert!(format!("{error:?}").contains("already exists"));
+    assert_eq!(fs::read("strip_overwrite_out.pna").unwrap(), b"sentinel");
+}
+
+/// Precondition: An archive and a pre-existing output file exist.
+/// Action: Run the same strip with `--overwrite`.
+/// Expectation: The output is replaced; the original is untouched.
+#[test]
+fn strip_output_with_overwrite_replaces() {
+    setup();
+    let path = "strip_overwrite_ok.pna";
+    archive::create_archive_with_permissions(
+        path,
+        &[FileEntryDef {
+            path: "strip.txt",
+            content: b"strip",
+            permission: 0o644,
+        }],
+    )
+    .unwrap();
+    fs::write("strip_overwrite_ok_out.pna", b"sentinel").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "strip",
+        "-f",
+        path,
+        "--output",
+        "strip_overwrite_ok_out.pna",
+        "--overwrite",
+        "strip.txt",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    assert_ne!(fs::read("strip_overwrite_ok_out.pna").unwrap(), b"sentinel");
+    let mut entries = Vec::new();
+    archive::for_each_entry(path, |entry| {
+        entries.push(entry.metadata().permission_mode().map(|m| m.get()));
+    })
+    .unwrap();
+    assert_eq!(entries, [Some(0o644)]);
+}

--- a/cli/tests/cli/update/option_output.rs
+++ b/cli/tests/cli/update/option_output.rs
@@ -1,7 +1,7 @@
 use crate::utils::{archive, setup};
 use clap::Parser;
 use portable_network_archive::cli;
-use std::{fs, io::prelude::*, time};
+use std::{collections::HashSet, fs, io::prelude::*, time};
 
 const DURATION_24_HOURS: time::Duration = time::Duration::from_secs(24 * 60 * 60);
 
@@ -161,4 +161,87 @@ fn update_with_output() {
         b"old-b",
         "output archive should keep unmodified file content"
     );
+}
+
+fn create_overwrite_fixture(dir: &str) {
+    fs::create_dir_all(format!("{dir}/in")).unwrap();
+    fs::write(format!("{dir}/in/file.txt"), b"data").unwrap();
+    fs::write(format!("{dir}/in/new.txt"), b"new").unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "c",
+        "-f",
+        &format!("{dir}/archive.pna"),
+        "--overwrite",
+        &format!("{dir}/in/"),
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+}
+
+/// Precondition: An archive and a pre-existing output file exist.
+/// Action: Run `pna experimental update` with `--output` pointing at the existing file.
+/// Expectation: The command fails without touching either file.
+#[test]
+fn update_output_without_overwrite_refuses_to_clobber() {
+    setup();
+    create_overwrite_fixture("update_overwrite");
+    fs::write("update_overwrite/out.pna", b"sentinel").unwrap();
+
+    let error = cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "-f",
+        "update_overwrite/archive.pna",
+        "--output",
+        "update_overwrite/out.pna",
+        "update_overwrite/in/new.txt",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap_err();
+
+    assert!(format!("{error:?}").contains("already exists"));
+    assert_eq!(fs::read("update_overwrite/out.pna").unwrap(), b"sentinel");
+}
+
+/// Precondition: An archive and a pre-existing output file exist.
+/// Action: Run the same update with `--overwrite`.
+/// Expectation: The output is replaced; the original is untouched.
+#[test]
+fn update_output_with_overwrite_replaces() {
+    setup();
+    create_overwrite_fixture("update_overwrite_ok");
+    fs::write("update_overwrite_ok/out.pna", b"sentinel").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "experimental",
+        "update",
+        "-f",
+        "update_overwrite_ok/archive.pna",
+        "--output",
+        "update_overwrite_ok/out.pna",
+        "--overwrite",
+        "update_overwrite_ok/in/new.txt",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    assert_ne!(
+        fs::read("update_overwrite_ok/out.pna").unwrap(),
+        b"sentinel"
+    );
+    let mut seen = HashSet::new();
+    archive::for_each_entry("update_overwrite_ok/archive.pna", |entry| {
+        seen.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+    assert!(!seen.is_empty(), "original archive must be untouched");
 }

--- a/cli/tests/cli/xattr/set/option_output.rs
+++ b/cli/tests/cli/xattr/set/option_output.rs
@@ -1,6 +1,7 @@
 use crate::utils::{EmbedExt, TestResources, archive, setup};
 use clap::Parser;
 use portable_network_archive::cli;
+use std::fs;
 
 /// Precondition: An archive with multiple entries exists.
 /// Action: Set an extended attribute with `--output` to a new path.
@@ -8,6 +9,7 @@ use portable_network_archive::cli;
 #[test]
 fn xattr_set_output() {
     setup();
+    let _ = std::fs::remove_file("xattr_set_output/out.pna");
     TestResources::extract_in("zstd.pna", "xattr_set_output/").unwrap();
 
     cli::Cli::try_parse_from([
@@ -35,6 +37,84 @@ fn xattr_set_output() {
     );
     assert_eq!(
         archive::xattrs_by_entry("xattr_set_output/out.pna", None),
+        vec![(
+            "raw/empty.txt".to_string(),
+            vec![archive::xattr("user.name", b"pna developers!")]
+        )]
+    );
+}
+
+/// Precondition: An archive and a pre-existing output file exist.
+/// Action: Run `pna xattr set` with `--output` pointing at the existing file.
+/// Expectation: The command fails without touching either file.
+#[test]
+fn xattr_set_output_without_overwrite_refuses_to_clobber() {
+    setup();
+    TestResources::extract_in("zstd.pna", "xattr_ow_guard/").unwrap();
+    fs::write("xattr_ow_guard/out.pna", b"sentinel").unwrap();
+
+    let error = cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "xattr",
+        "set",
+        "-f",
+        "xattr_ow_guard/zstd.pna",
+        "--output",
+        "xattr_ow_guard/out.pna",
+        "--name",
+        "user.name",
+        "--value",
+        "pna developers!",
+        "raw/empty.txt",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap_err();
+
+    assert!(format!("{error:?}").contains("already exists"));
+    assert_eq!(fs::read("xattr_ow_guard/out.pna").unwrap(), b"sentinel");
+    assert_eq!(
+        archive::xattrs_by_entry("xattr_ow_guard/zstd.pna", None),
+        vec![]
+    );
+}
+
+/// Precondition: An archive and a pre-existing output file exist.
+/// Action: Run the same set with `--overwrite`.
+/// Expectation: The output holds the xattr; the original is untouched.
+#[test]
+fn xattr_set_output_with_overwrite_replaces() {
+    setup();
+    TestResources::extract_in("zstd.pna", "xattr_ow_guard_ok/").unwrap();
+    fs::write("xattr_ow_guard_ok/out.pna", b"sentinel").unwrap();
+
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "xattr",
+        "set",
+        "-f",
+        "xattr_ow_guard_ok/zstd.pna",
+        "--output",
+        "xattr_ow_guard_ok/out.pna",
+        "--overwrite",
+        "--name",
+        "user.name",
+        "--value",
+        "pna developers!",
+        "raw/empty.txt",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    assert_eq!(
+        archive::xattrs_by_entry("xattr_ow_guard_ok/zstd.pna", None),
+        vec![]
+    );
+    assert_eq!(
+        archive::xattrs_by_entry("xattr_ow_guard_ok/out.pna", None),
         vec![(
             "raw/empty.txt".to_string(),
             vec![archive::xattr("user.name", b"pna developers!")]


### PR DESCRIPTION
## Summary

Follows up #3521, which added `--output` to the rewrite subcommands. This change adds an `--overwrite` / `--no-overwrite` pair to the nine transform subcommands (`delete`, `strip`, `sort`, `update`, `migrate`, `chmod`, `chown`, `xattr set`, `acl set`) so an explicit `--output` never silently replaces an existing file.

- `--overwrite` allows replacing the destination; `--no-overwrite` makes the refusal explicit. Both require `--output`.
- Without `--overwrite`, an occupied destination (file, directory, or dangling symlink) is refused, including `--output` naming the input itself.
- The guard is enforced atomically at commit time via hard-link based `rename_no_overwrite`, so no check-then-act race exists between the fail-fast existence check and publishing.

## Test plan

- `cargo clippy -p portable-network-archive --tests`: no warnings
- `cargo test -p portable-network-archive --test cli -- delete strip sort update migrate xattr acl chmod chown`: 239 passed, twice in a row (rerun idempotence)
- `cargo test -p portable-network-archive --lib`: 556 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `--overwrite` and `--no-overwrite` options to archive rewrite commands, including ACL, chmod, chown, delete, migrate, sort, strip, update, and xattr operations.
  - In-place updates remain supported when no separate output path is specified.
  - Archive updates preserve file permissions by default.

- **Bug Fixes**
  - Existing output files, including dangling symbolic links, are now protected from accidental replacement unless `--overwrite` is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->