### PR TITLE
:recycle: Make `salt_string` fallible

### DIFF
--- a/lib/src/entry/write.rs
+++ b/lib/src/entry/write.rs
@@ -66,7 +66,7 @@ pub(crate) fn derive_key_material(
     hash_algorithm: HashAlgorithm,
     password: &[u8],
 ) -> io::Result<DerivedKeyMaterial> {
-    let salt = random::salt_string();
+    let salt = random::salt_string()?;
     let (key, phsf) = hash(cipher_algorithm, hash_algorithm, password, &salt)?;
     Ok(DerivedKeyMaterial { phsf, key })
 }

--- a/lib/src/hash.rs
+++ b/lib/src/hash.rs
@@ -93,7 +93,7 @@ mod tests {
 
     #[test]
     fn derive_argon2() {
-        let salt = random::salt_string();
+        let salt = random::salt_string().unwrap();
         let mut ph = argon2_with_salt(
             b"pass",
             argon2::Algorithm::Argon2id,
@@ -113,7 +113,7 @@ mod tests {
 
     #[test]
     fn derive_pbkdf2() {
-        let salt = random::salt_string();
+        let salt = random::salt_string().unwrap();
         let mut ph = pbkdf2_with_salt(
             b"pass",
             pbkdf2::Algorithm::Pbkdf2Sha256,

--- a/lib/src/random.rs
+++ b/lib/src/random.rs
@@ -1,6 +1,6 @@
 //! Random salt and initialization vector generation.
 
-use password_hash::SaltString;
+use password_hash::{Salt, SaltString};
 use rand::prelude::*;
 use rand_chacha::ChaCha20Rng;
 use std::io;
@@ -16,6 +16,8 @@ pub(crate) fn random_vec(size: usize) -> io::Result<Vec<u8>> {
     Ok(v)
 }
 
-pub(crate) fn salt_string() -> SaltString {
-    SaltString::generate(ChaCha20Rng::from_entropy())
+pub(crate) fn salt_string() -> io::Result<SaltString> {
+    let mut bytes = [0u8; Salt::RECOMMENDED_LENGTH];
+    random_bytes(&mut bytes)?;
+    SaltString::encode_b64(&bytes).map_err(io::Error::other)
 }


### PR DESCRIPTION
## Summary
Extract only the `pub(crate) fn salt_string() -> io::Result<SaltString>` change from b07c9b39 (Reapply rand 0.9.0 #1535) as a preparatory refactor, without the rand version bump.

## Changes (vs main)
- `lib/src/random.rs`: `salt_string()` now returns `io::Result<SaltString>` via `random_bytes` + `SaltString::encode_b64`; add `Salt` import. `random_bytes` / rand 0.8 untouched.
- `lib/src/entry/write.rs`: `derive_key_material` handles `?` (main moved caller from old `to_hashed` to `derive_key_material`, adapted accordingly).
- `lib/src/hash.rs`: tests use `.unwrap()`.

## Motivation
- Split fallible-API change out of the large rand 0.8 -> 0.9 bump for easier review.
- New impl works with both old (`from_entropy`) and new (`try_from_os_rng`) `random_bytes`.

## Verification
- `cargo check -p libpna` ok
- `cargo test -p libpna --lib hash` : 3 passed
- `cargo clippy -p libpna --lib -- -D warnings` ok

Ref: b07c9b393205332bcf68b59015ecd0c7f07a5878

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Salt generation failures are now surfaced instead of being silently treated as successful.
  * Password-derived key and hash operations now handle salt-generation errors more reliably.

* **Tests**
  * Updated hashing tests to account for possible salt-generation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->