### PR TITLE
:bug: Reject in-place split of a part file

### DIFF
--- a/cli/src/command/split.rs
+++ b/cli/src/command/split.rs
@@ -7,7 +7,11 @@ use anyhow::{Context, ensure};
 use bytesize::ByteSize;
 use clap::{ArgAction, Parser, ValueHint};
 use pna::{Archive, MIN_SPLIT_PART_BYTES};
-use std::{borrow::Cow, fs, path::PathBuf};
+use std::{
+    borrow::Cow,
+    fs,
+    path::{Path, PathBuf},
+};
 
 #[derive(Parser, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub(crate) struct SplitCommand {
@@ -48,22 +52,10 @@ fn split_archive(args: SplitCommand) -> anyhow::Result<()> {
         "The value for --max-size must be at least {MIN_SPLIT_PART_BYTES} bytes ({}).",
         ByteSize::b(MIN_SPLIT_PART_BYTES as u64)
     );
-    let base_out_file_name = if let Some(out_dir) = args.out_dir {
-        fs::create_dir_all(&out_dir)?;
-        Cow::Owned(out_dir.join(archive_path.file_name().unwrap_or_default()))
-    } else {
-        Cow::Borrowed(archive_path.as_path())
-    };
-    if archive_path.remove_part() != archive_path.as_path() {
-        let same_path = base_out_file_name.as_ref() == archive_path.as_path();
-        let same_file =
-            same_file::is_same_file(&base_out_file_name, &archive_path).unwrap_or(false);
-        if same_path || same_file {
-            anyhow::bail!(
-                "splitting `{}` in place would overwrite the input; specify --out-dir",
-                PathWithCwd::new(&archive_path)
-            );
-        }
+    let base_out_file_name = resolve_split_base(&archive_path, args.out_dir.as_deref());
+    ensure_not_self_overwrite(&archive_path, &base_out_file_name)?;
+    if let Some(out_dir) = &args.out_dir {
+        fs::create_dir_all(out_dir)?;
     }
     let read_file = fs::File::open(&archive_path)?;
     #[cfg(not(feature = "memmap"))]
@@ -85,4 +77,26 @@ fn split_archive(args: SplitCommand) -> anyhow::Result<()> {
             )
         },
     )
+}
+
+#[inline]
+fn resolve_split_base<'a>(archive_path: &'a Path, out_dir: Option<&'a Path>) -> Cow<'a, Path> {
+    match out_dir {
+        Some(dir) => Cow::Owned(dir.join(archive_path.file_name().unwrap_or_default())),
+        None => Cow::Borrowed(archive_path),
+    }
+}
+
+#[inline]
+fn ensure_not_self_overwrite(input: &Path, out_base: &Path) -> anyhow::Result<()> {
+    if !input.is_split_part() {
+        return Ok(());
+    }
+    if same_file::is_same_file(out_base, input).unwrap_or(false) {
+        anyhow::bail!(
+            "splitting `{}` in place would overwrite the input; specify --out-dir",
+            PathWithCwd::new(input)
+        );
+    }
+    Ok(())
 }

--- a/cli/src/command/split.rs
+++ b/cli/src/command/split.rs
@@ -1,7 +1,7 @@
 use crate::{
     cli::ArchiveFileArgs,
     command::{Command, core::write_split_archive},
-    utils::PathWithCwd,
+    utils::{PathPartExt, PathWithCwd},
 };
 use anyhow::{Context, ensure};
 use bytesize::ByteSize;
@@ -48,6 +48,23 @@ fn split_archive(args: SplitCommand) -> anyhow::Result<()> {
         "The value for --max-size must be at least {MIN_SPLIT_PART_BYTES} bytes ({}).",
         ByteSize::b(MIN_SPLIT_PART_BYTES as u64)
     );
+    let base_out_file_name = if let Some(out_dir) = args.out_dir {
+        fs::create_dir_all(&out_dir)?;
+        Cow::Owned(out_dir.join(archive_path.file_name().unwrap_or_default()))
+    } else {
+        Cow::Borrowed(archive_path.as_path())
+    };
+    if archive_path.remove_part() != archive_path.as_path() {
+        let same_path = base_out_file_name.as_ref() == archive_path.as_path();
+        let same_file =
+            same_file::is_same_file(&base_out_file_name, &archive_path).unwrap_or(false);
+        if same_path || same_file {
+            anyhow::bail!(
+                "splitting `{}` in place would overwrite the input; specify --out-dir",
+                PathWithCwd::new(&archive_path)
+            );
+        }
+    }
     let read_file = fs::File::open(&archive_path)?;
     #[cfg(not(feature = "memmap"))]
     let mut read_archive = Archive::read_header(read_file)?;
@@ -60,12 +77,6 @@ fn split_archive(args: SplitCommand) -> anyhow::Result<()> {
     #[cfg(feature = "memmap")]
     let entries = read_archive.raw_entries_slice();
 
-    let base_out_file_name = if let Some(out_dir) = args.out_dir {
-        fs::create_dir_all(&out_dir)?;
-        Cow::Owned(out_dir.join(archive_path.file_name().unwrap_or_default()))
-    } else {
-        Cow::Borrowed(archive_path.as_path())
-    };
     write_split_archive(&base_out_file_name, entries, max_file_size, args.overwrite).with_context(
         || {
             format!(

--- a/cli/src/utils/path.rs
+++ b/cli/src/utils/path.rs
@@ -1,11 +1,14 @@
 use std::{
-    env, fmt,
+    env,
+    ffi::OsStr,
+    fmt,
     path::{Path, PathBuf},
 };
 
 pub(crate) trait PathPartExt {
     fn with_part(&self, n: usize) -> PathBuf;
     fn remove_part(&self) -> PathBuf;
+    fn is_split_part(&self) -> bool;
 }
 
 impl PathPartExt for Path {
@@ -17,6 +20,37 @@ impl PathPartExt for Path {
     #[inline]
     fn remove_part(&self) -> PathBuf {
         remove_part_n(self)
+    }
+
+    #[inline]
+    fn is_split_part(&self) -> bool {
+        is_split_part_path(self)
+    }
+}
+
+/// Whether `path` ends with a split-part suffix `part<N>`.
+///
+/// Matches both `foo.part1` and `foo.part1.pna`. A `part` prefix without
+/// trailing digits (e.g. `foo.partial.pna`) is not a split part.
+#[inline]
+fn is_split_part_path(path: &Path) -> bool {
+    let Some(file_name) = path.file_name().map(Path::new) else {
+        return false;
+    };
+    if matches!(file_name.extension(), Some(ext) if is_part_n(ext)) {
+        return true;
+    }
+    matches!(
+        file_name.file_stem().map(Path::new).and_then(|stem| stem.extension()),
+        Some(ext) if is_part_n(ext)
+    )
+}
+
+#[inline]
+fn is_part_n(ext: &OsStr) -> bool {
+    match ext.as_encoded_bytes().strip_prefix(b"part") {
+        Some(rest) => !rest.is_empty() && rest.iter().all(|b| b.is_ascii_digit()),
+        None => false,
     }
 }
 
@@ -48,13 +82,6 @@ fn with_part_n<P: AsRef<Path>>(p: P, n: usize) -> PathBuf {
 
 #[inline]
 fn remove_part_n<P: AsRef<Path>>(path: P) -> PathBuf {
-    #[inline]
-    fn is_part_n(ext: &std::ffi::OsStr) -> bool {
-        match ext.as_encoded_bytes().strip_prefix(b"part") {
-            Some(rest) => !rest.is_empty() && rest.iter().all(|b| b.is_ascii_digit()),
-            None => false,
-        }
-    }
     #[inline]
     fn inner(path: &Path) -> PathBuf {
         let Some(file_name) = path.file_name() else {
@@ -183,5 +210,15 @@ mod tests {
             remove_part_n("dir/foo.partial.pna"),
             Path::new("dir/foo.partial.pna")
         );
+    }
+
+    #[test]
+    fn is_split_part_detects_part() {
+        assert!(!Path::new("foo.pna").is_split_part());
+        assert!(Path::new("foo.part1.pna").is_split_part());
+        assert!(Path::new("dir/foo.part1.pna").is_split_part());
+        assert!(Path::new("foo.part1").is_split_part());
+        assert!(!Path::new("foo.partial.pna").is_split_part());
+        assert!(!Path::new("foo.part").is_split_part());
     }
 }

--- a/cli/tests/cli/split.rs
+++ b/cli/tests/cli/split.rs
@@ -252,3 +252,74 @@ fn split_fails_with_missing_archive() {
         "split should fail with non-existent archive"
     );
 }
+
+/// Precondition: A split part file exists.
+/// Action: Run `pna split` on the part file without `--out-dir`.
+/// Expectation: The command fails before truncating the input, and the
+/// original part file is left untouched.
+#[test]
+fn split_part_file_without_out_dir_fails_and_keeps_original() {
+    setup();
+
+    let test_dir = "split_same_file/in/";
+    fs::create_dir_all(test_dir).unwrap();
+    for i in 0..5 {
+        let filename = format!("{test_dir}file{i}.txt");
+        let mut file = fs::File::create(&filename).unwrap();
+        file.write_all(&[b'A' + i; 20]).unwrap();
+    }
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "create",
+        "-f",
+        "split_same_file/test.pna",
+        "--overwrite",
+        test_dir,
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+    cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "split",
+        "-f",
+        "split_same_file/test.pna",
+        "--overwrite",
+        "--max-size",
+        "150",
+        "--out-dir",
+        "split_same_file/split/",
+    ])
+    .unwrap()
+    .execute()
+    .unwrap();
+
+    let part = "split_same_file/split/test.part1.pna";
+    let before = fs::read(part).unwrap();
+    assert!(!before.is_empty(), "precondition: part file must exist");
+
+    let result = cli::Cli::try_parse_from([
+        "pna",
+        "--quiet",
+        "split",
+        "-f",
+        part,
+        "--overwrite",
+        "--max-size",
+        "150",
+    ])
+    .unwrap()
+    .execute();
+
+    assert!(
+        result.is_err(),
+        "splitting a part file in place should fail"
+    );
+    assert_eq!(
+        fs::read(part).unwrap(),
+        before,
+        "input part file must be left untouched"
+    );
+}


### PR DESCRIPTION
Splitting a .partN.pna without --out-dir maps the first output part back onto the input path (with_part), so file_create truncates the input mid-read and leaves a broken 28B archive.

Detect part-like inputs whose output base resolves to the same file and fail before touching anything, guiding toward --out-dir. Adds a regression test asserting the error and that the original part is untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the `split` command from overwriting an existing split-part input when no output directory is specified.
  * The command now fails safely while preserving the original input file.
  * Output directories are created before archive processing begins, improving handling of destination paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->