### PR TITLE
:arrow_up: Bump password-hashing crates (pbkdf2 0.13, argon2 0.6, password-hash 0.6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,13 +149,13 @@ checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 
 [[package]]
 name = "argon2"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+checksum = "134c52ddac6d63c576bef8168db10c83c49c26444ecbc68060fef078925a901c"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures 0.2.12",
+ "cpufeatures 0.3.0",
  "password-hash",
 ]
 
@@ -205,9 +205,9 @@ checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
@@ -226,11 +226,11 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+checksum = "5b5d4d889834ee8ecfc0f8426ad30faf7cdcb10f741a8e6d7224d95325479f6f"
 dependencies = [
- "digest 0.10.7",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1541,10 +1541,10 @@ dependencies = [
  "hkdf",
  "liblzma",
  "password-hash",
- "pbkdf2 0.12.2",
+ "pbkdf2",
  "rand",
  "rand_chacha",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "time",
  "tokio",
@@ -1607,7 +1607,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47bb1e988e6fb779cf720ad431242d3f03167c1b3f2b1aae7f1a94b2495b36ae"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1827,13 +1827,11 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+checksum = "aab41826031698d6ffcd9cff78ef56ef998e39dc7e5067cdfebe373842d4723b"
 dependencies = [
- "base64ct",
- "rand_core",
- "subtle",
+ "phc",
 ]
 
 [[package]]
@@ -1844,25 +1842,14 @@ checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
 name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest 0.10.7",
- "hmac 0.12.1",
- "password-hash",
- "rayon",
- "sha2",
-]
-
-[[package]]
-name = "pbkdf2"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
  "digest 0.11.2",
  "hmac 0.13.0",
+ "password-hash",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -1870,6 +1857,16 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "phc"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
+dependencies = [
+ "base64ct",
+ "ctutils",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2293,7 +2290,7 @@ version = "8.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b161f275cb337fe0a44d924a5f4df0ed69c2c39519858f931ce61c779d3475"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
  "walkdir",
 ]
 
@@ -2433,6 +2430,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.12",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -3509,7 +3517,7 @@ dependencies = [
  "indexmap",
  "lzma-rust2",
  "memchr",
- "pbkdf2 0.13.0",
+ "pbkdf2",
  "ppmd-rust",
  "sha1",
  "time",

--- a/cli/src/command/core.rs
+++ b/cli/src/command/core.rs
@@ -2288,7 +2288,7 @@ mod tests {
         let source_options = WriteOptions::builder()
             .encryption(pna::Encryption::AES)
             .cipher_mode(pna::CipherMode::GCM)
-            .hash_algorithm(pna::HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .hash_algorithm(pna::HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
             .password(Some("password"))
             .build();
         let mut source =
@@ -2334,7 +2334,7 @@ mod tests {
             .compression(pna::Compression::ZSTANDARD)
             .encryption(pna::Encryption::AES)
             .cipher_mode(pna::CipherMode::GCM)
-            .hash_algorithm(pna::HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .hash_algorithm(pna::HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
             .password(Some("password"))
             .build();
         let mut source =
@@ -2345,7 +2345,7 @@ mod tests {
             .compression(pna::Compression::NO)
             .encryption(pna::Encryption::CAMELLIA)
             .cipher_mode(pna::CipherMode::CTR)
-            .hash_algorithm(pna::HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .hash_algorithm(pna::HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
             .password(Some("password"))
             .build();
         let mut cache = ReencryptOptionsCache::new();
@@ -2381,7 +2381,7 @@ mod tests {
         let camellia_options = WriteOptions::builder()
             .encryption(pna::Encryption::CAMELLIA)
             .cipher_mode(pna::CipherMode::GCM)
-            .hash_algorithm(pna::HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .hash_algorithm(pna::HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
             .password(Some("password"))
             .build();
         let mut aes_source =
@@ -2424,7 +2424,7 @@ mod tests {
         let source_options = WriteOptions::builder()
             .encryption(pna::Encryption::AES)
             .cipher_mode(pna::CipherMode::GCM)
-            .hash_algorithm(pna::HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .hash_algorithm(pna::HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
             .password(Some("password"))
             .build();
         let mut source =
@@ -2434,7 +2434,7 @@ mod tests {
         let create_options = WriteOptions::builder()
             .encryption(pna::Encryption::AES)
             .cipher_mode(pna::CipherMode::GCM)
-            .hash_algorithm(pna::HashAlgorithm::pbkdf2_sha256_with(Some(2)))
+            .hash_algorithm(pna::HashAlgorithm::pbkdf2_sha256_with(Some(1001)))
             .password(Some("password"))
             .build();
         let mut cache = ReencryptOptionsCache::new();
@@ -2452,15 +2452,15 @@ mod tests {
         archive.add_entry(renamed).unwrap();
         let bytes = archive.finalize().unwrap();
         let text = String::from_utf8_lossy(&bytes);
-        assert!(text.contains("$pbkdf2-sha256$i=2"), "{text}");
-        assert!(!text.contains("$pbkdf2-sha256$i=1"), "{text}");
+        assert!(text.contains("$pbkdf2-sha256$i=1001"), "{text}");
+        assert!(!text.contains("$pbkdf2-sha256$i=1000"), "{text}");
     }
 
     fn gcm_write_options() -> WriteOptions {
         WriteOptions::builder()
             .encryption(pna::Encryption::AES)
             .cipher_mode(pna::CipherMode::GCM)
-            .hash_algorithm(pna::HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .hash_algorithm(pna::HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
             .password(Some("password"))
             .build()
     }

--- a/cli/tests/cli/bsdtar/encrypted_rename.rs
+++ b/cli/tests/cli/bsdtar/encrypted_rename.rs
@@ -19,7 +19,7 @@ fn create_encrypted_archive(
     let options = pna::WriteOptions::builder()
         .encryption(pna::Encryption::AES)
         .cipher_mode(cipher_mode)
-        .hash_algorithm(pna::HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+        .hash_algorithm(pna::HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
         .password(Some(PASSWORD))
         .build();
     let file = File::create(path).unwrap();

--- a/cli/tests/cli/combination.rs
+++ b/cli/tests/cli/combination.rs
@@ -33,7 +33,7 @@ const ENCRYPTION_OPTIONS: &[Option<[&str; 2]>] = &[
     Some(["--camellia", "gcm"]),
 ];
 
-const HASH_OPTIONS: &[[&str; 2]] = &[["--pbkdf2", "r=1"], ["--argon2", "t=1,m=50"]];
+const HASH_OPTIONS: &[[&str; 2]] = &[["--pbkdf2", "r=1000"], ["--argon2", "t=1,m=50"]];
 
 const SOLID_OPTIONS: &[Option<&str>] = &[None, Some("--solid")];
 

--- a/cli/tests/cli/create/option_password_hash.rs
+++ b/cli/tests/cli/create/option_password_hash.rs
@@ -151,7 +151,7 @@ fn aes_ctr_pbkdf2_with_params_archive() {
         "--aes",
         "ctr",
         "--pbkdf2",
-        "r=1",
+        "r=1000",
     ])
     .unwrap()
     .execute()

--- a/fuzz/fuzz_targets/aes_gcm.rs
+++ b/fuzz/fuzz_targets/aes_gcm.rs
@@ -12,7 +12,7 @@ fuzz_target!(|data: &[u8]| {
         .encryption(Encryption::AES)
         .cipher_mode(CipherMode::GCM)
         .compression(Compression::NO)
-        .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+        .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
         .build();
     let mut builder = FileEntryBuilder::new_with_options("fuzz".into(), write_option).unwrap();
     builder.write_all(data).unwrap();

--- a/fuzz/fuzz_targets/camellia_gcm.rs
+++ b/fuzz/fuzz_targets/camellia_gcm.rs
@@ -12,7 +12,7 @@ fuzz_target!(|data: &[u8]| {
         .encryption(Encryption::CAMELLIA)
         .cipher_mode(CipherMode::GCM)
         .compression(Compression::NO)
-        .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+        .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
         .build();
     let mut builder = FileEntryBuilder::new_with_options("fuzz".into(), write_option).unwrap();
     builder.write_all(data).unwrap();

--- a/fuzz/fuzz_targets/gcm_datastream_mutation.rs
+++ b/fuzz/fuzz_targets/gcm_datastream_mutation.rs
@@ -65,7 +65,7 @@ fuzz_target!(|data: (usize, usize, u8)| {
         .encryption(Encryption::AES)
         .cipher_mode(CipherMode::GCM)
         .compression(Compression::NO)
-        .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+        .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
         .build();
     let mut builder = FileEntryBuilder::new_with_options("fuzz".into(), write_option).unwrap();
     builder.write_all(PLAIN).unwrap();

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.88"
 [dependencies]
 aes = "0.9.1"
 aes-gcm = { version = "0.11.0", default-features = false, features = ["aes", "alloc"] }
-argon2 = { version = "0.5.3", features = ["std"] }
+argon2 = { version = "0.6.0", default-features = false, features = ["alloc", "password-hash"] }
 arrayvec = "0.7.6"
 block-buffer = "0.12.0"
 camellia = "0.2.0"
@@ -29,8 +29,8 @@ futures-io = { version = "0.3.32", optional = true }
 futures-util = { version = "0.3.32", features = ["io"], optional = true }
 hkdf = "0.12.4"
 liblzma = { version = "0.4.6", features = ["static"] }
-password-hash = { version = "0.5.0", default-features = false }
-pbkdf2 = { version = "0.12.2", features = ["simple"] }
+password-hash = { version = "0.6.0", default-features = false, features = ["alloc", "phc"] }
+pbkdf2 = { version = "0.13.0", features = ["phc"] }
 rand = "0.8.6"
 rand_chacha = "0.3.1"
 sha2 = "0.10.9"
@@ -42,9 +42,6 @@ zstd = { version = "0.14.0", default-features = false }
 getrandom = { version = "0.2", features = ["js"] }
 liblzma = { version = "0.4.6", features = ["wasm"] }
 zstd = { version = "0.14.0", features = ["wasm"] }
-
-[target.'cfg(not(target_os = "emscripten"))'.dependencies]
-pbkdf2 = { version = "0.12.2", features = ["simple", "parallel"] }
 
 [dev-dependencies]
 version-sync = "0.9.5"

--- a/lib/src/archive.rs
+++ b/lib/src/archive.rs
@@ -260,7 +260,7 @@ mod tests {
                 .compression(Compression::NO)
                 .encryption(Encryption::AES)
                 .cipher_mode(CipherMode::CBC)
-                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
                 .password(Some("password"))
                 .build(),
         )
@@ -275,7 +275,7 @@ mod tests {
                 .compression(Compression::ZSTANDARD)
                 .encryption(Encryption::AES)
                 .cipher_mode(CipherMode::CTR)
-                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
                 .password(Some("password"))
                 .build(),
         )
@@ -290,7 +290,7 @@ mod tests {
                 .compression(Compression::ZSTANDARD)
                 .encryption(Encryption::AES)
                 .cipher_mode(CipherMode::CBC)
-                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
                 .password(Some("password"))
                 .build(),
         )
@@ -305,7 +305,7 @@ mod tests {
                 .compression(Compression::ZSTANDARD)
                 .encryption(Encryption::CAMELLIA)
                 .cipher_mode(CipherMode::CTR)
-                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
                 .password(Some("password"))
                 .build(),
         )
@@ -320,7 +320,7 @@ mod tests {
                 .compression(Compression::ZSTANDARD)
                 .encryption(Encryption::CAMELLIA)
                 .cipher_mode(CipherMode::CBC)
-                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
                 .password(Some("password"))
                 .build(),
         )
@@ -335,7 +335,7 @@ mod tests {
                 .compression(Compression::XZ)
                 .encryption(Encryption::AES)
                 .cipher_mode(CipherMode::CBC)
-                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
                 .password(Some("password"))
                 .build(),
         )
@@ -350,7 +350,7 @@ mod tests {
                 .compression(Compression::XZ)
                 .encryption(Encryption::CAMELLIA)
                 .cipher_mode(CipherMode::CBC)
-                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
                 .password(Some("password"))
                 .build(),
         )
@@ -493,7 +493,7 @@ mod tests {
     fn read_options_cache_is_reused_across_solid_blocks() {
         let write_options = WriteOptions::builder()
             .encryption(Encryption::AES)
-            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
             .password(Some("password"))
             .try_build()
             .unwrap();
@@ -602,7 +602,7 @@ mod tests {
                 .compression(Compression::NO)
                 .encryption(Encryption::CAMELLIA)
                 .cipher_mode(CipherMode::CBC)
-                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
                 .password(Some("PASSWORD"))
                 .build(),
         );
@@ -693,7 +693,7 @@ mod tests {
             .compression(Compression::ZSTANDARD)
             .encryption(Encryption::AES)
             .cipher_mode(CipherMode::CTR)
-            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
             .password(Some("password"))
             .build();
         let mut archive = Archive::write_header(Vec::new()).unwrap();
@@ -1010,7 +1010,7 @@ mod tests {
                 .compression(compression)
                 .encryption(encryption)
                 .cipher_mode(CipherMode::GCM)
-                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
                 .password(Some("password"));
             builder.segment_size(segment_size);
             builder.build()
@@ -1362,7 +1362,7 @@ mod tests {
                 .compression(Compression::NO)
                 .encryption(Encryption::AES)
                 .cipher_mode(CipherMode::GCM)
-                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
                 .password(Some(PASSWORD));
             builder.segment_size(segment_size);
             builder.build()

--- a/lib/src/archive/split_parts.rs
+++ b/lib/src/archive/split_parts.rs
@@ -549,13 +549,13 @@ mod tests {
     #[test]
     fn stream_chunk_split_across_parts_remains_decryptable() {
         let (parts, next) = part_collector();
-        let max = MIN_SPLIT_PART_BYTES + 64;
+        let max = MIN_SPLIT_PART_BYTES + 128;
         let mut archive = Archive::write_split_header(max, next).unwrap();
         let options = WriteOptions::builder()
             .compression(Compression::NO)
             .encryption(crate::entry::Encryption::AES)
             .cipher_mode(crate::entry::CipherMode::GCM)
-            .hash_algorithm(crate::entry::HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .hash_algorithm(crate::entry::HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
             .password(Some("password"))
             .segment_size(4)
             .build();

--- a/lib/src/archive/write.rs
+++ b/lib/src/archive/write.rs
@@ -1174,7 +1174,7 @@ mod tests {
         WriteOptions::builder()
             .encryption(Encryption::AES)
             .cipher_mode(CipherMode::GCM)
-            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
             .password(Some("password"))
             .build()
     }

--- a/lib/src/entry.rs
+++ b/lib/src/entry.rs
@@ -1912,7 +1912,7 @@ mod tests {
         let options = WriteOptions::builder()
             .encryption(Encryption::AES)
             .cipher_mode(CipherMode::GCM)
-            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
             .password(Some("password"))
             .build();
         let mut builder =
@@ -1928,7 +1928,7 @@ mod tests {
         let options = WriteOptions::builder()
             .encryption(Encryption::AES)
             .cipher_mode(CipherMode::GCM)
-            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
             .password(Some("password"))
             .build();
         let mut builder =
@@ -1957,7 +1957,7 @@ mod tests {
         let options = WriteOptions::builder()
             .encryption(Encryption::AES)
             .cipher_mode(CipherMode::CBC)
-            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
             .password(Some("password"))
             .build();
         let mut builder =
@@ -1980,7 +1980,7 @@ mod tests {
         let options = WriteOptions::builder()
             .encryption(Encryption::AES)
             .cipher_mode(CipherMode::CBC)
-            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
             .password(Some("password"))
             .build();
         let mut builder =

--- a/lib/src/entry/builder.rs
+++ b/lib/src/entry/builder.rs
@@ -1069,7 +1069,7 @@ mod tests {
             builder
                 .encryption(encryption)
                 .cipher_mode(CipherMode::GCM)
-                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
                 .password(Some("password"));
             builder.segment_size(segment_size);
             builder.build()

--- a/lib/src/entry/builder/solid.rs
+++ b/lib/src/entry/builder/solid.rs
@@ -372,7 +372,7 @@ mod tests {
         let options = WriteOptions::builder()
             .encryption(Encryption::AES)
             .cipher_mode(CipherMode::GCM)
-            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+            .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
             .password(Some("password"))
             .build();
         let mut builder = SolidEntryBuilder::new(options).unwrap();

--- a/lib/src/entry/options.rs
+++ b/lib/src/entry/options.rs
@@ -1482,7 +1482,7 @@ mod tests {
             let mut builder = WriteOptions::builder();
             builder
                 .encryption(Encryption::AES)
-                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
                 .password(Some("password"));
             builder.segment_size(size);
             let err = builder.try_build().unwrap_err();
@@ -1496,7 +1496,7 @@ mod tests {
             let mut builder = WriteOptions::builder();
             builder
                 .encryption(Encryption::AES)
-                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1)))
+                .hash_algorithm(HashAlgorithm::pbkdf2_sha256_with(Some(1000)))
                 .password(Some("password"));
             builder.segment_size(size);
             let options = builder.try_build().unwrap();

--- a/lib/src/entry/options.rs
+++ b/lib/src/entry/options.rs
@@ -6,7 +6,7 @@ use crate::{
     entry::write::derive_key_material,
     error::UnknownValueError,
 };
-use password_hash::Output;
+use password_hash::phc::Output;
 pub(crate) use private::*;
 use std::{
     collections::HashMap,

--- a/lib/src/entry/read.rs
+++ b/lib/src/entry/read.rs
@@ -15,7 +15,7 @@ use crate::{
 use aes::Aes256;
 use camellia::Camellia256;
 use crypto_common::BlockSizeUser;
-use password_hash::Output;
+use password_hash::phc::Output;
 use std::io::{self, Read};
 
 /// Resolves the cipher key for a PHC string, reusing a previously derived
@@ -30,10 +30,7 @@ fn resolve_key(phsf: &str, password: &[u8], key_cache: Option<&KeyCache>) -> io:
     {
         return Ok(key);
     }
-    let password_hash = derive_password_hash(phsf, password)?;
-    let key = password_hash
-        .hash
-        .ok_or_else(|| io::Error::new(io::ErrorKind::Unsupported, "failed to get hash"))?;
+    let key = derive_password_hash(phsf, password)?;
     if let Some(cache) = key_cache {
         cache.insert(phsf, key);
     }

--- a/lib/src/entry/write.rs
+++ b/lib/src/entry/write.rs
@@ -16,7 +16,7 @@ use camellia::Camellia256;
 use crypto_common::{BlockSizeUser, KeySizeUser};
 use flate2::write::ZlibEncoder;
 use liblzma::write::XzEncoder;
-use password_hash::{Output, SaltString};
+use password_hash::phc::{Output, SaltString};
 use std::io::{self, Write};
 use zstd::stream::write::Encoder as ZstdEncoder;
 
@@ -150,13 +150,13 @@ fn key_size(cipher_algorithm: CipherAlgorithm) -> usize {
 }
 
 #[inline]
-fn hash<'s, 'p: 's>(
+fn hash(
     cipher_algorithm: CipherAlgorithm,
     hash_algorithm: HashAlgorithm,
-    password: &'p [u8],
-    salt: &'s SaltString,
+    password: &[u8],
+    salt: &SaltString,
 ) -> io::Result<(Output, String)> {
-    let mut password_hash = match hash_algorithm.0 {
+    match hash_algorithm.0 {
         HashAlgorithmParams::Argon2Id {
             time_cost,
             memory_cost,
@@ -171,18 +171,12 @@ fn hash<'s, 'p: 's>(
             salt,
         ),
         HashAlgorithmParams::Pbkdf2Sha256 { rounds } => {
-            let mut params = pbkdf2::Params::default();
-            if let Some(rounds) = rounds {
-                params.rounds = rounds;
-            }
+            let rounds = rounds.unwrap_or(pbkdf2::Params::RECOMMENDED_ROUNDS);
+            let params = pbkdf2::Params::new_with_output_len(rounds, key_size(cipher_algorithm))
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
             hash::pbkdf2_with_salt(password, pbkdf2::Algorithm::Pbkdf2Sha256, params, salt)
         }
-    }?;
-    let hash = password_hash
-        .hash
-        .take()
-        .ok_or_else(|| io::Error::new(io::ErrorKind::Unsupported, "failed to get hash"))?;
-    Ok((hash, password_hash.to_string()))
+    }
 }
 
 #[inline]

--- a/lib/src/hash.rs
+++ b/lib/src/hash.rs
@@ -1,17 +1,25 @@
 //! Password hashing helpers.
 use argon2::{Argon2, ParamsBuilder, Version};
-use password_hash::{PasswordHash, PasswordHasher, SaltString};
+use password_hash::{
+    CustomizedPasswordHasher, PasswordHasher,
+    phc::{Output, PasswordHash, SaltString},
+};
 use std::io;
 
-pub(crate) fn argon2_with_salt<'a>(
-    password: &'a [u8],
+#[inline]
+fn invalid_data<E: std::fmt::Display>(e: E) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, e.to_string())
+}
+
+pub(crate) fn argon2_with_salt(
+    password: &[u8],
     algorithm: argon2::Algorithm,
     time_cost: Option<u32>,
     memory_cost: Option<u32>,
     parallelism_cost: Option<u32>,
     hash_length: usize,
-    salt: &'a SaltString,
-) -> io::Result<PasswordHash<'a>> {
+    salt: &SaltString,
+) -> io::Result<(Output, String)> {
     let mut builder = ParamsBuilder::default();
     if let Some(time_cost) = time_cost {
         builder.t_cost(time_cost);
@@ -26,62 +34,96 @@ pub(crate) fn argon2_with_salt<'a>(
         .output_len(hash_length)
         .context(algorithm, Version::default())
         .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
-    argon2
-        .hash_password(password, salt)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+    let pwhash = argon2
+        .hash_password_with_salt(password, salt.as_ref().as_bytes())
+        .map_err(invalid_data)?;
+    finalize(pwhash.hash, pwhash.to_string())
 }
 
-pub(crate) fn pbkdf2_with_salt<'a>(
-    password: &'a [u8],
+pub(crate) fn pbkdf2_with_salt(
+    password: &[u8],
     algorithm: pbkdf2::Algorithm,
     params: pbkdf2::Params,
-    salt: &'a SaltString,
-) -> io::Result<PasswordHash<'a>> {
-    pbkdf2::Pbkdf2
-        .hash_password_customized(password, Some(algorithm.ident()), None, params, salt)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+    salt: &SaltString,
+) -> io::Result<(Output, String)> {
+    let pwhash = pbkdf2::Pbkdf2::default()
+        .hash_password_customized(
+            password,
+            salt.as_ref().as_bytes(),
+            Some(algorithm.as_ref()),
+            None,
+            params,
+        )
+        .map_err(invalid_data)?;
+    let phc_string = pwhash.to_string();
+    let raw = pwhash
+        .hash
+        .ok_or_else(|| io::Error::other("pbkdf2 returned no hash"))?;
+    Ok((Output::new(raw.as_ref()).map_err(invalid_data)?, phc_string))
 }
 
-pub(crate) fn derive_password_hash<'a>(
-    phsf: &'a str,
-    password: &'a [u8],
-) -> io::Result<PasswordHash<'a>> {
-    let password_hash =
-        PasswordHash::new(phsf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-    let salt = password_hash.salt.ok_or_else(|| {
-        io::Error::new(io::ErrorKind::InvalidData, "missing salt in password hash")
-    })?;
-    match password_hash.algorithm {
-        argon2::ARGON2D_IDENT | argon2::ARGON2I_IDENT | argon2::ARGON2ID_IDENT => {
-            let argon2 = Argon2::default();
-            argon2
-                .hash_password_customized(
-                    password,
-                    Some(password_hash.algorithm),
-                    password_hash.version,
-                    argon2::Params::try_from(&password_hash)
-                        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
-                    salt,
-                )
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
-        }
-        pbkdf2::Algorithm::PBKDF2_SHA256_IDENT | pbkdf2::Algorithm::PBKDF2_SHA512_IDENT => {
-            pbkdf2::Pbkdf2
-                .hash_password_customized(
-                    password,
-                    Some(password_hash.algorithm),
-                    password_hash.version,
-                    pbkdf2::Params::try_from(&password_hash)
-                        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
-                    salt,
-                )
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
-        }
-        a => Err(io::Error::new(
+#[inline]
+fn finalize(hash: Option<Output>, phc_string: String) -> io::Result<(Output, String)> {
+    Ok((
+        hash.ok_or_else(|| io::Error::other("hasher returned no hash"))?,
+        phc_string,
+    ))
+}
+
+pub(crate) fn derive_password_hash(phsf: &str, password: &[u8]) -> io::Result<Output> {
+    let pwhash = PasswordHash::new(phsf).map_err(invalid_data)?;
+    let alg = pwhash.algorithm.as_str();
+    if alg == argon2::ARGON2D_IDENT.as_str()
+        || alg == argon2::ARGON2I_IDENT.as_str()
+        || alg == argon2::ARGON2ID_IDENT.as_str()
+    {
+        let salt = pwhash
+            .salt
+            .ok_or_else(|| invalid_data("missing salt in password hash"))?;
+        let params = argon2::Params::try_from(&pwhash).map_err(invalid_data)?;
+        let derived = Argon2::default()
+            .hash_password_customized(
+                password,
+                salt.as_ref(),
+                Some(pwhash.algorithm.as_str()),
+                pwhash.version,
+                params,
+            )
+            .map_err(invalid_data)?;
+        derived
+            .hash
+            .ok_or_else(|| io::Error::other("argon2 returned no hash"))
+    } else if alg == pbkdf2::Algorithm::PBKDF2_SHA256_ID
+        || alg == pbkdf2::Algorithm::PBKDF2_SHA512_ID
+    {
+        derive_pbkdf2(phsf, password)
+    } else {
+        Err(io::Error::new(
             io::ErrorKind::Unsupported,
-            format!("unsupported algorithm {a:?}"),
-        )),
+            format!("unsupported algorithm {alg:?}"),
+        ))
     }
+}
+
+fn derive_pbkdf2(phsf: &str, password: &[u8]) -> io::Result<Output> {
+    let pwhash = PasswordHash::new(phsf).map_err(invalid_data)?;
+    let salt = pwhash
+        .salt
+        .ok_or_else(|| invalid_data("missing salt in password hash"))?;
+    let params = pbkdf2::Params::try_from(&pwhash).map_err(invalid_data)?;
+    let derived = pbkdf2::Pbkdf2::default()
+        .hash_password_customized(
+            password,
+            salt.as_ref(),
+            Some(pwhash.algorithm.as_str()),
+            pwhash.version,
+            params,
+        )
+        .map_err(invalid_data)?;
+    let raw = derived
+        .hash
+        .ok_or_else(|| io::Error::other("pbkdf2 returned no hash"))?;
+    Output::new(raw.as_ref()).map_err(invalid_data)
 }
 
 #[cfg(test)]
@@ -94,7 +136,7 @@ mod tests {
     #[test]
     fn derive_argon2() {
         let salt = random::salt_string().unwrap();
-        let mut ph = argon2_with_salt(
+        let (expected, ps) = argon2_with_salt(
             b"pass",
             argon2::Algorithm::Argon2id,
             None,
@@ -104,27 +146,21 @@ mod tests {
             &salt,
         )
         .unwrap();
-        ph.hash.take();
-        assert_eq!(ph.hash, None);
-        let ps = ph.to_string();
-        let ph = derive_password_hash(&ps, b"pass").unwrap();
-        assert!(ph.hash.is_some());
+        let derived = derive_password_hash(&ps, b"pass").unwrap();
+        assert_eq!(derived.as_bytes(), expected.as_bytes());
     }
 
     #[test]
     fn derive_pbkdf2() {
         let salt = random::salt_string().unwrap();
-        let mut ph = pbkdf2_with_salt(
+        let (expected, ps) = pbkdf2_with_salt(
             b"pass",
             pbkdf2::Algorithm::Pbkdf2Sha256,
             pbkdf2::Params::default(),
             &salt,
         )
         .unwrap();
-        ph.hash.take();
-        assert_eq!(ph.hash, None);
-        let ps = ph.to_string();
-        let ph = derive_password_hash(&ps, b"pass").unwrap();
-        assert!(ph.hash.is_some());
+        let derived = derive_password_hash(&ps, b"pass").unwrap();
+        assert_eq!(derived.as_bytes(), expected.as_bytes());
     }
 }

--- a/lib/src/random.rs
+++ b/lib/src/random.rs
@@ -1,6 +1,6 @@
 //! Random salt and initialization vector generation.
 
-use password_hash::{Salt, SaltString};
+use password_hash::phc::{Salt, SaltString};
 use rand::prelude::*;
 use rand_chacha::ChaCha20Rng;
 use std::io;
@@ -19,5 +19,7 @@ pub(crate) fn random_vec(size: usize) -> io::Result<Vec<u8>> {
 pub(crate) fn salt_string() -> io::Result<SaltString> {
     let mut bytes = [0u8; Salt::RECOMMENDED_LENGTH];
     random_bytes(&mut bytes)?;
-    SaltString::encode_b64(&bytes).map_err(io::Error::other)
+    Ok(Salt::new(&bytes)
+        .map_err(io::Error::other)?
+        .to_salt_string())
 }


### PR DESCRIPTION
Unify libpna on password-hash 0.6 and drop the getrandom dependency.

## Commits
1. :white_check_mark: Bump test PBKDF2 rounds to 1000
   - pbkdf2 0.13 rejects rounds below MIN_ROUNDS = 1000 via Params::new_with_output_len; update all fixtures first (1000 is valid on both 0.12 and 0.13)
2. :arrow_up: Bump password-hashing crates (pbkdf2 0.13, argon2 0.6, password-hash 0.6)
   - pbkdf2 0.12 -> 0.13 (simple/parallel features removed upstream in favor of phc; drop the emscripten parallel override)
   - argon2 0.5.3 -> 0.6.0, password-hash 0.5.0 -> 0.6.1, unified on password_hash::phc
   - hash.rs returns concrete (Output, String) / Output; argon2 uses hash_password_with_salt
   - entry::write::hash builds pbkdf2 Params with Params::new_with_output_len(rounds, key_size)
   - salt_string() stays fallible and ChaCha-based (random_bytes + Salt::new), avoiding the getrandom-gated SaltString::generate
   - argon2/password-hash default features disabled (alloc/password-hash/phc only), dropping getrandom 0.4 from the tree