### PR TITLE
Add --output option to concat subcommand

### DIFF
--- a/cli/src/command/concat.rs
+++ b/cli/src/command/concat.rs
@@ -25,6 +25,12 @@ pub(crate) struct ConcatCommand {
     no_overwrite: (),
     #[arg(short, long, required = true, help = "Archive files to concatenate", value_hint = ValueHint::FilePath)]
     files: Vec<PathBuf>,
+    #[arg(
+        long,
+        help = "Output archive file path",
+        value_hint = ValueHint::FilePath
+    )]
+    output: Option<PathBuf>,
 }
 
 impl Command for ConcatCommand {
@@ -36,8 +42,18 @@ impl Command for ConcatCommand {
 
 #[hooq::hooq(anyhow)]
 fn concat_entry(args: ConcatCommand) -> anyhow::Result<()> {
-    let mut archives = args.files;
-    let archive = archives.remove(0);
+    let (archive, archives) = match args.output {
+        Some(output) => (output, args.files),
+        None => {
+            let mut files = args.files;
+            let archive = files.remove(0);
+            log::warn!(
+                "using the first input '{}' as the output destination is deprecated; specify the destination explicitly with --output",
+                archive.display()
+            );
+            (archive, files)
+        }
+    };
     for item in &archives {
         if !utils::fs::is_pna(item)? {
             anyhow::bail!("{} is not a pna file", item.display());

--- a/cli/tests/cli/concat.rs
+++ b/cli/tests/cli/concat.rs
@@ -1,4 +1,6 @@
 #[cfg(not(target_family = "wasm"))]
+mod option_output;
+#[cfg(not(target_family = "wasm"))]
 mod option_overwrite;
 
 use crate::utils::{EmbedExt, TestResources, diff::assert_dirs_equal, setup};

--- a/cli/tests/cli/concat/option_output.rs
+++ b/cli/tests/cli/concat/option_output.rs
@@ -1,0 +1,101 @@
+use crate::utils::{archive, setup};
+use assert_cmd::cargo::cargo_bin_cmd;
+use clap::Parser;
+use predicates::{boolean::PredicateBooleanExt, str::contains};
+use std::{collections::HashSet, fs};
+
+fn create_fixture(dir: &str, name: &str, content: &[u8]) {
+    fs::create_dir_all(format!("{dir}/in")).unwrap();
+    fs::write(format!("{dir}/in/{name}"), content).unwrap();
+    portable_network_archive::cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "create",
+        "-f",
+        &format!("{dir}/{name}.pna"),
+        "--overwrite",
+        &format!("{dir}/in/{name}"),
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+}
+
+/// Precondition: Two input archives exist.
+/// Action: Run concat with explicit `--output`.
+/// Expectation: Every input (including the first) is concatenated as an
+/// input, and no deprecation warning is emitted.
+#[test]
+fn explicit_output_treats_every_file_as_input() {
+    setup();
+    let _ = fs::remove_dir_all("concat_output");
+    create_fixture("concat_output", "a", b"a-content");
+    create_fixture("concat_output", "b", b"b-content");
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "concat",
+            "-f",
+            "concat_output/a.pna",
+            "-f",
+            "concat_output/b.pna",
+            "--output",
+            "concat_output/out.pna",
+        ])
+        .assert()
+        .success()
+        .stderr(contains("deprecated").not());
+
+    let mut seen = HashSet::new();
+    archive::for_each_entry("concat_output/out.pna", |entry| {
+        seen.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+    assert!(
+        seen.iter().any(|p| p.ends_with("a")),
+        "first --file must be read as an input: {seen:?}"
+    );
+    assert!(
+        seen.iter().any(|p| p.ends_with("b")),
+        "second --file must be read as an input: {seen:?}"
+    );
+}
+
+/// Precondition: One input archive exists.
+/// Action: Run concat without `--output` (legacy form).
+/// Expectation: The first input is still used as the destination, with a
+/// deprecation warning guiding toward `--output`.
+#[test]
+fn legacy_first_file_destination_warns_but_works() {
+    setup();
+    let _ = fs::remove_dir_all("concat_legacy");
+    create_fixture("concat_legacy", "a", b"a-content");
+    let before = fs::read("concat_legacy/a.pna").unwrap();
+
+    cargo_bin_cmd!("pna")
+        .args([
+            "concat",
+            "-f",
+            "concat_legacy/out.pna",
+            "-f",
+            "concat_legacy/a.pna",
+        ])
+        .assert()
+        .success()
+        .stderr(contains("--output"));
+
+    let mut seen = HashSet::new();
+    archive::for_each_entry("concat_legacy/out.pna", |entry| {
+        seen.insert(entry.header().path().to_string());
+    })
+    .unwrap();
+    assert!(
+        seen.iter().any(|p| p.ends_with("a")),
+        "legacy destination must contain the input: {seen:?}"
+    );
+    assert_eq!(
+        fs::read("concat_legacy/a.pna").unwrap(),
+        before,
+        "input archive must be untouched"
+    );
+}


### PR DESCRIPTION
Adds a forward-compatible `--output` option to `concat` as a migration bridge toward the stage-19 syntax.

- When `--output` is given, every input (`-f`/`--files`) is concatenated as an input.
- When omitted, the first input is still used as the destination (unchanged behavior), with a deprecation warning on stderr guiding toward `--output`.
- No changes to `--overwrite`/`--no-overwrite` constraints.

Tests: adds `cli/tests/cli/concat/option_output.rs` covering explicit-output concatenation and the legacy warning path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an explicit `--output` option to the `concat` command, allowing users to select the destination archive while treating all specified files as inputs.
  - Preserved the legacy format, which uses the first input as the output destination and displays a deprecation warning.

- **Bug Fixes**
  - Prevented the first input archive from being unintentionally excluded when an explicit output path is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->