### PR TITLE
Centralize SystemTime conversion via jiff

### DIFF
--- a/cli/src/cli/value.rs
+++ b/cli/src/cli/value.rs
@@ -21,7 +21,7 @@ pub(crate) use chunk_type::ChunkType;
 pub(crate) use color_choice::ColorChoice;
 pub(crate) use compression_level::{DeflateLevel, XzLevel, ZstdLevel};
 pub use datetime::DateTime;
-pub(crate) use datetime::DateTimeError;
+pub(crate) use datetime::{DateTimeError, system_time_to_unix_timestamp};
 pub(crate) use log_level::LogLevel;
 pub(crate) use missing_time_policy::MissingTimePolicy;
 pub(crate) use name_id_pair::NameIdPair;

--- a/cli/src/cli/value/datetime.rs
+++ b/cli/src/cli/value/datetime.rs
@@ -113,10 +113,7 @@ pub(crate) fn system_time_to_unix_timestamp(time: SystemTime) -> Option<(i64, u3
     if subsec >= 0 {
         Some((ts.as_second(), subsec as u32))
     } else {
-        Some((
-            ts.as_second() - 1,
-            (1_000_000_000 + subsec) as u32,
-        ))
+        Some((ts.as_second() - 1, (1_000_000_000 + subsec) as u32))
     }
 }
 
@@ -231,10 +228,7 @@ mod tests {
     #[test]
     fn system_time_to_unix_timestamp_floors_negative_subsecond() {
         // jiff truncates toward zero; we floor so nanos stay in 0..1e9.
-        assert_eq!(
-            system_time_to_unix_timestamp(UNIX_EPOCH),
-            Some((0, 0))
-        );
+        assert_eq!(system_time_to_unix_timestamp(UNIX_EPOCH), Some((0, 0)));
         assert_eq!(
             system_time_to_unix_timestamp(UNIX_EPOCH - std::time::Duration::from_millis(1)),
             Some((-1, 999_000_000))

--- a/cli/src/cli/value/datetime.rs
+++ b/cli/src/cli/value/datetime.rs
@@ -97,6 +97,29 @@ fn epoch_to_system_time(seconds: i64, nanoseconds: u32) -> Option<SystemTime> {
     floor.checked_add(subsec)
 }
 
+/// Converts `SystemTime` to floored `(seconds, subsec_nanos)` such that the
+/// instant equals `UNIX_EPOCH + seconds * 1s + nanos * 1ns` with `nanos < 1e9`.
+///
+/// Single source of truth for this conversion (previously duplicated in
+/// `command::list`). Delegates borrow handling to `jiff` instead of manual
+/// `duration_since` arithmetic. Returns `None` when outside jiff's
+/// representable window (`Timestamp::MIN..=MAX`).
+#[inline]
+pub(crate) fn system_time_to_unix_timestamp(time: SystemTime) -> Option<(i64, u32)> {
+    let ts = jiff::Timestamp::try_from(time).ok()?;
+    // jiff uses truncated seconds + signed subsec (e.g. -1ms => sec 0, subsec
+    // -1_000_000). Floor to non-negative nanos for `Timestamp::new` round-trip.
+    let subsec = ts.subsec_nanosecond();
+    if subsec >= 0 {
+        Some((ts.as_second(), subsec as u32))
+    } else {
+        Some((
+            ts.as_second() - 1,
+            (1_000_000_000 + subsec) as u32,
+        ))
+    }
+}
+
 impl Display for DateTime {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
@@ -204,6 +227,23 @@ impl FromStr for DateTime {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn system_time_to_unix_timestamp_floors_negative_subsecond() {
+        // jiff truncates toward zero; we floor so nanos stay in 0..1e9.
+        assert_eq!(
+            system_time_to_unix_timestamp(UNIX_EPOCH),
+            Some((0, 0))
+        );
+        assert_eq!(
+            system_time_to_unix_timestamp(UNIX_EPOCH - std::time::Duration::from_millis(1)),
+            Some((-1, 999_000_000))
+        );
+        assert_eq!(
+            system_time_to_unix_timestamp(UNIX_EPOCH - std::time::Duration::from_secs(1)),
+            Some((-1, 0))
+        );
+    }
 
     #[test]
     fn test_datetime_parse_valid() {

--- a/cli/src/command/list.rs
+++ b/cli/src/command/list.rs
@@ -1,6 +1,9 @@
 use crate::{
     chunk,
-    cli::{ArchiveFileArgs, ColorChoice, DateTime, FileOperands, MissingTimePolicy, PasswordArgs},
+    cli::{
+        ArchiveFileArgs, ColorChoice, DateTime, FileOperands, MissingTimePolicy, PasswordArgs,
+        system_time_to_unix_timestamp,
+    },
     command::{
         Command, ask_password,
         core::{
@@ -1120,22 +1123,6 @@ const UNREPRESENTABLE_TIME_PLACEHOLDER: &str = "-- -- ----";
 fn system_time_to_local_opt(tz: &TimeZone, time: SystemTime) -> Option<Zoned> {
     let (sec, nsec) = system_time_to_unix_timestamp(time)?;
     unix_timestamp_to_local_opt(tz, sec, nsec)
-}
-
-#[inline]
-fn system_time_to_unix_timestamp(time: SystemTime) -> Option<(i64, u32)> {
-    match time.duration_since(SystemTime::UNIX_EPOCH) {
-        Ok(d) => Some((i64::try_from(d.as_secs()).ok()?, d.subsec_nanos())),
-        Err(e) => {
-            let d = e.duration();
-            let secs = i64::try_from(d.as_secs()).ok()?;
-            let (carry, nsec) = match d.subsec_nanos() {
-                0 => (0, 0),
-                n => (1, 1_000_000_000 - n),
-            };
-            Some((-secs - carry, nsec))
-        }
-    }
 }
 
 #[inline]


### PR DESCRIPTION
Removes manual duration_since borrow logic from command/list.rs. Adds shared system_time_to_unix_timestamp in cli/value/datetime.rs backed by Timestamp::try_from with flooring for negative subsec (jiff truncates toward zero). list.rs now imports the helper. Adds regression test for -1ms floor. Fixes item 2.