### PR TITLE
:recycle: Share chunk length limit check across framing implementations

### DIFF
--- a/lib/src/async_io.rs
+++ b/lib/src/async_io.rs
@@ -56,12 +56,7 @@ pub async fn read_chunk<R: AsyncRead + Unpin + ?Sized>(
     let mut length = [0u8; mem::size_of::<u32>()];
     reader.read_exact(&mut length).await?;
     let length = u32::from_be_bytes(length);
-    if length > max_data_len {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("chunk data length {length} exceeds limit {max_data_len}"),
-        ));
-    }
+    crate::format::check_chunk_length_limit(length, max_data_len)?;
 
     let mut ty = [0u8; mem::size_of::<ChunkType>()];
     reader.read_exact(&mut ty).await?;

--- a/lib/src/bytes.rs
+++ b/lib/src/bytes.rs
@@ -41,12 +41,7 @@ pub fn read_chunk(bytes: &[u8], max_data_len: u32) -> io::Result<(RawChunk<&[u8]
         .split_first_chunk::<{ mem::size_of::<u32>() }>()
         .ok_or(io::ErrorKind::UnexpectedEof)?;
     let length = u32::from_be_bytes(*length);
-    if length > max_data_len {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("chunk data length {length} exceeds limit {max_data_len}"),
-        ));
-    }
+    crate::format::check_chunk_length_limit(length, max_data_len)?;
 
     let (ty, bytes) = bytes
         .split_first_chunk::<{ mem::size_of::<ChunkType>() }>()

--- a/lib/src/format.rs
+++ b/lib/src/format.rs
@@ -3,6 +3,6 @@
 mod chunk;
 mod signature;
 
-pub(crate) use chunk::{chunk_crc, validate_chunk_crc};
+pub(crate) use chunk::{check_chunk_length_limit, chunk_crc, validate_chunk_crc};
 pub use signature::PNA_SIGNATURE;
 pub(crate) use signature::validate_signature;

--- a/lib/src/format/chunk.rs
+++ b/lib/src/format/chunk.rs
@@ -20,6 +20,18 @@ pub(crate) fn validate_chunk_crc(ty: &[u8; 4], data: &[u8], stored: u32) -> io::
     Ok(())
 }
 
+/// Rejects a chunk data length exceeding the inclusive limit.
+#[inline]
+pub(crate) fn check_chunk_length_limit(length: u32, max_data_len: u32) -> io::Result<()> {
+    if length > max_data_len {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("chunk data length {length} exceeds limit {max_data_len}"),
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/lib/src/io.rs
+++ b/lib/src/io.rs
@@ -121,12 +121,7 @@ pub fn read_chunk<R: io::Read + ?Sized>(
     let mut length = [0u8; mem::size_of::<u32>()];
     reader.read_exact(&mut length)?;
     let length = u32::from_be_bytes(length);
-    if length > max_data_len {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("chunk data length {length} exceeds limit {max_data_len}"),
-        ));
-    }
+    crate::format::check_chunk_length_limit(length, max_data_len)?;
 
     let mut ty = [0u8; mem::size_of::<ChunkType>()];
     reader.read_exact(&mut ty)?;


### PR DESCRIPTION
## Summary

The chunk length limit rule (inclusive bound, `InvalidData` with a fixed message) was textually duplicated in the three framing implementations (`io`, `bytes`, `async_io`). This change extracts exactly that rule into `format::check_chunk_length_limit` so all three report the same kind and message for the same input.

Deliberately out of scope: the read sequencing in each adapter is left untouched, so every adapter stays locally complete with no new ordering contract. Type validation (`ChunkType::new`) and CRC validation (`validate_chunk_crc`) were already shared and are unchanged. No test changes were needed: the existing per-adapter matrices keep proving the rule end to end through each transport.

## Test plan

- `cargo clippy -p libpna --all-targets`: no warnings
- `cargo test -p libpna --lib`: 485 passed
- `cargo test -p libpna --features unstable-async --lib`: 502 passed
- `cargo test -p libpna --doc`: 124 passed
- `cargo test -p pna --lib`, `cargo test -p portable-network-archive --lib`: passed (24 / 556)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized validation for oversized data chunks across supported input paths.
  * Oversized chunks continue to be rejected with an invalid-data error, preserving existing behavior while applying the same limit consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->